### PR TITLE
Use source/build directory paths in testing environment

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,16 +17,11 @@ file(GLOB headers_utils utilities/*.h)
 
 add_library(TestDataModel SHARED ${sources} ${sources_utils} ${headers} ${headers_utils})
 target_link_libraries(TestDataModel podio )
-install(TARGETS TestDataModel DESTINATION tests)
 
 REFLEX_GENERATE_DICTIONARY(TestDataModel ${headers} SELECTION src/selection.xml)
 add_library(TestDataModelDict SHARED TestDataModel.cxx)
 add_dependencies(TestDataModelDict TestDataModel-dictgen)
 target_link_libraries(TestDataModelDict TestDataModel podio )
-install(TARGETS TestDataModelDict DESTINATION tests)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/TestDataModelDict.rootmap DESTINATION tests)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/TestDataModel_rdict.pcm DESTINATION tests)
-
 
 file(GLOB executables RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
@@ -34,7 +29,6 @@ foreach( sourcefile ${executables} )
   string( REPLACE ".cpp" "" name ${sourcefile} )
   add_executable( ${name} ${sourcefile} )
   target_link_libraries( ${name} TestDataModelDict )
-  install(TARGETS ${name} DESTINATION tests)
 endforeach( sourcefile ${executables} )
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,16 +39,21 @@ endforeach( sourcefile ${executables} )
 
 
 #--- Adding tests --------------------------------------------------------------
+set(__dynamic_loader_envvar LD_LIBRARY_PATH)
+if(APPLE)
+  set(__dynamic_loader_envvar DYLD_FALLBACK_LIBRARY_PATH)
+endif()
+
 add_test(NAME write COMMAND write)
-set_property(TEST write PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{LD_LIBRARY_PATH})
+set_property(TEST write PROPERTY ENVIRONMENT ${__dynamic_loader_envvar}=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{${__dynamic_loader_envvar}})
 
 add_test(NAME read COMMAND read)
-set_property(TEST read PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{LD_LIBRARY_PATH})
+set_property(TEST read PROPERTY ENVIRONMENT ${__dynamic_loader_envvar}=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{${__dynamic_loader_envvar}})
 set_property(TEST read PROPERTY DEPENDS write)
 
 add_test( NAME pyunittest COMMAND python -m unittest discover -s ${PROJECT_SOURCE_DIR}/python)
 set_property(TEST pyunittest PROPERTY ENVIRONMENT
-  LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{LD_LIBRARY_PATH}
+  ${__dynamic_loader_envvar}=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{${__dynamic_loader_envvar}}
   PYTHONPATH=${PROJECT_SOURCE_DIR}/python:$ENV{PYTHONPATH}
   )
 set_property(TEST pyunittest PROPERTY DEPENDS write)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,14 +40,17 @@ endforeach( sourcefile ${executables} )
 
 #--- Adding tests --------------------------------------------------------------
 add_test(NAME write COMMAND write)
-set_property(TEST write PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/tests:$ENV{LD_LIBRARY_PATH})
+set_property(TEST write PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{LD_LIBRARY_PATH})
 
 add_test(NAME read COMMAND read)
-set_property(TEST read PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/tests:$ENV{LD_LIBRARY_PATH})
+set_property(TEST read PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{LD_LIBRARY_PATH})
 set_property(TEST read PROPERTY DEPENDS write)
 
-add_test( NAME pyunittest COMMAND python -m unittest discover -s ${CMAKE_INSTALL_PREFIX}/python)
-set_property(TEST pyunittest PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/tests:$ENV{LD_LIBRARY_PATH} PYTHONPATH=${CMAKE_INSTALL_PREFIX}/python:$ENV{PYTHONPATH})
+add_test( NAME pyunittest COMMAND python -m unittest discover -s ${PROJECT_SOURCE_DIR}/python)
+set_property(TEST pyunittest PROPERTY ENVIRONMENT
+  LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$ENV{LD_LIBRARY_PATH}
+  PYTHONPATH=${PROJECT_SOURCE_DIR}/python:$ENV{PYTHONPATH}
+  )
 set_property(TEST pyunittest PROPERTY DEPENDS write)
 
 add_test(NAME unittest COMMAND unittest)


### PR DESCRIPTION
In building/testing podio, I found that the test environment was set up to use the install locations of the libraries/Python modules rather than the expected local build.source tress. This resulted in test failures as the libraries and python test modules were not the located.

This PR changes the test's run environment to use a dynamic loader path set up that points to the build locations of the podio core/test libraries, plus a python path pointing to the python subdir of the source tree. The dynamic loader path environment variable names is also set based on the platform (though still UNIX only). On OS X, `DYLD_FALLBACK_LIBRARY_PATH` is used as this works on El Capitan.

The last commit removes the install of the tests - this no longer seems necessary given the test run fine from the build directory, but can be reverted if there are other use cases.
