### PR TITLE
Add vector members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 install
 *pyc
+*~

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -15,6 +15,7 @@ namespace podio {
 
   typedef std::vector<std::pair<std::string,podio::CollectionBase*>> CollRegistry;
   typedef std::vector<std::vector<podio::ObjectID>*> CollRefCollection;
+  typedef std::vector<std::pair<std::string,void*>> VectorMembersInfo;
 
   //class CollectionBuffer {
   //public:
@@ -56,6 +57,9 @@ namespace podio {
 
     /// return the buffers containing the object-relation information
     virtual CollRefCollection* referenceCollections() = 0;
+
+    /// return pointers to vector members
+    virtual VectorMembersInfo* vectorMembers() {return nullptr ; }
   };
 
 } // namespace

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -59,7 +59,7 @@ namespace podio {
     virtual CollRefCollection* referenceCollections() = 0;
 
     /// return pointers to vector members
-    virtual VectorMembersInfo* vectorMembers() {return nullptr ; }
+    virtual VectorMembersInfo* vectorMembers() = 0;
   };
 
 } // namespace

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -549,7 +549,7 @@ class ClassGenerator(object):
       push_back_relations = ""
       prepareafterread_refmembers = ""
       prepareforwriting_refmembers = ""
-
+      vecmembers = ""
       #------------------ create ostream operator --------------------------
       # create colum based output for data members using scientific format
       #
@@ -692,6 +692,7 @@ class ClassGenerator(object):
 
       for counter, item in enumerate(vectormembers):
         name  = item["name"]
+        klass = item["type"]
         get_name = name
         if( self.getSyntax ):
             get_name = "get" + name[:1].upper() + name[1:]
@@ -699,6 +700,7 @@ class ClassGenerator(object):
         ostream_implementation += ( '  for(unsigned j=0,N=v[i].%s_size(); j<N ; ++j)\n' % name )
         ostream_implementation += ( '    o << v[i].%s(j) << " " ; \n'  % get_name  )
         ostream_implementation +=   '  o << std::endl ;\n'
+        vecmembers += declarations["vecmembers"].format(type=klass, name=name)
 
       ostream_implementation += '  }\no.flags(old_flags);\n'
       ostream_implementation += "  return o ;\n}\n"
@@ -718,6 +720,7 @@ class ClassGenerator(object):
                         "create_relations" : create_relations,
                         "clear_relations"  : clear_relations,
                         "push_back_relations" : push_back_relations,
+                        "vecmembers" : vecmembers,
                         "package_name" : self.package_name,
                         "vectorized_access_declaration" : vectorized_access_decl,
                         "vectorized_access_implementation" : vectorized_access_impl,

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -690,6 +690,8 @@ class ClassGenerator(object):
           ostream_implementation += ( '  o << "     %s : " ;\n' % name  )
           ostream_implementation += ( '  o << v[i].%s().id() << std::endl;\n'  % get_name  )
 
+      if len(vectormembers)>0:
+          includes += '#include <numeric>\n'
       for counter, item in enumerate(vectormembers):
         name  = item["name"]
         klass = item["type"]
@@ -704,7 +706,11 @@ class ClassGenerator(object):
         destructorbody += "\tif(m_vec_{name} != nullptr) delete m_vec_{name};\n".format(name=name)
         clear_relations += "\tm_vec_{name}->clear();\n".format(name=name)
         clear_relations += "\tm_vecs_{name}.clear();\n".format(name=name)
+        prepareforwritinghead += "\tint {name}_size = std::accumulate( m_entries.begin(), m_entries.end(), 0, ".format(name=name)
+        prepareforwritinghead += "[](int sum, const {rawclassname}Obj*  obj){{ return sum + obj->m_{name}->size();}} );\n".format(rawclassname=rawclassname, name=name)
+        prepareforwritinghead += "\tm_vec_{name}->reserve( {name}_size );\n".format(name=name)
         prepareforwritinghead += "\tint {name}_index =0;\n".format(name=name)
+
         prepareforwritingbody += self.evaluate_template("CollectionPrepareForWritingVecMember.cc.template", {"name"  : name })
         push_back_relations += "\tm_vecs_{name}.push_back(obj->m_{name});\n".format(name=name)
 

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -696,11 +696,24 @@ class ClassGenerator(object):
         get_name = name
         if( self.getSyntax ):
             get_name = "get" + name[:1].upper() + name[1:]
+
+        vecmembers += declarations["vecmembers"].format(type=klass, name=name)
+        constructorbody += "\tm_vecmem_info.push_back( std::make_pair( \"{type}\", &m_vec_{name} )) ; \n".format(type=klass, name=name)
+        constructorbody += "\tm_vec_{name} = new std::vector<{type}>() ;\n".format(type=klass, name=name)
+        create_relations += "\tm_vecs_{name}.push_back(obj->m_{name});\n".format(name=name)
+        destructorbody += "\tif(m_vec_{name} != nullptr) delete m_vec_{name};\n".format(name=name)
+        clear_relations += "\tm_vec_{name}->clear();\n".format(name=name)
+        clear_relations += "\tm_vecs_{name}.clear();\n".format(name=name)
+        prepareforwritinghead += "\tint {name}_index =0;\n".format(name=name)
+        prepareforwritingbody += self.evaluate_template("CollectionPrepareForWritingVecMember.cc.template", {"name"  : name })
+        push_back_relations += "\tm_vecs_{name}.push_back(obj->m_{name});\n".format(name=name)
+
+        prepareafterread += "\t\tobj->m_{name} = m_vec_{name};\n".format(name=name)
+
         ostream_implementation += ( '  o << "     %s : " ;\n' % name  )
         ostream_implementation += ( '  for(unsigned j=0,N=v[i].%s_size(); j<N ; ++j)\n' % name )
         ostream_implementation += ( '    o << v[i].%s(j) << " " ; \n'  % get_name  )
         ostream_implementation +=   '  o << std::endl ;\n'
-        vecmembers += declarations["vecmembers"].format(type=klass, name=name)
 
       ostream_implementation += '  }\no.flags(old_flags);\n'
       ostream_implementation += "  return o ;\n}\n"

--- a/python/podio_templates.py
+++ b/python/podio_templates.py
@@ -117,3 +117,8 @@ declarations["relation"] = "\tstd::vector<{namespace}::Const{type}>* m_rel_{name
 declarations["relation_collection"] = "\tstd::vector<std::vector<{namespace}::Const{type}>*> m_rel_{name}_tmp; ///< Relation buffer for internal book-keeping\n"
 
 implementations["ctor_list_relation"] = ", m_rel_{name}(new std::vector<{namespace}::Const{type}>())"
+
+# Vector Members
+#-----------------------------------
+declarations["vecmembers"] = "\tstd::vector<{type}>* m_vec_{name}; /// combined vector of all objects in collection\n"
+declarations["vecmembers"] += "\tstd::vector<std::vector<{type}>*> m_vecs_{name}; /// pointers to individual member vectors\n"

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -70,6 +70,15 @@ namespace podio {
         branch->GetEntry(m_eventNumber);
       }
     }
+    // load the collections containing vector members
+    auto vecmeminfo = collection->vectorMembers();
+    if (vecmeminfo != nullptr) {
+      for (int i = 0, end = vecmeminfo->size(); i!=end; ++i){
+        branch = m_eventTree->GetBranch((name+"_"+std::to_string(i)).c_str());
+        branch->SetAddress((*vecmeminfo)[i].second);
+        branch->GetEntry(m_eventNumber);
+      }
+    }
     auto id = m_table->collectionID(name);
     collection->setID(id);
     collection->prepareAfterRead();

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -75,9 +75,22 @@ namespace podio {
         m_datatree->Branch((name+"#"+std::to_string(i)).c_str(),c);
         ++i;
       }
-    }
+      }
+// ---- vector members
+      auto vminfo = coll->vectorMembers();
+      if (vminfo != nullptr){
+      	int i = 0;
+      	for(auto& c : (*vminfo)){
+      	  std::string typeName = "vector<"+c.first+">" ;
+      	  void* add = c.second ;
+      	  m_datatree->Branch((name+"_"+std::to_string(i)).c_str(),
+      			     typeName.c_str(),
+      			     add);
+      	  ++i;
+      	}
+      }
       m_storedCollections.emplace_back(coll);
     }
-  }
+ }
 
 } // namespace

--- a/templates/Collection.h.template
+++ b/templates/Collection.h.template
@@ -92,6 +92,8 @@ public:
 
   podio::CollRefCollection* referenceCollections() override final { return &m_refCollections;};
 
+  podio::VectorMembersInfo* vectorMembers() override {return &m_vecmem_info ; }
+
   void setID(unsigned ID) override final {
     m_collectionID = ID;
     std::for_each(m_entries.begin(),m_entries.end(),
@@ -125,8 +127,11 @@ private:
   ${name}ObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
 ${relations}
+  //members to handle vector members
+${vecmembers}
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
+  podio::VectorMembersInfo m_vecmem_info ;
   ${name}DataContainer* m_data;
 };
 

--- a/templates/CollectionPrepareForWritingVecMember.cc.template
+++ b/templates/CollectionPrepareForWritingVecMember.cc.template
@@ -1,0 +1,5 @@
+   (*m_data)[i].${name}_begin=${name}_index;
+   (*m_data)[i].${name}_end+=${name}_index;
+   ${name}_index = (*m_data)[i].${name}_end;
+   m_vec_${name}->insert(m_vec_${name}->end(), *m_vecs_${name}[i]->begin(), *m_vecs_${name}[i]->end() );
+//   for(auto it : (*m_vecs_${name}[i])) { m_vec_${name}->push_back(it); }

--- a/templates/CollectionPrepareForWritingVecMember.cc.template
+++ b/templates/CollectionPrepareForWritingVecMember.cc.template
@@ -1,5 +1,4 @@
    (*m_data)[i].${name}_begin=${name}_index;
    (*m_data)[i].${name}_end+=${name}_index;
    ${name}_index = (*m_data)[i].${name}_end;
-   m_vec_${name}->insert(m_vec_${name}->end(), *m_vecs_${name}[i]->begin(), *m_vecs_${name}[i]->end() );
-//   for(auto it : (*m_vecs_${name}[i])) { m_vec_${name}->push_back(it); }
+   for(auto it : (*m_vecs_${name}[i])) { m_vec_${name}->push_back(it); }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,8 +40,8 @@ endforeach( sourcefile ${executables} )
 
 #--- Adding tests --------------------------------------------------------------
 # uncomment this to actually run the EDM generation in the tests
-#add_test(NAME generate-edm COMMAND python $ENV{PODIO}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel --clangformat
-add_test(NAME generate-edm COMMAND python $ENV{PODIO}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel --dryrun --clangformat
+add_test(NAME generate-edm COMMAND python $ENV{PODIO}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel --clangformat
+#add_test(NAME generate-edm COMMAND python $ENV{PODIO}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel --dryrun --clangformat
          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 set_property(TEST generate-edm PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/tests:$ENV{LD_LIBRARY_PATH})
 

--- a/tests/datamodel/EventInfo.h
+++ b/tests/datamodel/EventInfo.h
@@ -1,18 +1,15 @@
 #ifndef EventInfo_H
 #define EventInfo_H
 #include "EventInfoData.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "EventInfoConst.h"
 #include "EventInfoObj.h"
-
-
 
 class EventInfoCollection;
 class EventInfoCollectionIterator;
@@ -29,66 +26,59 @@ class EventInfo {
   friend ConstEventInfo;
 
 public:
-
   /// default constructor
   EventInfo();
   EventInfo(int Number);
 
   /// constructor from existing EventInfoObj
-  EventInfo(EventInfoObj* obj);
+  EventInfo(EventInfoObj *obj);
   /// copy constructor
-  EventInfo(const EventInfo& other);
+  EventInfo(const EventInfo &other);
   /// copy-assignment operator
-  EventInfo& operator=(const EventInfo& other);
+  EventInfo &operator=(const EventInfo &other);
   /// support cloning (deep-copy)
   EventInfo clone() const;
   /// destructor
   ~EventInfo();
 
   /// conversion to const object
-  operator ConstEventInfo () const;
+  operator ConstEventInfo() const;
 
 public:
-
   /// Access the  event number
-  const int& Number() const;
+  const int &Number() const;
 
   /// Set the  event number
   void Number(int value);
 
-
-
-void setNumber(int n) { Number( n ) ; } 
-int getNumber() const; 
+  void setNumber(int n) { Number(n); }
+  int getNumber() const;
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from EventInfoObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const EventInfo& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const EventInfo &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstEventInfo& other) const;
+  bool operator==(const ConstEventInfo &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const EventInfo& p1,
-//       const EventInfo& p2 );
-  bool operator<(const EventInfo& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const EventInfo& p1,
+  //       const EventInfo& p2 );
+  bool operator<(const EventInfo &other) const { return m_obj < other.m_obj; }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  EventInfoObj* m_obj;
-
+  EventInfoObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstEventInfo& value );
-
-
-
+std::ostream &operator<<(std::ostream &o, const ConstEventInfo &value);
 
 #endif

--- a/tests/datamodel/EventInfoCollection.h
+++ b/tests/datamodel/EventInfoCollection.h
@@ -1,47 +1,48 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef EventInfoCollection_H
-#define  EventInfoCollection_H
+#define EventInfoCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "EventInfoData.h"
 #include "EventInfo.h"
+#include "EventInfoData.h"
 #include "EventInfoObj.h"
 
-
 typedef std::vector<EventInfoData> EventInfoDataContainer;
-typedef std::deque<EventInfoObj*> EventInfoObjPointerContainer;
+typedef std::deque<EventInfoObj *> EventInfoObjPointerContainer;
 
 class EventInfoCollectionIterator {
 
-  public:
-    EventInfoCollectionIterator(int index, const EventInfoObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  EventInfoCollectionIterator(int index,
+                              const EventInfoObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const EventInfoCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const EventInfoCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const EventInfo operator*() const;
-    const EventInfo* operator->() const;
-    const EventInfoCollectionIterator& operator++() const;
+  const EventInfo operator*() const;
+  const EventInfo *operator->() const;
+  const EventInfoCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable EventInfo m_object;
-    const EventInfoObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable EventInfo m_object;
+  const EventInfoObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +55,22 @@ public:
   typedef const EventInfoCollectionIterator const_iterator;
 
   EventInfoCollection();
-//  EventInfoCollection(const EventInfoCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  EventInfoCollection(EventInfoVector* data, int collectionID);
+  //  EventInfoCollection(const EventInfoCollection& ) = delete; // deletion
+  //  doesn't work w/ ROOT IO ! :-( EventInfoCollection(EventInfoVector* data,
+  //  int collectionID);
   ~EventInfoCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  EventInfoCollection* operator->() { return (EventInfoCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  EventInfoCollection *operator->() { return (EventInfoCollection *)this; }
 
   /// Append a new object to the collection, and return this object.
   EventInfo create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  EventInfo create(Args&&... args);
+  template <typename... Args> EventInfo create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,45 +82,43 @@ public:
   /// Returns the object of given index
   EventInfo at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstEventInfo object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](EventInfoObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(), [ID](EventInfoObj *obj) {
+      obj->id = {obj->id.index, static_cast<int>(ID)};
+    });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<EventInfoData>* _getBuffer() { return m_data;};
+  std::vector<EventInfoData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<int,arraysize> Number() const;
-
+  template <size_t arraysize> const std::array<int, arraysize> Number() const;
 
 private:
   bool m_isValid;
@@ -127,31 +126,32 @@ private:
   EventInfoObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
 
+  // members to handle vector members
+
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  EventInfoDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  EventInfoDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const EventInfoCollection& v);
+std::ostream &operator<<(std::ostream &o, const EventInfoCollection &v);
 
-
-template<typename... Args>
-EventInfo  EventInfoCollection::create(Args&&... args){
+template <typename... Args>
+EventInfo EventInfoCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new EventInfoObj({size,m_collectionID},{args...});
+  auto obj = new EventInfoObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return EventInfo(obj);
 }
 
-template<size_t arraysize>
-const std::array<int,arraysize> EventInfoCollection::Number() const {
-  std::array<int,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<int, arraysize> EventInfoCollection::Number() const {
+  std::array<int, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.Number;
- }
- return tmp;
+  }
+  return tmp;
 }
-
 
 #endif

--- a/tests/datamodel/EventInfoConst.h
+++ b/tests/datamodel/EventInfoConst.h
@@ -1,15 +1,12 @@
 #ifndef ConstEventInfo_H
 #define ConstEventInfo_H
 #include "EventInfoData.h"
-#include <vector>
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "EventInfoObj.h"
-
-
 
 class EventInfoObj;
 class EventInfo;
@@ -28,54 +25,52 @@ class ConstEventInfo {
   friend EventInfoCollectionIterator;
 
 public:
-
   /// default constructor
   ConstEventInfo();
   ConstEventInfo(int Number);
 
   /// constructor from existing EventInfoObj
-  ConstEventInfo(EventInfoObj* obj);
+  ConstEventInfo(EventInfoObj *obj);
   /// copy constructor
-  ConstEventInfo(const ConstEventInfo& other);
+  ConstEventInfo(const ConstEventInfo &other);
   /// copy-assignment operator
-  ConstEventInfo& operator=(const ConstEventInfo& other);
+  ConstEventInfo &operator=(const ConstEventInfo &other);
   /// support cloning (deep-copy)
   ConstEventInfo clone() const;
   /// destructor
   ~ConstEventInfo();
 
-
 public:
-
   /// Access the  event number
-  const int& Number() const;
+  const int &Number() const;
 
-
-int getNumber() const; 
+  int getNumber() const;
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from EventInfoObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstEventInfo& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstEventInfo &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const EventInfo& other) const;
+  bool operator==(const EventInfo &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const EventInfo& p1,
-//       const EventInfo& p2 );
-  bool operator<(const ConstEventInfo& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const EventInfo& p1,
+  //       const EventInfo& p2 );
+  bool operator<(const ConstEventInfo &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  EventInfoObj* m_obj;
-
+  EventInfoObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/EventInfoData.h
+++ b/tests/datamodel/EventInfoData.h
@@ -1,9 +1,6 @@
 #ifndef EventInfoDATA_H
 #define EventInfoDATA_H
 
-
-
-
 /** @class EventInfoData
  *  Event info
  *  @author: B. Hegner
@@ -11,8 +8,7 @@
 
 class EventInfoData {
 public:
-  int Number;  ///< event number
+  int Number; ///< event number
 };
-
 
 #endif

--- a/tests/datamodel/EventInfoObj.h
+++ b/tests/datamodel/EventInfoObj.h
@@ -6,23 +6,19 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "EventInfoData.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class EventInfo;
 class ConstEventInfo;
-
-
 
 class EventInfoObj : public podio::ObjBase {
 public:
   /// constructor
   EventInfoObj();
   /// copy constructor (does a deep-copy of relation containers)
-  EventInfoObj(const EventInfoObj&);
+  EventInfoObj(const EventInfoObj &);
   /// constructor from ObjectID and EventInfoData
   /// does not initialize the internal relation containers
   EventInfoObj(const podio::ObjectID id, EventInfoData data);
@@ -30,10 +26,6 @@ public:
 
 public:
   EventInfoData data;
-
-
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleCluster.h
+++ b/tests/datamodel/ExampleCluster.h
@@ -1,21 +1,17 @@
 #ifndef ExampleCluster_H
 #define ExampleCluster_H
-#include "ExampleClusterData.h"
-#include <vector>
-#include "ExampleHit.h"
 #include "ExampleCluster.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
+#include "ExampleClusterData.h"
+#include "ExampleHit.h"
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleClusterConst.h"
 #include "ExampleClusterObj.h"
-
-
 
 class ExampleClusterCollection;
 class ExampleClusterCollectionIterator;
@@ -32,33 +28,30 @@ class ExampleCluster {
   friend ConstExampleCluster;
 
 public:
-
   /// default constructor
   ExampleCluster();
   ExampleCluster(double energy);
 
   /// constructor from existing ExampleClusterObj
-  ExampleCluster(ExampleClusterObj* obj);
+  ExampleCluster(ExampleClusterObj *obj);
   /// copy constructor
-  ExampleCluster(const ExampleCluster& other);
+  ExampleCluster(const ExampleCluster &other);
   /// copy-assignment operator
-  ExampleCluster& operator=(const ExampleCluster& other);
+  ExampleCluster &operator=(const ExampleCluster &other);
   /// support cloning (deep-copy)
   ExampleCluster clone() const;
   /// destructor
   ~ExampleCluster();
 
   /// conversion to const object
-  operator ConstExampleCluster () const;
+  operator ConstExampleCluster() const;
 
 public:
-
   /// Access the  cluster energy
-  const double& energy() const;
+  const double &energy() const;
 
   /// Set the  cluster energy
   void energy(double value);
-
 
   void addHits(::ConstExampleHit);
   unsigned int Hits_size() const;
@@ -72,37 +65,34 @@ public:
   std::vector<::ConstExampleCluster>::const_iterator Clusters_begin() const;
   std::vector<::ConstExampleCluster>::const_iterator Clusters_end() const;
 
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleClusterObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleCluster& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleCluster &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleCluster& other) const;
+  bool operator==(const ConstExampleCluster &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleCluster& p1,
-//       const ExampleCluster& p2 );
-  bool operator<(const ExampleCluster& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleCluster& p1,
+  //       const ExampleCluster& p2 );
+  bool operator<(const ExampleCluster &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleClusterObj* m_obj;
-
+  ExampleClusterObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleCluster& value );
-
-
-
+std::ostream &operator<<(std::ostream &o, const ConstExampleCluster &value);
 
 #endif

--- a/tests/datamodel/ExampleClusterCollection.h
+++ b/tests/datamodel/ExampleClusterCollection.h
@@ -1,47 +1,48 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleClusterCollection_H
-#define  ExampleClusterCollection_H
+#define ExampleClusterCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleClusterData.h"
 #include "ExampleCluster.h"
+#include "ExampleClusterData.h"
 #include "ExampleClusterObj.h"
 
-
 typedef std::vector<ExampleClusterData> ExampleClusterDataContainer;
-typedef std::deque<ExampleClusterObj*> ExampleClusterObjPointerContainer;
+typedef std::deque<ExampleClusterObj *> ExampleClusterObjPointerContainer;
 
 class ExampleClusterCollectionIterator {
 
-  public:
-    ExampleClusterCollectionIterator(int index, const ExampleClusterObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleClusterCollectionIterator(
+      int index, const ExampleClusterObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleClusterCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleClusterCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleCluster operator*() const;
-    const ExampleCluster* operator->() const;
-    const ExampleClusterCollectionIterator& operator++() const;
+  const ExampleCluster operator*() const;
+  const ExampleCluster *operator->() const;
+  const ExampleClusterCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleCluster m_object;
-    const ExampleClusterObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleCluster m_object;
+  const ExampleClusterObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +55,24 @@ public:
   typedef const ExampleClusterCollectionIterator const_iterator;
 
   ExampleClusterCollection();
-//  ExampleClusterCollection(const ExampleClusterCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleClusterCollection(ExampleClusterVector* data, int collectionID);
+  //  ExampleClusterCollection(const ExampleClusterCollection& ) = delete; //
+  //  deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleClusterCollection(ExampleClusterVector* data, int collectionID);
   ~ExampleClusterCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleClusterCollection* operator->() { return (ExampleClusterCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleClusterCollection *operator->() {
+    return (ExampleClusterCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleCluster create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleCluster create(Args&&... args);
+  template <typename... Args> ExampleCluster create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,81 +84,86 @@ public:
   /// Returns the object of given index
   ExampleCluster at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleCluster object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleClusterObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleClusterObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleClusterData>* _getBuffer() { return m_data;};
+  std::vector<ExampleClusterData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<double,arraysize> energy() const;
-
+  template <size_t arraysize>
+  const std::array<double, arraysize> energy() const;
 
 private:
   bool m_isValid;
   int m_collectionID;
   ExampleClusterObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
-  std::vector<::ConstExampleHit>* m_rel_Hits; ///< Relation buffer for read / write
-  std::vector<std::vector<::ConstExampleHit>*> m_rel_Hits_tmp; ///< Relation buffer for internal book-keeping
-  std::vector<::ConstExampleCluster>* m_rel_Clusters; ///< Relation buffer for read / write
-  std::vector<std::vector<::ConstExampleCluster>*> m_rel_Clusters_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<::ConstExampleHit>
+      *m_rel_Hits; ///< Relation buffer for read / write
+  std::vector<std::vector<::ConstExampleHit> *>
+      m_rel_Hits_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<::ConstExampleCluster>
+      *m_rel_Clusters; ///< Relation buffer for read / write
+  std::vector<std::vector<::ConstExampleCluster> *>
+      m_rel_Clusters_tmp; ///< Relation buffer for internal book-keeping
+
+  // members to handle vector members
 
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleClusterDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleClusterDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleClusterCollection& v);
+std::ostream &operator<<(std::ostream &o, const ExampleClusterCollection &v);
 
-
-template<typename... Args>
-ExampleCluster  ExampleClusterCollection::create(Args&&... args){
+template <typename... Args>
+ExampleCluster ExampleClusterCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleClusterObj({size,m_collectionID},{args...});
+  auto obj = new ExampleClusterObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleCluster(obj);
 }
 
-template<size_t arraysize>
-const std::array<double,arraysize> ExampleClusterCollection::energy() const {
-  std::array<double,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<double, arraysize> ExampleClusterCollection::energy() const {
+  std::array<double, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.energy;
- }
- return tmp;
+  }
+  return tmp;
 }
-
 
 #endif

--- a/tests/datamodel/ExampleClusterConst.h
+++ b/tests/datamodel/ExampleClusterConst.h
@@ -1,18 +1,14 @@
 #ifndef ConstExampleCluster_H
 #define ConstExampleCluster_H
-#include "ExampleClusterData.h"
-#include <vector>
-#include "ExampleHit.h"
 #include "ExampleCluster.h"
-#include <vector>
+#include "ExampleClusterData.h"
+#include "ExampleHit.h"
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleClusterObj.h"
-
-
 
 class ExampleClusterObj;
 class ExampleCluster;
@@ -31,27 +27,24 @@ class ConstExampleCluster {
   friend ExampleClusterCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleCluster();
   ConstExampleCluster(double energy);
 
   /// constructor from existing ExampleClusterObj
-  ConstExampleCluster(ExampleClusterObj* obj);
+  ConstExampleCluster(ExampleClusterObj *obj);
   /// copy constructor
-  ConstExampleCluster(const ConstExampleCluster& other);
+  ConstExampleCluster(const ConstExampleCluster &other);
   /// copy-assignment operator
-  ConstExampleCluster& operator=(const ConstExampleCluster& other);
+  ConstExampleCluster &operator=(const ConstExampleCluster &other);
   /// support cloning (deep-copy)
   ConstExampleCluster clone() const;
   /// destructor
   ~ConstExampleCluster();
 
-
 public:
-
   /// Access the  cluster energy
-  const double& energy() const;
+  const double &energy() const;
 
   unsigned int Hits_size() const;
   ::ConstExampleHit Hits(unsigned int) const;
@@ -62,31 +55,32 @@ public:
   std::vector<::ConstExampleCluster>::const_iterator Clusters_begin() const;
   std::vector<::ConstExampleCluster>::const_iterator Clusters_end() const;
 
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleClusterObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleCluster& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleCluster &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleCluster& other) const;
+  bool operator==(const ExampleCluster &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleCluster& p1,
-//       const ExampleCluster& p2 );
-  bool operator<(const ConstExampleCluster& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleCluster& p1,
+  //       const ExampleCluster& p2 );
+  bool operator<(const ConstExampleCluster &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleClusterObj* m_obj;
-
+  ExampleClusterObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleClusterData.h
+++ b/tests/datamodel/ExampleClusterData.h
@@ -1,9 +1,6 @@
 #ifndef ExampleClusterDATA_H
 #define ExampleClusterDATA_H
 
-
-
-
 /** @class ExampleClusterData
  *  Cluster
  *  @author: B. Hegner
@@ -11,12 +8,11 @@
 
 class ExampleClusterData {
 public:
-  double energy;  ///< cluster energy
+  double energy; ///< cluster energy
   unsigned int Hits_begin;
   unsigned int Hits_end;
   unsigned int Clusters_begin;
   unsigned int Clusters_end;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleClusterObj.h
+++ b/tests/datamodel/ExampleClusterObj.h
@@ -6,25 +6,22 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleClusterData.h"
+#include "podio/ObjBase.h"
 
-#include <vector>
 #include "ExampleHit.h"
-
+#include <vector>
 
 // forward declarations
 class ExampleCluster;
 class ConstExampleCluster;
-
-
 
 class ExampleClusterObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleClusterObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleClusterObj(const ExampleClusterObj&);
+  ExampleClusterObj(const ExampleClusterObj &);
   /// constructor from ObjectID and ExampleClusterData
   /// does not initialize the internal relation containers
   ExampleClusterObj(const podio::ObjectID id, ExampleClusterData data);
@@ -32,12 +29,8 @@ public:
 
 public:
   ExampleClusterData data;
-  std::vector<ConstExampleHit>* m_Hits;
-  std::vector<ConstExampleCluster>* m_Clusters;
-
-
+  std::vector<ConstExampleHit> *m_Hits;
+  std::vector<ConstExampleCluster> *m_Clusters;
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency1.h
+++ b/tests/datamodel/ExampleForCyclicDependency1.h
@@ -1,20 +1,17 @@
 #ifndef ExampleForCyclicDependency1_H
 #define ExampleForCyclicDependency1_H
 #include "ExampleForCyclicDependency1Data.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
+// forward declarations
 class ExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency2;
 
-
 #include "ExampleForCyclicDependency1Const.h"
 #include "ExampleForCyclicDependency1Obj.h"
-
-
 
 class ExampleForCyclicDependency1Collection;
 class ExampleForCyclicDependency1CollectionIterator;
@@ -31,63 +28,60 @@ class ExampleForCyclicDependency1 {
   friend ConstExampleForCyclicDependency1;
 
 public:
-
   /// default constructor
   ExampleForCyclicDependency1();
 
   /// constructor from existing ExampleForCyclicDependency1Obj
-  ExampleForCyclicDependency1(ExampleForCyclicDependency1Obj* obj);
+  ExampleForCyclicDependency1(ExampleForCyclicDependency1Obj *obj);
   /// copy constructor
-  ExampleForCyclicDependency1(const ExampleForCyclicDependency1& other);
+  ExampleForCyclicDependency1(const ExampleForCyclicDependency1 &other);
   /// copy-assignment operator
-  ExampleForCyclicDependency1& operator=(const ExampleForCyclicDependency1& other);
+  ExampleForCyclicDependency1 &
+  operator=(const ExampleForCyclicDependency1 &other);
   /// support cloning (deep-copy)
   ExampleForCyclicDependency1 clone() const;
   /// destructor
   ~ExampleForCyclicDependency1();
 
   /// conversion to const object
-  operator ConstExampleForCyclicDependency1 () const;
+  operator ConstExampleForCyclicDependency1() const;
 
 public:
-
   /// Access the  a ref
   const ::ConstExampleForCyclicDependency2 ref() const;
 
   /// Set the  a ref
   void ref(::ConstExampleForCyclicDependency2 value);
 
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleForCyclicDependency1Obj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleForCyclicDependency1& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleForCyclicDependency1 &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleForCyclicDependency1& other) const;
+  bool operator==(const ConstExampleForCyclicDependency1 &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleForCyclicDependency1& p1,
-//       const ExampleForCyclicDependency1& p2 );
-  bool operator<(const ExampleForCyclicDependency1& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleForCyclicDependency1& p1,
+  //       const ExampleForCyclicDependency1& p2 );
+  bool operator<(const ExampleForCyclicDependency1 &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleForCyclicDependency1Obj* m_obj;
-
+  ExampleForCyclicDependency1Obj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleForCyclicDependency1& value );
-
-
-
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleForCyclicDependency1 &value);
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency1Collection.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Collection.h
@@ -1,47 +1,52 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleForCyclicDependency1Collection_H
-#define  ExampleForCyclicDependency1Collection_H
+#define ExampleForCyclicDependency1Collection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleForCyclicDependency1Data.h"
 #include "ExampleForCyclicDependency1.h"
+#include "ExampleForCyclicDependency1Data.h"
 #include "ExampleForCyclicDependency1Obj.h"
 
-
-typedef std::vector<ExampleForCyclicDependency1Data> ExampleForCyclicDependency1DataContainer;
-typedef std::deque<ExampleForCyclicDependency1Obj*> ExampleForCyclicDependency1ObjPointerContainer;
+typedef std::vector<ExampleForCyclicDependency1Data>
+    ExampleForCyclicDependency1DataContainer;
+typedef std::deque<ExampleForCyclicDependency1Obj *>
+    ExampleForCyclicDependency1ObjPointerContainer;
 
 class ExampleForCyclicDependency1CollectionIterator {
 
-  public:
-    ExampleForCyclicDependency1CollectionIterator(int index, const ExampleForCyclicDependency1ObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleForCyclicDependency1CollectionIterator(
+      int index,
+      const ExampleForCyclicDependency1ObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleForCyclicDependency1CollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool
+  operator!=(const ExampleForCyclicDependency1CollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleForCyclicDependency1 operator*() const;
-    const ExampleForCyclicDependency1* operator->() const;
-    const ExampleForCyclicDependency1CollectionIterator& operator++() const;
+  const ExampleForCyclicDependency1 operator*() const;
+  const ExampleForCyclicDependency1 *operator->() const;
+  const ExampleForCyclicDependency1CollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleForCyclicDependency1 m_object;
-    const ExampleForCyclicDependency1ObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleForCyclicDependency1 m_object;
+  const ExampleForCyclicDependency1ObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +59,27 @@ public:
   typedef const ExampleForCyclicDependency1CollectionIterator const_iterator;
 
   ExampleForCyclicDependency1Collection();
-//  ExampleForCyclicDependency1Collection(const ExampleForCyclicDependency1Collection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleForCyclicDependency1Collection(ExampleForCyclicDependency1Vector* data, int collectionID);
+  //  ExampleForCyclicDependency1Collection(const
+  //  ExampleForCyclicDependency1Collection& ) = delete; // deletion doesn't
+  //  work w/ ROOT IO ! :-(
+  //  ExampleForCyclicDependency1Collection(ExampleForCyclicDependency1Vector*
+  //  data, int collectionID);
   ~ExampleForCyclicDependency1Collection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleForCyclicDependency1Collection* operator->() { return (ExampleForCyclicDependency1Collection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleForCyclicDependency1Collection *operator->() {
+    return (ExampleForCyclicDependency1Collection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleForCyclicDependency1 create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleForCyclicDependency1 create(Args&&... args);
+  template <typename... Args>
+  ExampleForCyclicDependency1 create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,67 +91,70 @@ public:
   /// Returns the object of given index
   ExampleForCyclicDependency1 at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleForCyclicDependency1 object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleForCyclicDependency1Obj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleForCyclicDependency1Obj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleForCyclicDependency1Data>* _getBuffer() { return m_data;};
-
-   
+  std::vector<ExampleForCyclicDependency1Data> *_getBuffer() { return m_data; };
 
 private:
   bool m_isValid;
   int m_collectionID;
   ExampleForCyclicDependency1ObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
-  std::vector<::ConstExampleForCyclicDependency2>* m_rel_ref; ///< Relation buffer for read / write
+  std::vector<::ConstExampleForCyclicDependency2>
+      *m_rel_ref; ///< Relation buffer for read / write
+
+  // members to handle vector members
 
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleForCyclicDependency1DataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleForCyclicDependency1DataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleForCyclicDependency1Collection& v);
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleForCyclicDependency1Collection &v);
 
-
-template<typename... Args>
-ExampleForCyclicDependency1  ExampleForCyclicDependency1Collection::create(Args&&... args){
+template <typename... Args>
+ExampleForCyclicDependency1
+ExampleForCyclicDependency1Collection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleForCyclicDependency1Obj({size,m_collectionID},{args...});
+  auto obj =
+      new ExampleForCyclicDependency1Obj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleForCyclicDependency1(obj);
 }
-
-
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency1Const.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Const.h
@@ -1,17 +1,14 @@
 #ifndef ConstExampleForCyclicDependency1_H
 #define ConstExampleForCyclicDependency1_H
 #include "ExampleForCyclicDependency1Data.h"
-#include <vector>
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
+// forward declarations
 class ExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency2;
 
-
 #include "ExampleForCyclicDependency1Obj.h"
-
-
 
 class ExampleForCyclicDependency1Obj;
 class ExampleForCyclicDependency1;
@@ -30,53 +27,52 @@ class ConstExampleForCyclicDependency1 {
   friend ExampleForCyclicDependency1CollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleForCyclicDependency1();
-  
+
   /// constructor from existing ExampleForCyclicDependency1Obj
-  ConstExampleForCyclicDependency1(ExampleForCyclicDependency1Obj* obj);
+  ConstExampleForCyclicDependency1(ExampleForCyclicDependency1Obj *obj);
   /// copy constructor
-  ConstExampleForCyclicDependency1(const ConstExampleForCyclicDependency1& other);
+  ConstExampleForCyclicDependency1(
+      const ConstExampleForCyclicDependency1 &other);
   /// copy-assignment operator
-  ConstExampleForCyclicDependency1& operator=(const ConstExampleForCyclicDependency1& other);
+  ConstExampleForCyclicDependency1 &
+  operator=(const ConstExampleForCyclicDependency1 &other);
   /// support cloning (deep-copy)
   ConstExampleForCyclicDependency1 clone() const;
   /// destructor
   ~ConstExampleForCyclicDependency1();
 
-
 public:
-
   /// Access the  a ref
   const ::ConstExampleForCyclicDependency2 ref() const;
-
-
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleForCyclicDependency1Obj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleForCyclicDependency1& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleForCyclicDependency1 &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleForCyclicDependency1& other) const;
+  bool operator==(const ExampleForCyclicDependency1 &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleForCyclicDependency1& p1,
-//       const ExampleForCyclicDependency1& p2 );
-  bool operator<(const ConstExampleForCyclicDependency1& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleForCyclicDependency1& p1,
+  //       const ExampleForCyclicDependency1& p2 );
+  bool operator<(const ConstExampleForCyclicDependency1 &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleForCyclicDependency1Obj* m_obj;
-
+  ExampleForCyclicDependency1Obj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency1Data.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Data.h
@@ -1,9 +1,6 @@
 #ifndef ExampleForCyclicDependency1DATA_H
 #define ExampleForCyclicDependency1DATA_H
 
-
-
-
 /** @class ExampleForCyclicDependency1Data
  *  Type for cyclic dependency
  *  @author: Benedikt Hegner
@@ -11,8 +8,6 @@
 
 class ExampleForCyclicDependency1Data {
 public:
-
 };
-
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency1Obj.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Obj.h
@@ -6,36 +6,29 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleForCyclicDependency1Data.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class ExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency2;
 
-
-
 class ExampleForCyclicDependency1Obj : public podio::ObjBase {
 public:
   /// constructor
   ExampleForCyclicDependency1Obj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleForCyclicDependency1Obj(const ExampleForCyclicDependency1Obj&);
+  ExampleForCyclicDependency1Obj(const ExampleForCyclicDependency1Obj &);
   /// constructor from ObjectID and ExampleForCyclicDependency1Data
   /// does not initialize the internal relation containers
-  ExampleForCyclicDependency1Obj(const podio::ObjectID id, ExampleForCyclicDependency1Data data);
+  ExampleForCyclicDependency1Obj(const podio::ObjectID id,
+                                 ExampleForCyclicDependency1Data data);
   virtual ~ExampleForCyclicDependency1Obj();
 
 public:
   ExampleForCyclicDependency1Data data;
-  ConstExampleForCyclicDependency2* m_ref;
-
-
+  ConstExampleForCyclicDependency2 *m_ref;
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency2.h
+++ b/tests/datamodel/ExampleForCyclicDependency2.h
@@ -1,20 +1,17 @@
 #ifndef ExampleForCyclicDependency2_H
 #define ExampleForCyclicDependency2_H
 #include "ExampleForCyclicDependency2Data.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
+// forward declarations
 class ExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency1;
 
-
 #include "ExampleForCyclicDependency2Const.h"
 #include "ExampleForCyclicDependency2Obj.h"
-
-
 
 class ExampleForCyclicDependency2Collection;
 class ExampleForCyclicDependency2CollectionIterator;
@@ -31,63 +28,60 @@ class ExampleForCyclicDependency2 {
   friend ConstExampleForCyclicDependency2;
 
 public:
-
   /// default constructor
   ExampleForCyclicDependency2();
 
   /// constructor from existing ExampleForCyclicDependency2Obj
-  ExampleForCyclicDependency2(ExampleForCyclicDependency2Obj* obj);
+  ExampleForCyclicDependency2(ExampleForCyclicDependency2Obj *obj);
   /// copy constructor
-  ExampleForCyclicDependency2(const ExampleForCyclicDependency2& other);
+  ExampleForCyclicDependency2(const ExampleForCyclicDependency2 &other);
   /// copy-assignment operator
-  ExampleForCyclicDependency2& operator=(const ExampleForCyclicDependency2& other);
+  ExampleForCyclicDependency2 &
+  operator=(const ExampleForCyclicDependency2 &other);
   /// support cloning (deep-copy)
   ExampleForCyclicDependency2 clone() const;
   /// destructor
   ~ExampleForCyclicDependency2();
 
   /// conversion to const object
-  operator ConstExampleForCyclicDependency2 () const;
+  operator ConstExampleForCyclicDependency2() const;
 
 public:
-
   /// Access the  a ref
   const ::ConstExampleForCyclicDependency1 ref() const;
 
   /// Set the  a ref
   void ref(::ConstExampleForCyclicDependency1 value);
 
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleForCyclicDependency2Obj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleForCyclicDependency2& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleForCyclicDependency2 &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleForCyclicDependency2& other) const;
+  bool operator==(const ConstExampleForCyclicDependency2 &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleForCyclicDependency2& p1,
-//       const ExampleForCyclicDependency2& p2 );
-  bool operator<(const ExampleForCyclicDependency2& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleForCyclicDependency2& p1,
+  //       const ExampleForCyclicDependency2& p2 );
+  bool operator<(const ExampleForCyclicDependency2 &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleForCyclicDependency2Obj* m_obj;
-
+  ExampleForCyclicDependency2Obj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleForCyclicDependency2& value );
-
-
-
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleForCyclicDependency2 &value);
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency2Collection.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Collection.h
@@ -1,47 +1,52 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleForCyclicDependency2Collection_H
-#define  ExampleForCyclicDependency2Collection_H
+#define ExampleForCyclicDependency2Collection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleForCyclicDependency2Data.h"
 #include "ExampleForCyclicDependency2.h"
+#include "ExampleForCyclicDependency2Data.h"
 #include "ExampleForCyclicDependency2Obj.h"
 
-
-typedef std::vector<ExampleForCyclicDependency2Data> ExampleForCyclicDependency2DataContainer;
-typedef std::deque<ExampleForCyclicDependency2Obj*> ExampleForCyclicDependency2ObjPointerContainer;
+typedef std::vector<ExampleForCyclicDependency2Data>
+    ExampleForCyclicDependency2DataContainer;
+typedef std::deque<ExampleForCyclicDependency2Obj *>
+    ExampleForCyclicDependency2ObjPointerContainer;
 
 class ExampleForCyclicDependency2CollectionIterator {
 
-  public:
-    ExampleForCyclicDependency2CollectionIterator(int index, const ExampleForCyclicDependency2ObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleForCyclicDependency2CollectionIterator(
+      int index,
+      const ExampleForCyclicDependency2ObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleForCyclicDependency2CollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool
+  operator!=(const ExampleForCyclicDependency2CollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleForCyclicDependency2 operator*() const;
-    const ExampleForCyclicDependency2* operator->() const;
-    const ExampleForCyclicDependency2CollectionIterator& operator++() const;
+  const ExampleForCyclicDependency2 operator*() const;
+  const ExampleForCyclicDependency2 *operator->() const;
+  const ExampleForCyclicDependency2CollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleForCyclicDependency2 m_object;
-    const ExampleForCyclicDependency2ObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleForCyclicDependency2 m_object;
+  const ExampleForCyclicDependency2ObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +59,27 @@ public:
   typedef const ExampleForCyclicDependency2CollectionIterator const_iterator;
 
   ExampleForCyclicDependency2Collection();
-//  ExampleForCyclicDependency2Collection(const ExampleForCyclicDependency2Collection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleForCyclicDependency2Collection(ExampleForCyclicDependency2Vector* data, int collectionID);
+  //  ExampleForCyclicDependency2Collection(const
+  //  ExampleForCyclicDependency2Collection& ) = delete; // deletion doesn't
+  //  work w/ ROOT IO ! :-(
+  //  ExampleForCyclicDependency2Collection(ExampleForCyclicDependency2Vector*
+  //  data, int collectionID);
   ~ExampleForCyclicDependency2Collection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleForCyclicDependency2Collection* operator->() { return (ExampleForCyclicDependency2Collection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleForCyclicDependency2Collection *operator->() {
+    return (ExampleForCyclicDependency2Collection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleForCyclicDependency2 create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleForCyclicDependency2 create(Args&&... args);
+  template <typename... Args>
+  ExampleForCyclicDependency2 create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,67 +91,70 @@ public:
   /// Returns the object of given index
   ExampleForCyclicDependency2 at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleForCyclicDependency2 object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleForCyclicDependency2Obj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleForCyclicDependency2Obj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleForCyclicDependency2Data>* _getBuffer() { return m_data;};
-
-   
+  std::vector<ExampleForCyclicDependency2Data> *_getBuffer() { return m_data; };
 
 private:
   bool m_isValid;
   int m_collectionID;
   ExampleForCyclicDependency2ObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
-  std::vector<::ConstExampleForCyclicDependency1>* m_rel_ref; ///< Relation buffer for read / write
+  std::vector<::ConstExampleForCyclicDependency1>
+      *m_rel_ref; ///< Relation buffer for read / write
+
+  // members to handle vector members
 
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleForCyclicDependency2DataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleForCyclicDependency2DataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleForCyclicDependency2Collection& v);
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleForCyclicDependency2Collection &v);
 
-
-template<typename... Args>
-ExampleForCyclicDependency2  ExampleForCyclicDependency2Collection::create(Args&&... args){
+template <typename... Args>
+ExampleForCyclicDependency2
+ExampleForCyclicDependency2Collection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleForCyclicDependency2Obj({size,m_collectionID},{args...});
+  auto obj =
+      new ExampleForCyclicDependency2Obj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleForCyclicDependency2(obj);
 }
-
-
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency2Const.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Const.h
@@ -1,17 +1,14 @@
 #ifndef ConstExampleForCyclicDependency2_H
 #define ConstExampleForCyclicDependency2_H
 #include "ExampleForCyclicDependency2Data.h"
-#include <vector>
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
+// forward declarations
 class ExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency1;
 
-
 #include "ExampleForCyclicDependency2Obj.h"
-
-
 
 class ExampleForCyclicDependency2Obj;
 class ExampleForCyclicDependency2;
@@ -30,53 +27,52 @@ class ConstExampleForCyclicDependency2 {
   friend ExampleForCyclicDependency2CollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleForCyclicDependency2();
-  
+
   /// constructor from existing ExampleForCyclicDependency2Obj
-  ConstExampleForCyclicDependency2(ExampleForCyclicDependency2Obj* obj);
+  ConstExampleForCyclicDependency2(ExampleForCyclicDependency2Obj *obj);
   /// copy constructor
-  ConstExampleForCyclicDependency2(const ConstExampleForCyclicDependency2& other);
+  ConstExampleForCyclicDependency2(
+      const ConstExampleForCyclicDependency2 &other);
   /// copy-assignment operator
-  ConstExampleForCyclicDependency2& operator=(const ConstExampleForCyclicDependency2& other);
+  ConstExampleForCyclicDependency2 &
+  operator=(const ConstExampleForCyclicDependency2 &other);
   /// support cloning (deep-copy)
   ConstExampleForCyclicDependency2 clone() const;
   /// destructor
   ~ConstExampleForCyclicDependency2();
 
-
 public:
-
   /// Access the  a ref
   const ::ConstExampleForCyclicDependency1 ref() const;
-
-
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleForCyclicDependency2Obj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleForCyclicDependency2& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleForCyclicDependency2 &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleForCyclicDependency2& other) const;
+  bool operator==(const ExampleForCyclicDependency2 &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleForCyclicDependency2& p1,
-//       const ExampleForCyclicDependency2& p2 );
-  bool operator<(const ConstExampleForCyclicDependency2& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleForCyclicDependency2& p1,
+  //       const ExampleForCyclicDependency2& p2 );
+  bool operator<(const ConstExampleForCyclicDependency2 &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleForCyclicDependency2Obj* m_obj;
-
+  ExampleForCyclicDependency2Obj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency2Data.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Data.h
@@ -1,9 +1,6 @@
 #ifndef ExampleForCyclicDependency2DATA_H
 #define ExampleForCyclicDependency2DATA_H
 
-
-
-
 /** @class ExampleForCyclicDependency2Data
  *  Type for cyclic dependency
  *  @author: Benedikt Hegner
@@ -11,8 +8,6 @@
 
 class ExampleForCyclicDependency2Data {
 public:
-
 };
-
 
 #endif

--- a/tests/datamodel/ExampleForCyclicDependency2Obj.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Obj.h
@@ -6,36 +6,29 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleForCyclicDependency2Data.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class ExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency1;
 
-
-
 class ExampleForCyclicDependency2Obj : public podio::ObjBase {
 public:
   /// constructor
   ExampleForCyclicDependency2Obj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleForCyclicDependency2Obj(const ExampleForCyclicDependency2Obj&);
+  ExampleForCyclicDependency2Obj(const ExampleForCyclicDependency2Obj &);
   /// constructor from ObjectID and ExampleForCyclicDependency2Data
   /// does not initialize the internal relation containers
-  ExampleForCyclicDependency2Obj(const podio::ObjectID id, ExampleForCyclicDependency2Data data);
+  ExampleForCyclicDependency2Obj(const podio::ObjectID id,
+                                 ExampleForCyclicDependency2Data data);
   virtual ~ExampleForCyclicDependency2Obj();
 
 public:
   ExampleForCyclicDependency2Data data;
-  ConstExampleForCyclicDependency1* m_ref;
-
-
+  ConstExampleForCyclicDependency1 *m_ref;
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleHit.h
+++ b/tests/datamodel/ExampleHit.h
@@ -1,18 +1,15 @@
 #ifndef ExampleHit_H
 #define ExampleHit_H
 #include "ExampleHitData.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleHitConst.h"
 #include "ExampleHitObj.h"
-
-
 
 class ExampleHitCollection;
 class ExampleHitCollectionIterator;
@@ -29,35 +26,33 @@ class ExampleHit {
   friend ConstExampleHit;
 
 public:
-
   /// default constructor
   ExampleHit();
-  ExampleHit(double x,double y,double z,double energy);
+  ExampleHit(double x, double y, double z, double energy);
 
   /// constructor from existing ExampleHitObj
-  ExampleHit(ExampleHitObj* obj);
+  ExampleHit(ExampleHitObj *obj);
   /// copy constructor
-  ExampleHit(const ExampleHit& other);
+  ExampleHit(const ExampleHit &other);
   /// copy-assignment operator
-  ExampleHit& operator=(const ExampleHit& other);
+  ExampleHit &operator=(const ExampleHit &other);
   /// support cloning (deep-copy)
   ExampleHit clone() const;
   /// destructor
   ~ExampleHit();
 
   /// conversion to const object
-  operator ConstExampleHit () const;
+  operator ConstExampleHit() const;
 
 public:
-
   /// Access the  x-coordinate
-  const double& x() const;
+  const double &x() const;
   /// Access the  y-coordinate
-  const double& y() const;
+  const double &y() const;
   /// Access the  z-coordinate
-  const double& z() const;
+  const double &z() const;
   /// Access the  measured energy deposit
-  const double& energy() const;
+  const double &energy() const;
 
   /// Set the  x-coordinate
   void x(double value);
@@ -71,38 +66,32 @@ public:
   /// Set the  measured energy deposit
   void energy(double value);
 
-
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleHitObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleHit& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleHit &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleHit& other) const;
+  bool operator==(const ConstExampleHit &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleHit& p1,
-//       const ExampleHit& p2 );
-  bool operator<(const ExampleHit& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleHit& p1,
+  //       const ExampleHit& p2 );
+  bool operator<(const ExampleHit &other) const { return m_obj < other.m_obj; }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleHitObj* m_obj;
-
+  ExampleHitObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleHit& value );
-
-
-
+std::ostream &operator<<(std::ostream &o, const ConstExampleHit &value);
 
 #endif

--- a/tests/datamodel/ExampleHitCollection.h
+++ b/tests/datamodel/ExampleHitCollection.h
@@ -1,47 +1,48 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleHitCollection_H
-#define  ExampleHitCollection_H
+#define ExampleHitCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleHitData.h"
 #include "ExampleHit.h"
+#include "ExampleHitData.h"
 #include "ExampleHitObj.h"
 
-
 typedef std::vector<ExampleHitData> ExampleHitDataContainer;
-typedef std::deque<ExampleHitObj*> ExampleHitObjPointerContainer;
+typedef std::deque<ExampleHitObj *> ExampleHitObjPointerContainer;
 
 class ExampleHitCollectionIterator {
 
-  public:
-    ExampleHitCollectionIterator(int index, const ExampleHitObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleHitCollectionIterator(int index,
+                               const ExampleHitObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleHitCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleHitCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleHit operator*() const;
-    const ExampleHit* operator->() const;
-    const ExampleHitCollectionIterator& operator++() const;
+  const ExampleHit operator*() const;
+  const ExampleHit *operator->() const;
+  const ExampleHitCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleHit m_object;
-    const ExampleHitObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleHit m_object;
+  const ExampleHitObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +55,22 @@ public:
   typedef const ExampleHitCollectionIterator const_iterator;
 
   ExampleHitCollection();
-//  ExampleHitCollection(const ExampleHitCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleHitCollection(ExampleHitVector* data, int collectionID);
+  //  ExampleHitCollection(const ExampleHitCollection& ) = delete; // deletion
+  //  doesn't work w/ ROOT IO ! :-( ExampleHitCollection(ExampleHitVector* data,
+  //  int collectionID);
   ~ExampleHitCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleHitCollection* operator->() { return (ExampleHitCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleHitCollection *operator->() { return (ExampleHitCollection *)this; }
 
   /// Append a new object to the collection, and return this object.
   ExampleHit create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleHit create(Args&&... args);
+  template <typename... Args> ExampleHit create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,51 +82,47 @@ public:
   /// Returns the object of given index
   ExampleHit at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleHit object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleHitObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(), [ID](ExampleHitObj *obj) {
+      obj->id = {obj->id.index, static_cast<int>(ID)};
+    });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleHitData>* _getBuffer() { return m_data;};
+  std::vector<ExampleHitData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<double,arraysize> x() const;
-  template<size_t arraysize>
-  const std::array<double,arraysize> y() const;
-  template<size_t arraysize>
-  const std::array<double,arraysize> z() const;
-  template<size_t arraysize>
-  const std::array<double,arraysize> energy() const;
-
+  template <size_t arraysize> const std::array<double, arraysize> x() const;
+  template <size_t arraysize> const std::array<double, arraysize> y() const;
+  template <size_t arraysize> const std::array<double, arraysize> z() const;
+  template <size_t arraysize>
+  const std::array<double, arraysize> energy() const;
 
 private:
   bool m_isValid;
@@ -133,58 +130,59 @@ private:
   ExampleHitObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
 
+  // members to handle vector members
+
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleHitDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleHitDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleHitCollection& v);
+std::ostream &operator<<(std::ostream &o, const ExampleHitCollection &v);
 
-
-template<typename... Args>
-ExampleHit  ExampleHitCollection::create(Args&&... args){
+template <typename... Args>
+ExampleHit ExampleHitCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleHitObj({size,m_collectionID},{args...});
+  auto obj = new ExampleHitObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleHit(obj);
 }
 
-template<size_t arraysize>
-const std::array<double,arraysize> ExampleHitCollection::x() const {
-  std::array<double,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<double, arraysize> ExampleHitCollection::x() const {
+  std::array<double, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.x;
- }
- return tmp;
+  }
+  return tmp;
 }
-template<size_t arraysize>
-const std::array<double,arraysize> ExampleHitCollection::y() const {
-  std::array<double,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<double, arraysize> ExampleHitCollection::y() const {
+  std::array<double, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.y;
- }
- return tmp;
+  }
+  return tmp;
 }
-template<size_t arraysize>
-const std::array<double,arraysize> ExampleHitCollection::z() const {
-  std::array<double,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<double, arraysize> ExampleHitCollection::z() const {
+  std::array<double, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.z;
- }
- return tmp;
+  }
+  return tmp;
 }
-template<size_t arraysize>
-const std::array<double,arraysize> ExampleHitCollection::energy() const {
-  std::array<double,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<double, arraysize> ExampleHitCollection::energy() const {
+  std::array<double, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.energy;
- }
- return tmp;
+  }
+  return tmp;
 }
-
 
 #endif

--- a/tests/datamodel/ExampleHitConst.h
+++ b/tests/datamodel/ExampleHitConst.h
@@ -1,15 +1,12 @@
 #ifndef ConstExampleHit_H
 #define ConstExampleHit_H
 #include "ExampleHitData.h"
-#include <vector>
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleHitObj.h"
-
-
 
 class ExampleHitObj;
 class ExampleHit;
@@ -28,60 +25,57 @@ class ConstExampleHit {
   friend ExampleHitCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleHit();
-  ConstExampleHit(double x,double y,double z,double energy);
+  ConstExampleHit(double x, double y, double z, double energy);
 
   /// constructor from existing ExampleHitObj
-  ConstExampleHit(ExampleHitObj* obj);
+  ConstExampleHit(ExampleHitObj *obj);
   /// copy constructor
-  ConstExampleHit(const ConstExampleHit& other);
+  ConstExampleHit(const ConstExampleHit &other);
   /// copy-assignment operator
-  ConstExampleHit& operator=(const ConstExampleHit& other);
+  ConstExampleHit &operator=(const ConstExampleHit &other);
   /// support cloning (deep-copy)
   ConstExampleHit clone() const;
   /// destructor
   ~ConstExampleHit();
 
-
 public:
-
   /// Access the  x-coordinate
-  const double& x() const;
+  const double &x() const;
   /// Access the  y-coordinate
-  const double& y() const;
+  const double &y() const;
   /// Access the  z-coordinate
-  const double& z() const;
+  const double &z() const;
   /// Access the  measured energy deposit
-  const double& energy() const;
-
-
+  const double &energy() const;
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleHitObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleHit& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleHit &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleHit& other) const;
+  bool operator==(const ExampleHit &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleHit& p1,
-//       const ExampleHit& p2 );
-  bool operator<(const ConstExampleHit& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleHit& p1,
+  //       const ExampleHit& p2 );
+  bool operator<(const ConstExampleHit &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleHitObj* m_obj;
-
+  ExampleHitObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleHitData.h
+++ b/tests/datamodel/ExampleHitData.h
@@ -1,9 +1,6 @@
 #ifndef ExampleHitDATA_H
 #define ExampleHitDATA_H
 
-
-
-
 /** @class ExampleHitData
  *  Example Hit
  *  @author: B. Hegner
@@ -11,11 +8,10 @@
 
 class ExampleHitData {
 public:
-  double x;  ///< x-coordinate
-  double y;  ///< y-coordinate
-  double z;  ///< z-coordinate
-  double energy;  ///< measured energy deposit
+  double x;      ///< x-coordinate
+  double y;      ///< y-coordinate
+  double z;      ///< z-coordinate
+  double energy; ///< measured energy deposit
 };
-
 
 #endif

--- a/tests/datamodel/ExampleHitObj.h
+++ b/tests/datamodel/ExampleHitObj.h
@@ -6,23 +6,19 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleHitData.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class ExampleHit;
 class ConstExampleHit;
-
-
 
 class ExampleHitObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleHitObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleHitObj(const ExampleHitObj&);
+  ExampleHitObj(const ExampleHitObj &);
   /// constructor from ObjectID and ExampleHitData
   /// does not initialize the internal relation containers
   ExampleHitObj(const podio::ObjectID id, ExampleHitData data);
@@ -30,10 +26,6 @@ public:
 
 public:
   ExampleHitData data;
-
-
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleMC.h
+++ b/tests/datamodel/ExampleMC.h
@@ -1,21 +1,16 @@
 #ifndef ExampleMC_H
 #define ExampleMC_H
+#include "ExampleMC.h"
 #include "ExampleMCData.h"
-#include <vector>
-#include "ExampleMC.h"
-#include "ExampleMC.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleMCConst.h"
 #include "ExampleMCObj.h"
-
-
 
 class ExampleMCCollection;
 class ExampleMCCollectionIterator;
@@ -32,38 +27,35 @@ class ExampleMC {
   friend ConstExampleMC;
 
 public:
-
   /// default constructor
   ExampleMC();
-  ExampleMC(double energy,int PDG);
+  ExampleMC(double energy, int PDG);
 
   /// constructor from existing ExampleMCObj
-  ExampleMC(ExampleMCObj* obj);
+  ExampleMC(ExampleMCObj *obj);
   /// copy constructor
-  ExampleMC(const ExampleMC& other);
+  ExampleMC(const ExampleMC &other);
   /// copy-assignment operator
-  ExampleMC& operator=(const ExampleMC& other);
+  ExampleMC &operator=(const ExampleMC &other);
   /// support cloning (deep-copy)
   ExampleMC clone() const;
   /// destructor
   ~ExampleMC();
 
   /// conversion to const object
-  operator ConstExampleMC () const;
+  operator ConstExampleMC() const;
 
 public:
-
   /// Access the  energy
-  const double& energy() const;
+  const double &energy() const;
   /// Access the  PDG code
-  const int& PDG() const;
+  const int &PDG() const;
 
   /// Set the  energy
   void energy(double value);
 
   /// Set the  PDG code
   void PDG(int value);
-
 
   void addparents(::ConstExampleMC);
   unsigned int parents_size() const;
@@ -77,37 +69,32 @@ public:
   std::vector<::ConstExampleMC>::const_iterator daughters_begin() const;
   std::vector<::ConstExampleMC>::const_iterator daughters_end() const;
 
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleMCObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleMC& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleMC &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleMC& other) const;
+  bool operator==(const ConstExampleMC &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleMC& p1,
-//       const ExampleMC& p2 );
-  bool operator<(const ExampleMC& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleMC& p1,
+  //       const ExampleMC& p2 );
+  bool operator<(const ExampleMC &other) const { return m_obj < other.m_obj; }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleMCObj* m_obj;
-
+  ExampleMCObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleMC& value );
-
-
-
+std::ostream &operator<<(std::ostream &o, const ConstExampleMC &value);
 
 #endif

--- a/tests/datamodel/ExampleMCCollection.h
+++ b/tests/datamodel/ExampleMCCollection.h
@@ -1,47 +1,48 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleMCCollection_H
-#define  ExampleMCCollection_H
+#define ExampleMCCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleMCData.h"
 #include "ExampleMC.h"
+#include "ExampleMCData.h"
 #include "ExampleMCObj.h"
 
-
 typedef std::vector<ExampleMCData> ExampleMCDataContainer;
-typedef std::deque<ExampleMCObj*> ExampleMCObjPointerContainer;
+typedef std::deque<ExampleMCObj *> ExampleMCObjPointerContainer;
 
 class ExampleMCCollectionIterator {
 
-  public:
-    ExampleMCCollectionIterator(int index, const ExampleMCObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleMCCollectionIterator(int index,
+                              const ExampleMCObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleMCCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleMCCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleMC operator*() const;
-    const ExampleMC* operator->() const;
-    const ExampleMCCollectionIterator& operator++() const;
+  const ExampleMC operator*() const;
+  const ExampleMC *operator->() const;
+  const ExampleMCCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleMC m_object;
-    const ExampleMCObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleMC m_object;
+  const ExampleMCObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +55,22 @@ public:
   typedef const ExampleMCCollectionIterator const_iterator;
 
   ExampleMCCollection();
-//  ExampleMCCollection(const ExampleMCCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleMCCollection(ExampleMCVector* data, int collectionID);
+  //  ExampleMCCollection(const ExampleMCCollection& ) = delete; // deletion
+  //  doesn't work w/ ROOT IO ! :-( ExampleMCCollection(ExampleMCVector* data,
+  //  int collectionID);
   ~ExampleMCCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleMCCollection* operator->() { return (ExampleMCCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleMCCollection *operator->() { return (ExampleMCCollection *)this; }
 
   /// Append a new object to the collection, and return this object.
   ExampleMC create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleMC create(Args&&... args);
+  template <typename... Args> ExampleMC create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,92 +82,95 @@ public:
   /// Returns the object of given index
   ExampleMC at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleMC object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleMCObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(), [ID](ExampleMCObj *obj) {
+      obj->id = {obj->id.index, static_cast<int>(ID)};
+    });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleMCData>* _getBuffer() { return m_data;};
+  std::vector<ExampleMCData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<double,arraysize> energy() const;
-  template<size_t arraysize>
-  const std::array<int,arraysize> PDG() const;
-
+  template <size_t arraysize>
+  const std::array<double, arraysize> energy() const;
+  template <size_t arraysize> const std::array<int, arraysize> PDG() const;
 
 private:
   bool m_isValid;
   int m_collectionID;
   ExampleMCObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
-  std::vector<::ConstExampleMC>* m_rel_parents; ///< Relation buffer for read / write
-  std::vector<std::vector<::ConstExampleMC>*> m_rel_parents_tmp; ///< Relation buffer for internal book-keeping
-  std::vector<::ConstExampleMC>* m_rel_daughters; ///< Relation buffer for read / write
-  std::vector<std::vector<::ConstExampleMC>*> m_rel_daughters_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<::ConstExampleMC>
+      *m_rel_parents; ///< Relation buffer for read / write
+  std::vector<std::vector<::ConstExampleMC> *>
+      m_rel_parents_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<::ConstExampleMC>
+      *m_rel_daughters; ///< Relation buffer for read / write
+  std::vector<std::vector<::ConstExampleMC> *>
+      m_rel_daughters_tmp; ///< Relation buffer for internal book-keeping
+
+  // members to handle vector members
 
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleMCDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleMCDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleMCCollection& v);
+std::ostream &operator<<(std::ostream &o, const ExampleMCCollection &v);
 
-
-template<typename... Args>
-ExampleMC  ExampleMCCollection::create(Args&&... args){
+template <typename... Args>
+ExampleMC ExampleMCCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleMCObj({size,m_collectionID},{args...});
+  auto obj = new ExampleMCObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleMC(obj);
 }
 
-template<size_t arraysize>
-const std::array<double,arraysize> ExampleMCCollection::energy() const {
-  std::array<double,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<double, arraysize> ExampleMCCollection::energy() const {
+  std::array<double, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.energy;
- }
- return tmp;
+  }
+  return tmp;
 }
-template<size_t arraysize>
-const std::array<int,arraysize> ExampleMCCollection::PDG() const {
-  std::array<int,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<int, arraysize> ExampleMCCollection::PDG() const {
+  std::array<int, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.PDG;
- }
- return tmp;
+  }
+  return tmp;
 }
-
 
 #endif

--- a/tests/datamodel/ExampleMCConst.h
+++ b/tests/datamodel/ExampleMCConst.h
@@ -1,18 +1,13 @@
 #ifndef ConstExampleMC_H
 #define ConstExampleMC_H
+#include "ExampleMC.h"
 #include "ExampleMCData.h"
-#include <vector>
-#include "ExampleMC.h"
-#include "ExampleMC.h"
-#include <vector>
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleMCObj.h"
-
-
 
 class ExampleMCObj;
 class ExampleMC;
@@ -31,29 +26,26 @@ class ConstExampleMC {
   friend ExampleMCCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleMC();
-  ConstExampleMC(double energy,int PDG);
+  ConstExampleMC(double energy, int PDG);
 
   /// constructor from existing ExampleMCObj
-  ConstExampleMC(ExampleMCObj* obj);
+  ConstExampleMC(ExampleMCObj *obj);
   /// copy constructor
-  ConstExampleMC(const ConstExampleMC& other);
+  ConstExampleMC(const ConstExampleMC &other);
   /// copy-assignment operator
-  ConstExampleMC& operator=(const ConstExampleMC& other);
+  ConstExampleMC &operator=(const ConstExampleMC &other);
   /// support cloning (deep-copy)
   ConstExampleMC clone() const;
   /// destructor
   ~ConstExampleMC();
 
-
 public:
-
   /// Access the  energy
-  const double& energy() const;
+  const double &energy() const;
   /// Access the  PDG code
-  const int& PDG() const;
+  const int &PDG() const;
 
   unsigned int parents_size() const;
   ::ConstExampleMC parents(unsigned int) const;
@@ -64,31 +56,32 @@ public:
   std::vector<::ConstExampleMC>::const_iterator daughters_begin() const;
   std::vector<::ConstExampleMC>::const_iterator daughters_end() const;
 
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleMCObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleMC& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleMC &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleMC& other) const;
+  bool operator==(const ExampleMC &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleMC& p1,
-//       const ExampleMC& p2 );
-  bool operator<(const ConstExampleMC& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleMC& p1,
+  //       const ExampleMC& p2 );
+  bool operator<(const ConstExampleMC &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleMCObj* m_obj;
-
+  ExampleMCObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleMCData.h
+++ b/tests/datamodel/ExampleMCData.h
@@ -1,9 +1,6 @@
 #ifndef ExampleMCDATA_H
 #define ExampleMCDATA_H
 
-
-
-
 /** @class ExampleMCData
  *  Example MC-particle
  *  @author: F.Gaede
@@ -11,13 +8,12 @@
 
 class ExampleMCData {
 public:
-  double energy;  ///< energy
-  int PDG;  ///< PDG code
+  double energy; ///< energy
+  int PDG;       ///< PDG code
   unsigned int parents_begin;
   unsigned int parents_end;
   unsigned int daughters_begin;
   unsigned int daughters_end;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleMCObj.h
+++ b/tests/datamodel/ExampleMCObj.h
@@ -6,24 +6,21 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleMCData.h"
+#include "podio/ObjBase.h"
 
 #include <vector>
-
 
 // forward declarations
 class ExampleMC;
 class ConstExampleMC;
-
-
 
 class ExampleMCObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleMCObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleMCObj(const ExampleMCObj&);
+  ExampleMCObj(const ExampleMCObj &);
   /// constructor from ObjectID and ExampleMCData
   /// does not initialize the internal relation containers
   ExampleMCObj(const podio::ObjectID id, ExampleMCData data);
@@ -31,12 +28,8 @@ public:
 
 public:
   ExampleMCData data;
-  std::vector<ConstExampleMC>* m_parents;
-  std::vector<ConstExampleMC>* m_daughters;
-
-
+  std::vector<ConstExampleMC> *m_parents;
+  std::vector<ConstExampleMC> *m_daughters;
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleReferencingType.h
+++ b/tests/datamodel/ExampleReferencingType.h
@@ -1,21 +1,17 @@
 #ifndef ExampleReferencingType_H
 #define ExampleReferencingType_H
-#include "ExampleReferencingTypeData.h"
-#include <vector>
 #include "ExampleCluster.h"
 #include "ExampleReferencingType.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
+#include "ExampleReferencingTypeData.h"
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleReferencingTypeConst.h"
 #include "ExampleReferencingTypeObj.h"
-
-
 
 class ExampleReferencingTypeCollection;
 class ExampleReferencingTypeCollectionIterator;
@@ -32,28 +28,24 @@ class ExampleReferencingType {
   friend ConstExampleReferencingType;
 
 public:
-
   /// default constructor
   ExampleReferencingType();
 
   /// constructor from existing ExampleReferencingTypeObj
-  ExampleReferencingType(ExampleReferencingTypeObj* obj);
+  ExampleReferencingType(ExampleReferencingTypeObj *obj);
   /// copy constructor
-  ExampleReferencingType(const ExampleReferencingType& other);
+  ExampleReferencingType(const ExampleReferencingType &other);
   /// copy-assignment operator
-  ExampleReferencingType& operator=(const ExampleReferencingType& other);
+  ExampleReferencingType &operator=(const ExampleReferencingType &other);
   /// support cloning (deep-copy)
   ExampleReferencingType clone() const;
   /// destructor
   ~ExampleReferencingType();
 
   /// conversion to const object
-  operator ConstExampleReferencingType () const;
+  operator ConstExampleReferencingType() const;
 
 public:
-
-
-
   void addClusters(::ConstExampleCluster);
   unsigned int Clusters_size() const;
   ::ConstExampleCluster Clusters(unsigned int) const;
@@ -66,37 +58,35 @@ public:
   std::vector<::ConstExampleReferencingType>::const_iterator Refs_begin() const;
   std::vector<::ConstExampleReferencingType>::const_iterator Refs_end() const;
 
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleReferencingTypeObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleReferencingType& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleReferencingType &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleReferencingType& other) const;
+  bool operator==(const ConstExampleReferencingType &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleReferencingType& p1,
-//       const ExampleReferencingType& p2 );
-  bool operator<(const ExampleReferencingType& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleReferencingType& p1,
+  //       const ExampleReferencingType& p2 );
+  bool operator<(const ExampleReferencingType &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleReferencingTypeObj* m_obj;
-
+  ExampleReferencingTypeObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleReferencingType& value );
-
-
-
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleReferencingType &value);
 
 #endif

--- a/tests/datamodel/ExampleReferencingTypeCollection.h
+++ b/tests/datamodel/ExampleReferencingTypeCollection.h
@@ -1,47 +1,50 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleReferencingTypeCollection_H
-#define  ExampleReferencingTypeCollection_H
+#define ExampleReferencingTypeCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleReferencingTypeData.h"
 #include "ExampleReferencingType.h"
+#include "ExampleReferencingTypeData.h"
 #include "ExampleReferencingTypeObj.h"
 
-
-typedef std::vector<ExampleReferencingTypeData> ExampleReferencingTypeDataContainer;
-typedef std::deque<ExampleReferencingTypeObj*> ExampleReferencingTypeObjPointerContainer;
+typedef std::vector<ExampleReferencingTypeData>
+    ExampleReferencingTypeDataContainer;
+typedef std::deque<ExampleReferencingTypeObj *>
+    ExampleReferencingTypeObjPointerContainer;
 
 class ExampleReferencingTypeCollectionIterator {
 
-  public:
-    ExampleReferencingTypeCollectionIterator(int index, const ExampleReferencingTypeObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleReferencingTypeCollectionIterator(
+      int index, const ExampleReferencingTypeObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleReferencingTypeCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleReferencingTypeCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleReferencingType operator*() const;
-    const ExampleReferencingType* operator->() const;
-    const ExampleReferencingTypeCollectionIterator& operator++() const;
+  const ExampleReferencingType operator*() const;
+  const ExampleReferencingType *operator->() const;
+  const ExampleReferencingTypeCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleReferencingType m_object;
-    const ExampleReferencingTypeObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleReferencingType m_object;
+  const ExampleReferencingTypeObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +57,25 @@ public:
   typedef const ExampleReferencingTypeCollectionIterator const_iterator;
 
   ExampleReferencingTypeCollection();
-//  ExampleReferencingTypeCollection(const ExampleReferencingTypeCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleReferencingTypeCollection(ExampleReferencingTypeVector* data, int collectionID);
+  //  ExampleReferencingTypeCollection(const ExampleReferencingTypeCollection& )
+  //  = delete; // deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleReferencingTypeCollection(ExampleReferencingTypeVector* data, int
+  //  collectionID);
   ~ExampleReferencingTypeCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleReferencingTypeCollection* operator->() { return (ExampleReferencingTypeCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleReferencingTypeCollection *operator->() {
+    return (ExampleReferencingTypeCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleReferencingType create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleReferencingType create(Args&&... args);
+  template <typename... Args> ExampleReferencingType create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,70 +87,75 @@ public:
   /// Returns the object of given index
   ExampleReferencingType at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleReferencingType object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleReferencingTypeObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleReferencingTypeObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleReferencingTypeData>* _getBuffer() { return m_data;};
-
-   
+  std::vector<ExampleReferencingTypeData> *_getBuffer() { return m_data; };
 
 private:
   bool m_isValid;
   int m_collectionID;
   ExampleReferencingTypeObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
-  std::vector<::ConstExampleCluster>* m_rel_Clusters; ///< Relation buffer for read / write
-  std::vector<std::vector<::ConstExampleCluster>*> m_rel_Clusters_tmp; ///< Relation buffer for internal book-keeping
-  std::vector<::ConstExampleReferencingType>* m_rel_Refs; ///< Relation buffer for read / write
-  std::vector<std::vector<::ConstExampleReferencingType>*> m_rel_Refs_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<::ConstExampleCluster>
+      *m_rel_Clusters; ///< Relation buffer for read / write
+  std::vector<std::vector<::ConstExampleCluster> *>
+      m_rel_Clusters_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<::ConstExampleReferencingType>
+      *m_rel_Refs; ///< Relation buffer for read / write
+  std::vector<std::vector<::ConstExampleReferencingType> *>
+      m_rel_Refs_tmp; ///< Relation buffer for internal book-keeping
+
+  // members to handle vector members
 
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleReferencingTypeDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleReferencingTypeDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleReferencingTypeCollection& v);
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleReferencingTypeCollection &v);
 
-
-template<typename... Args>
-ExampleReferencingType  ExampleReferencingTypeCollection::create(Args&&... args){
+template <typename... Args>
+ExampleReferencingType
+ExampleReferencingTypeCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleReferencingTypeObj({size,m_collectionID},{args...});
+  auto obj = new ExampleReferencingTypeObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleReferencingType(obj);
 }
-
-
 
 #endif

--- a/tests/datamodel/ExampleReferencingTypeConst.h
+++ b/tests/datamodel/ExampleReferencingTypeConst.h
@@ -1,18 +1,14 @@
 #ifndef ConstExampleReferencingType_H
 #define ConstExampleReferencingType_H
-#include "ExampleReferencingTypeData.h"
-#include <vector>
 #include "ExampleCluster.h"
 #include "ExampleReferencingType.h"
-#include <vector>
+#include "ExampleReferencingTypeData.h"
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleReferencingTypeObj.h"
-
-
 
 class ExampleReferencingTypeObj;
 class ExampleReferencingType;
@@ -31,25 +27,22 @@ class ConstExampleReferencingType {
   friend ExampleReferencingTypeCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleReferencingType();
-  
+
   /// constructor from existing ExampleReferencingTypeObj
-  ConstExampleReferencingType(ExampleReferencingTypeObj* obj);
+  ConstExampleReferencingType(ExampleReferencingTypeObj *obj);
   /// copy constructor
-  ConstExampleReferencingType(const ConstExampleReferencingType& other);
+  ConstExampleReferencingType(const ConstExampleReferencingType &other);
   /// copy-assignment operator
-  ConstExampleReferencingType& operator=(const ConstExampleReferencingType& other);
+  ConstExampleReferencingType &
+  operator=(const ConstExampleReferencingType &other);
   /// support cloning (deep-copy)
   ConstExampleReferencingType clone() const;
   /// destructor
   ~ConstExampleReferencingType();
 
-
 public:
-
-
   unsigned int Clusters_size() const;
   ::ConstExampleCluster Clusters(unsigned int) const;
   std::vector<::ConstExampleCluster>::const_iterator Clusters_begin() const;
@@ -59,31 +52,32 @@ public:
   std::vector<::ConstExampleReferencingType>::const_iterator Refs_begin() const;
   std::vector<::ConstExampleReferencingType>::const_iterator Refs_end() const;
 
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleReferencingTypeObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleReferencingType& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleReferencingType &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleReferencingType& other) const;
+  bool operator==(const ExampleReferencingType &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleReferencingType& p1,
-//       const ExampleReferencingType& p2 );
-  bool operator<(const ConstExampleReferencingType& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleReferencingType& p1,
+  //       const ExampleReferencingType& p2 );
+  bool operator<(const ConstExampleReferencingType &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleReferencingTypeObj* m_obj;
-
+  ExampleReferencingTypeObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleReferencingTypeData.h
+++ b/tests/datamodel/ExampleReferencingTypeData.h
@@ -1,9 +1,6 @@
 #ifndef ExampleReferencingTypeDATA_H
 #define ExampleReferencingTypeDATA_H
 
-
-
-
 /** @class ExampleReferencingTypeData
  *  Referencing Type
  *  @author: B. Hegner
@@ -16,6 +13,5 @@ public:
   unsigned int Refs_begin;
   unsigned int Refs_end;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleReferencingTypeObj.h
+++ b/tests/datamodel/ExampleReferencingTypeObj.h
@@ -6,38 +6,32 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleReferencingTypeData.h"
+#include "podio/ObjBase.h"
 
-#include <vector>
 #include "ExampleCluster.h"
-
+#include <vector>
 
 // forward declarations
 class ExampleReferencingType;
 class ConstExampleReferencingType;
-
-
 
 class ExampleReferencingTypeObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleReferencingTypeObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleReferencingTypeObj(const ExampleReferencingTypeObj&);
+  ExampleReferencingTypeObj(const ExampleReferencingTypeObj &);
   /// constructor from ObjectID and ExampleReferencingTypeData
   /// does not initialize the internal relation containers
-  ExampleReferencingTypeObj(const podio::ObjectID id, ExampleReferencingTypeData data);
+  ExampleReferencingTypeObj(const podio::ObjectID id,
+                            ExampleReferencingTypeData data);
   virtual ~ExampleReferencingTypeObj();
 
 public:
   ExampleReferencingTypeData data;
-  std::vector<ConstExampleCluster>* m_Clusters;
-  std::vector<ConstExampleReferencingType>* m_Refs;
-
-
+  std::vector<ConstExampleCluster> *m_Clusters;
+  std::vector<ConstExampleReferencingType> *m_Refs;
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleWithARelation.h
+++ b/tests/datamodel/ExampleWithARelation.h
@@ -1,19 +1,17 @@
 #ifndef ExampleWithARelation_H
 #define ExampleWithARelation_H
 #include "ExampleWithARelationData.h"
-#include <vector>
 #include "ExampleWithNamespace.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
+// forward declarations
 namespace ex {
 class ExampleWithNamespace;
 class ConstExampleWithNamespace;
-}
-
+} // namespace ex
 
 #include "ExampleWithARelationConst.h"
 #include "ExampleWithARelationObj.h"
@@ -35,29 +33,27 @@ class ExampleWithARelation {
   friend ConstExampleWithARelation;
 
 public:
-
   /// default constructor
   ExampleWithARelation();
   ExampleWithARelation(float number);
 
   /// constructor from existing ExampleWithARelationObj
-  ExampleWithARelation(ExampleWithARelationObj* obj);
+  ExampleWithARelation(ExampleWithARelationObj *obj);
   /// copy constructor
-  ExampleWithARelation(const ExampleWithARelation& other);
+  ExampleWithARelation(const ExampleWithARelation &other);
   /// copy-assignment operator
-  ExampleWithARelation& operator=(const ExampleWithARelation& other);
+  ExampleWithARelation &operator=(const ExampleWithARelation &other);
   /// support cloning (deep-copy)
   ExampleWithARelation clone() const;
   /// destructor
   ~ExampleWithARelation();
 
   /// conversion to const object
-  operator ConstExampleWithARelation () const;
+  operator ConstExampleWithARelation() const;
 
 public:
-
   /// Access the  just a number
-  const float& number() const;
+  const float &number() const;
   /// Access the  a ref in a namespace
   const ex::ConstExampleWithNamespace ref() const;
 
@@ -73,36 +69,36 @@ public:
   std::vector<ex::ConstExampleWithNamespace>::const_iterator refs_begin() const;
   std::vector<ex::ConstExampleWithNamespace>::const_iterator refs_end() const;
 
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithARelationObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleWithARelation& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleWithARelation &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleWithARelation& other) const;
+  bool operator==(const ConstExampleWithARelation &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithARelation& p1,
-//       const ExampleWithARelation& p2 );
-  bool operator<(const ExampleWithARelation& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithARelation& p1,
+  //       const ExampleWithARelation& p2 );
+  bool operator<(const ExampleWithARelation &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithARelationObj* m_obj;
-
+  ExampleWithARelationObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithARelation& value );
-
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithARelation &value);
 
 } // namespace ex
 

--- a/tests/datamodel/ExampleWithARelationCollection.h
+++ b/tests/datamodel/ExampleWithARelationCollection.h
@@ -1,47 +1,50 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleWithARelationCollection_H
-#define  ExampleWithARelationCollection_H
+#define ExampleWithARelationCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleWithARelationData.h"
 #include "ExampleWithARelation.h"
+#include "ExampleWithARelationData.h"
 #include "ExampleWithARelationObj.h"
 
 namespace ex {
 typedef std::vector<ExampleWithARelationData> ExampleWithARelationDataContainer;
-typedef std::deque<ExampleWithARelationObj*> ExampleWithARelationObjPointerContainer;
+typedef std::deque<ExampleWithARelationObj *>
+    ExampleWithARelationObjPointerContainer;
 
 class ExampleWithARelationCollectionIterator {
 
-  public:
-    ExampleWithARelationCollectionIterator(int index, const ExampleWithARelationObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleWithARelationCollectionIterator(
+      int index, const ExampleWithARelationObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleWithARelationCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleWithARelationCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleWithARelation operator*() const;
-    const ExampleWithARelation* operator->() const;
-    const ExampleWithARelationCollectionIterator& operator++() const;
+  const ExampleWithARelation operator*() const;
+  const ExampleWithARelation *operator->() const;
+  const ExampleWithARelationCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleWithARelation m_object;
-    const ExampleWithARelationObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleWithARelation m_object;
+  const ExampleWithARelationObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +57,25 @@ public:
   typedef const ExampleWithARelationCollectionIterator const_iterator;
 
   ExampleWithARelationCollection();
-//  ExampleWithARelationCollection(const ExampleWithARelationCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleWithARelationCollection(ExampleWithARelationVector* data, int collectionID);
+  //  ExampleWithARelationCollection(const ExampleWithARelationCollection& ) =
+  //  delete; // deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleWithARelationCollection(ExampleWithARelationVector* data, int
+  //  collectionID);
   ~ExampleWithARelationCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleWithARelationCollection* operator->() { return (ExampleWithARelationCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleWithARelationCollection *operator->() {
+    return (ExampleWithARelationCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleWithARelation create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleWithARelation create(Args&&... args);
+  template <typename... Args> ExampleWithARelation create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,79 +87,85 @@ public:
   /// Returns the object of given index
   ExampleWithARelation at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleWithARelation object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleWithARelationObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleWithARelationObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleWithARelationData>* _getBuffer() { return m_data;};
+  std::vector<ExampleWithARelationData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<float,arraysize> number() const;
-
+  template <size_t arraysize> const std::array<float, arraysize> number() const;
 
 private:
   bool m_isValid;
   int m_collectionID;
   ExampleWithARelationObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
-  std::vector<ex::ConstExampleWithNamespace>* m_rel_refs; ///< Relation buffer for read / write
-  std::vector<std::vector<ex::ConstExampleWithNamespace>*> m_rel_refs_tmp; ///< Relation buffer for internal book-keeping
-  std::vector<ex::ConstExampleWithNamespace>* m_rel_ref; ///< Relation buffer for read / write
+  std::vector<ex::ConstExampleWithNamespace>
+      *m_rel_refs; ///< Relation buffer for read / write
+  std::vector<std::vector<ex::ConstExampleWithNamespace> *>
+      m_rel_refs_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<ex::ConstExampleWithNamespace>
+      *m_rel_ref; ///< Relation buffer for read / write
+
+  // members to handle vector members
 
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleWithARelationDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleWithARelationDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithARelationCollection& v);
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithARelationCollection &v);
 
-
-template<typename... Args>
-ExampleWithARelation  ExampleWithARelationCollection::create(Args&&... args){
+template <typename... Args>
+ExampleWithARelation ExampleWithARelationCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleWithARelationObj({size,m_collectionID},{args...});
+  auto obj = new ExampleWithARelationObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleWithARelation(obj);
 }
 
-template<size_t arraysize>
-const std::array<float,arraysize> ExampleWithARelationCollection::number() const {
-  std::array<float,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<float, arraysize>
+ExampleWithARelationCollection::number() const {
+  std::array<float, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.number;
- }
- return tmp;
+  }
+  return tmp;
 }
 
 } // namespace ex

--- a/tests/datamodel/ExampleWithARelationConst.h
+++ b/tests/datamodel/ExampleWithARelationConst.h
@@ -1,17 +1,15 @@
 #ifndef ConstExampleWithARelation_H
 #define ConstExampleWithARelation_H
 #include "ExampleWithARelationData.h"
-#include <vector>
 #include "ExampleWithNamespace.h"
-#include <vector>
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
+// forward declarations
 namespace ex {
 class ExampleWithNamespace;
 class ConstExampleWithNamespace;
-}
-
+} // namespace ex
 
 #include "ExampleWithARelationObj.h"
 
@@ -34,27 +32,24 @@ class ConstExampleWithARelation {
   friend ExampleWithARelationCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleWithARelation();
   ConstExampleWithARelation(float number);
 
   /// constructor from existing ExampleWithARelationObj
-  ConstExampleWithARelation(ExampleWithARelationObj* obj);
+  ConstExampleWithARelation(ExampleWithARelationObj *obj);
   /// copy constructor
-  ConstExampleWithARelation(const ConstExampleWithARelation& other);
+  ConstExampleWithARelation(const ConstExampleWithARelation &other);
   /// copy-assignment operator
-  ConstExampleWithARelation& operator=(const ConstExampleWithARelation& other);
+  ConstExampleWithARelation &operator=(const ConstExampleWithARelation &other);
   /// support cloning (deep-copy)
   ConstExampleWithARelation clone() const;
   /// destructor
   ~ConstExampleWithARelation();
 
-
 public:
-
   /// Access the  just a number
-  const float& number() const;
+  const float &number() const;
   /// Access the  a ref in a namespace
   const ex::ConstExampleWithNamespace ref() const;
 
@@ -63,30 +58,32 @@ public:
   std::vector<ex::ConstExampleWithNamespace>::const_iterator refs_begin() const;
   std::vector<ex::ConstExampleWithNamespace>::const_iterator refs_end() const;
 
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithARelationObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleWithARelation& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleWithARelation &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleWithARelation& other) const;
+  bool operator==(const ExampleWithARelation &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithARelation& p1,
-//       const ExampleWithARelation& p2 );
-  bool operator<(const ConstExampleWithARelation& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithARelation& p1,
+  //       const ExampleWithARelation& p2 );
+  bool operator<(const ConstExampleWithARelation &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithARelationObj* m_obj;
-
+  ExampleWithARelationObj *m_obj;
 };
 } // namespace ex
 

--- a/tests/datamodel/ExampleWithARelationData.h
+++ b/tests/datamodel/ExampleWithARelationData.h
@@ -1,8 +1,6 @@
 #ifndef ExampleWithARelationDATA_H
 #define ExampleWithARelationDATA_H
 
-
-
 namespace ex {
 /** @class ExampleWithARelationData
  *  Type with namespace and namespaced relation
@@ -11,7 +9,7 @@ namespace ex {
 
 class ExampleWithARelationData {
 public:
-  float number;  ///< just a number
+  float number; ///< just a number
   unsigned int refs_begin;
   unsigned int refs_end;
 };

--- a/tests/datamodel/ExampleWithARelationObj.h
+++ b/tests/datamodel/ExampleWithARelationObj.h
@@ -6,19 +6,18 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleWithARelationData.h"
+#include "podio/ObjBase.h"
 
-#include <vector>
 #include "ExampleWithNamespace.h"
-
+#include <vector>
 
 // forward declarations
 class ExampleWithARelation;
 class ConstExampleWithARelation;
-namespace ex {class ConstExampleWithNamespace;
+namespace ex {
+class ConstExampleWithNamespace;
 }
-
 
 namespace ex {
 class ExampleWithARelationObj : public podio::ObjBase {
@@ -26,20 +25,18 @@ public:
   /// constructor
   ExampleWithARelationObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleWithARelationObj(const ExampleWithARelationObj&);
+  ExampleWithARelationObj(const ExampleWithARelationObj &);
   /// constructor from ObjectID and ExampleWithARelationData
   /// does not initialize the internal relation containers
-  ExampleWithARelationObj(const podio::ObjectID id, ExampleWithARelationData data);
+  ExampleWithARelationObj(const podio::ObjectID id,
+                          ExampleWithARelationData data);
   virtual ~ExampleWithARelationObj();
 
 public:
   ExampleWithARelationData data;
-  ::ex::ConstExampleWithNamespace* m_ref;
-  std::vector<::ex::ConstExampleWithNamespace>* m_refs;
-
-
+  ::ex::ConstExampleWithNamespace *m_ref;
+  std::vector<::ex::ConstExampleWithNamespace> *m_refs;
 };
 } // namespace ex
-
 
 #endif

--- a/tests/datamodel/ExampleWithArray.h
+++ b/tests/datamodel/ExampleWithArray.h
@@ -1,22 +1,19 @@
 #ifndef ExampleWithArray_H
 #define ExampleWithArray_H
-#include <array>
 #include "NamespaceStruct.h"
+#include <array>
 
-#include "NotSoSimpleStruct.h"
 #include "ExampleWithArrayData.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
+#include "NotSoSimpleStruct.h"
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithArrayConst.h"
 #include "ExampleWithArrayObj.h"
-
-
 
 class ExampleWithArrayCollection;
 class ExampleWithArrayCollectionIterator;
@@ -33,58 +30,60 @@ class ExampleWithArray {
   friend ConstExampleWithArray;
 
 public:
-
   /// default constructor
   ExampleWithArray();
-  ExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3,std::array<ex2::NamespaceStruct, 4> structArray);
+  ExampleWithArray(NotSoSimpleStruct arrayStruct, std::array<int, 4> myArray,
+                   std::array<int, 4> anotherArray2,
+                   std::array<int, 4> snail_case_array,
+                   std::array<int, 4> snail_case_Array3,
+                   std::array<ex2::NamespaceStruct, 4> structArray);
 
   /// constructor from existing ExampleWithArrayObj
-  ExampleWithArray(ExampleWithArrayObj* obj);
+  ExampleWithArray(ExampleWithArrayObj *obj);
   /// copy constructor
-  ExampleWithArray(const ExampleWithArray& other);
+  ExampleWithArray(const ExampleWithArray &other);
   /// copy-assignment operator
-  ExampleWithArray& operator=(const ExampleWithArray& other);
+  ExampleWithArray &operator=(const ExampleWithArray &other);
   /// support cloning (deep-copy)
   ExampleWithArray clone() const;
   /// destructor
   ~ExampleWithArray();
 
   /// conversion to const object
-  operator ConstExampleWithArray () const;
+  operator ConstExampleWithArray() const;
 
 public:
-
   /// Access the  component that contains an array
-  const NotSoSimpleStruct& arrayStruct() const;
+  const NotSoSimpleStruct &arrayStruct() const;
   /// Access the member of  component that contains an array
-  const SimpleStruct& data() const;
+  const SimpleStruct &data() const;
   /// Access the array-member without space to test regex
-  const std::array<int, 4>& myArray() const;
+  const std::array<int, 4> &myArray() const;
   /// Access item i in the array-member without space to test regex
-  const int& myArray(size_t i) const;
+  const int &myArray(size_t i) const;
   /// Access the array-member with space to test regex
-  const std::array<int, 4>& anotherArray2() const;
+  const std::array<int, 4> &anotherArray2() const;
   /// Access item i in the array-member with space to test regex
-  const int& anotherArray2(size_t i) const;
+  const int &anotherArray2(size_t i) const;
   /// Access the snail case to test regex
-  const std::array<int, 4>& snail_case_array() const;
+  const std::array<int, 4> &snail_case_array() const;
   /// Access item i in the snail case to test regex
-  const int& snail_case_array(size_t i) const;
+  const int &snail_case_array(size_t i) const;
   /// Access the mixing things up for regex
-  const std::array<int, 4>& snail_case_Array3() const;
+  const std::array<int, 4> &snail_case_Array3() const;
   /// Access item i in the mixing things up for regex
-  const int& snail_case_Array3(size_t i) const;
+  const int &snail_case_Array3(size_t i) const;
   /// Access the an array containing structs
-  const std::array<ex2::NamespaceStruct, 4>& structArray() const;
+  const std::array<ex2::NamespaceStruct, 4> &structArray() const;
   /// Access item i in the an array containing structs
-  const ex2::NamespaceStruct& structArray(size_t i) const;
+  const ex2::NamespaceStruct &structArray(size_t i) const;
 
   /// Get reference to the  component that contains an array
-  NotSoSimpleStruct& arrayStruct();
+  NotSoSimpleStruct &arrayStruct();
   /// Set the  component that contains an array
   void arrayStruct(class NotSoSimpleStruct value);
   /// Get reference to the member of  component that contains an array
-  SimpleStruct& data();
+  SimpleStruct &data();
   /// Set the  member of  component that contains an array
   void data(class SimpleStruct value);
   /// Set the array-member without space to test regex
@@ -117,38 +116,34 @@ public:
   /// Set item i in an array containing structs
   void structArray(size_t i, ex2::NamespaceStruct value);
 
-
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithArrayObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleWithArray& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleWithArray &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleWithArray& other) const;
+  bool operator==(const ConstExampleWithArray &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithArray& p1,
-//       const ExampleWithArray& p2 );
-  bool operator<(const ExampleWithArray& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithArray& p1,
+  //       const ExampleWithArray& p2 );
+  bool operator<(const ExampleWithArray &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithArrayObj* m_obj;
-
+  ExampleWithArrayObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithArray& value );
-
-
-
+std::ostream &operator<<(std::ostream &o, const ConstExampleWithArray &value);
 
 #endif

--- a/tests/datamodel/ExampleWithArrayCollection.h
+++ b/tests/datamodel/ExampleWithArrayCollection.h
@@ -1,47 +1,48 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleWithArrayCollection_H
-#define  ExampleWithArrayCollection_H
+#define ExampleWithArrayCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleWithArrayData.h"
 #include "ExampleWithArray.h"
+#include "ExampleWithArrayData.h"
 #include "ExampleWithArrayObj.h"
 
-
 typedef std::vector<ExampleWithArrayData> ExampleWithArrayDataContainer;
-typedef std::deque<ExampleWithArrayObj*> ExampleWithArrayObjPointerContainer;
+typedef std::deque<ExampleWithArrayObj *> ExampleWithArrayObjPointerContainer;
 
 class ExampleWithArrayCollectionIterator {
 
-  public:
-    ExampleWithArrayCollectionIterator(int index, const ExampleWithArrayObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleWithArrayCollectionIterator(
+      int index, const ExampleWithArrayObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleWithArrayCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleWithArrayCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleWithArray operator*() const;
-    const ExampleWithArray* operator->() const;
-    const ExampleWithArrayCollectionIterator& operator++() const;
+  const ExampleWithArray operator*() const;
+  const ExampleWithArray *operator->() const;
+  const ExampleWithArrayCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleWithArray m_object;
-    const ExampleWithArrayObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleWithArray m_object;
+  const ExampleWithArrayObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,21 +55,25 @@ public:
   typedef const ExampleWithArrayCollectionIterator const_iterator;
 
   ExampleWithArrayCollection();
-//  ExampleWithArrayCollection(const ExampleWithArrayCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleWithArrayCollection(ExampleWithArrayVector* data, int collectionID);
+  //  ExampleWithArrayCollection(const ExampleWithArrayCollection& ) = delete;
+  //  // deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleWithArrayCollection(ExampleWithArrayVector* data, int
+  //  collectionID);
   ~ExampleWithArrayCollection();
 
-  void clear() override;
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleWithArrayCollection* operator->() { return (ExampleWithArrayCollection*) this ; }
+  void clear() override final;
+
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleWithArrayCollection *operator->() {
+    return (ExampleWithArrayCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleWithArray create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleWithArray create(Args&&... args);
+  template <typename... Args> ExampleWithArray create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -80,55 +85,56 @@ public:
   /// Returns the object of given index
   ExampleWithArray at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleWithArray object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleWithArrayObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleWithArrayObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleWithArrayData>* _getBuffer() { return m_data;};
+  std::vector<ExampleWithArrayData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<NotSoSimpleStruct,arraysize> arrayStruct() const;
-  template<size_t arraysize>
-  const std::array<std::array<int, 4>,arraysize> myArray() const;
-  template<size_t arraysize>
-  const std::array<std::array<int, 4>,arraysize> anotherArray2() const;
-  template<size_t arraysize>
-  const std::array<std::array<int, 4>,arraysize> snail_case_array() const;
-  template<size_t arraysize>
-  const std::array<std::array<int, 4>,arraysize> snail_case_Array3() const;
-  template<size_t arraysize>
-  const std::array<std::array<ex2::NamespaceStruct, 4>,arraysize> structArray() const;
-
+  template <size_t arraysize>
+  const std::array<NotSoSimpleStruct, arraysize> arrayStruct() const;
+  template <size_t arraysize>
+  const std::array<std::array<int, 4>, arraysize> myArray() const;
+  template <size_t arraysize>
+  const std::array<std::array<int, 4>, arraysize> anotherArray2() const;
+  template <size_t arraysize>
+  const std::array<std::array<int, 4>, arraysize> snail_case_array() const;
+  template <size_t arraysize>
+  const std::array<std::array<int, 4>, arraysize> snail_case_Array3() const;
+  template <size_t arraysize>
+  const std::array<std::array<ex2::NamespaceStruct, 4>, arraysize>
+  structArray() const;
 
 private:
   bool m_isValid;
@@ -136,76 +142,79 @@ private:
   ExampleWithArrayObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
 
+  // members to handle vector members
+
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleWithArrayDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleWithArrayDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithArrayCollection& v);
+std::ostream &operator<<(std::ostream &o, const ExampleWithArrayCollection &v);
 
-
-template<typename... Args>
-ExampleWithArray  ExampleWithArrayCollection::create(Args&&... args){
+template <typename... Args>
+ExampleWithArray ExampleWithArrayCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleWithArrayObj({size,m_collectionID},{args...});
+  auto obj = new ExampleWithArrayObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleWithArray(obj);
 }
 
-template<size_t arraysize>
-const std::array<class NotSoSimpleStruct,arraysize> ExampleWithArrayCollection::arrayStruct() const {
-  std::array<class NotSoSimpleStruct,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<class NotSoSimpleStruct, arraysize>
+ExampleWithArrayCollection::arrayStruct() const {
+  std::array<class NotSoSimpleStruct, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.arrayStruct;
- }
- return tmp;
+  }
+  return tmp;
 }
-template<size_t arraysize>
-const std::array<class std::array<int, 4>,arraysize> ExampleWithArrayCollection::myArray() const {
-  std::array<class std::array<int, 4>,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<class std::array<int, 4>, arraysize>
+ExampleWithArrayCollection::myArray() const {
+  std::array<class std::array<int, 4>, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.myArray;
- }
- return tmp;
-}
-template<size_t arraysize>
-const std::array<class std::array<int, 4>,arraysize> ExampleWithArrayCollection::anotherArray2() const {
-  std::array<class std::array<int, 4>,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+  }
+  return tmp;
+} template <size_t arraysize>
+const std::array<class std::array<int, 4>, arraysize>
+ExampleWithArrayCollection::anotherArray2() const {
+  std::array<class std::array<int, 4>, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.anotherArray2;
- }
- return tmp;
-}
-template<size_t arraysize>
-const std::array<class std::array<int, 4>,arraysize> ExampleWithArrayCollection::snail_case_array() const {
-  std::array<class std::array<int, 4>,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+  }
+  return tmp;
+} template <size_t arraysize>
+const std::array<class std::array<int, 4>, arraysize>
+ExampleWithArrayCollection::snail_case_array() const {
+  std::array<class std::array<int, 4>, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.snail_case_array;
- }
- return tmp;
-}
-template<size_t arraysize>
-const std::array<class std::array<int, 4>,arraysize> ExampleWithArrayCollection::snail_case_Array3() const {
-  std::array<class std::array<int, 4>,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+  }
+  return tmp;
+} template <size_t arraysize>
+const std::array<class std::array<int, 4>, arraysize>
+ExampleWithArrayCollection::snail_case_Array3() const {
+  std::array<class std::array<int, 4>, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.snail_case_Array3;
- }
- return tmp;
-}
-template<size_t arraysize>
-const std::array<class std::array<ex2::NamespaceStruct, 4>,arraysize> ExampleWithArrayCollection::structArray() const {
-  std::array<class std::array<ex2::NamespaceStruct, 4>,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+  }
+  return tmp;
+} template <size_t arraysize>
+const std::array<class std::array<ex2::NamespaceStruct, 4>, arraysize>
+ExampleWithArrayCollection::structArray() const {
+  std::array<class std::array<ex2::NamespaceStruct, 4>, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.structArray;
- }
- return tmp;
+  }
+  return tmp;
 }
-
 
 #endif

--- a/tests/datamodel/ExampleWithArrayConst.h
+++ b/tests/datamodel/ExampleWithArrayConst.h
@@ -1,19 +1,16 @@
 #ifndef ConstExampleWithArray_H
 #define ConstExampleWithArray_H
-#include <array>
 #include "NamespaceStruct.h"
+#include <array>
 
-#include "NotSoSimpleStruct.h"
 #include "ExampleWithArrayData.h"
-#include <vector>
+#include "NotSoSimpleStruct.h"
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithArrayObj.h"
-
-
 
 class ExampleWithArrayObj;
 class ExampleWithArray;
@@ -32,76 +29,78 @@ class ConstExampleWithArray {
   friend ExampleWithArrayCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleWithArray();
-  ConstExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3,std::array<ex2::NamespaceStruct, 4> structArray);
+  ConstExampleWithArray(NotSoSimpleStruct arrayStruct,
+                        std::array<int, 4> myArray,
+                        std::array<int, 4> anotherArray2,
+                        std::array<int, 4> snail_case_array,
+                        std::array<int, 4> snail_case_Array3,
+                        std::array<ex2::NamespaceStruct, 4> structArray);
 
   /// constructor from existing ExampleWithArrayObj
-  ConstExampleWithArray(ExampleWithArrayObj* obj);
+  ConstExampleWithArray(ExampleWithArrayObj *obj);
   /// copy constructor
-  ConstExampleWithArray(const ConstExampleWithArray& other);
+  ConstExampleWithArray(const ConstExampleWithArray &other);
   /// copy-assignment operator
-  ConstExampleWithArray& operator=(const ConstExampleWithArray& other);
+  ConstExampleWithArray &operator=(const ConstExampleWithArray &other);
   /// support cloning (deep-copy)
   ConstExampleWithArray clone() const;
   /// destructor
   ~ConstExampleWithArray();
 
-
 public:
-
   /// Access the  component that contains an array
-  const NotSoSimpleStruct& arrayStruct() const;
+  const NotSoSimpleStruct &arrayStruct() const;
   /// Access the member of  component that contains an array
-  const SimpleStruct& data() const;
+  const SimpleStruct &data() const;
   /// Access the array-member without space to test regex
-  const std::array<int, 4>& myArray() const;
+  const std::array<int, 4> &myArray() const;
   /// Access item i in the array-member without space to test regex
-  const int& myArray(size_t i) const;
+  const int &myArray(size_t i) const;
   /// Access the array-member with space to test regex
-  const std::array<int, 4>& anotherArray2() const;
+  const std::array<int, 4> &anotherArray2() const;
   /// Access item i in the array-member with space to test regex
-  const int& anotherArray2(size_t i) const;
+  const int &anotherArray2(size_t i) const;
   /// Access the snail case to test regex
-  const std::array<int, 4>& snail_case_array() const;
+  const std::array<int, 4> &snail_case_array() const;
   /// Access item i in the snail case to test regex
-  const int& snail_case_array(size_t i) const;
+  const int &snail_case_array(size_t i) const;
   /// Access the mixing things up for regex
-  const std::array<int, 4>& snail_case_Array3() const;
+  const std::array<int, 4> &snail_case_Array3() const;
   /// Access item i in the mixing things up for regex
-  const int& snail_case_Array3(size_t i) const;
+  const int &snail_case_Array3(size_t i) const;
   /// Access the an array containing structs
-  const std::array<ex2::NamespaceStruct, 4>& structArray() const;
+  const std::array<ex2::NamespaceStruct, 4> &structArray() const;
   /// Access item i in the an array containing structs
-  const ex2::NamespaceStruct& structArray(size_t i) const;
-
-
+  const ex2::NamespaceStruct &structArray(size_t i) const;
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithArrayObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleWithArray& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleWithArray &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleWithArray& other) const;
+  bool operator==(const ExampleWithArray &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithArray& p1,
-//       const ExampleWithArray& p2 );
-  bool operator<(const ConstExampleWithArray& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithArray& p1,
+  //       const ExampleWithArray& p2 );
+  bool operator<(const ConstExampleWithArray &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithArrayObj* m_obj;
-
+  ExampleWithArrayObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithArrayData.h
+++ b/tests/datamodel/ExampleWithArrayData.h
@@ -1,11 +1,10 @@
 #ifndef ExampleWithArrayDATA_H
 #define ExampleWithArrayDATA_H
 
-#include <array>
 #include "NamespaceStruct.h"
+#include <array>
 
 #include "NotSoSimpleStruct.h"
-
 
 /** @class ExampleWithArrayData
  *  Datatype with an array member
@@ -14,13 +13,13 @@
 
 class ExampleWithArrayData {
 public:
-  NotSoSimpleStruct arrayStruct;  ///< component that contains an array
-  std::array<int, 4> myArray;  ///<array-member without space to test regex
-  std::array<int, 4> anotherArray2;  ///<array-member with space to test regex
-  std::array<int, 4> snail_case_array;  ///<snail case to test regex
-  std::array<int, 4> snail_case_Array3;  ///<mixing things up for regex
-  std::array<ex2::NamespaceStruct, 4> structArray;  ///<an array containing structs
+  NotSoSimpleStruct arrayStruct; ///< component that contains an array
+  std::array<int, 4> myArray;    ///< array-member without space to test regex
+  std::array<int, 4> anotherArray2; ///< array-member with space to test regex
+  std::array<int, 4> snail_case_array;  ///< snail case to test regex
+  std::array<int, 4> snail_case_Array3; ///< mixing things up for regex
+  std::array<ex2::NamespaceStruct, 4>
+      structArray; ///< an array containing structs
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithArrayObj.h
+++ b/tests/datamodel/ExampleWithArrayObj.h
@@ -6,23 +6,19 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleWithArrayData.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class ExampleWithArray;
 class ConstExampleWithArray;
-
-
 
 class ExampleWithArrayObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleWithArrayObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleWithArrayObj(const ExampleWithArrayObj&);
+  ExampleWithArrayObj(const ExampleWithArrayObj &);
   /// constructor from ObjectID and ExampleWithArrayData
   /// does not initialize the internal relation containers
   ExampleWithArrayObj(const podio::ObjectID id, ExampleWithArrayData data);
@@ -30,10 +26,6 @@ public:
 
 public:
   ExampleWithArrayData data;
-
-
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleWithComponent.h
+++ b/tests/datamodel/ExampleWithComponent.h
@@ -1,19 +1,16 @@
 #ifndef ExampleWithComponent_H
 #define ExampleWithComponent_H
-#include "NotSoSimpleStruct.h"
 #include "ExampleWithComponentData.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
+#include "NotSoSimpleStruct.h"
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithComponentConst.h"
 #include "ExampleWithComponentObj.h"
-
-
 
 class ExampleWithComponentCollection;
 class ExampleWithComponentCollectionIterator;
@@ -30,72 +27,68 @@ class ExampleWithComponent {
   friend ConstExampleWithComponent;
 
 public:
-
   /// default constructor
   ExampleWithComponent();
   ExampleWithComponent(NotSoSimpleStruct component);
 
   /// constructor from existing ExampleWithComponentObj
-  ExampleWithComponent(ExampleWithComponentObj* obj);
+  ExampleWithComponent(ExampleWithComponentObj *obj);
   /// copy constructor
-  ExampleWithComponent(const ExampleWithComponent& other);
+  ExampleWithComponent(const ExampleWithComponent &other);
   /// copy-assignment operator
-  ExampleWithComponent& operator=(const ExampleWithComponent& other);
+  ExampleWithComponent &operator=(const ExampleWithComponent &other);
   /// support cloning (deep-copy)
   ExampleWithComponent clone() const;
   /// destructor
   ~ExampleWithComponent();
 
   /// conversion to const object
-  operator ConstExampleWithComponent () const;
+  operator ConstExampleWithComponent() const;
 
 public:
-
   /// Access the  a component
-  const NotSoSimpleStruct& component() const;
+  const NotSoSimpleStruct &component() const;
   /// Access the member of  a component
-  const SimpleStruct& data() const;
+  const SimpleStruct &data() const;
 
   /// Get reference to the  a component
-  NotSoSimpleStruct& component();
+  NotSoSimpleStruct &component();
   /// Set the  a component
   void component(class NotSoSimpleStruct value);
   /// Get reference to the member of  a component
-  SimpleStruct& data();
+  SimpleStruct &data();
   /// Set the  member of  a component
   void data(class SimpleStruct value);
-
-
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithComponentObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleWithComponent& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleWithComponent &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleWithComponent& other) const;
+  bool operator==(const ConstExampleWithComponent &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithComponent& p1,
-//       const ExampleWithComponent& p2 );
-  bool operator<(const ExampleWithComponent& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithComponent& p1,
+  //       const ExampleWithComponent& p2 );
+  bool operator<(const ExampleWithComponent &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithComponentObj* m_obj;
-
+  ExampleWithComponentObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithComponent& value );
-
-
-
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithComponent &value);
 
 #endif

--- a/tests/datamodel/ExampleWithComponentCollection.h
+++ b/tests/datamodel/ExampleWithComponentCollection.h
@@ -1,47 +1,49 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleWithComponentCollection_H
-#define  ExampleWithComponentCollection_H
+#define ExampleWithComponentCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleWithComponentData.h"
 #include "ExampleWithComponent.h"
+#include "ExampleWithComponentData.h"
 #include "ExampleWithComponentObj.h"
 
-
 typedef std::vector<ExampleWithComponentData> ExampleWithComponentDataContainer;
-typedef std::deque<ExampleWithComponentObj*> ExampleWithComponentObjPointerContainer;
+typedef std::deque<ExampleWithComponentObj *>
+    ExampleWithComponentObjPointerContainer;
 
 class ExampleWithComponentCollectionIterator {
 
-  public:
-    ExampleWithComponentCollectionIterator(int index, const ExampleWithComponentObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleWithComponentCollectionIterator(
+      int index, const ExampleWithComponentObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleWithComponentCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleWithComponentCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleWithComponent operator*() const;
-    const ExampleWithComponent* operator->() const;
-    const ExampleWithComponentCollectionIterator& operator++() const;
+  const ExampleWithComponent operator*() const;
+  const ExampleWithComponent *operator->() const;
+  const ExampleWithComponentCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleWithComponent m_object;
-    const ExampleWithComponentObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleWithComponent m_object;
+  const ExampleWithComponentObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +56,25 @@ public:
   typedef const ExampleWithComponentCollectionIterator const_iterator;
 
   ExampleWithComponentCollection();
-//  ExampleWithComponentCollection(const ExampleWithComponentCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleWithComponentCollection(ExampleWithComponentVector* data, int collectionID);
+  //  ExampleWithComponentCollection(const ExampleWithComponentCollection& ) =
+  //  delete; // deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleWithComponentCollection(ExampleWithComponentVector* data, int
+  //  collectionID);
   ~ExampleWithComponentCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleWithComponentCollection* operator->() { return (ExampleWithComponentCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleWithComponentCollection *operator->() {
+    return (ExampleWithComponentCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleWithComponent create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleWithComponent create(Args&&... args);
+  template <typename... Args> ExampleWithComponent create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,45 +86,45 @@ public:
   /// Returns the object of given index
   ExampleWithComponent at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleWithComponent object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleWithComponentObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleWithComponentObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleWithComponentData>* _getBuffer() { return m_data;};
+  std::vector<ExampleWithComponentData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<NotSoSimpleStruct,arraysize> component() const;
-
+  template <size_t arraysize>
+  const std::array<NotSoSimpleStruct, arraysize> component() const;
 
 private:
   bool m_isValid;
@@ -127,31 +132,34 @@ private:
   ExampleWithComponentObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
 
+  // members to handle vector members
+
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleWithComponentDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleWithComponentDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithComponentCollection& v);
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithComponentCollection &v);
 
-
-template<typename... Args>
-ExampleWithComponent  ExampleWithComponentCollection::create(Args&&... args){
+template <typename... Args>
+ExampleWithComponent ExampleWithComponentCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleWithComponentObj({size,m_collectionID},{args...});
+  auto obj = new ExampleWithComponentObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleWithComponent(obj);
 }
 
-template<size_t arraysize>
-const std::array<class NotSoSimpleStruct,arraysize> ExampleWithComponentCollection::component() const {
-  std::array<class NotSoSimpleStruct,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<class NotSoSimpleStruct, arraysize>
+ExampleWithComponentCollection::component() const {
+  std::array<class NotSoSimpleStruct, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.component;
- }
- return tmp;
+  }
+  return tmp;
 }
-
 
 #endif

--- a/tests/datamodel/ExampleWithComponentConst.h
+++ b/tests/datamodel/ExampleWithComponentConst.h
@@ -1,16 +1,13 @@
 #ifndef ConstExampleWithComponent_H
 #define ConstExampleWithComponent_H
-#include "NotSoSimpleStruct.h"
 #include "ExampleWithComponentData.h"
-#include <vector>
+#include "NotSoSimpleStruct.h"
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithComponentObj.h"
-
-
 
 class ExampleWithComponentObj;
 class ExampleWithComponent;
@@ -29,56 +26,53 @@ class ConstExampleWithComponent {
   friend ExampleWithComponentCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleWithComponent();
   ConstExampleWithComponent(NotSoSimpleStruct component);
 
   /// constructor from existing ExampleWithComponentObj
-  ConstExampleWithComponent(ExampleWithComponentObj* obj);
+  ConstExampleWithComponent(ExampleWithComponentObj *obj);
   /// copy constructor
-  ConstExampleWithComponent(const ConstExampleWithComponent& other);
+  ConstExampleWithComponent(const ConstExampleWithComponent &other);
   /// copy-assignment operator
-  ConstExampleWithComponent& operator=(const ConstExampleWithComponent& other);
+  ConstExampleWithComponent &operator=(const ConstExampleWithComponent &other);
   /// support cloning (deep-copy)
   ConstExampleWithComponent clone() const;
   /// destructor
   ~ConstExampleWithComponent();
 
-
 public:
-
   /// Access the  a component
-  const NotSoSimpleStruct& component() const;
+  const NotSoSimpleStruct &component() const;
   /// Access the member of  a component
-  const SimpleStruct& data() const;
-
-
+  const SimpleStruct &data() const;
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithComponentObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleWithComponent& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleWithComponent &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleWithComponent& other) const;
+  bool operator==(const ExampleWithComponent &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithComponent& p1,
-//       const ExampleWithComponent& p2 );
-  bool operator<(const ConstExampleWithComponent& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithComponent& p1,
+  //       const ExampleWithComponent& p2 );
+  bool operator<(const ConstExampleWithComponent &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithComponentObj* m_obj;
-
+  ExampleWithComponentObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithComponentData.h
+++ b/tests/datamodel/ExampleWithComponentData.h
@@ -3,7 +3,6 @@
 
 #include "NotSoSimpleStruct.h"
 
-
 /** @class ExampleWithComponentData
  *  Type with one component
  *  @author: Benedikt Hegner
@@ -11,8 +10,7 @@
 
 class ExampleWithComponentData {
 public:
-  NotSoSimpleStruct component;  ///< a component
+  NotSoSimpleStruct component; ///< a component
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithComponentObj.h
+++ b/tests/datamodel/ExampleWithComponentObj.h
@@ -6,34 +6,27 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleWithComponentData.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class ExampleWithComponent;
 class ConstExampleWithComponent;
-
-
 
 class ExampleWithComponentObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleWithComponentObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleWithComponentObj(const ExampleWithComponentObj&);
+  ExampleWithComponentObj(const ExampleWithComponentObj &);
   /// constructor from ObjectID and ExampleWithComponentData
   /// does not initialize the internal relation containers
-  ExampleWithComponentObj(const podio::ObjectID id, ExampleWithComponentData data);
+  ExampleWithComponentObj(const podio::ObjectID id,
+                          ExampleWithComponentData data);
   virtual ~ExampleWithComponentObj();
 
 public:
   ExampleWithComponentData data;
-
-
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleWithNamespace.h
+++ b/tests/datamodel/ExampleWithNamespace.h
@@ -1,14 +1,13 @@
 #ifndef ExampleWithNamespace_H
 #define ExampleWithNamespace_H
-#include "NamespaceStruct.h"
 #include "ExampleWithNamespaceData.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
+#include "NamespaceStruct.h"
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithNamespaceConst.h"
 #include "ExampleWithNamespaceObj.h"
@@ -30,36 +29,34 @@ class ExampleWithNamespace {
   friend ConstExampleWithNamespace;
 
 public:
-
   /// default constructor
   ExampleWithNamespace();
   ExampleWithNamespace(ex2::NamespaceStruct data);
 
   /// constructor from existing ExampleWithNamespaceObj
-  ExampleWithNamespace(ExampleWithNamespaceObj* obj);
+  ExampleWithNamespace(ExampleWithNamespaceObj *obj);
   /// copy constructor
-  ExampleWithNamespace(const ExampleWithNamespace& other);
+  ExampleWithNamespace(const ExampleWithNamespace &other);
   /// copy-assignment operator
-  ExampleWithNamespace& operator=(const ExampleWithNamespace& other);
+  ExampleWithNamespace &operator=(const ExampleWithNamespace &other);
   /// support cloning (deep-copy)
   ExampleWithNamespace clone() const;
   /// destructor
   ~ExampleWithNamespace();
 
   /// conversion to const object
-  operator ConstExampleWithNamespace () const;
+  operator ConstExampleWithNamespace() const;
 
 public:
-
   /// Access the  a component
-  const ex2::NamespaceStruct& data() const;
+  const ex2::NamespaceStruct &data() const;
   /// Access the member of  a component
-  const int& x() const;
+  const int &x() const;
   /// Access the member of  a component
-  const int& y() const;
+  const int &y() const;
 
   /// Get reference to the  a component
-  ex2::NamespaceStruct& data();
+  ex2::NamespaceStruct &data();
   /// Set the  a component
   void data(class ex2::NamespaceStruct value);
   /// Set the  member of  a component
@@ -68,37 +65,36 @@ public:
   /// Set the  member of  a component
   void y(int value);
 
-
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithNamespaceObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleWithNamespace& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleWithNamespace &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleWithNamespace& other) const;
+  bool operator==(const ConstExampleWithNamespace &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithNamespace& p1,
-//       const ExampleWithNamespace& p2 );
-  bool operator<(const ExampleWithNamespace& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithNamespace& p1,
+  //       const ExampleWithNamespace& p2 );
+  bool operator<(const ExampleWithNamespace &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithNamespaceObj* m_obj;
-
+  ExampleWithNamespaceObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithNamespace& value );
-
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithNamespace &value);
 
 } // namespace ex
 

--- a/tests/datamodel/ExampleWithNamespaceCollection.h
+++ b/tests/datamodel/ExampleWithNamespaceCollection.h
@@ -1,47 +1,50 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleWithNamespaceCollection_H
-#define  ExampleWithNamespaceCollection_H
+#define ExampleWithNamespaceCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleWithNamespaceData.h"
 #include "ExampleWithNamespace.h"
+#include "ExampleWithNamespaceData.h"
 #include "ExampleWithNamespaceObj.h"
 
 namespace ex {
 typedef std::vector<ExampleWithNamespaceData> ExampleWithNamespaceDataContainer;
-typedef std::deque<ExampleWithNamespaceObj*> ExampleWithNamespaceObjPointerContainer;
+typedef std::deque<ExampleWithNamespaceObj *>
+    ExampleWithNamespaceObjPointerContainer;
 
 class ExampleWithNamespaceCollectionIterator {
 
-  public:
-    ExampleWithNamespaceCollectionIterator(int index, const ExampleWithNamespaceObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleWithNamespaceCollectionIterator(
+      int index, const ExampleWithNamespaceObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleWithNamespaceCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleWithNamespaceCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleWithNamespace operator*() const;
-    const ExampleWithNamespace* operator->() const;
-    const ExampleWithNamespaceCollectionIterator& operator++() const;
+  const ExampleWithNamespace operator*() const;
+  const ExampleWithNamespace *operator->() const;
+  const ExampleWithNamespaceCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleWithNamespace m_object;
-    const ExampleWithNamespaceObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleWithNamespace m_object;
+  const ExampleWithNamespaceObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +57,25 @@ public:
   typedef const ExampleWithNamespaceCollectionIterator const_iterator;
 
   ExampleWithNamespaceCollection();
-//  ExampleWithNamespaceCollection(const ExampleWithNamespaceCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleWithNamespaceCollection(ExampleWithNamespaceVector* data, int collectionID);
+  //  ExampleWithNamespaceCollection(const ExampleWithNamespaceCollection& ) =
+  //  delete; // deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleWithNamespaceCollection(ExampleWithNamespaceVector* data, int
+  //  collectionID);
   ~ExampleWithNamespaceCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleWithNamespaceCollection* operator->() { return (ExampleWithNamespaceCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleWithNamespaceCollection *operator->() {
+    return (ExampleWithNamespaceCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleWithNamespace create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleWithNamespace create(Args&&... args);
+  template <typename... Args> ExampleWithNamespace create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,45 +87,45 @@ public:
   /// Returns the object of given index
   ExampleWithNamespace at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleWithNamespace object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleWithNamespaceObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleWithNamespaceObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleWithNamespaceData>* _getBuffer() { return m_data;};
+  std::vector<ExampleWithNamespaceData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<ex2::NamespaceStruct,arraysize> data() const;
-
+  template <size_t arraysize>
+  const std::array<ex2::NamespaceStruct, arraysize> data() const;
 
 private:
   bool m_isValid;
@@ -127,30 +133,34 @@ private:
   ExampleWithNamespaceObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
 
+  // members to handle vector members
+
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleWithNamespaceDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleWithNamespaceDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithNamespaceCollection& v);
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithNamespaceCollection &v);
 
-
-template<typename... Args>
-ExampleWithNamespace  ExampleWithNamespaceCollection::create(Args&&... args){
+template <typename... Args>
+ExampleWithNamespace ExampleWithNamespaceCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleWithNamespaceObj({size,m_collectionID},{args...});
+  auto obj = new ExampleWithNamespaceObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleWithNamespace(obj);
 }
 
-template<size_t arraysize>
-const std::array<class ex2::NamespaceStruct,arraysize> ExampleWithNamespaceCollection::data() const {
-  std::array<class ex2::NamespaceStruct,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<class ex2::NamespaceStruct, arraysize>
+ExampleWithNamespaceCollection::data() const {
+  std::array<class ex2::NamespaceStruct, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.data;
- }
- return tmp;
+  }
+  return tmp;
 }
 
 } // namespace ex

--- a/tests/datamodel/ExampleWithNamespaceConst.h
+++ b/tests/datamodel/ExampleWithNamespaceConst.h
@@ -1,12 +1,11 @@
 #ifndef ConstExampleWithNamespace_H
 #define ConstExampleWithNamespace_H
-#include "NamespaceStruct.h"
 #include "ExampleWithNamespaceData.h"
-#include <vector>
+#include "NamespaceStruct.h"
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithNamespaceObj.h"
 
@@ -29,57 +28,55 @@ class ConstExampleWithNamespace {
   friend ExampleWithNamespaceCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleWithNamespace();
   ConstExampleWithNamespace(ex2::NamespaceStruct data);
 
   /// constructor from existing ExampleWithNamespaceObj
-  ConstExampleWithNamespace(ExampleWithNamespaceObj* obj);
+  ConstExampleWithNamespace(ExampleWithNamespaceObj *obj);
   /// copy constructor
-  ConstExampleWithNamespace(const ConstExampleWithNamespace& other);
+  ConstExampleWithNamespace(const ConstExampleWithNamespace &other);
   /// copy-assignment operator
-  ConstExampleWithNamespace& operator=(const ConstExampleWithNamespace& other);
+  ConstExampleWithNamespace &operator=(const ConstExampleWithNamespace &other);
   /// support cloning (deep-copy)
   ConstExampleWithNamespace clone() const;
   /// destructor
   ~ConstExampleWithNamespace();
 
-
 public:
-
   /// Access the  a component
-  const ex2::NamespaceStruct& data() const;
+  const ex2::NamespaceStruct &data() const;
   /// Access the member of  a component
-  const int& x() const;
+  const int &x() const;
   /// Access the member of  a component
-  const int& y() const;
-
-
+  const int &y() const;
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithNamespaceObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleWithNamespace& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleWithNamespace &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleWithNamespace& other) const;
+  bool operator==(const ExampleWithNamespace &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithNamespace& p1,
-//       const ExampleWithNamespace& p2 );
-  bool operator<(const ConstExampleWithNamespace& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithNamespace& p1,
+  //       const ExampleWithNamespace& p2 );
+  bool operator<(const ConstExampleWithNamespace &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithNamespaceObj* m_obj;
-
+  ExampleWithNamespaceObj *m_obj;
 };
 } // namespace ex
 

--- a/tests/datamodel/ExampleWithNamespaceData.h
+++ b/tests/datamodel/ExampleWithNamespaceData.h
@@ -11,7 +11,7 @@ namespace ex {
 
 class ExampleWithNamespaceData {
 public:
-  ex2::NamespaceStruct data;  ///< a component
+  ex2::NamespaceStruct data; ///< a component
 };
 } // namespace ex
 

--- a/tests/datamodel/ExampleWithNamespaceObj.h
+++ b/tests/datamodel/ExampleWithNamespaceObj.h
@@ -6,15 +6,12 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleWithNamespaceData.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class ExampleWithNamespace;
 class ConstExampleWithNamespace;
-
 
 namespace ex {
 class ExampleWithNamespaceObj : public podio::ObjBase {
@@ -22,18 +19,16 @@ public:
   /// constructor
   ExampleWithNamespaceObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleWithNamespaceObj(const ExampleWithNamespaceObj&);
+  ExampleWithNamespaceObj(const ExampleWithNamespaceObj &);
   /// constructor from ObjectID and ExampleWithNamespaceData
   /// does not initialize the internal relation containers
-  ExampleWithNamespaceObj(const podio::ObjectID id, ExampleWithNamespaceData data);
+  ExampleWithNamespaceObj(const podio::ObjectID id,
+                          ExampleWithNamespaceData data);
   virtual ~ExampleWithNamespaceObj();
 
 public:
   ExampleWithNamespaceData data;
-
-
 };
 } // namespace ex
-
 
 #endif

--- a/tests/datamodel/ExampleWithOneRelation.h
+++ b/tests/datamodel/ExampleWithOneRelation.h
@@ -1,20 +1,17 @@
 #ifndef ExampleWithOneRelation_H
 #define ExampleWithOneRelation_H
 #include "ExampleWithOneRelationData.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
+// forward declarations
 class ExampleCluster;
 class ConstExampleCluster;
 
-
 #include "ExampleWithOneRelationConst.h"
 #include "ExampleWithOneRelationObj.h"
-
-
 
 class ExampleWithOneRelationCollection;
 class ExampleWithOneRelationCollectionIterator;
@@ -31,63 +28,59 @@ class ExampleWithOneRelation {
   friend ConstExampleWithOneRelation;
 
 public:
-
   /// default constructor
   ExampleWithOneRelation();
 
   /// constructor from existing ExampleWithOneRelationObj
-  ExampleWithOneRelation(ExampleWithOneRelationObj* obj);
+  ExampleWithOneRelation(ExampleWithOneRelationObj *obj);
   /// copy constructor
-  ExampleWithOneRelation(const ExampleWithOneRelation& other);
+  ExampleWithOneRelation(const ExampleWithOneRelation &other);
   /// copy-assignment operator
-  ExampleWithOneRelation& operator=(const ExampleWithOneRelation& other);
+  ExampleWithOneRelation &operator=(const ExampleWithOneRelation &other);
   /// support cloning (deep-copy)
   ExampleWithOneRelation clone() const;
   /// destructor
   ~ExampleWithOneRelation();
 
   /// conversion to const object
-  operator ConstExampleWithOneRelation () const;
+  operator ConstExampleWithOneRelation() const;
 
 public:
-
   /// Access the  a particular cluster
   const ::ConstExampleCluster cluster() const;
 
   /// Set the  a particular cluster
   void cluster(::ConstExampleCluster value);
 
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithOneRelationObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleWithOneRelation& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleWithOneRelation &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleWithOneRelation& other) const;
+  bool operator==(const ConstExampleWithOneRelation &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithOneRelation& p1,
-//       const ExampleWithOneRelation& p2 );
-  bool operator<(const ExampleWithOneRelation& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithOneRelation& p1,
+  //       const ExampleWithOneRelation& p2 );
+  bool operator<(const ExampleWithOneRelation &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithOneRelationObj* m_obj;
-
+  ExampleWithOneRelationObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithOneRelation& value );
-
-
-
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithOneRelation &value);
 
 #endif

--- a/tests/datamodel/ExampleWithOneRelationCollection.h
+++ b/tests/datamodel/ExampleWithOneRelationCollection.h
@@ -1,47 +1,50 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleWithOneRelationCollection_H
-#define  ExampleWithOneRelationCollection_H
+#define ExampleWithOneRelationCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleWithOneRelationData.h"
 #include "ExampleWithOneRelation.h"
+#include "ExampleWithOneRelationData.h"
 #include "ExampleWithOneRelationObj.h"
 
-
-typedef std::vector<ExampleWithOneRelationData> ExampleWithOneRelationDataContainer;
-typedef std::deque<ExampleWithOneRelationObj*> ExampleWithOneRelationObjPointerContainer;
+typedef std::vector<ExampleWithOneRelationData>
+    ExampleWithOneRelationDataContainer;
+typedef std::deque<ExampleWithOneRelationObj *>
+    ExampleWithOneRelationObjPointerContainer;
 
 class ExampleWithOneRelationCollectionIterator {
 
-  public:
-    ExampleWithOneRelationCollectionIterator(int index, const ExampleWithOneRelationObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleWithOneRelationCollectionIterator(
+      int index, const ExampleWithOneRelationObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleWithOneRelationCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleWithOneRelationCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleWithOneRelation operator*() const;
-    const ExampleWithOneRelation* operator->() const;
-    const ExampleWithOneRelationCollectionIterator& operator++() const;
+  const ExampleWithOneRelation operator*() const;
+  const ExampleWithOneRelation *operator->() const;
+  const ExampleWithOneRelationCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleWithOneRelation m_object;
-    const ExampleWithOneRelationObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleWithOneRelation m_object;
+  const ExampleWithOneRelationObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +57,25 @@ public:
   typedef const ExampleWithOneRelationCollectionIterator const_iterator;
 
   ExampleWithOneRelationCollection();
-//  ExampleWithOneRelationCollection(const ExampleWithOneRelationCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleWithOneRelationCollection(ExampleWithOneRelationVector* data, int collectionID);
+  //  ExampleWithOneRelationCollection(const ExampleWithOneRelationCollection& )
+  //  = delete; // deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleWithOneRelationCollection(ExampleWithOneRelationVector* data, int
+  //  collectionID);
   ~ExampleWithOneRelationCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleWithOneRelationCollection* operator->() { return (ExampleWithOneRelationCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleWithOneRelationCollection *operator->() {
+    return (ExampleWithOneRelationCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleWithOneRelation create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleWithOneRelation create(Args&&... args);
+  template <typename... Args> ExampleWithOneRelation create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,67 +87,69 @@ public:
   /// Returns the object of given index
   ExampleWithOneRelation at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleWithOneRelation object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleWithOneRelationObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleWithOneRelationObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleWithOneRelationData>* _getBuffer() { return m_data;};
-
-   
+  std::vector<ExampleWithOneRelationData> *_getBuffer() { return m_data; };
 
 private:
   bool m_isValid;
   int m_collectionID;
   ExampleWithOneRelationObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
-  std::vector<::ConstExampleCluster>* m_rel_cluster; ///< Relation buffer for read / write
+  std::vector<::ConstExampleCluster>
+      *m_rel_cluster; ///< Relation buffer for read / write
+
+  // members to handle vector members
 
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleWithOneRelationDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleWithOneRelationDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithOneRelationCollection& v);
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithOneRelationCollection &v);
 
-
-template<typename... Args>
-ExampleWithOneRelation  ExampleWithOneRelationCollection::create(Args&&... args){
+template <typename... Args>
+ExampleWithOneRelation
+ExampleWithOneRelationCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleWithOneRelationObj({size,m_collectionID},{args...});
+  auto obj = new ExampleWithOneRelationObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleWithOneRelation(obj);
 }
-
-
 
 #endif

--- a/tests/datamodel/ExampleWithOneRelationConst.h
+++ b/tests/datamodel/ExampleWithOneRelationConst.h
@@ -1,17 +1,14 @@
 #ifndef ConstExampleWithOneRelation_H
 #define ConstExampleWithOneRelation_H
 #include "ExampleWithOneRelationData.h"
-#include <vector>
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
+// forward declarations
 class ExampleCluster;
 class ConstExampleCluster;
 
-
 #include "ExampleWithOneRelationObj.h"
-
-
 
 class ExampleWithOneRelationObj;
 class ExampleWithOneRelation;
@@ -30,53 +27,51 @@ class ConstExampleWithOneRelation {
   friend ExampleWithOneRelationCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleWithOneRelation();
-  
+
   /// constructor from existing ExampleWithOneRelationObj
-  ConstExampleWithOneRelation(ExampleWithOneRelationObj* obj);
+  ConstExampleWithOneRelation(ExampleWithOneRelationObj *obj);
   /// copy constructor
-  ConstExampleWithOneRelation(const ConstExampleWithOneRelation& other);
+  ConstExampleWithOneRelation(const ConstExampleWithOneRelation &other);
   /// copy-assignment operator
-  ConstExampleWithOneRelation& operator=(const ConstExampleWithOneRelation& other);
+  ConstExampleWithOneRelation &
+  operator=(const ConstExampleWithOneRelation &other);
   /// support cloning (deep-copy)
   ConstExampleWithOneRelation clone() const;
   /// destructor
   ~ConstExampleWithOneRelation();
 
-
 public:
-
   /// Access the  a particular cluster
   const ::ConstExampleCluster cluster() const;
-
-
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithOneRelationObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleWithOneRelation& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleWithOneRelation &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleWithOneRelation& other) const;
+  bool operator==(const ExampleWithOneRelation &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithOneRelation& p1,
-//       const ExampleWithOneRelation& p2 );
-  bool operator<(const ConstExampleWithOneRelation& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithOneRelation& p1,
+  //       const ExampleWithOneRelation& p2 );
+  bool operator<(const ConstExampleWithOneRelation &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithOneRelationObj* m_obj;
-
+  ExampleWithOneRelationObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithOneRelationData.h
+++ b/tests/datamodel/ExampleWithOneRelationData.h
@@ -1,9 +1,6 @@
 #ifndef ExampleWithOneRelationDATA_H
 #define ExampleWithOneRelationDATA_H
 
-
-
-
 /** @class ExampleWithOneRelationData
  *  Type with one relation member
  *  @author: Benedikt Hegner
@@ -11,8 +8,6 @@
 
 class ExampleWithOneRelationData {
 public:
-
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithOneRelationObj.h
+++ b/tests/datamodel/ExampleWithOneRelationObj.h
@@ -6,36 +6,29 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleWithOneRelationData.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class ExampleWithOneRelation;
 class ConstExampleWithOneRelation;
 class ConstExampleCluster;
 
-
-
 class ExampleWithOneRelationObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleWithOneRelationObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleWithOneRelationObj(const ExampleWithOneRelationObj&);
+  ExampleWithOneRelationObj(const ExampleWithOneRelationObj &);
   /// constructor from ObjectID and ExampleWithOneRelationData
   /// does not initialize the internal relation containers
-  ExampleWithOneRelationObj(const podio::ObjectID id, ExampleWithOneRelationData data);
+  ExampleWithOneRelationObj(const podio::ObjectID id,
+                            ExampleWithOneRelationData data);
   virtual ~ExampleWithOneRelationObj();
 
 public:
   ExampleWithOneRelationData data;
-  ConstExampleCluster* m_cluster;
-
-
+  ConstExampleCluster *m_cluster;
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleWithString.h
+++ b/tests/datamodel/ExampleWithString.h
@@ -1,19 +1,16 @@
 #ifndef ExampleWithString_H
 #define ExampleWithString_H
-#include <string>
 #include "ExampleWithStringData.h"
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithStringConst.h"
 #include "ExampleWithStringObj.h"
-
-
 
 class ExampleWithStringCollection;
 class ExampleWithStringCollectionIterator;
@@ -30,65 +27,59 @@ class ExampleWithString {
   friend ConstExampleWithString;
 
 public:
-
   /// default constructor
   ExampleWithString();
   ExampleWithString(std::string theString);
 
   /// constructor from existing ExampleWithStringObj
-  ExampleWithString(ExampleWithStringObj* obj);
+  ExampleWithString(ExampleWithStringObj *obj);
   /// copy constructor
-  ExampleWithString(const ExampleWithString& other);
+  ExampleWithString(const ExampleWithString &other);
   /// copy-assignment operator
-  ExampleWithString& operator=(const ExampleWithString& other);
+  ExampleWithString &operator=(const ExampleWithString &other);
   /// support cloning (deep-copy)
   ExampleWithString clone() const;
   /// destructor
   ~ExampleWithString();
 
   /// conversion to const object
-  operator ConstExampleWithString () const;
+  operator ConstExampleWithString() const;
 
 public:
-
   /// Access the  the string
-  const std::string& theString() const;
+  const std::string &theString() const;
 
   /// Set the  the string
   void theString(std::string value);
 
-
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithStringObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleWithString& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleWithString &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleWithString& other) const;
+  bool operator==(const ConstExampleWithString &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithString& p1,
-//       const ExampleWithString& p2 );
-  bool operator<(const ExampleWithString& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithString& p1,
+  //       const ExampleWithString& p2 );
+  bool operator<(const ExampleWithString &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithStringObj* m_obj;
-
+  ExampleWithStringObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithString& value );
-
-
-
+std::ostream &operator<<(std::ostream &o, const ConstExampleWithString &value);
 
 #endif

--- a/tests/datamodel/ExampleWithStringCollection.h
+++ b/tests/datamodel/ExampleWithStringCollection.h
@@ -1,47 +1,48 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleWithStringCollection_H
-#define  ExampleWithStringCollection_H
+#define ExampleWithStringCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleWithStringData.h"
 #include "ExampleWithString.h"
+#include "ExampleWithStringData.h"
 #include "ExampleWithStringObj.h"
 
-
 typedef std::vector<ExampleWithStringData> ExampleWithStringDataContainer;
-typedef std::deque<ExampleWithStringObj*> ExampleWithStringObjPointerContainer;
+typedef std::deque<ExampleWithStringObj *> ExampleWithStringObjPointerContainer;
 
 class ExampleWithStringCollectionIterator {
 
-  public:
-    ExampleWithStringCollectionIterator(int index, const ExampleWithStringObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleWithStringCollectionIterator(
+      int index, const ExampleWithStringObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleWithStringCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleWithStringCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleWithString operator*() const;
-    const ExampleWithString* operator->() const;
-    const ExampleWithStringCollectionIterator& operator++() const;
+  const ExampleWithString operator*() const;
+  const ExampleWithString *operator->() const;
+  const ExampleWithStringCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleWithString m_object;
-    const ExampleWithStringObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleWithString m_object;
+  const ExampleWithStringObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +55,25 @@ public:
   typedef const ExampleWithStringCollectionIterator const_iterator;
 
   ExampleWithStringCollection();
-//  ExampleWithStringCollection(const ExampleWithStringCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleWithStringCollection(ExampleWithStringVector* data, int collectionID);
+  //  ExampleWithStringCollection(const ExampleWithStringCollection& ) = delete;
+  //  // deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleWithStringCollection(ExampleWithStringVector* data, int
+  //  collectionID);
   ~ExampleWithStringCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleWithStringCollection* operator->() { return (ExampleWithStringCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleWithStringCollection *operator->() {
+    return (ExampleWithStringCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleWithString create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleWithString create(Args&&... args);
+  template <typename... Args> ExampleWithString create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,45 +85,45 @@ public:
   /// Returns the object of given index
   ExampleWithString at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleWithString object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleWithStringObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleWithStringObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleWithStringData>* _getBuffer() { return m_data;};
+  std::vector<ExampleWithStringData> *_getBuffer() { return m_data; };
 
-    template<size_t arraysize>
-  const std::array<std::string,arraysize> theString() const;
-
+  template <size_t arraysize>
+  const std::array<std::string, arraysize> theString() const;
 
 private:
   bool m_isValid;
@@ -127,31 +131,33 @@ private:
   ExampleWithStringObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
 
+  // members to handle vector members
+
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleWithStringDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleWithStringDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithStringCollection& v);
+std::ostream &operator<<(std::ostream &o, const ExampleWithStringCollection &v);
 
-
-template<typename... Args>
-ExampleWithString  ExampleWithStringCollection::create(Args&&... args){
+template <typename... Args>
+ExampleWithString ExampleWithStringCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleWithStringObj({size,m_collectionID},{args...});
+  auto obj = new ExampleWithStringObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleWithString(obj);
 }
 
-template<size_t arraysize>
-const std::array<std::string,arraysize> ExampleWithStringCollection::theString() const {
-  std::array<std::string,arraysize> tmp;
-  auto valid_size = std::min(arraysize,m_entries.size());
-  for (unsigned i = 0; i<valid_size; ++i){
+template <size_t arraysize>
+const std::array<std::string, arraysize>
+ExampleWithStringCollection::theString() const {
+  std::array<std::string, arraysize> tmp;
+  auto valid_size = std::min(arraysize, m_entries.size());
+  for (unsigned i = 0; i < valid_size; ++i) {
     tmp[i] = m_entries[i]->data.theString;
- }
- return tmp;
+  }
+  return tmp;
 }
-
 
 #endif

--- a/tests/datamodel/ExampleWithStringConst.h
+++ b/tests/datamodel/ExampleWithStringConst.h
@@ -1,16 +1,13 @@
 #ifndef ConstExampleWithString_H
 #define ConstExampleWithString_H
-#include <string>
 #include "ExampleWithStringData.h"
-#include <vector>
 #include "podio/ObjectID.h"
+#include <string>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithStringObj.h"
-
-
 
 class ExampleWithStringObj;
 class ExampleWithString;
@@ -29,54 +26,51 @@ class ConstExampleWithString {
   friend ExampleWithStringCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleWithString();
   ConstExampleWithString(std::string theString);
 
   /// constructor from existing ExampleWithStringObj
-  ConstExampleWithString(ExampleWithStringObj* obj);
+  ConstExampleWithString(ExampleWithStringObj *obj);
   /// copy constructor
-  ConstExampleWithString(const ConstExampleWithString& other);
+  ConstExampleWithString(const ConstExampleWithString &other);
   /// copy-assignment operator
-  ConstExampleWithString& operator=(const ConstExampleWithString& other);
+  ConstExampleWithString &operator=(const ConstExampleWithString &other);
   /// support cloning (deep-copy)
   ConstExampleWithString clone() const;
   /// destructor
   ~ConstExampleWithString();
 
-
 public:
-
   /// Access the  the string
-  const std::string& theString() const;
-
-
+  const std::string &theString() const;
 
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithStringObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleWithString& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleWithString &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleWithString& other) const;
+  bool operator==(const ExampleWithString &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithString& p1,
-//       const ExampleWithString& p2 );
-  bool operator<(const ConstExampleWithString& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithString& p1,
+  //       const ExampleWithString& p2 );
+  bool operator<(const ConstExampleWithString &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithStringObj* m_obj;
-
+  ExampleWithStringObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithStringData.h
+++ b/tests/datamodel/ExampleWithStringData.h
@@ -3,7 +3,6 @@
 
 #include <string>
 
-
 /** @class ExampleWithStringData
  *  Type with a string
  *  @author: Benedikt Hegner
@@ -11,8 +10,7 @@
 
 class ExampleWithStringData {
 public:
-  std::string theString;  ///< the string
+  std::string theString; ///< the string
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithStringObj.h
+++ b/tests/datamodel/ExampleWithStringObj.h
@@ -6,23 +6,19 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleWithStringData.h"
-
-
+#include "podio/ObjBase.h"
 
 // forward declarations
 class ExampleWithString;
 class ConstExampleWithString;
-
-
 
 class ExampleWithStringObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleWithStringObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleWithStringObj(const ExampleWithStringObj&);
+  ExampleWithStringObj(const ExampleWithStringObj &);
   /// constructor from ObjectID and ExampleWithStringData
   /// does not initialize the internal relation containers
   ExampleWithStringObj(const podio::ObjectID id, ExampleWithStringData data);
@@ -30,10 +26,6 @@ public:
 
 public:
   ExampleWithStringData data;
-
-
 };
-
-
 
 #endif

--- a/tests/datamodel/ExampleWithVectorMember.h
+++ b/tests/datamodel/ExampleWithVectorMember.h
@@ -1,19 +1,15 @@
 #ifndef ExampleWithVectorMember_H
 #define ExampleWithVectorMember_H
 #include "ExampleWithVectorMemberData.h"
-#include <vector>
-#include <vector>
-#include <iostream>
-#include <iomanip>
 #include "podio/ObjectID.h"
+#include <iomanip>
+#include <iostream>
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithVectorMemberConst.h"
 #include "ExampleWithVectorMemberObj.h"
-
-
 
 class ExampleWithVectorMemberCollection;
 class ExampleWithVectorMemberCollectionIterator;
@@ -30,65 +26,59 @@ class ExampleWithVectorMember {
   friend ConstExampleWithVectorMember;
 
 public:
-
   /// default constructor
   ExampleWithVectorMember();
 
   /// constructor from existing ExampleWithVectorMemberObj
-  ExampleWithVectorMember(ExampleWithVectorMemberObj* obj);
+  ExampleWithVectorMember(ExampleWithVectorMemberObj *obj);
   /// copy constructor
-  ExampleWithVectorMember(const ExampleWithVectorMember& other);
+  ExampleWithVectorMember(const ExampleWithVectorMember &other);
   /// copy-assignment operator
-  ExampleWithVectorMember& operator=(const ExampleWithVectorMember& other);
+  ExampleWithVectorMember &operator=(const ExampleWithVectorMember &other);
   /// support cloning (deep-copy)
   ExampleWithVectorMember clone() const;
   /// destructor
   ~ExampleWithVectorMember();
 
   /// conversion to const object
-  operator ConstExampleWithVectorMember () const;
+  operator ConstExampleWithVectorMember() const;
 
 public:
-
-
-
   void addcount(int);
   unsigned int count_size() const;
   int count(unsigned int) const;
   std::vector<int>::const_iterator count_begin() const;
   std::vector<int>::const_iterator count_end() const;
 
-
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithVectorMemberObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ExampleWithVectorMember& other) const {
-    return (m_obj==other.m_obj);
+  bool operator==(const ExampleWithVectorMember &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ConstExampleWithVectorMember& other) const;
+  bool operator==(const ConstExampleWithVectorMember &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithVectorMember& p1,
-//       const ExampleWithVectorMember& p2 );
-  bool operator<(const ExampleWithVectorMember& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithVectorMember& p1,
+  //       const ExampleWithVectorMember& p2 );
+  bool operator<(const ExampleWithVectorMember &other) const {
+    return m_obj < other.m_obj;
+  }
 
-
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithVectorMemberObj* m_obj;
-
+  ExampleWithVectorMemberObj *m_obj;
 };
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithVectorMember& value );
-
-
-
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithVectorMember &value);
 
 #endif

--- a/tests/datamodel/ExampleWithVectorMemberCollection.h
+++ b/tests/datamodel/ExampleWithVectorMemberCollection.h
@@ -91,6 +91,7 @@ public:
   bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
 
   podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
+  podio::VectorMembersInfo* vectorMembers() override {return &m_vecmem_info ; }
 
   void setID(unsigned ID) override {
     m_collectionID = ID;
@@ -128,6 +129,9 @@ private:
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
   ExampleWithVectorMemberDataContainer* m_data;
+  podio::VectorMembersInfo m_vecmem_info ;
+  std::vector<int>* m_vec_count;
+  std::vector<std::vector<int>*> m_vecs_count;
 };
 
 std::ostream& operator<<( std::ostream& o,const ExampleWithVectorMemberCollection& v);

--- a/tests/datamodel/ExampleWithVectorMemberCollection.h
+++ b/tests/datamodel/ExampleWithVectorMemberCollection.h
@@ -1,47 +1,50 @@
-//AUTOMATICALLY GENERATED - DO NOT EDIT
+// AUTOMATICALLY GENERATED - DO NOT EDIT
 
 #ifndef ExampleWithVectorMemberCollection_H
-#define  ExampleWithVectorMemberCollection_H
+#define ExampleWithVectorMemberCollection_H
 
+#include <algorithm>
+#include <array>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <deque>
-#include <array>
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
 
 // podio specific includes
-#include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/ICollectionProvider.h"
 
 // datamodel specific includes
-#include "ExampleWithVectorMemberData.h"
 #include "ExampleWithVectorMember.h"
+#include "ExampleWithVectorMemberData.h"
 #include "ExampleWithVectorMemberObj.h"
 
-
-typedef std::vector<ExampleWithVectorMemberData> ExampleWithVectorMemberDataContainer;
-typedef std::deque<ExampleWithVectorMemberObj*> ExampleWithVectorMemberObjPointerContainer;
+typedef std::vector<ExampleWithVectorMemberData>
+    ExampleWithVectorMemberDataContainer;
+typedef std::deque<ExampleWithVectorMemberObj *>
+    ExampleWithVectorMemberObjPointerContainer;
 
 class ExampleWithVectorMemberCollectionIterator {
 
-  public:
-    ExampleWithVectorMemberCollectionIterator(int index, const ExampleWithVectorMemberObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+public:
+  ExampleWithVectorMemberCollectionIterator(
+      int index, const ExampleWithVectorMemberObjPointerContainer *collection)
+      : m_index(index), m_object(nullptr), m_collection(collection) {}
 
-    bool operator!=(const ExampleWithVectorMemberCollectionIterator& x) const {
-      return m_index != x.m_index; //TODO: may not be complete
-    }
+  bool operator!=(const ExampleWithVectorMemberCollectionIterator &x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
 
-    const ExampleWithVectorMember operator*() const;
-    const ExampleWithVectorMember* operator->() const;
-    const ExampleWithVectorMemberCollectionIterator& operator++() const;
+  const ExampleWithVectorMember operator*() const;
+  const ExampleWithVectorMember *operator->() const;
+  const ExampleWithVectorMemberCollectionIterator &operator++() const;
 
-  private:
-    mutable int m_index;
-    mutable ExampleWithVectorMember m_object;
-    const ExampleWithVectorMemberObjPointerContainer* m_collection;
+private:
+  mutable int m_index;
+  mutable ExampleWithVectorMember m_object;
+  const ExampleWithVectorMemberObjPointerContainer *m_collection;
 };
 
 /**
@@ -54,22 +57,25 @@ public:
   typedef const ExampleWithVectorMemberCollectionIterator const_iterator;
 
   ExampleWithVectorMemberCollection();
-//  ExampleWithVectorMemberCollection(const ExampleWithVectorMemberCollection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
-//  ExampleWithVectorMemberCollection(ExampleWithVectorMemberVector* data, int collectionID);
+  //  ExampleWithVectorMemberCollection(const ExampleWithVectorMemberCollection&
+  //  ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
+  //  ExampleWithVectorMemberCollection(ExampleWithVectorMemberVector* data, int
+  //  collectionID);
   ~ExampleWithVectorMemberCollection();
 
-  void clear() override;
+  void clear() override final;
 
-  /// operator to allow pointer like calling of members a la LCIO  \n     
-  ExampleWithVectorMemberCollection* operator->() { return (ExampleWithVectorMemberCollection*) this ; }
+  /// operator to allow pointer like calling of members a la LCIO  \n
+  ExampleWithVectorMemberCollection *operator->() {
+    return (ExampleWithVectorMemberCollection *)this;
+  }
 
   /// Append a new object to the collection, and return this object.
   ExampleWithVectorMember create();
 
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
-  template<typename... Args>
-  ExampleWithVectorMember create(Args&&... args);
+  template <typename... Args> ExampleWithVectorMember create(Args &&... args);
   int size() const;
 
   /// Returns the const object of given index
@@ -81,44 +87,42 @@ public:
   /// Returns the object of given index
   ExampleWithVectorMember at(unsigned int index);
 
-
   /// Append object to the collection
   void push_back(ConstExampleWithVectorMember object);
 
-  void prepareForWrite() override;
-  void prepareAfterRead() override;
-  void setBuffer(void* address) override;
-  bool setReferences(const podio::ICollectionProvider* collectionProvider) override;
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void *address) override final;
+  bool setReferences(
+      const podio::ICollectionProvider *collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override { return &m_refCollections;};
-  podio::VectorMembersInfo* vectorMembers() override {return &m_vecmem_info ; }
-
-  void setID(unsigned ID) override {
-    m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
-                 [ID](ExampleWithVectorMemberObj* obj){obj->id = {obj->id.index,static_cast<int>(ID)}; }
-    );
+  podio::CollRefCollection *referenceCollections() override final {
+    return &m_refCollections;
   };
 
-  bool isValid() const override {
-    return m_isValid;
-  }
+  podio::VectorMembersInfo *vectorMembers() override { return &m_vecmem_info; }
+
+  void setID(unsigned ID) override final {
+    m_collectionID = ID;
+    std::for_each(m_entries.begin(), m_entries.end(),
+                  [ID](ExampleWithVectorMemberObj *obj) {
+                    obj->id = {obj->id.index, static_cast<int>(ID)};
+                  });
+  };
+
+  bool isValid() const override final { return m_isValid; }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
-    return const_iterator(0, &m_entries);
-  }
+  const const_iterator begin() const { return const_iterator(0, &m_entries); }
   const const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 
   /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override { return (void*)&m_data;};
+  void *getBufferAddress() override final { return (void *)&m_data; };
 
   /// returns the pointer to the data buffer
-  std::vector<ExampleWithVectorMemberData>* _getBuffer() { return m_data;};
-
-   
+  std::vector<ExampleWithVectorMemberData> *_getBuffer() { return m_data; };
 
 private:
   bool m_isValid;
@@ -126,25 +130,28 @@ private:
   ExampleWithVectorMemberObjPointerContainer m_entries;
   // members to handle 1-to-N-relations
 
+  // members to handle vector members
+  std::vector<int>
+      *m_vec_count; /// combined vector of all objects in collection
+  std::vector<std::vector<int> *>
+      m_vecs_count; /// pointers to individual member vectors
+
   // members to handle streaming
   podio::CollRefCollection m_refCollections;
-  ExampleWithVectorMemberDataContainer* m_data;
-  podio::VectorMembersInfo m_vecmem_info ;
-  std::vector<int>* m_vec_count;
-  std::vector<std::vector<int>*> m_vecs_count;
+  podio::VectorMembersInfo m_vecmem_info;
+  ExampleWithVectorMemberDataContainer *m_data;
 };
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithVectorMemberCollection& v);
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithVectorMemberCollection &v);
 
-
-template<typename... Args>
-ExampleWithVectorMember  ExampleWithVectorMemberCollection::create(Args&&... args){
+template <typename... Args>
+ExampleWithVectorMember
+ExampleWithVectorMemberCollection::create(Args &&... args) {
   int size = m_entries.size();
-  auto obj = new ExampleWithVectorMemberObj({size,m_collectionID},{args...});
+  auto obj = new ExampleWithVectorMemberObj({size, m_collectionID}, {args...});
   m_entries.push_back(obj);
   return ExampleWithVectorMember(obj);
 }
-
-
 
 #endif

--- a/tests/datamodel/ExampleWithVectorMemberConst.h
+++ b/tests/datamodel/ExampleWithVectorMemberConst.h
@@ -1,16 +1,12 @@
 #ifndef ConstExampleWithVectorMember_H
 #define ConstExampleWithVectorMember_H
 #include "ExampleWithVectorMemberData.h"
-#include <vector>
-#include <vector>
 #include "podio/ObjectID.h"
+#include <vector>
 
-//forward declarations
-
+// forward declarations
 
 #include "ExampleWithVectorMemberObj.h"
-
-
 
 class ExampleWithVectorMemberObj;
 class ExampleWithVectorMember;
@@ -29,55 +25,53 @@ class ConstExampleWithVectorMember {
   friend ExampleWithVectorMemberCollectionIterator;
 
 public:
-
   /// default constructor
   ConstExampleWithVectorMember();
-  
+
   /// constructor from existing ExampleWithVectorMemberObj
-  ConstExampleWithVectorMember(ExampleWithVectorMemberObj* obj);
+  ConstExampleWithVectorMember(ExampleWithVectorMemberObj *obj);
   /// copy constructor
-  ConstExampleWithVectorMember(const ConstExampleWithVectorMember& other);
+  ConstExampleWithVectorMember(const ConstExampleWithVectorMember &other);
   /// copy-assignment operator
-  ConstExampleWithVectorMember& operator=(const ConstExampleWithVectorMember& other);
+  ConstExampleWithVectorMember &
+  operator=(const ConstExampleWithVectorMember &other);
   /// support cloning (deep-copy)
   ConstExampleWithVectorMember clone() const;
   /// destructor
   ~ConstExampleWithVectorMember();
 
-
 public:
-
-
   unsigned int count_size() const;
   int count(unsigned int) const;
   std::vector<int>::const_iterator count_begin() const;
   std::vector<int>::const_iterator count_end() const;
 
-
   /// check whether the object is actually available
   bool isAvailable() const;
   /// disconnect from ExampleWithVectorMemberObj instance
-  void unlink(){m_obj = nullptr;}
+  void unlink() { m_obj = nullptr; }
 
-  bool operator==(const ConstExampleWithVectorMember& other) const {
-       return (m_obj==other.m_obj);
+  bool operator==(const ConstExampleWithVectorMember &other) const {
+    return (m_obj == other.m_obj);
   }
 
-  bool operator==(const ExampleWithVectorMember& other) const;
+  bool operator==(const ExampleWithVectorMember &other) const;
 
-// less comparison operator, so that objects can be e.g. stored in sets.
-//  friend bool operator< (const ExampleWithVectorMember& p1,
-//       const ExampleWithVectorMember& p2 );
-  bool operator<(const ConstExampleWithVectorMember& other) const { return m_obj < other.m_obj  ; }
+  // less comparison operator, so that objects can be e.g. stored in sets.
+  //  friend bool operator< (const ExampleWithVectorMember& p1,
+  //       const ExampleWithVectorMember& p2 );
+  bool operator<(const ConstExampleWithVectorMember &other) const {
+    return m_obj < other.m_obj;
+  }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index  ;  } 
+  unsigned int id() const {
+    return getObjectID().collectionID * 10000000 + getObjectID().index;
+  }
 
   const podio::ObjectID getObjectID() const;
 
 private:
-  ExampleWithVectorMemberObj* m_obj;
-
+  ExampleWithVectorMemberObj *m_obj;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithVectorMemberData.h
+++ b/tests/datamodel/ExampleWithVectorMemberData.h
@@ -11,8 +11,8 @@
 
 class ExampleWithVectorMemberData {
 public:
-  unsigned int count_begin;
-  unsigned int count_end;
+  unsigned int count_begin{};
+  unsigned int count_end{};
 };
 
 

--- a/tests/datamodel/ExampleWithVectorMemberData.h
+++ b/tests/datamodel/ExampleWithVectorMemberData.h
@@ -1,9 +1,6 @@
 #ifndef ExampleWithVectorMemberDATA_H
 #define ExampleWithVectorMemberDATA_H
 
-
-
-
 /** @class ExampleWithVectorMemberData
  *  Type with a vector member
  *  @author: B. Hegner
@@ -11,9 +8,8 @@
 
 class ExampleWithVectorMemberData {
 public:
-  unsigned int count_begin{};
-  unsigned int count_end{};
+  unsigned int count_begin;
+  unsigned int count_end;
 };
-
 
 #endif

--- a/tests/datamodel/ExampleWithVectorMemberObj.h
+++ b/tests/datamodel/ExampleWithVectorMemberObj.h
@@ -6,36 +6,30 @@
 #include <iostream>
 
 // data model specific includes
-#include "podio/ObjBase.h"
 #include "ExampleWithVectorMemberData.h"
+#include "podio/ObjBase.h"
 
 #include <vector>
-
 
 // forward declarations
 class ExampleWithVectorMember;
 class ConstExampleWithVectorMember;
-
-
 
 class ExampleWithVectorMemberObj : public podio::ObjBase {
 public:
   /// constructor
   ExampleWithVectorMemberObj();
   /// copy constructor (does a deep-copy of relation containers)
-  ExampleWithVectorMemberObj(const ExampleWithVectorMemberObj&);
+  ExampleWithVectorMemberObj(const ExampleWithVectorMemberObj &);
   /// constructor from ObjectID and ExampleWithVectorMemberData
   /// does not initialize the internal relation containers
-  ExampleWithVectorMemberObj(const podio::ObjectID id, ExampleWithVectorMemberData data);
+  ExampleWithVectorMemberObj(const podio::ObjectID id,
+                             ExampleWithVectorMemberData data);
   virtual ~ExampleWithVectorMemberObj();
 
 public:
   ExampleWithVectorMemberData data;
-  std::vector<int>* m_count;
-
-
+  std::vector<int> *m_count;
 };
-
-
 
 #endif

--- a/tests/datamodel/NamespaceInNamespaceStruct.h
+++ b/tests/datamodel/NamespaceInNamespaceStruct.h
@@ -2,22 +2,19 @@
 #define NamespaceInNamespaceStruct_H
 #include "NamespaceStruct.h"
 
-
 #include <iostream>
 
 namespace ex2 {
 class NamespaceInNamespaceStruct {
 public:
- ::ex2::NamespaceStruct data;
-
-
+  ::ex2::NamespaceStruct data;
 };
 
-inline std::ostream& operator<<( std::ostream& o,const ex2::NamespaceInNamespaceStruct& value ){ 
-  o << value.data << " " ;
-  return o ;
+inline std::ostream &operator<<(std::ostream &o,
+                                const ex2::NamespaceInNamespaceStruct &value) {
+  o << value.data << " ";
+  return o;
 }
-
 
 } // namespace ex2
 

--- a/tests/datamodel/NamespaceStruct.h
+++ b/tests/datamodel/NamespaceStruct.h
@@ -1,7 +1,6 @@
 #ifndef NamespaceStruct_H
 #define NamespaceStruct_H
 
-
 #include <iostream>
 
 namespace ex2 {
@@ -9,16 +8,14 @@ class NamespaceStruct {
 public:
   int x;
   int y;
-
-
 };
 
-inline std::ostream& operator<<( std::ostream& o,const ex2::NamespaceStruct& value ){ 
-  o << value.x << " " ;
-  o << value.y << " " ;
-  return o ;
+inline std::ostream &operator<<(std::ostream &o,
+                                const ex2::NamespaceStruct &value) {
+  o << value.x << " ";
+  o << value.y << " ";
+  return o;
 }
-
 
 } // namespace ex2
 

--- a/tests/datamodel/NotSoSimpleStruct.h
+++ b/tests/datamodel/NotSoSimpleStruct.h
@@ -2,23 +2,17 @@
 #define NotSoSimpleStruct_H
 #include "SimpleStruct.h"
 
-
 #include <iostream>
-
 
 class NotSoSimpleStruct {
 public:
   SimpleStruct data;
-
-
 };
 
-inline std::ostream& operator<<( std::ostream& o,const NotSoSimpleStruct& value ){ 
-  o << value.data << " " ;
-  return o ;
+inline std::ostream &operator<<(std::ostream &o,
+                                const NotSoSimpleStruct &value) {
+  o << value.data << " ";
+  return o;
 }
-
-
-
 
 #endif

--- a/tests/datamodel/SimpleStruct.h
+++ b/tests/datamodel/SimpleStruct.h
@@ -2,28 +2,24 @@
 #define SimpleStruct_H
 #include <array>
 
-
 #include <iostream>
-
 
 class SimpleStruct {
 public:
- ::std::array<int, 4> p;
+  ::std::array<int, 4> p;
   int x;
   int y;
   int z;
 
- SimpleStruct() : x(0),y(0),z(0) {} SimpleStruct( const int* v) : x(v[0]),y(v[1]),z(v[2]) {} 
+  SimpleStruct() : x(0), y(0), z(0) {}
+  SimpleStruct(const int *v) : x(v[0]), y(v[1]), z(v[2]) {}
 };
 
-inline std::ostream& operator<<( std::ostream& o,const SimpleStruct& value ){ 
-  o << value.x << " " ;
-  o << value.y << " " ;
-  o << value.z << " " ;
-  return o ;
+inline std::ostream &operator<<(std::ostream &o, const SimpleStruct &value) {
+  o << value.x << " ";
+  o << value.y << " ";
+  o << value.z << " ";
+  return o;
 }
-
-
-
 
 #endif

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -128,11 +128,11 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
 //  std::cout << "Fetching collection 'WithVectorMember'" << std::endl;
   auto& vecs = store.get<ExampleWithVectorMemberCollection>("WithVectorMember");
   if(vecs.isValid()) {
-    auto item = vecs[0];
     std::cout << vecs.size() << std::endl;
-    for (auto c = item.count_begin(), end = item.count_end(); c!=end; ++c){
-      std::cout << "  Counter value " << (*c) << std::endl;
-      glob++;
+    for( auto item : vecs )
+      for (auto c = item.count_begin(), end = item.count_end(); c!=end; ++c){
+	std::cout << "  Counter value " << (*c) << std::endl;
+	glob++;
     }
   } else {
     throw std::runtime_error("Collection 'WithVectorMember' should be present");

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -128,12 +128,12 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
 //  std::cout << "Fetching collection 'WithVectorMember'" << std::endl;
   auto& vecs = store.get<ExampleWithVectorMemberCollection>("WithVectorMember");
   if(vecs.isValid()) {
-//    auto item = (*vecs)[0];
-//    std::cout << (*vecs).size() << std::endl;
-//    for (auto c = item.count_begin(), end = item.count_end(); c!=end; ++c){
-//      std::cout << "  Counter value " << (*c) << std::endl;
-//      glob++;
-//    }
+    auto item = vecs[0];
+    std::cout << vecs.size() << std::endl;
+    for (auto c = item.count_begin(), end = item.count_end(); c!=end; ++c){
+      std::cout << "  Counter value " << (*c) << std::endl;
+      glob++;
+    }
   } else {
     throw std::runtime_error("Collection 'WithVectorMember' should be present");
   }

--- a/tests/src/EventInfo.cc
+++ b/tests/src/EventInfo.cc
@@ -1,57 +1,49 @@
 // datamodel specific includes
 #include "EventInfo.h"
-#include "EventInfoConst.h"
-#include "EventInfoObj.h"
-#include "EventInfoData.h"
 #include "EventInfoCollection.h"
+#include "EventInfoConst.h"
+#include "EventInfoData.h"
+#include "EventInfoObj.h"
 #include <iostream>
 
-
-
-
-EventInfo::EventInfo() : m_obj(new EventInfoObj()){
- m_obj->acquire();
-}
+EventInfo::EventInfo() : m_obj(new EventInfoObj()) { m_obj->acquire(); }
 
 EventInfo::EventInfo(int Number) : m_obj(new EventInfoObj()) {
   m_obj->acquire();
-    m_obj->data.Number = Number;
+  m_obj->data.Number = Number;
 }
 
-
-EventInfo::EventInfo(const EventInfo& other) : m_obj(other.m_obj) {
+EventInfo::EventInfo(const EventInfo &other) : m_obj(other.m_obj) {
   m_obj->acquire();
 }
 
-EventInfo& EventInfo::operator=(const EventInfo& other) {
-  if ( m_obj != nullptr) m_obj->release();
+EventInfo &EventInfo::operator=(const EventInfo &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-EventInfo::EventInfo(EventInfoObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+EventInfo::EventInfo(EventInfoObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
-EventInfo EventInfo::clone() const {
-  return {new EventInfoObj(*m_obj)};
+EventInfo EventInfo::clone() const { return {new EventInfoObj(*m_obj)}; }
+
+EventInfo::~EventInfo() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-EventInfo::~EventInfo(){
-  if ( m_obj != nullptr) m_obj->release();
-}
+EventInfo::operator ConstEventInfo() const { return ConstEventInfo(m_obj); }
 
-EventInfo::operator ConstEventInfo() const {return ConstEventInfo(m_obj);}
-
-  const int& EventInfo::Number() const { return m_obj->data.Number; }
+const int &EventInfo::Number() const { return m_obj->data.Number; }
 
 void EventInfo::Number(int value) { m_obj->data.Number = value; }
 
-
-
-int EventInfo::getNumber() const { return Number(); } 
-bool  EventInfo::isAvailable() const {
+int EventInfo::getNumber() const { return Number(); }
+bool EventInfo::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -59,29 +51,26 @@ bool  EventInfo::isAvailable() const {
 }
 
 const podio::ObjectID EventInfo::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool EventInfo::operator==(const ConstEventInfo& other) const {
-  return (m_obj==other.m_obj);
+bool EventInfo::operator==(const ConstEventInfo &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstEventInfo& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " Number : " << value.Number() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o, const ConstEventInfo &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " Number : " << value.Number() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const EventInfo& p1, const EventInfo& p2 ) {
+// bool operator< (const EventInfo& p1, const EventInfo& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/EventInfoCollection.cc
+++ b/tests/src/EventInfoCollection.cc
@@ -1,19 +1,16 @@
 // standard includes
 #include <stdexcept>
 
-
 #include "EventInfoCollection.h"
 
-
-
-EventInfoCollection::EventInfoCollection() : m_isValid(false), m_collectionID(0), m_entries() ,m_data(new EventInfoDataContainer() ) {
-  
-}
+EventInfoCollection::EventInfoCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_data(new EventInfoDataContainer()) {}
 
 EventInfoCollection::~EventInfoCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-  
+  if (m_data != nullptr)
+    delete m_data;
 }
 
 const EventInfo EventInfoCollection::operator[](unsigned int index) const {
@@ -32,96 +29,98 @@ EventInfo EventInfoCollection::at(unsigned int index) {
   return EventInfo(m_entries.at(index));
 }
 
-int  EventInfoCollection::size() const {
-  return m_entries.size();
-}
+int EventInfoCollection::size() const { return m_entries.size(); }
 
-EventInfo EventInfoCollection::create(){
+EventInfo EventInfoCollection::create() {
   auto obj = new EventInfoObj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return EventInfo(obj);
 }
 
-void EventInfoCollection::clear(){
+void EventInfoCollection::clear() {
   m_data->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void EventInfoCollection::prepareForWrite(){
+void EventInfoCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
+  }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
   }
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
 }
 
-void EventInfoCollection::prepareAfterRead(){
+void EventInfoCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new EventInfoObj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj = new EventInfoObj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool EventInfoCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool EventInfoCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void EventInfoCollection::push_back(ConstEventInfo object){
+void EventInfoCollection::push_back(ConstEventInfo object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void EventInfoCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<EventInfoDataContainer*>(address);
+void EventInfoCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<EventInfoDataContainer *>(address);
 }
 
-
-const EventInfo EventInfoCollectionIterator::operator* () const {
+const EventInfo EventInfoCollectionIterator::operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const EventInfo* EventInfoCollectionIterator::operator-> () const {
+const EventInfo *EventInfoCollectionIterator::operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const EventInfoCollectionIterator& EventInfoCollectionIterator::operator++() const {
+const EventInfoCollectionIterator &EventInfoCollectionIterator::
+operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const EventInfoCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          Number:       " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].Number() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o, const EventInfoCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          Number:       " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].Number() << " " << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/EventInfoConst.cc
+++ b/tests/src/EventInfoConst.cc
@@ -1,36 +1,34 @@
 // datamodel specific includes
-#include "EventInfo.h"
 #include "EventInfoConst.h"
-#include "EventInfoObj.h"
-#include "EventInfoData.h"
+#include "EventInfo.h"
 #include "EventInfoCollection.h"
+#include "EventInfoData.h"
+#include "EventInfoObj.h"
 #include <iostream>
 
-
-
-
 ConstEventInfo::ConstEventInfo() : m_obj(new EventInfoObj()) {
- m_obj->acquire();
-}
-
-ConstEventInfo::ConstEventInfo(int Number) : m_obj(new EventInfoObj()){
- m_obj->acquire();
-   m_obj->data.Number = Number;
-}
-
-
-ConstEventInfo::ConstEventInfo(const ConstEventInfo& other) : m_obj(other.m_obj) {
   m_obj->acquire();
 }
 
-ConstEventInfo& ConstEventInfo::operator=(const ConstEventInfo& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstEventInfo::ConstEventInfo(int Number) : m_obj(new EventInfoObj()) {
+  m_obj->acquire();
+  m_obj->data.Number = Number;
+}
+
+ConstEventInfo::ConstEventInfo(const ConstEventInfo &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstEventInfo &ConstEventInfo::operator=(const ConstEventInfo &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstEventInfo::ConstEventInfo(EventInfoObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstEventInfo::ConstEventInfo(EventInfoObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,16 +36,16 @@ ConstEventInfo ConstEventInfo::clone() const {
   return {new EventInfoObj(*m_obj)};
 }
 
-ConstEventInfo::~ConstEventInfo(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstEventInfo::~ConstEventInfo() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  event number
-  const int& ConstEventInfo::Number() const { return m_obj->data.Number; }
+/// Access the  event number
+const int &ConstEventInfo::Number() const { return m_obj->data.Number; }
 
-
-int ConstEventInfo::getNumber() const { return Number(); } 
-bool  ConstEventInfo::isAvailable() const {
+int ConstEventInfo::getNumber() const { return Number(); }
+bool ConstEventInfo::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -55,22 +53,20 @@ bool  ConstEventInfo::isAvailable() const {
 }
 
 const podio::ObjectID ConstEventInfo::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstEventInfo::operator==(const EventInfo& other) const {
-     return (m_obj==other.m_obj);
+bool ConstEventInfo::operator==(const EventInfo &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const EventInfo& p1, const EventInfo& p2 ) {
+// bool operator< (const EventInfo& p1, const EventInfo& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/EventInfoObj.cc
+++ b/tests/src/EventInfoObj.cc
@@ -1,26 +1,17 @@
 #include "EventInfoObj.h"
 
+EventInfoObj::EventInfoObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data() {}
 
+EventInfoObj::EventInfoObj(const podio::ObjectID id, EventInfoData data)
+    : ObjBase{id, 0}, data(data) {}
 
-EventInfoObj::EventInfoObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data()
-{ }
-
-EventInfoObj::EventInfoObj(const podio::ObjectID id, EventInfoData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-EventInfoObj::EventInfoObj(const EventInfoObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
-{
-
-}
+EventInfoObj::EventInfoObj(const EventInfoObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data) {}
 
 EventInfoObj::~EventInfoObj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-
 }
-

--- a/tests/src/ExampleCluster.cc
+++ b/tests/src/ExampleCluster.cc
@@ -1,36 +1,34 @@
 // datamodel specific includes
 #include "ExampleCluster.h"
-#include "ExampleClusterConst.h"
-#include "ExampleClusterObj.h"
-#include "ExampleClusterData.h"
 #include "ExampleClusterCollection.h"
+#include "ExampleClusterConst.h"
+#include "ExampleClusterData.h"
+#include "ExampleClusterObj.h"
 #include <iostream>
 
-
-
-
-ExampleCluster::ExampleCluster() : m_obj(new ExampleClusterObj()){
- m_obj->acquire();
+ExampleCluster::ExampleCluster() : m_obj(new ExampleClusterObj()) {
+  m_obj->acquire();
 }
 
 ExampleCluster::ExampleCluster(double energy) : m_obj(new ExampleClusterObj()) {
   m_obj->acquire();
-    m_obj->data.energy = energy;
+  m_obj->data.energy = energy;
 }
 
-
-ExampleCluster::ExampleCluster(const ExampleCluster& other) : m_obj(other.m_obj) {
+ExampleCluster::ExampleCluster(const ExampleCluster &other)
+    : m_obj(other.m_obj) {
   m_obj->acquire();
 }
 
-ExampleCluster& ExampleCluster::operator=(const ExampleCluster& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleCluster &ExampleCluster::operator=(const ExampleCluster &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleCluster::ExampleCluster(ExampleClusterObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleCluster::ExampleCluster(ExampleClusterObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,23 +36,28 @@ ExampleCluster ExampleCluster::clone() const {
   return {new ExampleClusterObj(*m_obj)};
 }
 
-ExampleCluster::~ExampleCluster(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleCluster::~ExampleCluster() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleCluster::operator ConstExampleCluster() const {return ConstExampleCluster(m_obj);}
+ExampleCluster::operator ConstExampleCluster() const {
+  return ConstExampleCluster(m_obj);
+}
 
-  const double& ExampleCluster::energy() const { return m_obj->data.energy; }
+const double &ExampleCluster::energy() const { return m_obj->data.energy; }
 
 void ExampleCluster::energy(double value) { m_obj->data.energy = value; }
 
-std::vector<::ConstExampleHit>::const_iterator ExampleCluster::Hits_begin() const {
+std::vector<::ConstExampleHit>::const_iterator
+ExampleCluster::Hits_begin() const {
   auto ret_value = m_obj->m_Hits->begin();
   std::advance(ret_value, m_obj->data.Hits_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleHit>::const_iterator ExampleCluster::Hits_end() const {
+std::vector<::ConstExampleHit>::const_iterator
+ExampleCluster::Hits_end() const {
   auto ret_value = m_obj->m_Hits->begin();
   std::advance(ret_value, m_obj->data.Hits_end);
   return ret_value;
@@ -66,22 +69,24 @@ void ExampleCluster::addHits(::ConstExampleHit component) {
 }
 
 unsigned int ExampleCluster::Hits_size() const {
-  return (m_obj->data.Hits_end-m_obj->data.Hits_begin);
+  return (m_obj->data.Hits_end - m_obj->data.Hits_begin);
 }
 
 ::ConstExampleHit ExampleCluster::Hits(unsigned int index) const {
   if (Hits_size() > index) {
-    return m_obj->m_Hits->at(m_obj->data.Hits_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_Hits->at(m_obj->data.Hits_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
-std::vector<::ConstExampleCluster>::const_iterator ExampleCluster::Clusters_begin() const {
+std::vector<::ConstExampleCluster>::const_iterator
+ExampleCluster::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleCluster>::const_iterator ExampleCluster::Clusters_end() const {
+std::vector<::ConstExampleCluster>::const_iterator
+ExampleCluster::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_end);
   return ret_value;
@@ -93,18 +98,17 @@ void ExampleCluster::addClusters(::ConstExampleCluster component) {
 }
 
 unsigned int ExampleCluster::Clusters_size() const {
-  return (m_obj->data.Clusters_end-m_obj->data.Clusters_begin);
+  return (m_obj->data.Clusters_end - m_obj->data.Clusters_begin);
 }
 
 ::ConstExampleCluster ExampleCluster::Clusters(unsigned int index) const {
   if (Clusters_size() > index) {
-    return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_Clusters->at(m_obj->data.Clusters_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ExampleCluster::isAvailable() const {
+bool ExampleCluster::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -112,37 +116,34 @@ bool  ExampleCluster::isAvailable() const {
 }
 
 const podio::ObjectID ExampleCluster::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleCluster::operator==(const ConstExampleCluster& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleCluster::operator==(const ConstExampleCluster &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleCluster& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " energy : " << value.energy() << std::endl ;
-  o << " Hits : " ;
-  for(unsigned i=0,N=value.Hits_size(); i<N ; ++i)
-    o << value.Hits(i) << " " ; 
-  o << std::endl ;
-  o << " Clusters : " ;
-  for(unsigned i=0,N=value.Clusters_size(); i<N ; ++i)
-    o << value.Clusters(i) << " " ; 
-  o << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o, const ConstExampleCluster &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " energy : " << value.energy() << std::endl;
+  o << " Hits : ";
+  for (unsigned i = 0, N = value.Hits_size(); i < N; ++i)
+    o << value.Hits(i) << " ";
+  o << std::endl;
+  o << " Clusters : ";
+  for (unsigned i = 0, N = value.Clusters_size(); i < N; ++i)
+    o << value.Clusters(i) << " ";
+  o << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleCluster& p1, const ExampleCluster& p2 ) {
+// bool operator< (const ExampleCluster& p1, const ExampleCluster& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleClusterCollection.cc
+++ b/tests/src/ExampleClusterCollection.cc
@@ -1,29 +1,37 @@
 // standard includes
+#include "ExampleClusterCollection.h"
+#include "ExampleHitCollection.h"
 #include <stdexcept>
-#include "ExampleHitCollection.h" 
-#include "ExampleClusterCollection.h" 
-
 
 #include "ExampleClusterCollection.h"
 
-
-
-ExampleClusterCollection::ExampleClusterCollection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_Hits(new std::vector<::ConstExampleHit>()), m_rel_Clusters(new std::vector<::ConstExampleCluster>()),m_data(new ExampleClusterDataContainer() ) {
-    m_refCollections.push_back(new std::vector<podio::ObjectID>());
+ExampleClusterCollection::ExampleClusterCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_rel_Hits(new std::vector<::ConstExampleHit>()),
+      m_rel_Clusters(new std::vector<::ConstExampleCluster>()),
+      m_data(new ExampleClusterDataContainer()) {
   m_refCollections.push_back(new std::vector<podio::ObjectID>());
-
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
 }
 
 ExampleClusterCollection::~ExampleClusterCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-    for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
-  if (m_rel_Hits != nullptr) { delete m_rel_Hits; }
-  if (m_rel_Clusters != nullptr) { delete m_rel_Clusters; }
-
+  if (m_data != nullptr)
+    delete m_data;
+  for (auto &pointer : m_refCollections) {
+    if (pointer != nullptr)
+      delete pointer;
+  }
+  if (m_rel_Hits != nullptr) {
+    delete m_rel_Hits;
+  }
+  if (m_rel_Clusters != nullptr) {
+    delete m_rel_Clusters;
+  }
 }
 
-const ExampleCluster ExampleClusterCollection::operator[](unsigned int index) const {
+const ExampleCluster ExampleClusterCollection::
+operator[](unsigned int index) const {
   return ExampleCluster(m_entries[index]);
 }
 
@@ -39,110 +47,124 @@ ExampleCluster ExampleClusterCollection::at(unsigned int index) {
   return ExampleCluster(m_entries.at(index));
 }
 
-int  ExampleClusterCollection::size() const {
-  return m_entries.size();
-}
+int ExampleClusterCollection::size() const { return m_entries.size(); }
 
-ExampleCluster ExampleClusterCollection::create(){
+ExampleCluster ExampleClusterCollection::create() {
   auto obj = new ExampleClusterObj();
   m_entries.emplace_back(obj);
   m_rel_Hits_tmp.push_back(obj->m_Hits);
   m_rel_Clusters_tmp.push_back(obj->m_Clusters);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleCluster(obj);
 }
 
-void ExampleClusterCollection::clear(){
+void ExampleClusterCollection::clear() {
   m_data->clear();
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-  // clear relations to Hits. Make sure to unlink() the reference data s they may be gone already.
-  for (auto& pointer : m_rel_Hits_tmp) {
-    for(auto& item : (*pointer)) {
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  // clear relations to Hits. Make sure to unlink() the reference data s they
+  // may be gone already.
+  for (auto &pointer : m_rel_Hits_tmp) {
+    for (auto &item : (*pointer)) {
       item.unlink();
     };
     delete pointer;
   }
   m_rel_Hits_tmp.clear();
-  for (auto& item : (*m_rel_Hits)) { item.unlink(); }
+  for (auto &item : (*m_rel_Hits)) {
+    item.unlink();
+  }
   m_rel_Hits->clear();
-  // clear relations to Clusters. Make sure to unlink() the reference data s they may be gone already.
-  for (auto& pointer : m_rel_Clusters_tmp) {
-    for(auto& item : (*pointer)) {
+  // clear relations to Clusters. Make sure to unlink() the reference data s
+  // they may be gone already.
+  for (auto &pointer : m_rel_Clusters_tmp) {
+    for (auto &item : (*pointer)) {
       item.unlink();
     };
     delete pointer;
   }
   m_rel_Clusters_tmp.clear();
-  for (auto& item : (*m_rel_Clusters)) { item.unlink(); }
+  for (auto &item : (*m_rel_Clusters)) {
+    item.unlink();
+  }
   m_rel_Clusters->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleClusterCollection::prepareForWrite(){
+void ExampleClusterCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-  int Hits_index =0;
-  int Clusters_index =0;
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-   (*m_data)[i].Hits_begin=Hits_index;
-   (*m_data)[i].Hits_end+=Hits_index;
-   Hits_index = (*m_data)[i].Hits_end;
-   for(auto it : (*m_rel_Hits_tmp[i])) {
-     if (it.getObjectID().index == podio::ObjectID::untracked)
-       throw std::runtime_error("Trying to persistify untracked object");
-     m_refCollections[0]->emplace_back(it.getObjectID());
-     m_rel_Hits->push_back(it);
-   }
-   (*m_data)[i].Clusters_begin=Clusters_index;
-   (*m_data)[i].Clusters_end+=Clusters_index;
-   Clusters_index = (*m_data)[i].Clusters_end;
-   for(auto it : (*m_rel_Clusters_tmp[i])) {
-     if (it.getObjectID().index == podio::ObjectID::untracked)
-       throw std::runtime_error("Trying to persistify untracked object");
-     m_refCollections[1]->emplace_back(it.getObjectID());
-     m_rel_Clusters->push_back(it);
-   }
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
   }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  int Hits_index = 0;
+  int Clusters_index = 0;
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+    (*m_data)[i].Hits_begin = Hits_index;
+    (*m_data)[i].Hits_end += Hits_index;
+    Hits_index = (*m_data)[i].Hits_end;
+    for (auto it : (*m_rel_Hits_tmp[i])) {
+      if (it.getObjectID().index == podio::ObjectID::untracked)
+        throw std::runtime_error("Trying to persistify untracked object");
+      m_refCollections[0]->emplace_back(it.getObjectID());
+      m_rel_Hits->push_back(it);
+    }
+    (*m_data)[i].Clusters_begin = Clusters_index;
+    (*m_data)[i].Clusters_end += Clusters_index;
+    Clusters_index = (*m_data)[i].Clusters_end;
+    for (auto it : (*m_rel_Clusters_tmp[i])) {
+      if (it.getObjectID().index == podio::ObjectID::untracked)
+        throw std::runtime_error("Trying to persistify untracked object");
+      m_refCollections[1]->emplace_back(it.getObjectID());
+      m_rel_Clusters->push_back(it);
+    }
+  }
 }
 
-void ExampleClusterCollection::prepareAfterRead(){
+void ExampleClusterCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleClusterObj({index,m_collectionID}, data);
-        obj->m_Hits = m_rel_Hits;   obj->m_Clusters = m_rel_Clusters;
+  for (auto &data : *m_data) {
+    auto obj = new ExampleClusterObj({index, m_collectionID}, data);
+    obj->m_Hits = m_rel_Hits;
+    obj->m_Clusters = m_rel_Clusters;
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleClusterCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
-  for(unsigned int i=0, size=m_refCollections[0]->size();i!=size;++i) {
+bool ExampleClusterCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
+  for (unsigned int i = 0, size = m_refCollections[0]->size(); i != size; ++i) {
     auto id = (*m_refCollections[0])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleHitCollection* tmp_coll = static_cast<ExampleHitCollection*>(coll);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleHitCollection *tmp_coll =
+          static_cast<ExampleHitCollection *>(coll);
       auto tmp = (*tmp_coll)[id.index];
       m_rel_Hits->emplace_back(tmp);
     } else {
       m_rel_Hits->emplace_back(nullptr);
     }
   }
-  for(unsigned int i=0, size=m_refCollections[1]->size();i!=size;++i) {
+  for (unsigned int i = 0, size = m_refCollections[1]->size(); i != size; ++i) {
     auto id = (*m_refCollections[1])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleClusterCollection* tmp_coll = static_cast<ExampleClusterCollection*>(coll);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleClusterCollection *tmp_coll =
+          static_cast<ExampleClusterCollection *>(coll);
       auto tmp = (*tmp_coll)[id.index];
       m_rel_Clusters->emplace_back(tmp);
     } else {
@@ -150,54 +172,61 @@ bool ExampleClusterCollection::setReferences(const podio::ICollectionProvider* c
     }
   }
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleClusterCollection::push_back(ConstExampleCluster object){
+void ExampleClusterCollection::push_back(ConstExampleCluster object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-        m_rel_Hits_tmp.push_back(obj->m_Hits);
-  m_rel_Clusters_tmp.push_back(obj->m_Clusters);
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+    m_rel_Hits_tmp.push_back(obj->m_Hits);
+    m_rel_Clusters_tmp.push_back(obj->m_Clusters);
 
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleClusterCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleClusterDataContainer*>(address);
+void ExampleClusterCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleClusterDataContainer *>(address);
 }
 
-
-const ExampleCluster ExampleClusterCollectionIterator::operator* () const {
+const ExampleCluster ExampleClusterCollectionIterator::operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleCluster* ExampleClusterCollectionIterator::operator-> () const {
+const ExampleCluster *ExampleClusterCollectionIterator::operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleClusterCollectionIterator& ExampleClusterCollectionIterator::operator++() const {
+const ExampleClusterCollectionIterator &ExampleClusterCollectionIterator::
+operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleClusterCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          energy:       " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].energy() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o, const ExampleClusterCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          energy:       " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].energy() << " " << std::endl;
+    o << "     Hits : ";
+    for (unsigned j = 0, N = v[i].Hits_size(); j < N; ++j)
+      o << v[i].Hits(j).id() << " ";
+    o << std::endl;
+    o << "     Clusters : ";
+    for (unsigned j = 0, N = v[i].Clusters_size(); j < N; ++j)
+      o << v[i].Clusters(j).id() << " ";
+    o << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleClusterConst.cc
+++ b/tests/src/ExampleClusterConst.cc
@@ -1,36 +1,36 @@
 // datamodel specific includes
-#include "ExampleCluster.h"
 #include "ExampleClusterConst.h"
-#include "ExampleClusterObj.h"
-#include "ExampleClusterData.h"
+#include "ExampleCluster.h"
 #include "ExampleClusterCollection.h"
+#include "ExampleClusterData.h"
+#include "ExampleClusterObj.h"
 #include <iostream>
 
-
-
-
 ConstExampleCluster::ConstExampleCluster() : m_obj(new ExampleClusterObj()) {
- m_obj->acquire();
-}
-
-ConstExampleCluster::ConstExampleCluster(double energy) : m_obj(new ExampleClusterObj()){
- m_obj->acquire();
-   m_obj->data.energy = energy;
-}
-
-
-ConstExampleCluster::ConstExampleCluster(const ConstExampleCluster& other) : m_obj(other.m_obj) {
   m_obj->acquire();
 }
 
-ConstExampleCluster& ConstExampleCluster::operator=(const ConstExampleCluster& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleCluster::ConstExampleCluster(double energy)
+    : m_obj(new ExampleClusterObj()) {
+  m_obj->acquire();
+  m_obj->data.energy = energy;
+}
+
+ConstExampleCluster::ConstExampleCluster(const ConstExampleCluster &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleCluster &ConstExampleCluster::
+operator=(const ConstExampleCluster &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleCluster::ConstExampleCluster(ExampleClusterObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleCluster::ConstExampleCluster(ExampleClusterObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,60 +38,64 @@ ConstExampleCluster ConstExampleCluster::clone() const {
   return {new ExampleClusterObj(*m_obj)};
 }
 
-ConstExampleCluster::~ConstExampleCluster(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleCluster::~ConstExampleCluster() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  cluster energy
-  const double& ConstExampleCluster::energy() const { return m_obj->data.energy; }
+/// Access the  cluster energy
+const double &ConstExampleCluster::energy() const { return m_obj->data.energy; }
 
-std::vector<::ConstExampleHit>::const_iterator ConstExampleCluster::Hits_begin() const {
+std::vector<::ConstExampleHit>::const_iterator
+ConstExampleCluster::Hits_begin() const {
   auto ret_value = m_obj->m_Hits->begin();
   std::advance(ret_value, m_obj->data.Hits_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleHit>::const_iterator ConstExampleCluster::Hits_end() const {
+std::vector<::ConstExampleHit>::const_iterator
+ConstExampleCluster::Hits_end() const {
   auto ret_value = m_obj->m_Hits->begin();
-  std::advance(ret_value, m_obj->data.Hits_end-1);
+  std::advance(ret_value, m_obj->data.Hits_end - 1);
   return ++ret_value;
 }
 
 unsigned int ConstExampleCluster::Hits_size() const {
-  return (m_obj->data.Hits_end-m_obj->data.Hits_begin);
+  return (m_obj->data.Hits_end - m_obj->data.Hits_begin);
 }
 
 ::ConstExampleHit ConstExampleCluster::Hits(unsigned int index) const {
   if (Hits_size() > index) {
-    return m_obj->m_Hits->at(m_obj->data.Hits_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_Hits->at(m_obj->data.Hits_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
-std::vector<::ConstExampleCluster>::const_iterator ConstExampleCluster::Clusters_begin() const {
+std::vector<::ConstExampleCluster>::const_iterator
+ConstExampleCluster::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleCluster>::const_iterator ConstExampleCluster::Clusters_end() const {
+std::vector<::ConstExampleCluster>::const_iterator
+ConstExampleCluster::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
-  std::advance(ret_value, m_obj->data.Clusters_end-1);
+  std::advance(ret_value, m_obj->data.Clusters_end - 1);
   return ++ret_value;
 }
 
 unsigned int ConstExampleCluster::Clusters_size() const {
-  return (m_obj->data.Clusters_end-m_obj->data.Clusters_begin);
+  return (m_obj->data.Clusters_end - m_obj->data.Clusters_begin);
 }
 
 ::ConstExampleCluster ConstExampleCluster::Clusters(unsigned int index) const {
   if (Clusters_size() > index) {
-    return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_Clusters->at(m_obj->data.Clusters_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ConstExampleCluster::isAvailable() const {
+bool ConstExampleCluster::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -99,22 +103,20 @@ bool  ConstExampleCluster::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleCluster::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleCluster::operator==(const ExampleCluster& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleCluster::operator==(const ExampleCluster &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleCluster& p1, const ExampleCluster& p2 ) {
+// bool operator< (const ExampleCluster& p1, const ExampleCluster& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleClusterObj.cc
+++ b/tests/src/ExampleClusterObj.cc
@@ -1,29 +1,24 @@
 #include "ExampleClusterObj.h"
 #include "ExampleCluster.h"
 
+ExampleClusterObj::ExampleClusterObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(), m_Hits(new std::vector<ConstExampleHit>()),
+      m_Clusters(new std::vector<ConstExampleCluster>()) {}
 
+ExampleClusterObj::ExampleClusterObj(const podio::ObjectID id,
+                                     ExampleClusterData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleClusterObj::ExampleClusterObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_Hits(new std::vector<ConstExampleHit>()), m_Clusters(new std::vector<ConstExampleCluster>())
-{ }
-
-ExampleClusterObj::ExampleClusterObj(const podio::ObjectID id, ExampleClusterData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleClusterObj::ExampleClusterObj(const ExampleClusterObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_Hits(new std::vector<ConstExampleHit>(*(other.m_Hits))), m_Clusters(new std::vector<ConstExampleCluster>(*(other.m_Clusters)))
-{
-
-}
+ExampleClusterObj::ExampleClusterObj(const ExampleClusterObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data),
+      m_Hits(new std::vector<ConstExampleHit>(*(other.m_Hits))),
+      m_Clusters(new std::vector<ConstExampleCluster>(*(other.m_Clusters))) {}
 
 ExampleClusterObj::~ExampleClusterObj() {
   if (id.index == podio::ObjectID::untracked) {
     delete m_Hits;
     delete m_Clusters;
-
   }
-
 }
-

--- a/tests/src/ExampleForCyclicDependency1.cc
+++ b/tests/src/ExampleForCyclicDependency1.cc
@@ -1,33 +1,35 @@
 // datamodel specific includes
 #include "ExampleForCyclicDependency1.h"
-#include "ExampleForCyclicDependency1Const.h"
-#include "ExampleForCyclicDependency1Obj.h"
-#include "ExampleForCyclicDependency1Data.h"
 #include "ExampleForCyclicDependency1Collection.h"
-#include <iostream>
+#include "ExampleForCyclicDependency1Const.h"
+#include "ExampleForCyclicDependency1Data.h"
+#include "ExampleForCyclicDependency1Obj.h"
 #include "ExampleForCyclicDependency2.h"
+#include <iostream>
 
-
-
-
-ExampleForCyclicDependency1::ExampleForCyclicDependency1() : m_obj(new ExampleForCyclicDependency1Obj()){
- m_obj->acquire();
-}
-
-
-
-ExampleForCyclicDependency1::ExampleForCyclicDependency1(const ExampleForCyclicDependency1& other) : m_obj(other.m_obj) {
+ExampleForCyclicDependency1::ExampleForCyclicDependency1()
+    : m_obj(new ExampleForCyclicDependency1Obj()) {
   m_obj->acquire();
 }
 
-ExampleForCyclicDependency1& ExampleForCyclicDependency1::operator=(const ExampleForCyclicDependency1& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleForCyclicDependency1::ExampleForCyclicDependency1(
+    const ExampleForCyclicDependency1 &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleForCyclicDependency1 &ExampleForCyclicDependency1::
+operator=(const ExampleForCyclicDependency1 &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleForCyclicDependency1::ExampleForCyclicDependency1(ExampleForCyclicDependency1Obj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleForCyclicDependency1::ExampleForCyclicDependency1(
+    ExampleForCyclicDependency1Obj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -35,26 +37,30 @@ ExampleForCyclicDependency1 ExampleForCyclicDependency1::clone() const {
   return {new ExampleForCyclicDependency1Obj(*m_obj)};
 }
 
-ExampleForCyclicDependency1::~ExampleForCyclicDependency1(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleForCyclicDependency1::~ExampleForCyclicDependency1() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleForCyclicDependency1::operator ConstExampleForCyclicDependency1() const {return ConstExampleForCyclicDependency1(m_obj);}
+ExampleForCyclicDependency1::operator ConstExampleForCyclicDependency1() const {
+  return ConstExampleForCyclicDependency1(m_obj);
+}
 
-  const ::ConstExampleForCyclicDependency2 ExampleForCyclicDependency1::ref() const {
-    if (m_obj->m_ref == nullptr) {
-      return ::ConstExampleForCyclicDependency2(nullptr);
-    }
-    return ::ConstExampleForCyclicDependency2(*(m_obj->m_ref));
+const ::ConstExampleForCyclicDependency2
+ExampleForCyclicDependency1::ref() const {
+  if (m_obj->m_ref == nullptr) {
+    return ::ConstExampleForCyclicDependency2(nullptr);
   }
-void ExampleForCyclicDependency1::ref(::ConstExampleForCyclicDependency2 value) {
-  if (m_obj->m_ref != nullptr) delete m_obj->m_ref;
+  return ::ConstExampleForCyclicDependency2(*(m_obj->m_ref));
+}
+void ExampleForCyclicDependency1::ref(
+    ::ConstExampleForCyclicDependency2 value) {
+  if (m_obj->m_ref != nullptr)
+    delete m_obj->m_ref;
   m_obj->m_ref = new ConstExampleForCyclicDependency2(value);
 }
 
-
-
-bool  ExampleForCyclicDependency1::isAvailable() const {
+bool ExampleForCyclicDependency1::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -62,29 +68,29 @@ bool  ExampleForCyclicDependency1::isAvailable() const {
 }
 
 const podio::ObjectID ExampleForCyclicDependency1::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleForCyclicDependency1::operator==(const ConstExampleForCyclicDependency1& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleForCyclicDependency1::
+operator==(const ConstExampleForCyclicDependency1 &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleForCyclicDependency1& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " ref : " << value.ref().id() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleForCyclicDependency1 &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " ref : " << value.ref().id() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleForCyclicDependency1& p1, const ExampleForCyclicDependency1& p2 ) {
+// bool operator< (const ExampleForCyclicDependency1& p1, const
+// ExampleForCyclicDependency1& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleForCyclicDependency1Collection.cc
+++ b/tests/src/ExampleForCyclicDependency1Collection.cc
@@ -1,152 +1,179 @@
 // standard includes
-#include <stdexcept>
 #include "ExampleForCyclicDependency2Collection.h"
-
+#include <stdexcept>
 
 #include "ExampleForCyclicDependency1Collection.h"
 
-
-
-ExampleForCyclicDependency1Collection::ExampleForCyclicDependency1Collection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_ref(new std::vector<::ConstExampleForCyclicDependency2>()),m_data(new ExampleForCyclicDependency1DataContainer() ) {
-    m_refCollections.push_back(new std::vector<podio::ObjectID>());
-
+ExampleForCyclicDependency1Collection::ExampleForCyclicDependency1Collection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_rel_ref(new std::vector<::ConstExampleForCyclicDependency2>()),
+      m_data(new ExampleForCyclicDependency1DataContainer()) {
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
 }
 
-ExampleForCyclicDependency1Collection::~ExampleForCyclicDependency1Collection() {
+ExampleForCyclicDependency1Collection::
+    ~ExampleForCyclicDependency1Collection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-    for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
-  if (m_rel_ref != nullptr) { delete m_rel_ref; }
-
+  if (m_data != nullptr)
+    delete m_data;
+  for (auto &pointer : m_refCollections) {
+    if (pointer != nullptr)
+      delete pointer;
+  }
+  if (m_rel_ref != nullptr) {
+    delete m_rel_ref;
+  }
 }
 
-const ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::operator[](unsigned int index) const {
+const ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::
+operator[](unsigned int index) const {
   return ExampleForCyclicDependency1(m_entries[index]);
 }
 
-const ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::at(unsigned int index) const {
+const ExampleForCyclicDependency1
+ExampleForCyclicDependency1Collection::at(unsigned int index) const {
   return ExampleForCyclicDependency1(m_entries.at(index));
 }
 
-ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::operator[](unsigned int index) {
+ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::
+operator[](unsigned int index) {
   return ExampleForCyclicDependency1(m_entries[index]);
 }
 
-ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::at(unsigned int index) {
+ExampleForCyclicDependency1
+ExampleForCyclicDependency1Collection::at(unsigned int index) {
   return ExampleForCyclicDependency1(m_entries.at(index));
 }
 
-int  ExampleForCyclicDependency1Collection::size() const {
+int ExampleForCyclicDependency1Collection::size() const {
   return m_entries.size();
 }
 
-ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::create(){
+ExampleForCyclicDependency1 ExampleForCyclicDependency1Collection::create() {
   auto obj = new ExampleForCyclicDependency1Obj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleForCyclicDependency1(obj);
 }
 
-void ExampleForCyclicDependency1Collection::clear(){
+void ExampleForCyclicDependency1Collection::clear() {
   m_data->clear();
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-  for (auto& item : (*m_rel_ref)) { item.unlink(); }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  for (auto &item : (*m_rel_ref)) {
+    item.unlink();
+  }
   m_rel_ref->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleForCyclicDependency1Collection::prepareForWrite(){
+void ExampleForCyclicDependency1Collection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
   }
-  for (auto& obj : m_entries) {
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
+  for (auto &obj : m_entries) {
     if (obj->m_ref != nullptr) {
       m_refCollections[0]->emplace_back(obj->m_ref->getObjectID());
     } else {
-      m_refCollections[0]->push_back({-2,-2});
+      m_refCollections[0]->push_back({-2, -2});
     }
   }
-
 }
 
-void ExampleForCyclicDependency1Collection::prepareAfterRead(){
+void ExampleForCyclicDependency1Collection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleForCyclicDependency1Obj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj =
+        new ExampleForCyclicDependency1Obj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleForCyclicDependency1Collection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleForCyclicDependency1Collection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-  for(unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
+  for (unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
     auto id = (*m_refCollections[0])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleForCyclicDependency2Collection* tmp_coll = static_cast<ExampleForCyclicDependency2Collection*>(coll);
-      m_entries[i]->m_ref = new ConstExampleForCyclicDependency2((*tmp_coll)[id.index]);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleForCyclicDependency2Collection *tmp_coll =
+          static_cast<ExampleForCyclicDependency2Collection *>(coll);
+      m_entries[i]->m_ref =
+          new ConstExampleForCyclicDependency2((*tmp_coll)[id.index]);
     } else {
       m_entries[i]->m_ref = nullptr;
     }
   }
 
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleForCyclicDependency1Collection::push_back(ConstExampleForCyclicDependency1 object){
+void ExampleForCyclicDependency1Collection::push_back(
+    ConstExampleForCyclicDependency1 object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleForCyclicDependency1Collection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleForCyclicDependency1DataContainer*>(address);
+void ExampleForCyclicDependency1Collection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleForCyclicDependency1DataContainer *>(address);
 }
 
-
-const ExampleForCyclicDependency1 ExampleForCyclicDependency1CollectionIterator::operator* () const {
+const ExampleForCyclicDependency1
+    ExampleForCyclicDependency1CollectionIterator::operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleForCyclicDependency1* ExampleForCyclicDependency1CollectionIterator::operator-> () const {
+const ExampleForCyclicDependency1 *
+    ExampleForCyclicDependency1CollectionIterator::operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleForCyclicDependency1CollectionIterator& ExampleForCyclicDependency1CollectionIterator::operator++() const {
+const ExampleForCyclicDependency1CollectionIterator &
+ExampleForCyclicDependency1CollectionIterator::operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleForCyclicDependency1Collection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "   << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleForCyclicDependency1Collection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::endl;
+    o << "     ref : ";
+    o << v[i].ref().id() << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleForCyclicDependency1Const.cc
+++ b/tests/src/ExampleForCyclicDependency1Const.cc
@@ -1,53 +1,58 @@
 // datamodel specific includes
-#include "ExampleForCyclicDependency1.h"
 #include "ExampleForCyclicDependency1Const.h"
-#include "ExampleForCyclicDependency1Obj.h"
-#include "ExampleForCyclicDependency1Data.h"
+#include "ExampleForCyclicDependency1.h"
 #include "ExampleForCyclicDependency1Collection.h"
-#include <iostream>
+#include "ExampleForCyclicDependency1Data.h"
+#include "ExampleForCyclicDependency1Obj.h"
 #include "ExampleForCyclicDependency2.h"
+#include <iostream>
 
-
-
-
-ConstExampleForCyclicDependency1::ConstExampleForCyclicDependency1() : m_obj(new ExampleForCyclicDependency1Obj()) {
- m_obj->acquire();
-}
-
-
-
-ConstExampleForCyclicDependency1::ConstExampleForCyclicDependency1(const ConstExampleForCyclicDependency1& other) : m_obj(other.m_obj) {
+ConstExampleForCyclicDependency1::ConstExampleForCyclicDependency1()
+    : m_obj(new ExampleForCyclicDependency1Obj()) {
   m_obj->acquire();
 }
 
-ConstExampleForCyclicDependency1& ConstExampleForCyclicDependency1::operator=(const ConstExampleForCyclicDependency1& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleForCyclicDependency1::ConstExampleForCyclicDependency1(
+    const ConstExampleForCyclicDependency1 &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleForCyclicDependency1 &ConstExampleForCyclicDependency1::
+operator=(const ConstExampleForCyclicDependency1 &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleForCyclicDependency1::ConstExampleForCyclicDependency1(ExampleForCyclicDependency1Obj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleForCyclicDependency1::ConstExampleForCyclicDependency1(
+    ExampleForCyclicDependency1Obj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
-ConstExampleForCyclicDependency1 ConstExampleForCyclicDependency1::clone() const {
+ConstExampleForCyclicDependency1
+ConstExampleForCyclicDependency1::clone() const {
   return {new ExampleForCyclicDependency1Obj(*m_obj)};
 }
 
-ConstExampleForCyclicDependency1::~ConstExampleForCyclicDependency1(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleForCyclicDependency1::~ConstExampleForCyclicDependency1() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  a ref
-  const ::ConstExampleForCyclicDependency2 ConstExampleForCyclicDependency1::ref() const {
-    if (m_obj->m_ref == nullptr) {
-      return ::ConstExampleForCyclicDependency2(nullptr);
-    }
-    return ::ConstExampleForCyclicDependency2(*(m_obj->m_ref));}
+/// Access the  a ref
+const ::ConstExampleForCyclicDependency2
+ConstExampleForCyclicDependency1::ref() const {
+  if (m_obj->m_ref == nullptr) {
+    return ::ConstExampleForCyclicDependency2(nullptr);
+  }
+  return ::ConstExampleForCyclicDependency2(*(m_obj->m_ref));
+}
 
-
-bool  ConstExampleForCyclicDependency1::isAvailable() const {
+bool ConstExampleForCyclicDependency1::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -55,22 +60,22 @@ bool  ConstExampleForCyclicDependency1::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleForCyclicDependency1::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleForCyclicDependency1::operator==(const ExampleForCyclicDependency1& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleForCyclicDependency1::
+operator==(const ExampleForCyclicDependency1 &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleForCyclicDependency1& p1, const ExampleForCyclicDependency1& p2 ) {
+// bool operator< (const ExampleForCyclicDependency1& p1, const
+// ExampleForCyclicDependency1& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleForCyclicDependency1Obj.cc
+++ b/tests/src/ExampleForCyclicDependency1Obj.cc
@@ -1,32 +1,28 @@
 #include "ExampleForCyclicDependency1Obj.h"
 #include "ExampleForCyclicDependency2Const.h"
 
+ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(), m_ref(nullptr)
 
+{}
 
-ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_ref(nullptr)
+ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj(
+    const podio::ObjectID id, ExampleForCyclicDependency1Data data)
+    : ObjBase{id, 0}, data(data) {}
 
-{ }
-
-ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj(const podio::ObjectID id, ExampleForCyclicDependency1Data data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj(const ExampleForCyclicDependency1Obj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_ref(nullptr)
-{
+ExampleForCyclicDependency1Obj::ExampleForCyclicDependency1Obj(
+    const ExampleForCyclicDependency1Obj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data), m_ref(nullptr) {
   if (other.m_ref != nullptr) {
-     m_ref = new ConstExampleForCyclicDependency2(*(other.m_ref));
+    m_ref = new ConstExampleForCyclicDependency2(*(other.m_ref));
   }
-
 }
 
 ExampleForCyclicDependency1Obj::~ExampleForCyclicDependency1Obj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-    if (m_ref != nullptr) delete m_ref;
-
+  if (m_ref != nullptr)
+    delete m_ref;
 }
-

--- a/tests/src/ExampleForCyclicDependency2.cc
+++ b/tests/src/ExampleForCyclicDependency2.cc
@@ -1,33 +1,35 @@
 // datamodel specific includes
 #include "ExampleForCyclicDependency2.h"
-#include "ExampleForCyclicDependency2Const.h"
-#include "ExampleForCyclicDependency2Obj.h"
-#include "ExampleForCyclicDependency2Data.h"
-#include "ExampleForCyclicDependency2Collection.h"
-#include <iostream>
 #include "ExampleForCyclicDependency1.h"
+#include "ExampleForCyclicDependency2Collection.h"
+#include "ExampleForCyclicDependency2Const.h"
+#include "ExampleForCyclicDependency2Data.h"
+#include "ExampleForCyclicDependency2Obj.h"
+#include <iostream>
 
-
-
-
-ExampleForCyclicDependency2::ExampleForCyclicDependency2() : m_obj(new ExampleForCyclicDependency2Obj()){
- m_obj->acquire();
-}
-
-
-
-ExampleForCyclicDependency2::ExampleForCyclicDependency2(const ExampleForCyclicDependency2& other) : m_obj(other.m_obj) {
+ExampleForCyclicDependency2::ExampleForCyclicDependency2()
+    : m_obj(new ExampleForCyclicDependency2Obj()) {
   m_obj->acquire();
 }
 
-ExampleForCyclicDependency2& ExampleForCyclicDependency2::operator=(const ExampleForCyclicDependency2& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleForCyclicDependency2::ExampleForCyclicDependency2(
+    const ExampleForCyclicDependency2 &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleForCyclicDependency2 &ExampleForCyclicDependency2::
+operator=(const ExampleForCyclicDependency2 &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleForCyclicDependency2::ExampleForCyclicDependency2(ExampleForCyclicDependency2Obj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleForCyclicDependency2::ExampleForCyclicDependency2(
+    ExampleForCyclicDependency2Obj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -35,26 +37,30 @@ ExampleForCyclicDependency2 ExampleForCyclicDependency2::clone() const {
   return {new ExampleForCyclicDependency2Obj(*m_obj)};
 }
 
-ExampleForCyclicDependency2::~ExampleForCyclicDependency2(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleForCyclicDependency2::~ExampleForCyclicDependency2() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleForCyclicDependency2::operator ConstExampleForCyclicDependency2() const {return ConstExampleForCyclicDependency2(m_obj);}
+ExampleForCyclicDependency2::operator ConstExampleForCyclicDependency2() const {
+  return ConstExampleForCyclicDependency2(m_obj);
+}
 
-  const ::ConstExampleForCyclicDependency1 ExampleForCyclicDependency2::ref() const {
-    if (m_obj->m_ref == nullptr) {
-      return ::ConstExampleForCyclicDependency1(nullptr);
-    }
-    return ::ConstExampleForCyclicDependency1(*(m_obj->m_ref));
+const ::ConstExampleForCyclicDependency1
+ExampleForCyclicDependency2::ref() const {
+  if (m_obj->m_ref == nullptr) {
+    return ::ConstExampleForCyclicDependency1(nullptr);
   }
-void ExampleForCyclicDependency2::ref(::ConstExampleForCyclicDependency1 value) {
-  if (m_obj->m_ref != nullptr) delete m_obj->m_ref;
+  return ::ConstExampleForCyclicDependency1(*(m_obj->m_ref));
+}
+void ExampleForCyclicDependency2::ref(
+    ::ConstExampleForCyclicDependency1 value) {
+  if (m_obj->m_ref != nullptr)
+    delete m_obj->m_ref;
   m_obj->m_ref = new ConstExampleForCyclicDependency1(value);
 }
 
-
-
-bool  ExampleForCyclicDependency2::isAvailable() const {
+bool ExampleForCyclicDependency2::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -62,29 +68,29 @@ bool  ExampleForCyclicDependency2::isAvailable() const {
 }
 
 const podio::ObjectID ExampleForCyclicDependency2::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleForCyclicDependency2::operator==(const ConstExampleForCyclicDependency2& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleForCyclicDependency2::
+operator==(const ConstExampleForCyclicDependency2 &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleForCyclicDependency2& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " ref : " << value.ref().id() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleForCyclicDependency2 &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " ref : " << value.ref().id() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleForCyclicDependency2& p1, const ExampleForCyclicDependency2& p2 ) {
+// bool operator< (const ExampleForCyclicDependency2& p1, const
+// ExampleForCyclicDependency2& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleForCyclicDependency2Collection.cc
+++ b/tests/src/ExampleForCyclicDependency2Collection.cc
@@ -1,152 +1,179 @@
 // standard includes
-#include <stdexcept>
 #include "ExampleForCyclicDependency1Collection.h"
-
+#include <stdexcept>
 
 #include "ExampleForCyclicDependency2Collection.h"
 
-
-
-ExampleForCyclicDependency2Collection::ExampleForCyclicDependency2Collection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_ref(new std::vector<::ConstExampleForCyclicDependency1>()),m_data(new ExampleForCyclicDependency2DataContainer() ) {
-    m_refCollections.push_back(new std::vector<podio::ObjectID>());
-
+ExampleForCyclicDependency2Collection::ExampleForCyclicDependency2Collection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_rel_ref(new std::vector<::ConstExampleForCyclicDependency1>()),
+      m_data(new ExampleForCyclicDependency2DataContainer()) {
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
 }
 
-ExampleForCyclicDependency2Collection::~ExampleForCyclicDependency2Collection() {
+ExampleForCyclicDependency2Collection::
+    ~ExampleForCyclicDependency2Collection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-    for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
-  if (m_rel_ref != nullptr) { delete m_rel_ref; }
-
+  if (m_data != nullptr)
+    delete m_data;
+  for (auto &pointer : m_refCollections) {
+    if (pointer != nullptr)
+      delete pointer;
+  }
+  if (m_rel_ref != nullptr) {
+    delete m_rel_ref;
+  }
 }
 
-const ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::operator[](unsigned int index) const {
+const ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::
+operator[](unsigned int index) const {
   return ExampleForCyclicDependency2(m_entries[index]);
 }
 
-const ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::at(unsigned int index) const {
+const ExampleForCyclicDependency2
+ExampleForCyclicDependency2Collection::at(unsigned int index) const {
   return ExampleForCyclicDependency2(m_entries.at(index));
 }
 
-ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::operator[](unsigned int index) {
+ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::
+operator[](unsigned int index) {
   return ExampleForCyclicDependency2(m_entries[index]);
 }
 
-ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::at(unsigned int index) {
+ExampleForCyclicDependency2
+ExampleForCyclicDependency2Collection::at(unsigned int index) {
   return ExampleForCyclicDependency2(m_entries.at(index));
 }
 
-int  ExampleForCyclicDependency2Collection::size() const {
+int ExampleForCyclicDependency2Collection::size() const {
   return m_entries.size();
 }
 
-ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::create(){
+ExampleForCyclicDependency2 ExampleForCyclicDependency2Collection::create() {
   auto obj = new ExampleForCyclicDependency2Obj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleForCyclicDependency2(obj);
 }
 
-void ExampleForCyclicDependency2Collection::clear(){
+void ExampleForCyclicDependency2Collection::clear() {
   m_data->clear();
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-  for (auto& item : (*m_rel_ref)) { item.unlink(); }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  for (auto &item : (*m_rel_ref)) {
+    item.unlink();
+  }
   m_rel_ref->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleForCyclicDependency2Collection::prepareForWrite(){
+void ExampleForCyclicDependency2Collection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
   }
-  for (auto& obj : m_entries) {
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
+  for (auto &obj : m_entries) {
     if (obj->m_ref != nullptr) {
       m_refCollections[0]->emplace_back(obj->m_ref->getObjectID());
     } else {
-      m_refCollections[0]->push_back({-2,-2});
+      m_refCollections[0]->push_back({-2, -2});
     }
   }
-
 }
 
-void ExampleForCyclicDependency2Collection::prepareAfterRead(){
+void ExampleForCyclicDependency2Collection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleForCyclicDependency2Obj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj =
+        new ExampleForCyclicDependency2Obj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleForCyclicDependency2Collection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleForCyclicDependency2Collection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-  for(unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
+  for (unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
     auto id = (*m_refCollections[0])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleForCyclicDependency1Collection* tmp_coll = static_cast<ExampleForCyclicDependency1Collection*>(coll);
-      m_entries[i]->m_ref = new ConstExampleForCyclicDependency1((*tmp_coll)[id.index]);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleForCyclicDependency1Collection *tmp_coll =
+          static_cast<ExampleForCyclicDependency1Collection *>(coll);
+      m_entries[i]->m_ref =
+          new ConstExampleForCyclicDependency1((*tmp_coll)[id.index]);
     } else {
       m_entries[i]->m_ref = nullptr;
     }
   }
 
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleForCyclicDependency2Collection::push_back(ConstExampleForCyclicDependency2 object){
+void ExampleForCyclicDependency2Collection::push_back(
+    ConstExampleForCyclicDependency2 object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleForCyclicDependency2Collection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleForCyclicDependency2DataContainer*>(address);
+void ExampleForCyclicDependency2Collection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleForCyclicDependency2DataContainer *>(address);
 }
 
-
-const ExampleForCyclicDependency2 ExampleForCyclicDependency2CollectionIterator::operator* () const {
+const ExampleForCyclicDependency2
+    ExampleForCyclicDependency2CollectionIterator::operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleForCyclicDependency2* ExampleForCyclicDependency2CollectionIterator::operator-> () const {
+const ExampleForCyclicDependency2 *
+    ExampleForCyclicDependency2CollectionIterator::operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleForCyclicDependency2CollectionIterator& ExampleForCyclicDependency2CollectionIterator::operator++() const {
+const ExampleForCyclicDependency2CollectionIterator &
+ExampleForCyclicDependency2CollectionIterator::operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleForCyclicDependency2Collection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "   << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleForCyclicDependency2Collection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::endl;
+    o << "     ref : ";
+    o << v[i].ref().id() << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleForCyclicDependency2Const.cc
+++ b/tests/src/ExampleForCyclicDependency2Const.cc
@@ -1,53 +1,58 @@
 // datamodel specific includes
-#include "ExampleForCyclicDependency2.h"
 #include "ExampleForCyclicDependency2Const.h"
-#include "ExampleForCyclicDependency2Obj.h"
-#include "ExampleForCyclicDependency2Data.h"
-#include "ExampleForCyclicDependency2Collection.h"
-#include <iostream>
 #include "ExampleForCyclicDependency1.h"
+#include "ExampleForCyclicDependency2.h"
+#include "ExampleForCyclicDependency2Collection.h"
+#include "ExampleForCyclicDependency2Data.h"
+#include "ExampleForCyclicDependency2Obj.h"
+#include <iostream>
 
-
-
-
-ConstExampleForCyclicDependency2::ConstExampleForCyclicDependency2() : m_obj(new ExampleForCyclicDependency2Obj()) {
- m_obj->acquire();
-}
-
-
-
-ConstExampleForCyclicDependency2::ConstExampleForCyclicDependency2(const ConstExampleForCyclicDependency2& other) : m_obj(other.m_obj) {
+ConstExampleForCyclicDependency2::ConstExampleForCyclicDependency2()
+    : m_obj(new ExampleForCyclicDependency2Obj()) {
   m_obj->acquire();
 }
 
-ConstExampleForCyclicDependency2& ConstExampleForCyclicDependency2::operator=(const ConstExampleForCyclicDependency2& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleForCyclicDependency2::ConstExampleForCyclicDependency2(
+    const ConstExampleForCyclicDependency2 &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleForCyclicDependency2 &ConstExampleForCyclicDependency2::
+operator=(const ConstExampleForCyclicDependency2 &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleForCyclicDependency2::ConstExampleForCyclicDependency2(ExampleForCyclicDependency2Obj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleForCyclicDependency2::ConstExampleForCyclicDependency2(
+    ExampleForCyclicDependency2Obj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
-ConstExampleForCyclicDependency2 ConstExampleForCyclicDependency2::clone() const {
+ConstExampleForCyclicDependency2
+ConstExampleForCyclicDependency2::clone() const {
   return {new ExampleForCyclicDependency2Obj(*m_obj)};
 }
 
-ConstExampleForCyclicDependency2::~ConstExampleForCyclicDependency2(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleForCyclicDependency2::~ConstExampleForCyclicDependency2() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  a ref
-  const ::ConstExampleForCyclicDependency1 ConstExampleForCyclicDependency2::ref() const {
-    if (m_obj->m_ref == nullptr) {
-      return ::ConstExampleForCyclicDependency1(nullptr);
-    }
-    return ::ConstExampleForCyclicDependency1(*(m_obj->m_ref));}
+/// Access the  a ref
+const ::ConstExampleForCyclicDependency1
+ConstExampleForCyclicDependency2::ref() const {
+  if (m_obj->m_ref == nullptr) {
+    return ::ConstExampleForCyclicDependency1(nullptr);
+  }
+  return ::ConstExampleForCyclicDependency1(*(m_obj->m_ref));
+}
 
-
-bool  ConstExampleForCyclicDependency2::isAvailable() const {
+bool ConstExampleForCyclicDependency2::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -55,22 +60,22 @@ bool  ConstExampleForCyclicDependency2::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleForCyclicDependency2::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleForCyclicDependency2::operator==(const ExampleForCyclicDependency2& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleForCyclicDependency2::
+operator==(const ExampleForCyclicDependency2 &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleForCyclicDependency2& p1, const ExampleForCyclicDependency2& p2 ) {
+// bool operator< (const ExampleForCyclicDependency2& p1, const
+// ExampleForCyclicDependency2& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleForCyclicDependency2Obj.cc
+++ b/tests/src/ExampleForCyclicDependency2Obj.cc
@@ -1,32 +1,28 @@
 #include "ExampleForCyclicDependency2Obj.h"
 #include "ExampleForCyclicDependency1Const.h"
 
+ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(), m_ref(nullptr)
 
+{}
 
-ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_ref(nullptr)
+ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj(
+    const podio::ObjectID id, ExampleForCyclicDependency2Data data)
+    : ObjBase{id, 0}, data(data) {}
 
-{ }
-
-ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj(const podio::ObjectID id, ExampleForCyclicDependency2Data data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj(const ExampleForCyclicDependency2Obj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_ref(nullptr)
-{
+ExampleForCyclicDependency2Obj::ExampleForCyclicDependency2Obj(
+    const ExampleForCyclicDependency2Obj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data), m_ref(nullptr) {
   if (other.m_ref != nullptr) {
-     m_ref = new ConstExampleForCyclicDependency1(*(other.m_ref));
+    m_ref = new ConstExampleForCyclicDependency1(*(other.m_ref));
   }
-
 }
 
 ExampleForCyclicDependency2Obj::~ExampleForCyclicDependency2Obj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-    if (m_ref != nullptr) delete m_ref;
-
+  if (m_ref != nullptr)
+    delete m_ref;
 }
-

--- a/tests/src/ExampleHit.cc
+++ b/tests/src/ExampleHit.cc
@@ -1,62 +1,58 @@
 // datamodel specific includes
 #include "ExampleHit.h"
-#include "ExampleHitConst.h"
-#include "ExampleHitObj.h"
-#include "ExampleHitData.h"
 #include "ExampleHitCollection.h"
+#include "ExampleHitConst.h"
+#include "ExampleHitData.h"
+#include "ExampleHitObj.h"
 #include <iostream>
 
+ExampleHit::ExampleHit() : m_obj(new ExampleHitObj()) { m_obj->acquire(); }
 
-
-
-ExampleHit::ExampleHit() : m_obj(new ExampleHitObj()){
- m_obj->acquire();
-}
-
-ExampleHit::ExampleHit(double x,double y,double z,double energy) : m_obj(new ExampleHitObj()) {
+ExampleHit::ExampleHit(double x, double y, double z, double energy)
+    : m_obj(new ExampleHitObj()) {
   m_obj->acquire();
-    m_obj->data.x = x;  m_obj->data.y = y;  m_obj->data.z = z;  m_obj->data.energy = energy;
+  m_obj->data.x = x;
+  m_obj->data.y = y;
+  m_obj->data.z = z;
+  m_obj->data.energy = energy;
 }
 
-
-ExampleHit::ExampleHit(const ExampleHit& other) : m_obj(other.m_obj) {
+ExampleHit::ExampleHit(const ExampleHit &other) : m_obj(other.m_obj) {
   m_obj->acquire();
 }
 
-ExampleHit& ExampleHit::operator=(const ExampleHit& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleHit &ExampleHit::operator=(const ExampleHit &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleHit::ExampleHit(ExampleHitObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleHit::ExampleHit(ExampleHitObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
-ExampleHit ExampleHit::clone() const {
-  return {new ExampleHitObj(*m_obj)};
+ExampleHit ExampleHit::clone() const { return {new ExampleHitObj(*m_obj)}; }
+
+ExampleHit::~ExampleHit() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleHit::~ExampleHit(){
-  if ( m_obj != nullptr) m_obj->release();
-}
+ExampleHit::operator ConstExampleHit() const { return ConstExampleHit(m_obj); }
 
-ExampleHit::operator ConstExampleHit() const {return ConstExampleHit(m_obj);}
-
-  const double& ExampleHit::x() const { return m_obj->data.x; }
-  const double& ExampleHit::y() const { return m_obj->data.y; }
-  const double& ExampleHit::z() const { return m_obj->data.z; }
-  const double& ExampleHit::energy() const { return m_obj->data.energy; }
+const double &ExampleHit::x() const { return m_obj->data.x; }
+const double &ExampleHit::y() const { return m_obj->data.y; }
+const double &ExampleHit::z() const { return m_obj->data.z; }
+const double &ExampleHit::energy() const { return m_obj->data.energy; }
 
 void ExampleHit::x(double value) { m_obj->data.x = value; }
 void ExampleHit::y(double value) { m_obj->data.y = value; }
 void ExampleHit::z(double value) { m_obj->data.z = value; }
 void ExampleHit::energy(double value) { m_obj->data.energy = value; }
 
-
-
-bool  ExampleHit::isAvailable() const {
+bool ExampleHit::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -64,32 +60,29 @@ bool  ExampleHit::isAvailable() const {
 }
 
 const podio::ObjectID ExampleHit::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleHit::operator==(const ConstExampleHit& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleHit::operator==(const ConstExampleHit &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleHit& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " x : " << value.x() << std::endl ;
-  o << " y : " << value.y() << std::endl ;
-  o << " z : " << value.z() << std::endl ;
-  o << " energy : " << value.energy() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o, const ConstExampleHit &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " x : " << value.x() << std::endl;
+  o << " y : " << value.y() << std::endl;
+  o << " z : " << value.z() << std::endl;
+  o << " energy : " << value.energy() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleHit& p1, const ExampleHit& p2 ) {
+// bool operator< (const ExampleHit& p1, const ExampleHit& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleHitCollection.cc
+++ b/tests/src/ExampleHitCollection.cc
@@ -1,19 +1,16 @@
 // standard includes
 #include <stdexcept>
 
-
 #include "ExampleHitCollection.h"
 
-
-
-ExampleHitCollection::ExampleHitCollection() : m_isValid(false), m_collectionID(0), m_entries() ,m_data(new ExampleHitDataContainer() ) {
-  
-}
+ExampleHitCollection::ExampleHitCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_data(new ExampleHitDataContainer()) {}
 
 ExampleHitCollection::~ExampleHitCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-  
+  if (m_data != nullptr)
+    delete m_data;
 }
 
 const ExampleHit ExampleHitCollection::operator[](unsigned int index) const {
@@ -32,96 +29,101 @@ ExampleHit ExampleHitCollection::at(unsigned int index) {
   return ExampleHit(m_entries.at(index));
 }
 
-int  ExampleHitCollection::size() const {
-  return m_entries.size();
-}
+int ExampleHitCollection::size() const { return m_entries.size(); }
 
-ExampleHit ExampleHitCollection::create(){
+ExampleHit ExampleHitCollection::create() {
   auto obj = new ExampleHitObj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleHit(obj);
 }
 
-void ExampleHitCollection::clear(){
+void ExampleHitCollection::clear() {
   m_data->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleHitCollection::prepareForWrite(){
+void ExampleHitCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
+  }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
   }
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
 }
 
-void ExampleHitCollection::prepareAfterRead(){
+void ExampleHitCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleHitObj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj = new ExampleHitObj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleHitCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleHitCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleHitCollection::push_back(ConstExampleHit object){
+void ExampleHitCollection::push_back(ConstExampleHit object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleHitCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleHitDataContainer*>(address);
+void ExampleHitCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleHitDataContainer *>(address);
 }
 
-
-const ExampleHit ExampleHitCollectionIterator::operator* () const {
+const ExampleHit ExampleHitCollectionIterator::operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleHit* ExampleHitCollectionIterator::operator-> () const {
+const ExampleHit *ExampleHitCollectionIterator::operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleHitCollectionIterator& ExampleHitCollectionIterator::operator++() const {
+const ExampleHitCollectionIterator &ExampleHitCollectionIterator::
+operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleHitCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          x:            y:            z:            energy:       " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].x() << " " << std::setw(12) << v[i].y() << " " << std::setw(12) << v[i].z() << " " << std::setw(12) << v[i].energy() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o, const ExampleHitCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          x:            y:            z:            energy:       "
+    << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].x() << " " << std::setw(12) << v[i].y() << " "
+      << std::setw(12) << v[i].z() << " " << std::setw(12) << v[i].energy()
+      << " " << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleHitConst.cc
+++ b/tests/src/ExampleHitConst.cc
@@ -1,36 +1,38 @@
 // datamodel specific includes
-#include "ExampleHit.h"
 #include "ExampleHitConst.h"
-#include "ExampleHitObj.h"
-#include "ExampleHitData.h"
+#include "ExampleHit.h"
 #include "ExampleHitCollection.h"
+#include "ExampleHitData.h"
+#include "ExampleHitObj.h"
 #include <iostream>
 
-
-
-
 ConstExampleHit::ConstExampleHit() : m_obj(new ExampleHitObj()) {
- m_obj->acquire();
-}
-
-ConstExampleHit::ConstExampleHit(double x,double y,double z,double energy) : m_obj(new ExampleHitObj()){
- m_obj->acquire();
-   m_obj->data.x = x;  m_obj->data.y = y;  m_obj->data.z = z;  m_obj->data.energy = energy;
-}
-
-
-ConstExampleHit::ConstExampleHit(const ConstExampleHit& other) : m_obj(other.m_obj) {
   m_obj->acquire();
 }
 
-ConstExampleHit& ConstExampleHit::operator=(const ConstExampleHit& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleHit::ConstExampleHit(double x, double y, double z, double energy)
+    : m_obj(new ExampleHitObj()) {
+  m_obj->acquire();
+  m_obj->data.x = x;
+  m_obj->data.y = y;
+  m_obj->data.z = z;
+  m_obj->data.energy = energy;
+}
+
+ConstExampleHit::ConstExampleHit(const ConstExampleHit &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleHit &ConstExampleHit::operator=(const ConstExampleHit &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleHit::ConstExampleHit(ExampleHitObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleHit::ConstExampleHit(ExampleHitObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,22 +40,21 @@ ConstExampleHit ConstExampleHit::clone() const {
   return {new ExampleHitObj(*m_obj)};
 }
 
-ConstExampleHit::~ConstExampleHit(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleHit::~ConstExampleHit() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  x-coordinate
-  const double& ConstExampleHit::x() const { return m_obj->data.x; }
-  /// Access the  y-coordinate
-  const double& ConstExampleHit::y() const { return m_obj->data.y; }
-  /// Access the  z-coordinate
-  const double& ConstExampleHit::z() const { return m_obj->data.z; }
-  /// Access the  measured energy deposit
-  const double& ConstExampleHit::energy() const { return m_obj->data.energy; }
+/// Access the  x-coordinate
+const double &ConstExampleHit::x() const { return m_obj->data.x; }
+/// Access the  y-coordinate
+const double &ConstExampleHit::y() const { return m_obj->data.y; }
+/// Access the  z-coordinate
+const double &ConstExampleHit::z() const { return m_obj->data.z; }
+/// Access the  measured energy deposit
+const double &ConstExampleHit::energy() const { return m_obj->data.energy; }
 
-
-
-bool  ConstExampleHit::isAvailable() const {
+bool ConstExampleHit::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -61,22 +62,20 @@ bool  ConstExampleHit::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleHit::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleHit::operator==(const ExampleHit& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleHit::operator==(const ExampleHit &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleHit& p1, const ExampleHit& p2 ) {
+// bool operator< (const ExampleHit& p1, const ExampleHit& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleHitObj.cc
+++ b/tests/src/ExampleHitObj.cc
@@ -1,26 +1,17 @@
 #include "ExampleHitObj.h"
 
+ExampleHitObj::ExampleHitObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data() {}
 
+ExampleHitObj::ExampleHitObj(const podio::ObjectID id, ExampleHitData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleHitObj::ExampleHitObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data()
-{ }
-
-ExampleHitObj::ExampleHitObj(const podio::ObjectID id, ExampleHitData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleHitObj::ExampleHitObj(const ExampleHitObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
-{
-
-}
+ExampleHitObj::ExampleHitObj(const ExampleHitObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data) {}
 
 ExampleHitObj::~ExampleHitObj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-
 }
-

--- a/tests/src/ExampleMC.cc
+++ b/tests/src/ExampleMC.cc
@@ -1,51 +1,46 @@
 // datamodel specific includes
 #include "ExampleMC.h"
-#include "ExampleMCConst.h"
-#include "ExampleMCObj.h"
-#include "ExampleMCData.h"
 #include "ExampleMCCollection.h"
+#include "ExampleMCConst.h"
+#include "ExampleMCData.h"
+#include "ExampleMCObj.h"
 #include <iostream>
 
+ExampleMC::ExampleMC() : m_obj(new ExampleMCObj()) { m_obj->acquire(); }
 
-
-
-ExampleMC::ExampleMC() : m_obj(new ExampleMCObj()){
- m_obj->acquire();
-}
-
-ExampleMC::ExampleMC(double energy,int PDG) : m_obj(new ExampleMCObj()) {
+ExampleMC::ExampleMC(double energy, int PDG) : m_obj(new ExampleMCObj()) {
   m_obj->acquire();
-    m_obj->data.energy = energy;  m_obj->data.PDG = PDG;
+  m_obj->data.energy = energy;
+  m_obj->data.PDG = PDG;
 }
 
-
-ExampleMC::ExampleMC(const ExampleMC& other) : m_obj(other.m_obj) {
+ExampleMC::ExampleMC(const ExampleMC &other) : m_obj(other.m_obj) {
   m_obj->acquire();
 }
 
-ExampleMC& ExampleMC::operator=(const ExampleMC& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleMC &ExampleMC::operator=(const ExampleMC &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleMC::ExampleMC(ExampleMCObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleMC::ExampleMC(ExampleMCObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
-ExampleMC ExampleMC::clone() const {
-  return {new ExampleMCObj(*m_obj)};
+ExampleMC ExampleMC::clone() const { return {new ExampleMCObj(*m_obj)}; }
+
+ExampleMC::~ExampleMC() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleMC::~ExampleMC(){
-  if ( m_obj != nullptr) m_obj->release();
-}
+ExampleMC::operator ConstExampleMC() const { return ConstExampleMC(m_obj); }
 
-ExampleMC::operator ConstExampleMC() const {return ConstExampleMC(m_obj);}
-
-  const double& ExampleMC::energy() const { return m_obj->data.energy; }
-  const int& ExampleMC::PDG() const { return m_obj->data.PDG; }
+const double &ExampleMC::energy() const { return m_obj->data.energy; }
+const int &ExampleMC::PDG() const { return m_obj->data.PDG; }
 
 void ExampleMC::energy(double value) { m_obj->data.energy = value; }
 void ExampleMC::PDG(int value) { m_obj->data.PDG = value; }
@@ -68,16 +63,17 @@ void ExampleMC::addparents(::ConstExampleMC component) {
 }
 
 unsigned int ExampleMC::parents_size() const {
-  return (m_obj->data.parents_end-m_obj->data.parents_begin);
+  return (m_obj->data.parents_end - m_obj->data.parents_begin);
 }
 
 ::ConstExampleMC ExampleMC::parents(unsigned int index) const {
   if (parents_size() > index) {
-    return m_obj->m_parents->at(m_obj->data.parents_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_parents->at(m_obj->data.parents_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
-std::vector<::ConstExampleMC>::const_iterator ExampleMC::daughters_begin() const {
+std::vector<::ConstExampleMC>::const_iterator
+ExampleMC::daughters_begin() const {
   auto ret_value = m_obj->m_daughters->begin();
   std::advance(ret_value, m_obj->data.daughters_begin);
   return ret_value;
@@ -95,18 +91,17 @@ void ExampleMC::adddaughters(::ConstExampleMC component) {
 }
 
 unsigned int ExampleMC::daughters_size() const {
-  return (m_obj->data.daughters_end-m_obj->data.daughters_begin);
+  return (m_obj->data.daughters_end - m_obj->data.daughters_begin);
 }
 
 ::ConstExampleMC ExampleMC::daughters(unsigned int index) const {
   if (daughters_size() > index) {
-    return m_obj->m_daughters->at(m_obj->data.daughters_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_daughters->at(m_obj->data.daughters_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ExampleMC::isAvailable() const {
+bool ExampleMC::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -114,38 +109,35 @@ bool  ExampleMC::isAvailable() const {
 }
 
 const podio::ObjectID ExampleMC::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleMC::operator==(const ConstExampleMC& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleMC::operator==(const ConstExampleMC &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleMC& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " energy : " << value.energy() << std::endl ;
-  o << " PDG : " << value.PDG() << std::endl ;
-  o << " parents : " ;
-  for(unsigned i=0,N=value.parents_size(); i<N ; ++i)
-    o << value.parents(i) << " " ; 
-  o << std::endl ;
-  o << " daughters : " ;
-  for(unsigned i=0,N=value.daughters_size(); i<N ; ++i)
-    o << value.daughters(i) << " " ; 
-  o << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o, const ConstExampleMC &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " energy : " << value.energy() << std::endl;
+  o << " PDG : " << value.PDG() << std::endl;
+  o << " parents : ";
+  for (unsigned i = 0, N = value.parents_size(); i < N; ++i)
+    o << value.parents(i) << " ";
+  o << std::endl;
+  o << " daughters : ";
+  for (unsigned i = 0, N = value.daughters_size(); i < N; ++i)
+    o << value.daughters(i) << " ";
+  o << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleMC& p1, const ExampleMC& p2 ) {
+// bool operator< (const ExampleMC& p1, const ExampleMC& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleMCCollection.cc
+++ b/tests/src/ExampleMCCollection.cc
@@ -1,26 +1,32 @@
 // standard includes
+#include "ExampleMCCollection.h"
 #include <stdexcept>
-#include "ExampleMCCollection.h" 
-#include "ExampleMCCollection.h" 
-
 
 #include "ExampleMCCollection.h"
 
-
-
-ExampleMCCollection::ExampleMCCollection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_parents(new std::vector<::ConstExampleMC>()), m_rel_daughters(new std::vector<::ConstExampleMC>()),m_data(new ExampleMCDataContainer() ) {
-    m_refCollections.push_back(new std::vector<podio::ObjectID>());
+ExampleMCCollection::ExampleMCCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_rel_parents(new std::vector<::ConstExampleMC>()),
+      m_rel_daughters(new std::vector<::ConstExampleMC>()),
+      m_data(new ExampleMCDataContainer()) {
   m_refCollections.push_back(new std::vector<podio::ObjectID>());
-
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
 }
 
 ExampleMCCollection::~ExampleMCCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-    for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
-  if (m_rel_parents != nullptr) { delete m_rel_parents; }
-  if (m_rel_daughters != nullptr) { delete m_rel_daughters; }
-
+  if (m_data != nullptr)
+    delete m_data;
+  for (auto &pointer : m_refCollections) {
+    if (pointer != nullptr)
+      delete pointer;
+  }
+  if (m_rel_parents != nullptr) {
+    delete m_rel_parents;
+  }
+  if (m_rel_daughters != nullptr) {
+    delete m_rel_daughters;
+  }
 }
 
 const ExampleMC ExampleMCCollection::operator[](unsigned int index) const {
@@ -39,110 +45,122 @@ ExampleMC ExampleMCCollection::at(unsigned int index) {
   return ExampleMC(m_entries.at(index));
 }
 
-int  ExampleMCCollection::size() const {
-  return m_entries.size();
-}
+int ExampleMCCollection::size() const { return m_entries.size(); }
 
-ExampleMC ExampleMCCollection::create(){
+ExampleMC ExampleMCCollection::create() {
   auto obj = new ExampleMCObj();
   m_entries.emplace_back(obj);
   m_rel_parents_tmp.push_back(obj->m_parents);
   m_rel_daughters_tmp.push_back(obj->m_daughters);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleMC(obj);
 }
 
-void ExampleMCCollection::clear(){
+void ExampleMCCollection::clear() {
   m_data->clear();
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-  // clear relations to parents. Make sure to unlink() the reference data s they may be gone already.
-  for (auto& pointer : m_rel_parents_tmp) {
-    for(auto& item : (*pointer)) {
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  // clear relations to parents. Make sure to unlink() the reference data s they
+  // may be gone already.
+  for (auto &pointer : m_rel_parents_tmp) {
+    for (auto &item : (*pointer)) {
       item.unlink();
     };
     delete pointer;
   }
   m_rel_parents_tmp.clear();
-  for (auto& item : (*m_rel_parents)) { item.unlink(); }
+  for (auto &item : (*m_rel_parents)) {
+    item.unlink();
+  }
   m_rel_parents->clear();
-  // clear relations to daughters. Make sure to unlink() the reference data s they may be gone already.
-  for (auto& pointer : m_rel_daughters_tmp) {
-    for(auto& item : (*pointer)) {
+  // clear relations to daughters. Make sure to unlink() the reference data s
+  // they may be gone already.
+  for (auto &pointer : m_rel_daughters_tmp) {
+    for (auto &item : (*pointer)) {
       item.unlink();
     };
     delete pointer;
   }
   m_rel_daughters_tmp.clear();
-  for (auto& item : (*m_rel_daughters)) { item.unlink(); }
+  for (auto &item : (*m_rel_daughters)) {
+    item.unlink();
+  }
   m_rel_daughters->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleMCCollection::prepareForWrite(){
+void ExampleMCCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-  int parents_index =0;
-  int daughters_index =0;
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-   (*m_data)[i].parents_begin=parents_index;
-   (*m_data)[i].parents_end+=parents_index;
-   parents_index = (*m_data)[i].parents_end;
-   for(auto it : (*m_rel_parents_tmp[i])) {
-     if (it.getObjectID().index == podio::ObjectID::untracked)
-       throw std::runtime_error("Trying to persistify untracked object");
-     m_refCollections[0]->emplace_back(it.getObjectID());
-     m_rel_parents->push_back(it);
-   }
-   (*m_data)[i].daughters_begin=daughters_index;
-   (*m_data)[i].daughters_end+=daughters_index;
-   daughters_index = (*m_data)[i].daughters_end;
-   for(auto it : (*m_rel_daughters_tmp[i])) {
-     if (it.getObjectID().index == podio::ObjectID::untracked)
-       throw std::runtime_error("Trying to persistify untracked object");
-     m_refCollections[1]->emplace_back(it.getObjectID());
-     m_rel_daughters->push_back(it);
-   }
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
   }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  int parents_index = 0;
+  int daughters_index = 0;
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+    (*m_data)[i].parents_begin = parents_index;
+    (*m_data)[i].parents_end += parents_index;
+    parents_index = (*m_data)[i].parents_end;
+    for (auto it : (*m_rel_parents_tmp[i])) {
+      if (it.getObjectID().index == podio::ObjectID::untracked)
+        throw std::runtime_error("Trying to persistify untracked object");
+      m_refCollections[0]->emplace_back(it.getObjectID());
+      m_rel_parents->push_back(it);
+    }
+    (*m_data)[i].daughters_begin = daughters_index;
+    (*m_data)[i].daughters_end += daughters_index;
+    daughters_index = (*m_data)[i].daughters_end;
+    for (auto it : (*m_rel_daughters_tmp[i])) {
+      if (it.getObjectID().index == podio::ObjectID::untracked)
+        throw std::runtime_error("Trying to persistify untracked object");
+      m_refCollections[1]->emplace_back(it.getObjectID());
+      m_rel_daughters->push_back(it);
+    }
+  }
 }
 
-void ExampleMCCollection::prepareAfterRead(){
+void ExampleMCCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleMCObj({index,m_collectionID}, data);
-        obj->m_parents = m_rel_parents;   obj->m_daughters = m_rel_daughters;
+  for (auto &data : *m_data) {
+    auto obj = new ExampleMCObj({index, m_collectionID}, data);
+    obj->m_parents = m_rel_parents;
+    obj->m_daughters = m_rel_daughters;
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleMCCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
-  for(unsigned int i=0, size=m_refCollections[0]->size();i!=size;++i) {
+bool ExampleMCCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
+  for (unsigned int i = 0, size = m_refCollections[0]->size(); i != size; ++i) {
     auto id = (*m_refCollections[0])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleMCCollection* tmp_coll = static_cast<ExampleMCCollection*>(coll);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleMCCollection *tmp_coll = static_cast<ExampleMCCollection *>(coll);
       auto tmp = (*tmp_coll)[id.index];
       m_rel_parents->emplace_back(tmp);
     } else {
       m_rel_parents->emplace_back(nullptr);
     }
   }
-  for(unsigned int i=0, size=m_refCollections[1]->size();i!=size;++i) {
+  for (unsigned int i = 0, size = m_refCollections[1]->size(); i != size; ++i) {
     auto id = (*m_refCollections[1])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleMCCollection* tmp_coll = static_cast<ExampleMCCollection*>(coll);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleMCCollection *tmp_coll = static_cast<ExampleMCCollection *>(coll);
       auto tmp = (*tmp_coll)[id.index];
       m_rel_daughters->emplace_back(tmp);
     } else {
@@ -150,54 +168,62 @@ bool ExampleMCCollection::setReferences(const podio::ICollectionProvider* collec
     }
   }
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleMCCollection::push_back(ConstExampleMC object){
+void ExampleMCCollection::push_back(ConstExampleMC object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-        m_rel_parents_tmp.push_back(obj->m_parents);
-  m_rel_daughters_tmp.push_back(obj->m_daughters);
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+    m_rel_parents_tmp.push_back(obj->m_parents);
+    m_rel_daughters_tmp.push_back(obj->m_daughters);
 
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleMCCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleMCDataContainer*>(address);
+void ExampleMCCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleMCDataContainer *>(address);
 }
 
-
-const ExampleMC ExampleMCCollectionIterator::operator* () const {
+const ExampleMC ExampleMCCollectionIterator::operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleMC* ExampleMCCollectionIterator::operator-> () const {
+const ExampleMC *ExampleMCCollectionIterator::operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleMCCollectionIterator& ExampleMCCollectionIterator::operator++() const {
+const ExampleMCCollectionIterator &ExampleMCCollectionIterator::
+operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleMCCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          energy:       PDG:          " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].energy() << " " << std::setw(12) << v[i].PDG() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o, const ExampleMCCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          energy:       PDG:          " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].energy() << " " << std::setw(12) << v[i].PDG()
+      << " " << std::endl;
+    o << "     parents : ";
+    for (unsigned j = 0, N = v[i].parents_size(); j < N; ++j)
+      o << v[i].parents(j).id() << " ";
+    o << std::endl;
+    o << "     daughters : ";
+    for (unsigned j = 0, N = v[i].daughters_size(); j < N; ++j)
+      o << v[i].daughters(j).id() << " ";
+    o << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleMCConst.cc
+++ b/tests/src/ExampleMCConst.cc
@@ -1,36 +1,36 @@
 // datamodel specific includes
-#include "ExampleMC.h"
 #include "ExampleMCConst.h"
-#include "ExampleMCObj.h"
-#include "ExampleMCData.h"
+#include "ExampleMC.h"
 #include "ExampleMCCollection.h"
+#include "ExampleMCData.h"
+#include "ExampleMCObj.h"
 #include <iostream>
 
-
-
-
 ConstExampleMC::ConstExampleMC() : m_obj(new ExampleMCObj()) {
- m_obj->acquire();
-}
-
-ConstExampleMC::ConstExampleMC(double energy,int PDG) : m_obj(new ExampleMCObj()){
- m_obj->acquire();
-   m_obj->data.energy = energy;  m_obj->data.PDG = PDG;
-}
-
-
-ConstExampleMC::ConstExampleMC(const ConstExampleMC& other) : m_obj(other.m_obj) {
   m_obj->acquire();
 }
 
-ConstExampleMC& ConstExampleMC::operator=(const ConstExampleMC& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleMC::ConstExampleMC(double energy, int PDG)
+    : m_obj(new ExampleMCObj()) {
+  m_obj->acquire();
+  m_obj->data.energy = energy;
+  m_obj->data.PDG = PDG;
+}
+
+ConstExampleMC::ConstExampleMC(const ConstExampleMC &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleMC &ConstExampleMC::operator=(const ConstExampleMC &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleMC::ConstExampleMC(ExampleMCObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleMC::ConstExampleMC(ExampleMCObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,62 +38,66 @@ ConstExampleMC ConstExampleMC::clone() const {
   return {new ExampleMCObj(*m_obj)};
 }
 
-ConstExampleMC::~ConstExampleMC(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleMC::~ConstExampleMC() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  energy
-  const double& ConstExampleMC::energy() const { return m_obj->data.energy; }
-  /// Access the  PDG code
-  const int& ConstExampleMC::PDG() const { return m_obj->data.PDG; }
+/// Access the  energy
+const double &ConstExampleMC::energy() const { return m_obj->data.energy; }
+/// Access the  PDG code
+const int &ConstExampleMC::PDG() const { return m_obj->data.PDG; }
 
-std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::parents_begin() const {
+std::vector<::ConstExampleMC>::const_iterator
+ConstExampleMC::parents_begin() const {
   auto ret_value = m_obj->m_parents->begin();
   std::advance(ret_value, m_obj->data.parents_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::parents_end() const {
+std::vector<::ConstExampleMC>::const_iterator
+ConstExampleMC::parents_end() const {
   auto ret_value = m_obj->m_parents->begin();
-  std::advance(ret_value, m_obj->data.parents_end-1);
+  std::advance(ret_value, m_obj->data.parents_end - 1);
   return ++ret_value;
 }
 
 unsigned int ConstExampleMC::parents_size() const {
-  return (m_obj->data.parents_end-m_obj->data.parents_begin);
+  return (m_obj->data.parents_end - m_obj->data.parents_begin);
 }
 
 ::ConstExampleMC ConstExampleMC::parents(unsigned int index) const {
   if (parents_size() > index) {
-    return m_obj->m_parents->at(m_obj->data.parents_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_parents->at(m_obj->data.parents_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
-std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::daughters_begin() const {
+std::vector<::ConstExampleMC>::const_iterator
+ConstExampleMC::daughters_begin() const {
   auto ret_value = m_obj->m_daughters->begin();
   std::advance(ret_value, m_obj->data.daughters_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleMC>::const_iterator ConstExampleMC::daughters_end() const {
+std::vector<::ConstExampleMC>::const_iterator
+ConstExampleMC::daughters_end() const {
   auto ret_value = m_obj->m_daughters->begin();
-  std::advance(ret_value, m_obj->data.daughters_end-1);
+  std::advance(ret_value, m_obj->data.daughters_end - 1);
   return ++ret_value;
 }
 
 unsigned int ConstExampleMC::daughters_size() const {
-  return (m_obj->data.daughters_end-m_obj->data.daughters_begin);
+  return (m_obj->data.daughters_end - m_obj->data.daughters_begin);
 }
 
 ::ConstExampleMC ConstExampleMC::daughters(unsigned int index) const {
   if (daughters_size() > index) {
-    return m_obj->m_daughters->at(m_obj->data.daughters_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_daughters->at(m_obj->data.daughters_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ConstExampleMC::isAvailable() const {
+bool ConstExampleMC::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -101,22 +105,20 @@ bool  ConstExampleMC::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleMC::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleMC::operator==(const ExampleMC& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleMC::operator==(const ExampleMC &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleMC& p1, const ExampleMC& p2 ) {
+// bool operator< (const ExampleMC& p1, const ExampleMC& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleMCObj.cc
+++ b/tests/src/ExampleMCObj.cc
@@ -1,30 +1,23 @@
 #include "ExampleMCObj.h"
 #include "ExampleMC.h"
-#include "ExampleMC.h"
 
+ExampleMCObj::ExampleMCObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(), m_parents(new std::vector<ConstExampleMC>()),
+      m_daughters(new std::vector<ConstExampleMC>()) {}
 
+ExampleMCObj::ExampleMCObj(const podio::ObjectID id, ExampleMCData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleMCObj::ExampleMCObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_parents(new std::vector<ConstExampleMC>()), m_daughters(new std::vector<ConstExampleMC>())
-{ }
-
-ExampleMCObj::ExampleMCObj(const podio::ObjectID id, ExampleMCData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleMCObj::ExampleMCObj(const ExampleMCObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_parents(new std::vector<ConstExampleMC>(*(other.m_parents))), m_daughters(new std::vector<ConstExampleMC>(*(other.m_daughters)))
-{
-
-}
+ExampleMCObj::ExampleMCObj(const ExampleMCObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data),
+      m_parents(new std::vector<ConstExampleMC>(*(other.m_parents))),
+      m_daughters(new std::vector<ConstExampleMC>(*(other.m_daughters))) {}
 
 ExampleMCObj::~ExampleMCObj() {
   if (id.index == podio::ObjectID::untracked) {
     delete m_parents;
     delete m_daughters;
-
   }
-
 }
-

--- a/tests/src/ExampleReferencingType.cc
+++ b/tests/src/ExampleReferencingType.cc
@@ -1,32 +1,33 @@
 // datamodel specific includes
 #include "ExampleReferencingType.h"
-#include "ExampleReferencingTypeConst.h"
-#include "ExampleReferencingTypeObj.h"
-#include "ExampleReferencingTypeData.h"
 #include "ExampleReferencingTypeCollection.h"
+#include "ExampleReferencingTypeConst.h"
+#include "ExampleReferencingTypeData.h"
+#include "ExampleReferencingTypeObj.h"
 #include <iostream>
 
-
-
-
-ExampleReferencingType::ExampleReferencingType() : m_obj(new ExampleReferencingTypeObj()){
- m_obj->acquire();
-}
-
-
-
-ExampleReferencingType::ExampleReferencingType(const ExampleReferencingType& other) : m_obj(other.m_obj) {
+ExampleReferencingType::ExampleReferencingType()
+    : m_obj(new ExampleReferencingTypeObj()) {
   m_obj->acquire();
 }
 
-ExampleReferencingType& ExampleReferencingType::operator=(const ExampleReferencingType& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleReferencingType::ExampleReferencingType(
+    const ExampleReferencingType &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleReferencingType &ExampleReferencingType::
+operator=(const ExampleReferencingType &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleReferencingType::ExampleReferencingType(ExampleReferencingTypeObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleReferencingType::ExampleReferencingType(ExampleReferencingTypeObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -34,21 +35,24 @@ ExampleReferencingType ExampleReferencingType::clone() const {
   return {new ExampleReferencingTypeObj(*m_obj)};
 }
 
-ExampleReferencingType::~ExampleReferencingType(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleReferencingType::~ExampleReferencingType() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleReferencingType::operator ConstExampleReferencingType() const {return ConstExampleReferencingType(m_obj);}
+ExampleReferencingType::operator ConstExampleReferencingType() const {
+  return ConstExampleReferencingType(m_obj);
+}
 
-
-
-std::vector<::ConstExampleCluster>::const_iterator ExampleReferencingType::Clusters_begin() const {
+std::vector<::ConstExampleCluster>::const_iterator
+ExampleReferencingType::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleCluster>::const_iterator ExampleReferencingType::Clusters_end() const {
+std::vector<::ConstExampleCluster>::const_iterator
+ExampleReferencingType::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_end);
   return ret_value;
@@ -60,22 +64,25 @@ void ExampleReferencingType::addClusters(::ConstExampleCluster component) {
 }
 
 unsigned int ExampleReferencingType::Clusters_size() const {
-  return (m_obj->data.Clusters_end-m_obj->data.Clusters_begin);
+  return (m_obj->data.Clusters_end - m_obj->data.Clusters_begin);
 }
 
-::ConstExampleCluster ExampleReferencingType::Clusters(unsigned int index) const {
+::ConstExampleCluster
+ExampleReferencingType::Clusters(unsigned int index) const {
   if (Clusters_size() > index) {
-    return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_Clusters->at(m_obj->data.Clusters_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
-std::vector<::ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_begin() const {
+std::vector<::ConstExampleReferencingType>::const_iterator
+ExampleReferencingType::Refs_begin() const {
   auto ret_value = m_obj->m_Refs->begin();
   std::advance(ret_value, m_obj->data.Refs_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleReferencingType>::const_iterator ExampleReferencingType::Refs_end() const {
+std::vector<::ConstExampleReferencingType>::const_iterator
+ExampleReferencingType::Refs_end() const {
   auto ret_value = m_obj->m_Refs->begin();
   std::advance(ret_value, m_obj->data.Refs_end);
   return ret_value;
@@ -87,18 +94,18 @@ void ExampleReferencingType::addRefs(::ConstExampleReferencingType component) {
 }
 
 unsigned int ExampleReferencingType::Refs_size() const {
-  return (m_obj->data.Refs_end-m_obj->data.Refs_begin);
+  return (m_obj->data.Refs_end - m_obj->data.Refs_begin);
 }
 
-::ConstExampleReferencingType ExampleReferencingType::Refs(unsigned int index) const {
+::ConstExampleReferencingType
+ExampleReferencingType::Refs(unsigned int index) const {
   if (Refs_size() > index) {
-    return m_obj->m_Refs->at(m_obj->data.Refs_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_Refs->at(m_obj->data.Refs_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ExampleReferencingType::isAvailable() const {
+bool ExampleReferencingType::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -106,36 +113,36 @@ bool  ExampleReferencingType::isAvailable() const {
 }
 
 const podio::ObjectID ExampleReferencingType::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleReferencingType::operator==(const ConstExampleReferencingType& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleReferencingType::
+operator==(const ConstExampleReferencingType &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleReferencingType& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " Clusters : " ;
-  for(unsigned i=0,N=value.Clusters_size(); i<N ; ++i)
-    o << value.Clusters(i) << " " ; 
-  o << std::endl ;
-  o << " Refs : " ;
-  for(unsigned i=0,N=value.Refs_size(); i<N ; ++i)
-    o << value.Refs(i) << " " ; 
-  o << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleReferencingType &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " Clusters : ";
+  for (unsigned i = 0, N = value.Clusters_size(); i < N; ++i)
+    o << value.Clusters(i) << " ";
+  o << std::endl;
+  o << " Refs : ";
+  for (unsigned i = 0, N = value.Refs_size(); i < N; ++i)
+    o << value.Refs(i) << " ";
+  o << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleReferencingType& p1, const ExampleReferencingType& p2 ) {
+// bool operator< (const ExampleReferencingType& p1, const
+// ExampleReferencingType& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleReferencingTypeCollection.cc
+++ b/tests/src/ExampleReferencingTypeCollection.cc
@@ -1,148 +1,173 @@
 // standard includes
+#include "ExampleReferencingTypeCollection.h"
+#include "ExampleClusterCollection.h"
 #include <stdexcept>
-#include "ExampleClusterCollection.h" 
-#include "ExampleReferencingTypeCollection.h" 
-
 
 #include "ExampleReferencingTypeCollection.h"
 
-
-
-ExampleReferencingTypeCollection::ExampleReferencingTypeCollection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_Clusters(new std::vector<::ConstExampleCluster>()), m_rel_Refs(new std::vector<::ConstExampleReferencingType>()),m_data(new ExampleReferencingTypeDataContainer() ) {
-    m_refCollections.push_back(new std::vector<podio::ObjectID>());
+ExampleReferencingTypeCollection::ExampleReferencingTypeCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_rel_Clusters(new std::vector<::ConstExampleCluster>()),
+      m_rel_Refs(new std::vector<::ConstExampleReferencingType>()),
+      m_data(new ExampleReferencingTypeDataContainer()) {
   m_refCollections.push_back(new std::vector<podio::ObjectID>());
-
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
 }
 
 ExampleReferencingTypeCollection::~ExampleReferencingTypeCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-    for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
-  if (m_rel_Clusters != nullptr) { delete m_rel_Clusters; }
-  if (m_rel_Refs != nullptr) { delete m_rel_Refs; }
-
+  if (m_data != nullptr)
+    delete m_data;
+  for (auto &pointer : m_refCollections) {
+    if (pointer != nullptr)
+      delete pointer;
+  }
+  if (m_rel_Clusters != nullptr) {
+    delete m_rel_Clusters;
+  }
+  if (m_rel_Refs != nullptr) {
+    delete m_rel_Refs;
+  }
 }
 
-const ExampleReferencingType ExampleReferencingTypeCollection::operator[](unsigned int index) const {
+const ExampleReferencingType ExampleReferencingTypeCollection::
+operator[](unsigned int index) const {
   return ExampleReferencingType(m_entries[index]);
 }
 
-const ExampleReferencingType ExampleReferencingTypeCollection::at(unsigned int index) const {
+const ExampleReferencingType
+ExampleReferencingTypeCollection::at(unsigned int index) const {
   return ExampleReferencingType(m_entries.at(index));
 }
 
-ExampleReferencingType ExampleReferencingTypeCollection::operator[](unsigned int index) {
+ExampleReferencingType ExampleReferencingTypeCollection::
+operator[](unsigned int index) {
   return ExampleReferencingType(m_entries[index]);
 }
 
-ExampleReferencingType ExampleReferencingTypeCollection::at(unsigned int index) {
+ExampleReferencingType
+ExampleReferencingTypeCollection::at(unsigned int index) {
   return ExampleReferencingType(m_entries.at(index));
 }
 
-int  ExampleReferencingTypeCollection::size() const {
-  return m_entries.size();
-}
+int ExampleReferencingTypeCollection::size() const { return m_entries.size(); }
 
-ExampleReferencingType ExampleReferencingTypeCollection::create(){
+ExampleReferencingType ExampleReferencingTypeCollection::create() {
   auto obj = new ExampleReferencingTypeObj();
   m_entries.emplace_back(obj);
   m_rel_Clusters_tmp.push_back(obj->m_Clusters);
   m_rel_Refs_tmp.push_back(obj->m_Refs);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleReferencingType(obj);
 }
 
-void ExampleReferencingTypeCollection::clear(){
+void ExampleReferencingTypeCollection::clear() {
   m_data->clear();
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-  // clear relations to Clusters. Make sure to unlink() the reference data s they may be gone already.
-  for (auto& pointer : m_rel_Clusters_tmp) {
-    for(auto& item : (*pointer)) {
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  // clear relations to Clusters. Make sure to unlink() the reference data s
+  // they may be gone already.
+  for (auto &pointer : m_rel_Clusters_tmp) {
+    for (auto &item : (*pointer)) {
       item.unlink();
     };
     delete pointer;
   }
   m_rel_Clusters_tmp.clear();
-  for (auto& item : (*m_rel_Clusters)) { item.unlink(); }
+  for (auto &item : (*m_rel_Clusters)) {
+    item.unlink();
+  }
   m_rel_Clusters->clear();
-  // clear relations to Refs. Make sure to unlink() the reference data s they may be gone already.
-  for (auto& pointer : m_rel_Refs_tmp) {
-    for(auto& item : (*pointer)) {
+  // clear relations to Refs. Make sure to unlink() the reference data s they
+  // may be gone already.
+  for (auto &pointer : m_rel_Refs_tmp) {
+    for (auto &item : (*pointer)) {
       item.unlink();
     };
     delete pointer;
   }
   m_rel_Refs_tmp.clear();
-  for (auto& item : (*m_rel_Refs)) { item.unlink(); }
+  for (auto &item : (*m_rel_Refs)) {
+    item.unlink();
+  }
   m_rel_Refs->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleReferencingTypeCollection::prepareForWrite(){
+void ExampleReferencingTypeCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-  int Clusters_index =0;
-  int Refs_index =0;
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-   (*m_data)[i].Clusters_begin=Clusters_index;
-   (*m_data)[i].Clusters_end+=Clusters_index;
-   Clusters_index = (*m_data)[i].Clusters_end;
-   for(auto it : (*m_rel_Clusters_tmp[i])) {
-     if (it.getObjectID().index == podio::ObjectID::untracked)
-       throw std::runtime_error("Trying to persistify untracked object");
-     m_refCollections[0]->emplace_back(it.getObjectID());
-     m_rel_Clusters->push_back(it);
-   }
-   (*m_data)[i].Refs_begin=Refs_index;
-   (*m_data)[i].Refs_end+=Refs_index;
-   Refs_index = (*m_data)[i].Refs_end;
-   for(auto it : (*m_rel_Refs_tmp[i])) {
-     if (it.getObjectID().index == podio::ObjectID::untracked)
-       throw std::runtime_error("Trying to persistify untracked object");
-     m_refCollections[1]->emplace_back(it.getObjectID());
-     m_rel_Refs->push_back(it);
-   }
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
   }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  int Clusters_index = 0;
+  int Refs_index = 0;
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+    (*m_data)[i].Clusters_begin = Clusters_index;
+    (*m_data)[i].Clusters_end += Clusters_index;
+    Clusters_index = (*m_data)[i].Clusters_end;
+    for (auto it : (*m_rel_Clusters_tmp[i])) {
+      if (it.getObjectID().index == podio::ObjectID::untracked)
+        throw std::runtime_error("Trying to persistify untracked object");
+      m_refCollections[0]->emplace_back(it.getObjectID());
+      m_rel_Clusters->push_back(it);
+    }
+    (*m_data)[i].Refs_begin = Refs_index;
+    (*m_data)[i].Refs_end += Refs_index;
+    Refs_index = (*m_data)[i].Refs_end;
+    for (auto it : (*m_rel_Refs_tmp[i])) {
+      if (it.getObjectID().index == podio::ObjectID::untracked)
+        throw std::runtime_error("Trying to persistify untracked object");
+      m_refCollections[1]->emplace_back(it.getObjectID());
+      m_rel_Refs->push_back(it);
+    }
+  }
 }
 
-void ExampleReferencingTypeCollection::prepareAfterRead(){
+void ExampleReferencingTypeCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleReferencingTypeObj({index,m_collectionID}, data);
-        obj->m_Clusters = m_rel_Clusters;   obj->m_Refs = m_rel_Refs;
+  for (auto &data : *m_data) {
+    auto obj = new ExampleReferencingTypeObj({index, m_collectionID}, data);
+    obj->m_Clusters = m_rel_Clusters;
+    obj->m_Refs = m_rel_Refs;
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleReferencingTypeCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
-  for(unsigned int i=0, size=m_refCollections[0]->size();i!=size;++i) {
+bool ExampleReferencingTypeCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
+  for (unsigned int i = 0, size = m_refCollections[0]->size(); i != size; ++i) {
     auto id = (*m_refCollections[0])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleClusterCollection* tmp_coll = static_cast<ExampleClusterCollection*>(coll);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleClusterCollection *tmp_coll =
+          static_cast<ExampleClusterCollection *>(coll);
       auto tmp = (*tmp_coll)[id.index];
       m_rel_Clusters->emplace_back(tmp);
     } else {
       m_rel_Clusters->emplace_back(nullptr);
     }
   }
-  for(unsigned int i=0, size=m_refCollections[1]->size();i!=size;++i) {
+  for (unsigned int i = 0, size = m_refCollections[1]->size(); i != size; ++i) {
     auto id = (*m_refCollections[1])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleReferencingTypeCollection* tmp_coll = static_cast<ExampleReferencingTypeCollection*>(coll);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleReferencingTypeCollection *tmp_coll =
+          static_cast<ExampleReferencingTypeCollection *>(coll);
       auto tmp = (*tmp_coll)[id.index];
       m_rel_Refs->emplace_back(tmp);
     } else {
@@ -150,54 +175,65 @@ bool ExampleReferencingTypeCollection::setReferences(const podio::ICollectionPro
     }
   }
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleReferencingTypeCollection::push_back(ConstExampleReferencingType object){
+void ExampleReferencingTypeCollection::push_back(
+    ConstExampleReferencingType object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-        m_rel_Clusters_tmp.push_back(obj->m_Clusters);
-  m_rel_Refs_tmp.push_back(obj->m_Refs);
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+    m_rel_Clusters_tmp.push_back(obj->m_Clusters);
+    m_rel_Refs_tmp.push_back(obj->m_Refs);
 
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleReferencingTypeCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleReferencingTypeDataContainer*>(address);
+void ExampleReferencingTypeCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleReferencingTypeDataContainer *>(address);
 }
 
-
-const ExampleReferencingType ExampleReferencingTypeCollectionIterator::operator* () const {
+const ExampleReferencingType ExampleReferencingTypeCollectionIterator::
+operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleReferencingType* ExampleReferencingTypeCollectionIterator::operator-> () const {
+const ExampleReferencingType *ExampleReferencingTypeCollectionIterator::
+operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleReferencingTypeCollectionIterator& ExampleReferencingTypeCollectionIterator::operator++() const {
+const ExampleReferencingTypeCollectionIterator &
+ExampleReferencingTypeCollectionIterator::operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleReferencingTypeCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "   << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleReferencingTypeCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::endl;
+    o << "     Clusters : ";
+    for (unsigned j = 0, N = v[i].Clusters_size(); j < N; ++j)
+      o << v[i].Clusters(j).id() << " ";
+    o << std::endl;
+    o << "     Refs : ";
+    for (unsigned j = 0, N = v[i].Refs_size(); j < N; ++j)
+      o << v[i].Refs(j).id() << " ";
+    o << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleReferencingTypeConst.cc
+++ b/tests/src/ExampleReferencingTypeConst.cc
@@ -1,32 +1,34 @@
 // datamodel specific includes
-#include "ExampleReferencingType.h"
 #include "ExampleReferencingTypeConst.h"
-#include "ExampleReferencingTypeObj.h"
-#include "ExampleReferencingTypeData.h"
+#include "ExampleReferencingType.h"
 #include "ExampleReferencingTypeCollection.h"
+#include "ExampleReferencingTypeData.h"
+#include "ExampleReferencingTypeObj.h"
 #include <iostream>
 
-
-
-
-ConstExampleReferencingType::ConstExampleReferencingType() : m_obj(new ExampleReferencingTypeObj()) {
- m_obj->acquire();
-}
-
-
-
-ConstExampleReferencingType::ConstExampleReferencingType(const ConstExampleReferencingType& other) : m_obj(other.m_obj) {
+ConstExampleReferencingType::ConstExampleReferencingType()
+    : m_obj(new ExampleReferencingTypeObj()) {
   m_obj->acquire();
 }
 
-ConstExampleReferencingType& ConstExampleReferencingType::operator=(const ConstExampleReferencingType& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleReferencingType::ConstExampleReferencingType(
+    const ConstExampleReferencingType &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleReferencingType &ConstExampleReferencingType::
+operator=(const ConstExampleReferencingType &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleReferencingType::ConstExampleReferencingType(ExampleReferencingTypeObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleReferencingType::ConstExampleReferencingType(
+    ExampleReferencingTypeObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -34,58 +36,63 @@ ConstExampleReferencingType ConstExampleReferencingType::clone() const {
   return {new ExampleReferencingTypeObj(*m_obj)};
 }
 
-ConstExampleReferencingType::~ConstExampleReferencingType(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleReferencingType::~ConstExampleReferencingType() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-
-std::vector<::ConstExampleCluster>::const_iterator ConstExampleReferencingType::Clusters_begin() const {
+std::vector<::ConstExampleCluster>::const_iterator
+ConstExampleReferencingType::Clusters_begin() const {
   auto ret_value = m_obj->m_Clusters->begin();
   std::advance(ret_value, m_obj->data.Clusters_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleCluster>::const_iterator ConstExampleReferencingType::Clusters_end() const {
+std::vector<::ConstExampleCluster>::const_iterator
+ConstExampleReferencingType::Clusters_end() const {
   auto ret_value = m_obj->m_Clusters->begin();
-  std::advance(ret_value, m_obj->data.Clusters_end-1);
+  std::advance(ret_value, m_obj->data.Clusters_end - 1);
   return ++ret_value;
 }
 
 unsigned int ConstExampleReferencingType::Clusters_size() const {
-  return (m_obj->data.Clusters_end-m_obj->data.Clusters_begin);
+  return (m_obj->data.Clusters_end - m_obj->data.Clusters_begin);
 }
 
-::ConstExampleCluster ConstExampleReferencingType::Clusters(unsigned int index) const {
+::ConstExampleCluster
+ConstExampleReferencingType::Clusters(unsigned int index) const {
   if (Clusters_size() > index) {
-    return m_obj->m_Clusters->at(m_obj->data.Clusters_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_Clusters->at(m_obj->data.Clusters_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
-std::vector<::ConstExampleReferencingType>::const_iterator ConstExampleReferencingType::Refs_begin() const {
+std::vector<::ConstExampleReferencingType>::const_iterator
+ConstExampleReferencingType::Refs_begin() const {
   auto ret_value = m_obj->m_Refs->begin();
   std::advance(ret_value, m_obj->data.Refs_begin);
   return ret_value;
 }
 
-std::vector<::ConstExampleReferencingType>::const_iterator ConstExampleReferencingType::Refs_end() const {
+std::vector<::ConstExampleReferencingType>::const_iterator
+ConstExampleReferencingType::Refs_end() const {
   auto ret_value = m_obj->m_Refs->begin();
-  std::advance(ret_value, m_obj->data.Refs_end-1);
+  std::advance(ret_value, m_obj->data.Refs_end - 1);
   return ++ret_value;
 }
 
 unsigned int ConstExampleReferencingType::Refs_size() const {
-  return (m_obj->data.Refs_end-m_obj->data.Refs_begin);
+  return (m_obj->data.Refs_end - m_obj->data.Refs_begin);
 }
 
-::ConstExampleReferencingType ConstExampleReferencingType::Refs(unsigned int index) const {
+::ConstExampleReferencingType
+ConstExampleReferencingType::Refs(unsigned int index) const {
   if (Refs_size() > index) {
-    return m_obj->m_Refs->at(m_obj->data.Refs_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_Refs->at(m_obj->data.Refs_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ConstExampleReferencingType::isAvailable() const {
+bool ConstExampleReferencingType::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -93,22 +100,22 @@ bool  ConstExampleReferencingType::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleReferencingType::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleReferencingType::operator==(const ExampleReferencingType& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleReferencingType::
+operator==(const ExampleReferencingType &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleReferencingType& p1, const ExampleReferencingType& p2 ) {
+// bool operator< (const ExampleReferencingType& p1, const
+// ExampleReferencingType& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleReferencingTypeObj.cc
+++ b/tests/src/ExampleReferencingTypeObj.cc
@@ -1,29 +1,25 @@
 #include "ExampleReferencingTypeObj.h"
 #include "ExampleReferencingType.h"
 
+ExampleReferencingTypeObj::ExampleReferencingTypeObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(), m_Clusters(new std::vector<ConstExampleCluster>()),
+      m_Refs(new std::vector<ConstExampleReferencingType>()) {}
 
+ExampleReferencingTypeObj::ExampleReferencingTypeObj(
+    const podio::ObjectID id, ExampleReferencingTypeData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleReferencingTypeObj::ExampleReferencingTypeObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_Clusters(new std::vector<ConstExampleCluster>()), m_Refs(new std::vector<ConstExampleReferencingType>())
-{ }
-
-ExampleReferencingTypeObj::ExampleReferencingTypeObj(const podio::ObjectID id, ExampleReferencingTypeData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleReferencingTypeObj::ExampleReferencingTypeObj(const ExampleReferencingTypeObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_Clusters(new std::vector<ConstExampleCluster>(*(other.m_Clusters))), m_Refs(new std::vector<ConstExampleReferencingType>(*(other.m_Refs)))
-{
-
-}
+ExampleReferencingTypeObj::ExampleReferencingTypeObj(
+    const ExampleReferencingTypeObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data),
+      m_Clusters(new std::vector<ConstExampleCluster>(*(other.m_Clusters))),
+      m_Refs(new std::vector<ConstExampleReferencingType>(*(other.m_Refs))) {}
 
 ExampleReferencingTypeObj::~ExampleReferencingTypeObj() {
   if (id.index == podio::ObjectID::untracked) {
     delete m_Clusters;
     delete m_Refs;
-
   }
-
 }
-

--- a/tests/src/ExampleWithARelation.cc
+++ b/tests/src/ExampleWithARelation.cc
@@ -1,37 +1,41 @@
 // datamodel specific includes
 #include "ExampleWithARelation.h"
-#include "ExampleWithARelationConst.h"
-#include "ExampleWithARelationObj.h"
-#include "ExampleWithARelationData.h"
 #include "ExampleWithARelationCollection.h"
-#include <iostream>
+#include "ExampleWithARelationConst.h"
+#include "ExampleWithARelationData.h"
+#include "ExampleWithARelationObj.h"
 #include "ExampleWithNamespace.h"
-
+#include <iostream>
 
 namespace ex {
 
-ExampleWithARelation::ExampleWithARelation() : m_obj(new ExampleWithARelationObj()){
- m_obj->acquire();
-}
-
-ExampleWithARelation::ExampleWithARelation(float number) : m_obj(new ExampleWithARelationObj()) {
-  m_obj->acquire();
-    m_obj->data.number = number;
-}
-
-
-ExampleWithARelation::ExampleWithARelation(const ExampleWithARelation& other) : m_obj(other.m_obj) {
+ExampleWithARelation::ExampleWithARelation()
+    : m_obj(new ExampleWithARelationObj()) {
   m_obj->acquire();
 }
 
-ExampleWithARelation& ExampleWithARelation::operator=(const ExampleWithARelation& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithARelation::ExampleWithARelation(float number)
+    : m_obj(new ExampleWithARelationObj()) {
+  m_obj->acquire();
+  m_obj->data.number = number;
+}
+
+ExampleWithARelation::ExampleWithARelation(const ExampleWithARelation &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleWithARelation &ExampleWithARelation::
+operator=(const ExampleWithARelation &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleWithARelation::ExampleWithARelation(ExampleWithARelationObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleWithARelation::ExampleWithARelation(ExampleWithARelationObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -39,32 +43,38 @@ ExampleWithARelation ExampleWithARelation::clone() const {
   return {new ExampleWithARelationObj(*m_obj)};
 }
 
-ExampleWithARelation::~ExampleWithARelation(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithARelation::~ExampleWithARelation() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleWithARelation::operator ConstExampleWithARelation() const {return ConstExampleWithARelation(m_obj);}
+ExampleWithARelation::operator ConstExampleWithARelation() const {
+  return ConstExampleWithARelation(m_obj);
+}
 
-  const float& ExampleWithARelation::number() const { return m_obj->data.number; }
-  const ex::ConstExampleWithNamespace ExampleWithARelation::ref() const {
-    if (m_obj->m_ref == nullptr) {
-      return ex::ConstExampleWithNamespace(nullptr);
-    }
-    return ex::ConstExampleWithNamespace(*(m_obj->m_ref));
+const float &ExampleWithARelation::number() const { return m_obj->data.number; }
+const ex::ConstExampleWithNamespace ExampleWithARelation::ref() const {
+  if (m_obj->m_ref == nullptr) {
+    return ex::ConstExampleWithNamespace(nullptr);
   }
+  return ex::ConstExampleWithNamespace(*(m_obj->m_ref));
+}
 void ExampleWithARelation::number(float value) { m_obj->data.number = value; }
 void ExampleWithARelation::ref(ex::ConstExampleWithNamespace value) {
-  if (m_obj->m_ref != nullptr) delete m_obj->m_ref;
+  if (m_obj->m_ref != nullptr)
+    delete m_obj->m_ref;
   m_obj->m_ref = new ConstExampleWithNamespace(value);
 }
 
-std::vector<ex::ConstExampleWithNamespace>::const_iterator ExampleWithARelation::refs_begin() const {
+std::vector<ex::ConstExampleWithNamespace>::const_iterator
+ExampleWithARelation::refs_begin() const {
   auto ret_value = m_obj->m_refs->begin();
   std::advance(ret_value, m_obj->data.refs_begin);
   return ret_value;
 }
 
-std::vector<ex::ConstExampleWithNamespace>::const_iterator ExampleWithARelation::refs_end() const {
+std::vector<ex::ConstExampleWithNamespace>::const_iterator
+ExampleWithARelation::refs_end() const {
   auto ret_value = m_obj->m_refs->begin();
   std::advance(ret_value, m_obj->data.refs_end);
   return ret_value;
@@ -76,18 +86,18 @@ void ExampleWithARelation::addrefs(ex::ConstExampleWithNamespace component) {
 }
 
 unsigned int ExampleWithARelation::refs_size() const {
-  return (m_obj->data.refs_end-m_obj->data.refs_begin);
+  return (m_obj->data.refs_end - m_obj->data.refs_begin);
 }
 
-ex::ConstExampleWithNamespace ExampleWithARelation::refs(unsigned int index) const {
+ex::ConstExampleWithNamespace
+ExampleWithARelation::refs(unsigned int index) const {
   if (refs_size() > index) {
-    return m_obj->m_refs->at(m_obj->data.refs_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_refs->at(m_obj->data.refs_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ExampleWithARelation::isAvailable() const {
+bool ExampleWithARelation::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -95,29 +105,31 @@ bool  ExampleWithARelation::isAvailable() const {
 }
 
 const podio::ObjectID ExampleWithARelation::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleWithARelation::operator==(const ConstExampleWithARelation& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleWithARelation::
+operator==(const ConstExampleWithARelation &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithARelation& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " number : " << value.number() << std::endl ;
-  o << " ref : " << value.ref().id() << std::endl ;
-  o << " refs : " ;
-  for(unsigned i=0,N=value.refs_size(); i<N ; ++i)
-    o << value.refs(i) << " " ; 
-  o << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithARelation &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " number : " << value.number() << std::endl;
+  o << " ref : " << value.ref().id() << std::endl;
+  o << " refs : ";
+  for (unsigned i = 0, N = value.refs_size(); i < N; ++i)
+    o << value.refs(i) << " ";
+  o << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleWithARelation& p1, const ExampleWithARelation& p2 ) {
+// bool operator< (const ExampleWithARelation& p1, const ExampleWithARelation&
+// p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {

--- a/tests/src/ExampleWithARelationCollection.cc
+++ b/tests/src/ExampleWithARelationCollection.cc
@@ -1,37 +1,49 @@
 // standard includes
-#include <stdexcept>
-#include "ExampleWithNamespaceCollection.h" 
 #include "ExampleWithNamespaceCollection.h"
-
+#include "ExampleWithNamespaceCollection.h"
+#include <stdexcept>
 
 #include "ExampleWithARelationCollection.h"
 
 namespace ex {
 
-ExampleWithARelationCollection::ExampleWithARelationCollection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_refs(new std::vector<ex::ConstExampleWithNamespace>()), m_rel_ref(new std::vector<ex::ConstExampleWithNamespace>()),m_data(new ExampleWithARelationDataContainer() ) {
-    m_refCollections.push_back(new std::vector<podio::ObjectID>());
+ExampleWithARelationCollection::ExampleWithARelationCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_rel_refs(new std::vector<ex::ConstExampleWithNamespace>()),
+      m_rel_ref(new std::vector<ex::ConstExampleWithNamespace>()),
+      m_data(new ExampleWithARelationDataContainer()) {
   m_refCollections.push_back(new std::vector<podio::ObjectID>());
-
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
 }
 
 ExampleWithARelationCollection::~ExampleWithARelationCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-    for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
-  if (m_rel_refs != nullptr) { delete m_rel_refs; }
-  if (m_rel_ref != nullptr) { delete m_rel_ref; }
-
+  if (m_data != nullptr)
+    delete m_data;
+  for (auto &pointer : m_refCollections) {
+    if (pointer != nullptr)
+      delete pointer;
+  }
+  if (m_rel_refs != nullptr) {
+    delete m_rel_refs;
+  }
+  if (m_rel_ref != nullptr) {
+    delete m_rel_ref;
+  }
 }
 
-const ExampleWithARelation ExampleWithARelationCollection::operator[](unsigned int index) const {
+const ExampleWithARelation ExampleWithARelationCollection::
+operator[](unsigned int index) const {
   return ExampleWithARelation(m_entries[index]);
 }
 
-const ExampleWithARelation ExampleWithARelationCollection::at(unsigned int index) const {
+const ExampleWithARelation
+ExampleWithARelationCollection::at(unsigned int index) const {
   return ExampleWithARelation(m_entries.at(index));
 }
 
-ExampleWithARelation ExampleWithARelationCollection::operator[](unsigned int index) {
+ExampleWithARelation ExampleWithARelationCollection::
+operator[](unsigned int index) {
   return ExampleWithARelation(m_entries[index]);
 }
 
@@ -39,86 +51,97 @@ ExampleWithARelation ExampleWithARelationCollection::at(unsigned int index) {
   return ExampleWithARelation(m_entries.at(index));
 }
 
-int  ExampleWithARelationCollection::size() const {
-  return m_entries.size();
-}
+int ExampleWithARelationCollection::size() const { return m_entries.size(); }
 
-ExampleWithARelation ExampleWithARelationCollection::create(){
+ExampleWithARelation ExampleWithARelationCollection::create() {
   auto obj = new ExampleWithARelationObj();
   m_entries.emplace_back(obj);
   m_rel_refs_tmp.push_back(obj->m_refs);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleWithARelation(obj);
 }
 
-void ExampleWithARelationCollection::clear(){
+void ExampleWithARelationCollection::clear() {
   m_data->clear();
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-  // clear relations to refs. Make sure to unlink() the reference data s they may be gone already.
-  for (auto& pointer : m_rel_refs_tmp) {
-    for(auto& item : (*pointer)) {
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  // clear relations to refs. Make sure to unlink() the reference data s they
+  // may be gone already.
+  for (auto &pointer : m_rel_refs_tmp) {
+    for (auto &item : (*pointer)) {
       item.unlink();
     };
     delete pointer;
   }
   m_rel_refs_tmp.clear();
-  for (auto& item : (*m_rel_refs)) { item.unlink(); }
+  for (auto &item : (*m_rel_refs)) {
+    item.unlink();
+  }
   m_rel_refs->clear();
-  for (auto& item : (*m_rel_ref)) { item.unlink(); }
+  for (auto &item : (*m_rel_ref)) {
+    item.unlink();
+  }
   m_rel_ref->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleWithARelationCollection::prepareForWrite(){
+void ExampleWithARelationCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-  int refs_index =0;
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-   (*m_data)[i].refs_begin=refs_index;
-   (*m_data)[i].refs_end+=refs_index;
-   refs_index = (*m_data)[i].refs_end;
-   for(auto it : (*m_rel_refs_tmp[i])) {
-     if (it.getObjectID().index == podio::ObjectID::untracked)
-       throw std::runtime_error("Trying to persistify untracked object");
-     m_refCollections[0]->emplace_back(it.getObjectID());
-     m_rel_refs->push_back(it);
-   }
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
   }
-  for (auto& obj : m_entries) {
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  int refs_index = 0;
+
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+    (*m_data)[i].refs_begin = refs_index;
+    (*m_data)[i].refs_end += refs_index;
+    refs_index = (*m_data)[i].refs_end;
+    for (auto it : (*m_rel_refs_tmp[i])) {
+      if (it.getObjectID().index == podio::ObjectID::untracked)
+        throw std::runtime_error("Trying to persistify untracked object");
+      m_refCollections[0]->emplace_back(it.getObjectID());
+      m_rel_refs->push_back(it);
+    }
+  }
+  for (auto &obj : m_entries) {
     if (obj->m_ref != nullptr) {
       m_refCollections[1]->emplace_back(obj->m_ref->getObjectID());
     } else {
-      m_refCollections[1]->push_back({-2,-2});
+      m_refCollections[1]->push_back({-2, -2});
     }
   }
-
 }
 
-void ExampleWithARelationCollection::prepareAfterRead(){
+void ExampleWithARelationCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleWithARelationObj({index,m_collectionID}, data);
-        obj->m_refs = m_rel_refs;
+  for (auto &data : *m_data) {
+    auto obj = new ExampleWithARelationObj({index, m_collectionID}, data);
+    obj->m_refs = m_rel_refs;
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleWithARelationCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
-  for(unsigned int i=0, size=m_refCollections[0]->size();i!=size;++i) {
+bool ExampleWithARelationCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
+  for (unsigned int i = 0, size = m_refCollections[0]->size(); i != size; ++i) {
     auto id = (*m_refCollections[0])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ex::ExampleWithNamespaceCollection* tmp_coll = static_cast<ex::ExampleWithNamespaceCollection*>(coll);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ex::ExampleWithNamespaceCollection *tmp_coll =
+          static_cast<ex::ExampleWithNamespaceCollection *>(coll);
       auto tmp = (*tmp_coll)[id.index];
       m_rel_refs->emplace_back(tmp);
     } else {
@@ -126,64 +149,78 @@ bool ExampleWithARelationCollection::setReferences(const podio::ICollectionProvi
     }
   }
 
-  for(unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
+  for (unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
     auto id = (*m_refCollections[1])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ex::ExampleWithNamespaceCollection* tmp_coll = static_cast<ex::ExampleWithNamespaceCollection*>(coll);
-      m_entries[i]->m_ref = new ConstExampleWithNamespace((*tmp_coll)[id.index]);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ex::ExampleWithNamespaceCollection *tmp_coll =
+          static_cast<ex::ExampleWithNamespaceCollection *>(coll);
+      m_entries[i]->m_ref =
+          new ConstExampleWithNamespace((*tmp_coll)[id.index]);
     } else {
       m_entries[i]->m_ref = nullptr;
     }
   }
 
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleWithARelationCollection::push_back(ConstExampleWithARelation object){
+void ExampleWithARelationCollection::push_back(
+    ConstExampleWithARelation object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-        m_rel_refs_tmp.push_back(obj->m_refs);
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+    m_rel_refs_tmp.push_back(obj->m_refs);
 
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleWithARelationCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleWithARelationDataContainer*>(address);
+void ExampleWithARelationCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleWithARelationDataContainer *>(address);
 }
 
-
-const ExampleWithARelation ExampleWithARelationCollectionIterator::operator* () const {
+const ExampleWithARelation ExampleWithARelationCollectionIterator::
+operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleWithARelation* ExampleWithARelationCollectionIterator::operator-> () const {
+const ExampleWithARelation *ExampleWithARelationCollectionIterator::
+operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleWithARelationCollectionIterator& ExampleWithARelationCollectionIterator::operator++() const {
+const ExampleWithARelationCollectionIterator &
+ExampleWithARelationCollectionIterator::operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithARelationCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          number:       " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].number() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithARelationCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          number:       " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].number() << " " << std::endl;
+    o << "     refs : ";
+    for (unsigned j = 0, N = v[i].refs_size(); j < N; ++j)
+      o << v[i].refs(j).id() << " ";
+    o << std::endl;
+    o << "     ref : ";
+    o << v[i].ref().id() << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
 
 } // namespace ex

--- a/tests/src/ExampleWithARelationConst.cc
+++ b/tests/src/ExampleWithARelationConst.cc
@@ -1,37 +1,43 @@
 // datamodel specific includes
-#include "ExampleWithARelation.h"
 #include "ExampleWithARelationConst.h"
-#include "ExampleWithARelationObj.h"
-#include "ExampleWithARelationData.h"
+#include "ExampleWithARelation.h"
 #include "ExampleWithARelationCollection.h"
-#include <iostream>
+#include "ExampleWithARelationData.h"
+#include "ExampleWithARelationObj.h"
 #include "ExampleWithNamespace.h"
-
+#include <iostream>
 
 namespace ex {
 
-ConstExampleWithARelation::ConstExampleWithARelation() : m_obj(new ExampleWithARelationObj()) {
- m_obj->acquire();
-}
-
-ConstExampleWithARelation::ConstExampleWithARelation(float number) : m_obj(new ExampleWithARelationObj()){
- m_obj->acquire();
-   m_obj->data.number = number;
-}
-
-
-ConstExampleWithARelation::ConstExampleWithARelation(const ConstExampleWithARelation& other) : m_obj(other.m_obj) {
+ConstExampleWithARelation::ConstExampleWithARelation()
+    : m_obj(new ExampleWithARelationObj()) {
   m_obj->acquire();
 }
 
-ConstExampleWithARelation& ConstExampleWithARelation::operator=(const ConstExampleWithARelation& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithARelation::ConstExampleWithARelation(float number)
+    : m_obj(new ExampleWithARelationObj()) {
+  m_obj->acquire();
+  m_obj->data.number = number;
+}
+
+ConstExampleWithARelation::ConstExampleWithARelation(
+    const ConstExampleWithARelation &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleWithARelation &ConstExampleWithARelation::
+operator=(const ConstExampleWithARelation &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleWithARelation::ConstExampleWithARelation(ExampleWithARelationObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleWithARelation::ConstExampleWithARelation(
+    ExampleWithARelationObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -39,43 +45,49 @@ ConstExampleWithARelation ConstExampleWithARelation::clone() const {
   return {new ExampleWithARelationObj(*m_obj)};
 }
 
-ConstExampleWithARelation::~ConstExampleWithARelation(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithARelation::~ConstExampleWithARelation() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  just a number
-  const float& ConstExampleWithARelation::number() const { return m_obj->data.number; }
-  /// Access the  a ref in a namespace
-  const ex::ConstExampleWithNamespace ConstExampleWithARelation::ref() const {
-    if (m_obj->m_ref == nullptr) {
-      return ex::ConstExampleWithNamespace(nullptr);
-    }
-    return ex::ConstExampleWithNamespace(*(m_obj->m_ref));}
-std::vector<ex::ConstExampleWithNamespace>::const_iterator ConstExampleWithARelation::refs_begin() const {
+/// Access the  just a number
+const float &ConstExampleWithARelation::number() const {
+  return m_obj->data.number;
+}
+/// Access the  a ref in a namespace
+const ex::ConstExampleWithNamespace ConstExampleWithARelation::ref() const {
+  if (m_obj->m_ref == nullptr) {
+    return ex::ConstExampleWithNamespace(nullptr);
+  }
+  return ex::ConstExampleWithNamespace(*(m_obj->m_ref));
+}
+std::vector<ex::ConstExampleWithNamespace>::const_iterator
+ConstExampleWithARelation::refs_begin() const {
   auto ret_value = m_obj->m_refs->begin();
   std::advance(ret_value, m_obj->data.refs_begin);
   return ret_value;
 }
 
-std::vector<ex::ConstExampleWithNamespace>::const_iterator ConstExampleWithARelation::refs_end() const {
+std::vector<ex::ConstExampleWithNamespace>::const_iterator
+ConstExampleWithARelation::refs_end() const {
   auto ret_value = m_obj->m_refs->begin();
-  std::advance(ret_value, m_obj->data.refs_end-1);
+  std::advance(ret_value, m_obj->data.refs_end - 1);
   return ++ret_value;
 }
 
 unsigned int ConstExampleWithARelation::refs_size() const {
-  return (m_obj->data.refs_end-m_obj->data.refs_begin);
+  return (m_obj->data.refs_end - m_obj->data.refs_begin);
 }
 
-ex::ConstExampleWithNamespace ConstExampleWithARelation::refs(unsigned int index) const {
+ex::ConstExampleWithNamespace
+ConstExampleWithARelation::refs(unsigned int index) const {
   if (refs_size() > index) {
-    return m_obj->m_refs->at(m_obj->data.refs_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_refs->at(m_obj->data.refs_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ConstExampleWithARelation::isAvailable() const {
+bool ConstExampleWithARelation::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -83,17 +95,19 @@ bool  ConstExampleWithARelation::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleWithARelation::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleWithARelation::operator==(const ExampleWithARelation& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleWithARelation::
+operator==(const ExampleWithARelation &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleWithARelation& p1, const ExampleWithARelation& p2 ) {
+// bool operator< (const ExampleWithARelation& p1, const ExampleWithARelation&
+// p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {

--- a/tests/src/ExampleWithARelationObj.cc
+++ b/tests/src/ExampleWithARelationObj.cc
@@ -1,33 +1,32 @@
 #include "ExampleWithARelationObj.h"
 #include "ExampleWithNamespaceConst.h"
 
-
 namespace ex {
-ExampleWithARelationObj::ExampleWithARelationObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_ref(nullptr)
-, m_refs(new std::vector<::ex::ConstExampleWithNamespace>())
-{ }
+ExampleWithARelationObj::ExampleWithARelationObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(), m_ref(nullptr),
+      m_refs(new std::vector<::ex::ConstExampleWithNamespace>()) {}
 
-ExampleWithARelationObj::ExampleWithARelationObj(const podio::ObjectID id, ExampleWithARelationData data) :
-    ObjBase{id,0}, data(data)
-{ }
+ExampleWithARelationObj::ExampleWithARelationObj(const podio::ObjectID id,
+                                                 ExampleWithARelationData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleWithARelationObj::ExampleWithARelationObj(const ExampleWithARelationObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_ref(nullptr), m_refs(new std::vector<::ex::ConstExampleWithNamespace>(*(other.m_refs)))
-{
+ExampleWithARelationObj::ExampleWithARelationObj(
+    const ExampleWithARelationObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data), m_ref(nullptr),
+      m_refs(
+          new std::vector<::ex::ConstExampleWithNamespace>(*(other.m_refs))) {
   if (other.m_ref != nullptr) {
-     m_ref = new ::ex::ConstExampleWithNamespace(*(other.m_ref));
+    m_ref = new ::ex::ConstExampleWithNamespace(*(other.m_ref));
   }
-
 }
 
 ExampleWithARelationObj::~ExampleWithARelationObj() {
   if (id.index == podio::ObjectID::untracked) {
     delete m_refs;
-
   }
-    if (m_ref != nullptr) delete m_ref;
-
+  if (m_ref != nullptr)
+    delete m_ref;
 }
 } // namespace ex

--- a/tests/src/ExampleWithArray.cc
+++ b/tests/src/ExampleWithArray.cc
@@ -1,36 +1,44 @@
 // datamodel specific includes
 #include "ExampleWithArray.h"
-#include "ExampleWithArrayConst.h"
-#include "ExampleWithArrayObj.h"
-#include "ExampleWithArrayData.h"
 #include "ExampleWithArrayCollection.h"
+#include "ExampleWithArrayConst.h"
+#include "ExampleWithArrayData.h"
+#include "ExampleWithArrayObj.h"
 #include <iostream>
 
-
-
-
-ExampleWithArray::ExampleWithArray() : m_obj(new ExampleWithArrayObj()){
- m_obj->acquire();
-}
-
-ExampleWithArray::ExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3,std::array<ex2::NamespaceStruct, 4> structArray) : m_obj(new ExampleWithArrayObj()) {
-  m_obj->acquire();
-    m_obj->data.arrayStruct = arrayStruct;  m_obj->data.myArray = myArray;  m_obj->data.anotherArray2 = anotherArray2;  m_obj->data.snail_case_array = snail_case_array;  m_obj->data.snail_case_Array3 = snail_case_Array3;  m_obj->data.structArray = structArray;
-}
-
-
-ExampleWithArray::ExampleWithArray(const ExampleWithArray& other) : m_obj(other.m_obj) {
+ExampleWithArray::ExampleWithArray() : m_obj(new ExampleWithArrayObj()) {
   m_obj->acquire();
 }
 
-ExampleWithArray& ExampleWithArray::operator=(const ExampleWithArray& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithArray::ExampleWithArray(
+    NotSoSimpleStruct arrayStruct, std::array<int, 4> myArray,
+    std::array<int, 4> anotherArray2, std::array<int, 4> snail_case_array,
+    std::array<int, 4> snail_case_Array3,
+    std::array<ex2::NamespaceStruct, 4> structArray)
+    : m_obj(new ExampleWithArrayObj()) {
+  m_obj->acquire();
+  m_obj->data.arrayStruct = arrayStruct;
+  m_obj->data.myArray = myArray;
+  m_obj->data.anotherArray2 = anotherArray2;
+  m_obj->data.snail_case_array = snail_case_array;
+  m_obj->data.snail_case_Array3 = snail_case_Array3;
+  m_obj->data.structArray = structArray;
+}
+
+ExampleWithArray::ExampleWithArray(const ExampleWithArray &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleWithArray &ExampleWithArray::operator=(const ExampleWithArray &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleWithArray::ExampleWithArray(ExampleWithArrayObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleWithArray::ExampleWithArray(ExampleWithArrayObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,43 +46,95 @@ ExampleWithArray ExampleWithArray::clone() const {
   return {new ExampleWithArrayObj(*m_obj)};
 }
 
-ExampleWithArray::~ExampleWithArray(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithArray::~ExampleWithArray() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleWithArray::operator ConstExampleWithArray() const {return ConstExampleWithArray(m_obj);}
+ExampleWithArray::operator ConstExampleWithArray() const {
+  return ConstExampleWithArray(m_obj);
+}
 
-  const NotSoSimpleStruct& ExampleWithArray::arrayStruct() const { return m_obj->data.arrayStruct; }
-const SimpleStruct& ExampleWithArray::data() const { return m_obj->data.arrayStruct.data; }
-  const std::array<int, 4>& ExampleWithArray::myArray() const { return m_obj->data.myArray; }
-  const int& ExampleWithArray::myArray(size_t i) const { return m_obj->data.myArray.at(i); }
-  const std::array<int, 4>& ExampleWithArray::anotherArray2() const { return m_obj->data.anotherArray2; }
-  const int& ExampleWithArray::anotherArray2(size_t i) const { return m_obj->data.anotherArray2.at(i); }
-  const std::array<int, 4>& ExampleWithArray::snail_case_array() const { return m_obj->data.snail_case_array; }
-  const int& ExampleWithArray::snail_case_array(size_t i) const { return m_obj->data.snail_case_array.at(i); }
-  const std::array<int, 4>& ExampleWithArray::snail_case_Array3() const { return m_obj->data.snail_case_Array3; }
-  const int& ExampleWithArray::snail_case_Array3(size_t i) const { return m_obj->data.snail_case_Array3.at(i); }
-  const std::array<ex2::NamespaceStruct, 4>& ExampleWithArray::structArray() const { return m_obj->data.structArray; }
-  const ex2::NamespaceStruct& ExampleWithArray::structArray(size_t i) const { return m_obj->data.structArray.at(i); }
+const NotSoSimpleStruct &ExampleWithArray::arrayStruct() const {
+  return m_obj->data.arrayStruct;
+}
+const SimpleStruct &ExampleWithArray::data() const {
+  return m_obj->data.arrayStruct.data;
+}
+const std::array<int, 4> &ExampleWithArray::myArray() const {
+  return m_obj->data.myArray;
+}
+const int &ExampleWithArray::myArray(size_t i) const {
+  return m_obj->data.myArray.at(i);
+}
+const std::array<int, 4> &ExampleWithArray::anotherArray2() const {
+  return m_obj->data.anotherArray2;
+}
+const int &ExampleWithArray::anotherArray2(size_t i) const {
+  return m_obj->data.anotherArray2.at(i);
+}
+const std::array<int, 4> &ExampleWithArray::snail_case_array() const {
+  return m_obj->data.snail_case_array;
+}
+const int &ExampleWithArray::snail_case_array(size_t i) const {
+  return m_obj->data.snail_case_array.at(i);
+}
+const std::array<int, 4> &ExampleWithArray::snail_case_Array3() const {
+  return m_obj->data.snail_case_Array3;
+}
+const int &ExampleWithArray::snail_case_Array3(size_t i) const {
+  return m_obj->data.snail_case_Array3.at(i);
+}
+const std::array<ex2::NamespaceStruct, 4> &
+ExampleWithArray::structArray() const {
+  return m_obj->data.structArray;
+}
+const ex2::NamespaceStruct &ExampleWithArray::structArray(size_t i) const {
+  return m_obj->data.structArray.at(i);
+}
 
-  NotSoSimpleStruct& ExampleWithArray::arrayStruct() { return m_obj->data.arrayStruct; }
-void ExampleWithArray::arrayStruct(class NotSoSimpleStruct value) { m_obj->data.arrayStruct = value; }
-SimpleStruct& ExampleWithArray::data() { return m_obj->data.arrayStruct.data; }
-void ExampleWithArray::data(class SimpleStruct value) { m_obj->data.arrayStruct.data = value; }
-void ExampleWithArray::myArray(std::array<int, 4> value) { m_obj->data.myArray = value; }
-void ExampleWithArray::myArray(size_t i, int value) { m_obj->data.myArray.at(i) = value; }
-void ExampleWithArray::anotherArray2(std::array<int, 4> value) { m_obj->data.anotherArray2 = value; }
-void ExampleWithArray::anotherArray2(size_t i, int value) { m_obj->data.anotherArray2.at(i) = value; }
-void ExampleWithArray::snail_case_array(std::array<int, 4> value) { m_obj->data.snail_case_array = value; }
-void ExampleWithArray::snail_case_array(size_t i, int value) { m_obj->data.snail_case_array.at(i) = value; }
-void ExampleWithArray::snail_case_Array3(std::array<int, 4> value) { m_obj->data.snail_case_Array3 = value; }
-void ExampleWithArray::snail_case_Array3(size_t i, int value) { m_obj->data.snail_case_Array3.at(i) = value; }
-void ExampleWithArray::structArray(std::array<ex2::NamespaceStruct, 4> value) { m_obj->data.structArray = value; }
-void ExampleWithArray::structArray(size_t i, ex2::NamespaceStruct value) { m_obj->data.structArray.at(i) = value; }
+NotSoSimpleStruct &ExampleWithArray::arrayStruct() {
+  return m_obj->data.arrayStruct;
+}
+void ExampleWithArray::arrayStruct(class NotSoSimpleStruct value) {
+  m_obj->data.arrayStruct = value;
+}
+SimpleStruct &ExampleWithArray::data() { return m_obj->data.arrayStruct.data; }
+void ExampleWithArray::data(class SimpleStruct value) {
+  m_obj->data.arrayStruct.data = value;
+}
+void ExampleWithArray::myArray(std::array<int, 4> value) {
+  m_obj->data.myArray = value;
+}
+void ExampleWithArray::myArray(size_t i, int value) {
+  m_obj->data.myArray.at(i) = value;
+}
+void ExampleWithArray::anotherArray2(std::array<int, 4> value) {
+  m_obj->data.anotherArray2 = value;
+}
+void ExampleWithArray::anotherArray2(size_t i, int value) {
+  m_obj->data.anotherArray2.at(i) = value;
+}
+void ExampleWithArray::snail_case_array(std::array<int, 4> value) {
+  m_obj->data.snail_case_array = value;
+}
+void ExampleWithArray::snail_case_array(size_t i, int value) {
+  m_obj->data.snail_case_array.at(i) = value;
+}
+void ExampleWithArray::snail_case_Array3(std::array<int, 4> value) {
+  m_obj->data.snail_case_Array3 = value;
+}
+void ExampleWithArray::snail_case_Array3(size_t i, int value) {
+  m_obj->data.snail_case_Array3.at(i) = value;
+}
+void ExampleWithArray::structArray(std::array<ex2::NamespaceStruct, 4> value) {
+  m_obj->data.structArray = value;
+}
+void ExampleWithArray::structArray(size_t i, ex2::NamespaceStruct value) {
+  m_obj->data.structArray.at(i) = value;
+}
 
-
-
-bool  ExampleWithArray::isAvailable() const {
+bool ExampleWithArray::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -82,30 +142,27 @@ bool  ExampleWithArray::isAvailable() const {
 }
 
 const podio::ObjectID ExampleWithArray::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleWithArray::operator==(const ConstExampleWithArray& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleWithArray::operator==(const ConstExampleWithArray &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithArray& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " arrayStruct : " << value.arrayStruct() << std::endl ;
-  o << " data : " << value.data() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o, const ConstExampleWithArray &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " arrayStruct : " << value.arrayStruct() << std::endl;
+  o << " data : " << value.data() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleWithArray& p1, const ExampleWithArray& p2 ) {
+// bool operator< (const ExampleWithArray& p1, const ExampleWithArray& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithArrayCollection.cc
+++ b/tests/src/ExampleWithArrayCollection.cc
@@ -1,26 +1,25 @@
 // standard includes
 #include <stdexcept>
 
-
 #include "ExampleWithArrayCollection.h"
 
-
-
-ExampleWithArrayCollection::ExampleWithArrayCollection() : m_isValid(false), m_collectionID(0), m_entries() ,m_data(new ExampleWithArrayDataContainer() ) {
-  
-}
+ExampleWithArrayCollection::ExampleWithArrayCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_data(new ExampleWithArrayDataContainer()) {}
 
 ExampleWithArrayCollection::~ExampleWithArrayCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-  
+  if (m_data != nullptr)
+    delete m_data;
 }
 
-const ExampleWithArray ExampleWithArrayCollection::operator[](unsigned int index) const {
+const ExampleWithArray ExampleWithArrayCollection::
+operator[](unsigned int index) const {
   return ExampleWithArray(m_entries[index]);
 }
 
-const ExampleWithArray ExampleWithArrayCollection::at(unsigned int index) const {
+const ExampleWithArray
+ExampleWithArrayCollection::at(unsigned int index) const {
   return ExampleWithArray(m_entries.at(index));
 }
 
@@ -32,96 +31,100 @@ ExampleWithArray ExampleWithArrayCollection::at(unsigned int index) {
   return ExampleWithArray(m_entries.at(index));
 }
 
-int  ExampleWithArrayCollection::size() const {
-  return m_entries.size();
-}
+int ExampleWithArrayCollection::size() const { return m_entries.size(); }
 
-ExampleWithArray ExampleWithArrayCollection::create(){
+ExampleWithArray ExampleWithArrayCollection::create() {
   auto obj = new ExampleWithArrayObj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleWithArray(obj);
 }
 
-void ExampleWithArrayCollection::clear(){
+void ExampleWithArrayCollection::clear() {
   m_data->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleWithArrayCollection::prepareForWrite(){
+void ExampleWithArrayCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
+  }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
   }
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
 }
 
-void ExampleWithArrayCollection::prepareAfterRead(){
+void ExampleWithArrayCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleWithArrayObj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj = new ExampleWithArrayObj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleWithArrayCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleWithArrayCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleWithArrayCollection::push_back(ConstExampleWithArray object){
+void ExampleWithArrayCollection::push_back(ConstExampleWithArray object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleWithArrayCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleWithArrayDataContainer*>(address);
+void ExampleWithArrayCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleWithArrayDataContainer *>(address);
 }
 
-
-const ExampleWithArray ExampleWithArrayCollectionIterator::operator* () const {
+const ExampleWithArray ExampleWithArrayCollectionIterator::operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleWithArray* ExampleWithArrayCollectionIterator::operator-> () const {
+const ExampleWithArray *ExampleWithArrayCollectionIterator::operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleWithArrayCollectionIterator& ExampleWithArrayCollectionIterator::operator++() const {
+const ExampleWithArrayCollectionIterator &ExampleWithArrayCollectionIterator::
+operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithArrayCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          arrayStruct [data,]:myArray:      anotherArray: snail_case_a: snail_case_A: " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].arrayStruct() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o, const ExampleWithArrayCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          arrayStruct [data,]:myArray:      anotherArray: "
+       "snail_case_a: snail_case_A: structArray:  "
+    << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].arrayStruct() << " " << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleWithArrayConst.cc
+++ b/tests/src/ExampleWithArrayConst.cc
@@ -1,36 +1,47 @@
 // datamodel specific includes
-#include "ExampleWithArray.h"
 #include "ExampleWithArrayConst.h"
-#include "ExampleWithArrayObj.h"
-#include "ExampleWithArrayData.h"
+#include "ExampleWithArray.h"
 #include "ExampleWithArrayCollection.h"
+#include "ExampleWithArrayData.h"
+#include "ExampleWithArrayObj.h"
 #include <iostream>
 
-
-
-
-ConstExampleWithArray::ConstExampleWithArray() : m_obj(new ExampleWithArrayObj()) {
- m_obj->acquire();
-}
-
-ConstExampleWithArray::ConstExampleWithArray(NotSoSimpleStruct arrayStruct,std::array<int, 4> myArray,std::array<int, 4> anotherArray2,std::array<int, 4> snail_case_array,std::array<int, 4> snail_case_Array3,std::array<ex2::NamespaceStruct, 4> structArray) : m_obj(new ExampleWithArrayObj()){
- m_obj->acquire();
-   m_obj->data.arrayStruct = arrayStruct;  m_obj->data.myArray = myArray;  m_obj->data.anotherArray2 = anotherArray2;  m_obj->data.snail_case_array = snail_case_array;  m_obj->data.snail_case_Array3 = snail_case_Array3;  m_obj->data.structArray = structArray;
-}
-
-
-ConstExampleWithArray::ConstExampleWithArray(const ConstExampleWithArray& other) : m_obj(other.m_obj) {
+ConstExampleWithArray::ConstExampleWithArray()
+    : m_obj(new ExampleWithArrayObj()) {
   m_obj->acquire();
 }
 
-ConstExampleWithArray& ConstExampleWithArray::operator=(const ConstExampleWithArray& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithArray::ConstExampleWithArray(
+    NotSoSimpleStruct arrayStruct, std::array<int, 4> myArray,
+    std::array<int, 4> anotherArray2, std::array<int, 4> snail_case_array,
+    std::array<int, 4> snail_case_Array3,
+    std::array<ex2::NamespaceStruct, 4> structArray)
+    : m_obj(new ExampleWithArrayObj()) {
+  m_obj->acquire();
+  m_obj->data.arrayStruct = arrayStruct;
+  m_obj->data.myArray = myArray;
+  m_obj->data.anotherArray2 = anotherArray2;
+  m_obj->data.snail_case_array = snail_case_array;
+  m_obj->data.snail_case_Array3 = snail_case_Array3;
+  m_obj->data.structArray = structArray;
+}
+
+ConstExampleWithArray::ConstExampleWithArray(const ConstExampleWithArray &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleWithArray &ConstExampleWithArray::
+operator=(const ConstExampleWithArray &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleWithArray::ConstExampleWithArray(ExampleWithArrayObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleWithArray::ConstExampleWithArray(ExampleWithArrayObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,37 +49,61 @@ ConstExampleWithArray ConstExampleWithArray::clone() const {
   return {new ExampleWithArrayObj(*m_obj)};
 }
 
-ConstExampleWithArray::~ConstExampleWithArray(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithArray::~ConstExampleWithArray() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  const SimpleStruct& ConstExampleWithArray::data() const { return m_obj->data.arrayStruct.data; }
-  /// Access the  component that contains an array
-  const NotSoSimpleStruct& ConstExampleWithArray::arrayStruct() const { return m_obj->data.arrayStruct; }
-  /// Access the array-member without space to test regex
-  const int& ConstExampleWithArray::myArray(size_t i) const { return m_obj->data.myArray.at(i); }
-  /// Access the array-member without space to test regex
-  const std::array<int, 4>& ConstExampleWithArray::myArray() const { return m_obj->data.myArray; }
-  /// Access the array-member with space to test regex
-  const int& ConstExampleWithArray::anotherArray2(size_t i) const { return m_obj->data.anotherArray2.at(i); }
-  /// Access the array-member with space to test regex
-  const std::array<int, 4>& ConstExampleWithArray::anotherArray2() const { return m_obj->data.anotherArray2; }
-  /// Access the snail case to test regex
-  const int& ConstExampleWithArray::snail_case_array(size_t i) const { return m_obj->data.snail_case_array.at(i); }
-  /// Access the snail case to test regex
-  const std::array<int, 4>& ConstExampleWithArray::snail_case_array() const { return m_obj->data.snail_case_array; }
-  /// Access the mixing things up for regex
-  const int& ConstExampleWithArray::snail_case_Array3(size_t i) const { return m_obj->data.snail_case_Array3.at(i); }
-  /// Access the mixing things up for regex
-  const std::array<int, 4>& ConstExampleWithArray::snail_case_Array3() const { return m_obj->data.snail_case_Array3; }
-  /// Access the an array containing structs
-  const ex2::NamespaceStruct& ConstExampleWithArray::structArray(size_t i) const { return m_obj->data.structArray.at(i); }
-  /// Access the an array containing structs
-  const std::array<ex2::NamespaceStruct, 4>& ConstExampleWithArray::structArray() const { return m_obj->data.structArray; }
+const SimpleStruct &ConstExampleWithArray::data() const {
+  return m_obj->data.arrayStruct.data;
+}
+/// Access the  component that contains an array
+const NotSoSimpleStruct &ConstExampleWithArray::arrayStruct() const {
+  return m_obj->data.arrayStruct;
+}
+/// Access the array-member without space to test regex
+const int &ConstExampleWithArray::myArray(size_t i) const {
+  return m_obj->data.myArray.at(i);
+}
+/// Access the array-member without space to test regex
+const std::array<int, 4> &ConstExampleWithArray::myArray() const {
+  return m_obj->data.myArray;
+}
+/// Access the array-member with space to test regex
+const int &ConstExampleWithArray::anotherArray2(size_t i) const {
+  return m_obj->data.anotherArray2.at(i);
+}
+/// Access the array-member with space to test regex
+const std::array<int, 4> &ConstExampleWithArray::anotherArray2() const {
+  return m_obj->data.anotherArray2;
+}
+/// Access the snail case to test regex
+const int &ConstExampleWithArray::snail_case_array(size_t i) const {
+  return m_obj->data.snail_case_array.at(i);
+}
+/// Access the snail case to test regex
+const std::array<int, 4> &ConstExampleWithArray::snail_case_array() const {
+  return m_obj->data.snail_case_array;
+}
+/// Access the mixing things up for regex
+const int &ConstExampleWithArray::snail_case_Array3(size_t i) const {
+  return m_obj->data.snail_case_Array3.at(i);
+}
+/// Access the mixing things up for regex
+const std::array<int, 4> &ConstExampleWithArray::snail_case_Array3() const {
+  return m_obj->data.snail_case_Array3;
+}
+/// Access the an array containing structs
+const ex2::NamespaceStruct &ConstExampleWithArray::structArray(size_t i) const {
+  return m_obj->data.structArray.at(i);
+}
+/// Access the an array containing structs
+const std::array<ex2::NamespaceStruct, 4> &
+ConstExampleWithArray::structArray() const {
+  return m_obj->data.structArray;
+}
 
-
-
-bool  ConstExampleWithArray::isAvailable() const {
+bool ConstExampleWithArray::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -76,22 +111,20 @@ bool  ConstExampleWithArray::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleWithArray::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleWithArray::operator==(const ExampleWithArray& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleWithArray::operator==(const ExampleWithArray &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleWithArray& p1, const ExampleWithArray& p2 ) {
+// bool operator< (const ExampleWithArray& p1, const ExampleWithArray& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithArrayObj.cc
+++ b/tests/src/ExampleWithArrayObj.cc
@@ -1,26 +1,18 @@
 #include "ExampleWithArrayObj.h"
 
+ExampleWithArrayObj::ExampleWithArrayObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data() {}
 
+ExampleWithArrayObj::ExampleWithArrayObj(const podio::ObjectID id,
+                                         ExampleWithArrayData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleWithArrayObj::ExampleWithArrayObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data()
-{ }
-
-ExampleWithArrayObj::ExampleWithArrayObj(const podio::ObjectID id, ExampleWithArrayData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleWithArrayObj::ExampleWithArrayObj(const ExampleWithArrayObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
-{
-
-}
+ExampleWithArrayObj::ExampleWithArrayObj(const ExampleWithArrayObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data) {}
 
 ExampleWithArrayObj::~ExampleWithArrayObj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-
 }
-

--- a/tests/src/ExampleWithComponent.cc
+++ b/tests/src/ExampleWithComponent.cc
@@ -1,36 +1,38 @@
 // datamodel specific includes
 #include "ExampleWithComponent.h"
-#include "ExampleWithComponentConst.h"
-#include "ExampleWithComponentObj.h"
-#include "ExampleWithComponentData.h"
 #include "ExampleWithComponentCollection.h"
+#include "ExampleWithComponentConst.h"
+#include "ExampleWithComponentData.h"
+#include "ExampleWithComponentObj.h"
 #include <iostream>
 
-
-
-
-ExampleWithComponent::ExampleWithComponent() : m_obj(new ExampleWithComponentObj()){
- m_obj->acquire();
-}
-
-ExampleWithComponent::ExampleWithComponent(NotSoSimpleStruct component) : m_obj(new ExampleWithComponentObj()) {
-  m_obj->acquire();
-    m_obj->data.component = component;
-}
-
-
-ExampleWithComponent::ExampleWithComponent(const ExampleWithComponent& other) : m_obj(other.m_obj) {
+ExampleWithComponent::ExampleWithComponent()
+    : m_obj(new ExampleWithComponentObj()) {
   m_obj->acquire();
 }
 
-ExampleWithComponent& ExampleWithComponent::operator=(const ExampleWithComponent& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithComponent::ExampleWithComponent(NotSoSimpleStruct component)
+    : m_obj(new ExampleWithComponentObj()) {
+  m_obj->acquire();
+  m_obj->data.component = component;
+}
+
+ExampleWithComponent::ExampleWithComponent(const ExampleWithComponent &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleWithComponent &ExampleWithComponent::
+operator=(const ExampleWithComponent &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleWithComponent::ExampleWithComponent(ExampleWithComponentObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleWithComponent::ExampleWithComponent(ExampleWithComponentObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,23 +40,36 @@ ExampleWithComponent ExampleWithComponent::clone() const {
   return {new ExampleWithComponentObj(*m_obj)};
 }
 
-ExampleWithComponent::~ExampleWithComponent(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithComponent::~ExampleWithComponent() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleWithComponent::operator ConstExampleWithComponent() const {return ConstExampleWithComponent(m_obj);}
+ExampleWithComponent::operator ConstExampleWithComponent() const {
+  return ConstExampleWithComponent(m_obj);
+}
 
-  const NotSoSimpleStruct& ExampleWithComponent::component() const { return m_obj->data.component; }
-const SimpleStruct& ExampleWithComponent::data() const { return m_obj->data.component.data; }
+const NotSoSimpleStruct &ExampleWithComponent::component() const {
+  return m_obj->data.component;
+}
+const SimpleStruct &ExampleWithComponent::data() const {
+  return m_obj->data.component.data;
+}
 
-  NotSoSimpleStruct& ExampleWithComponent::component() { return m_obj->data.component; }
-void ExampleWithComponent::component(class NotSoSimpleStruct value) { m_obj->data.component = value; }
-SimpleStruct& ExampleWithComponent::data() { return m_obj->data.component.data; }
-void ExampleWithComponent::data(class SimpleStruct value) { m_obj->data.component.data = value; }
+NotSoSimpleStruct &ExampleWithComponent::component() {
+  return m_obj->data.component;
+}
+void ExampleWithComponent::component(class NotSoSimpleStruct value) {
+  m_obj->data.component = value;
+}
+SimpleStruct &ExampleWithComponent::data() {
+  return m_obj->data.component.data;
+}
+void ExampleWithComponent::data(class SimpleStruct value) {
+  m_obj->data.component.data = value;
+}
 
-
-
-bool  ExampleWithComponent::isAvailable() const {
+bool ExampleWithComponent::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -62,30 +77,30 @@ bool  ExampleWithComponent::isAvailable() const {
 }
 
 const podio::ObjectID ExampleWithComponent::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleWithComponent::operator==(const ConstExampleWithComponent& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleWithComponent::
+operator==(const ConstExampleWithComponent &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithComponent& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " component : " << value.component() << std::endl ;
-  o << " data : " << value.data() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithComponent &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " component : " << value.component() << std::endl;
+  o << " data : " << value.data() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleWithComponent& p1, const ExampleWithComponent& p2 ) {
+// bool operator< (const ExampleWithComponent& p1, const ExampleWithComponent&
+// p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithComponentCollection.cc
+++ b/tests/src/ExampleWithComponentCollection.cc
@@ -1,30 +1,30 @@
 // standard includes
 #include <stdexcept>
 
-
 #include "ExampleWithComponentCollection.h"
 
-
-
-ExampleWithComponentCollection::ExampleWithComponentCollection() : m_isValid(false), m_collectionID(0), m_entries() ,m_data(new ExampleWithComponentDataContainer() ) {
-  
-}
+ExampleWithComponentCollection::ExampleWithComponentCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_data(new ExampleWithComponentDataContainer()) {}
 
 ExampleWithComponentCollection::~ExampleWithComponentCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-  
+  if (m_data != nullptr)
+    delete m_data;
 }
 
-const ExampleWithComponent ExampleWithComponentCollection::operator[](unsigned int index) const {
+const ExampleWithComponent ExampleWithComponentCollection::
+operator[](unsigned int index) const {
   return ExampleWithComponent(m_entries[index]);
 }
 
-const ExampleWithComponent ExampleWithComponentCollection::at(unsigned int index) const {
+const ExampleWithComponent
+ExampleWithComponentCollection::at(unsigned int index) const {
   return ExampleWithComponent(m_entries.at(index));
 }
 
-ExampleWithComponent ExampleWithComponentCollection::operator[](unsigned int index) {
+ExampleWithComponent ExampleWithComponentCollection::
+operator[](unsigned int index) {
   return ExampleWithComponent(m_entries[index]);
 }
 
@@ -32,96 +32,102 @@ ExampleWithComponent ExampleWithComponentCollection::at(unsigned int index) {
   return ExampleWithComponent(m_entries.at(index));
 }
 
-int  ExampleWithComponentCollection::size() const {
-  return m_entries.size();
-}
+int ExampleWithComponentCollection::size() const { return m_entries.size(); }
 
-ExampleWithComponent ExampleWithComponentCollection::create(){
+ExampleWithComponent ExampleWithComponentCollection::create() {
   auto obj = new ExampleWithComponentObj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleWithComponent(obj);
 }
 
-void ExampleWithComponentCollection::clear(){
+void ExampleWithComponentCollection::clear() {
   m_data->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleWithComponentCollection::prepareForWrite(){
+void ExampleWithComponentCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
+  }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
   }
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
 }
 
-void ExampleWithComponentCollection::prepareAfterRead(){
+void ExampleWithComponentCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleWithComponentObj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj = new ExampleWithComponentObj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleWithComponentCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleWithComponentCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleWithComponentCollection::push_back(ConstExampleWithComponent object){
+void ExampleWithComponentCollection::push_back(
+    ConstExampleWithComponent object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleWithComponentCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleWithComponentDataContainer*>(address);
+void ExampleWithComponentCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleWithComponentDataContainer *>(address);
 }
 
-
-const ExampleWithComponent ExampleWithComponentCollectionIterator::operator* () const {
+const ExampleWithComponent ExampleWithComponentCollectionIterator::
+operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleWithComponent* ExampleWithComponentCollectionIterator::operator-> () const {
+const ExampleWithComponent *ExampleWithComponentCollectionIterator::
+operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleWithComponentCollectionIterator& ExampleWithComponentCollectionIterator::operator++() const {
+const ExampleWithComponentCollectionIterator &
+ExampleWithComponentCollectionIterator::operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithComponentCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          component [data,]:" << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].component() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithComponentCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          component [data,]:" << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].component() << " " << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleWithComponentConst.cc
+++ b/tests/src/ExampleWithComponentConst.cc
@@ -1,36 +1,41 @@
 // datamodel specific includes
-#include "ExampleWithComponent.h"
 #include "ExampleWithComponentConst.h"
-#include "ExampleWithComponentObj.h"
-#include "ExampleWithComponentData.h"
+#include "ExampleWithComponent.h"
 #include "ExampleWithComponentCollection.h"
+#include "ExampleWithComponentData.h"
+#include "ExampleWithComponentObj.h"
 #include <iostream>
 
-
-
-
-ConstExampleWithComponent::ConstExampleWithComponent() : m_obj(new ExampleWithComponentObj()) {
- m_obj->acquire();
-}
-
-ConstExampleWithComponent::ConstExampleWithComponent(NotSoSimpleStruct component) : m_obj(new ExampleWithComponentObj()){
- m_obj->acquire();
-   m_obj->data.component = component;
-}
-
-
-ConstExampleWithComponent::ConstExampleWithComponent(const ConstExampleWithComponent& other) : m_obj(other.m_obj) {
+ConstExampleWithComponent::ConstExampleWithComponent()
+    : m_obj(new ExampleWithComponentObj()) {
   m_obj->acquire();
 }
 
-ConstExampleWithComponent& ConstExampleWithComponent::operator=(const ConstExampleWithComponent& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithComponent::ConstExampleWithComponent(
+    NotSoSimpleStruct component)
+    : m_obj(new ExampleWithComponentObj()) {
+  m_obj->acquire();
+  m_obj->data.component = component;
+}
+
+ConstExampleWithComponent::ConstExampleWithComponent(
+    const ConstExampleWithComponent &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleWithComponent &ConstExampleWithComponent::
+operator=(const ConstExampleWithComponent &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleWithComponent::ConstExampleWithComponent(ExampleWithComponentObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleWithComponent::ConstExampleWithComponent(
+    ExampleWithComponentObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,17 +43,20 @@ ConstExampleWithComponent ConstExampleWithComponent::clone() const {
   return {new ExampleWithComponentObj(*m_obj)};
 }
 
-ConstExampleWithComponent::~ConstExampleWithComponent(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithComponent::~ConstExampleWithComponent() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  const SimpleStruct& ConstExampleWithComponent::data() const { return m_obj->data.component.data; }
-  /// Access the  a component
-  const NotSoSimpleStruct& ConstExampleWithComponent::component() const { return m_obj->data.component; }
+const SimpleStruct &ConstExampleWithComponent::data() const {
+  return m_obj->data.component.data;
+}
+/// Access the  a component
+const NotSoSimpleStruct &ConstExampleWithComponent::component() const {
+  return m_obj->data.component;
+}
 
-
-
-bool  ConstExampleWithComponent::isAvailable() const {
+bool ConstExampleWithComponent::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -56,22 +64,22 @@ bool  ConstExampleWithComponent::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleWithComponent::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleWithComponent::operator==(const ExampleWithComponent& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleWithComponent::
+operator==(const ExampleWithComponent &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleWithComponent& p1, const ExampleWithComponent& p2 ) {
+// bool operator< (const ExampleWithComponent& p1, const ExampleWithComponent&
+// p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithComponentObj.cc
+++ b/tests/src/ExampleWithComponentObj.cc
@@ -1,26 +1,19 @@
 #include "ExampleWithComponentObj.h"
 
+ExampleWithComponentObj::ExampleWithComponentObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data() {}
 
+ExampleWithComponentObj::ExampleWithComponentObj(const podio::ObjectID id,
+                                                 ExampleWithComponentData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleWithComponentObj::ExampleWithComponentObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data()
-{ }
-
-ExampleWithComponentObj::ExampleWithComponentObj(const podio::ObjectID id, ExampleWithComponentData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleWithComponentObj::ExampleWithComponentObj(const ExampleWithComponentObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
-{
-
-}
+ExampleWithComponentObj::ExampleWithComponentObj(
+    const ExampleWithComponentObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data) {}
 
 ExampleWithComponentObj::~ExampleWithComponentObj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-
 }
-

--- a/tests/src/ExampleWithNamespace.cc
+++ b/tests/src/ExampleWithNamespace.cc
@@ -1,36 +1,40 @@
 // datamodel specific includes
 #include "ExampleWithNamespace.h"
-#include "ExampleWithNamespaceConst.h"
-#include "ExampleWithNamespaceObj.h"
-#include "ExampleWithNamespaceData.h"
 #include "ExampleWithNamespaceCollection.h"
+#include "ExampleWithNamespaceConst.h"
+#include "ExampleWithNamespaceData.h"
+#include "ExampleWithNamespaceObj.h"
 #include <iostream>
-
 
 namespace ex {
 
-ExampleWithNamespace::ExampleWithNamespace() : m_obj(new ExampleWithNamespaceObj()){
- m_obj->acquire();
-}
-
-ExampleWithNamespace::ExampleWithNamespace(ex2::NamespaceStruct data) : m_obj(new ExampleWithNamespaceObj()) {
-  m_obj->acquire();
-    m_obj->data.data = data;
-}
-
-
-ExampleWithNamespace::ExampleWithNamespace(const ExampleWithNamespace& other) : m_obj(other.m_obj) {
+ExampleWithNamespace::ExampleWithNamespace()
+    : m_obj(new ExampleWithNamespaceObj()) {
   m_obj->acquire();
 }
 
-ExampleWithNamespace& ExampleWithNamespace::operator=(const ExampleWithNamespace& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithNamespace::ExampleWithNamespace(ex2::NamespaceStruct data)
+    : m_obj(new ExampleWithNamespaceObj()) {
+  m_obj->acquire();
+  m_obj->data.data = data;
+}
+
+ExampleWithNamespace::ExampleWithNamespace(const ExampleWithNamespace &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleWithNamespace &ExampleWithNamespace::
+operator=(const ExampleWithNamespace &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleWithNamespace::ExampleWithNamespace(ExampleWithNamespaceObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleWithNamespace::ExampleWithNamespace(ExampleWithNamespaceObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,24 +42,29 @@ ExampleWithNamespace ExampleWithNamespace::clone() const {
   return {new ExampleWithNamespaceObj(*m_obj)};
 }
 
-ExampleWithNamespace::~ExampleWithNamespace(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithNamespace::~ExampleWithNamespace() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleWithNamespace::operator ConstExampleWithNamespace() const {return ConstExampleWithNamespace(m_obj);}
+ExampleWithNamespace::operator ConstExampleWithNamespace() const {
+  return ConstExampleWithNamespace(m_obj);
+}
 
-  const ex2::NamespaceStruct& ExampleWithNamespace::data() const { return m_obj->data.data; }
-const int& ExampleWithNamespace::x() const { return m_obj->data.data.x; }
-const int& ExampleWithNamespace::y() const { return m_obj->data.data.y; }
+const ex2::NamespaceStruct &ExampleWithNamespace::data() const {
+  return m_obj->data.data;
+}
+const int &ExampleWithNamespace::x() const { return m_obj->data.data.x; }
+const int &ExampleWithNamespace::y() const { return m_obj->data.data.y; }
 
-  ex2::NamespaceStruct& ExampleWithNamespace::data() { return m_obj->data.data; }
-void ExampleWithNamespace::data(class ex2::NamespaceStruct value) { m_obj->data.data = value; }
-void ExampleWithNamespace::x(int value){ m_obj->data.data.x = value; }
-void ExampleWithNamespace::y(int value){ m_obj->data.data.y = value; }
+ex2::NamespaceStruct &ExampleWithNamespace::data() { return m_obj->data.data; }
+void ExampleWithNamespace::data(class ex2::NamespaceStruct value) {
+  m_obj->data.data = value;
+}
+void ExampleWithNamespace::x(int value) { m_obj->data.data.x = value; }
+void ExampleWithNamespace::y(int value) { m_obj->data.data.y = value; }
 
-
-
-bool  ExampleWithNamespace::isAvailable() const {
+bool ExampleWithNamespace::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -63,26 +72,28 @@ bool  ExampleWithNamespace::isAvailable() const {
 }
 
 const podio::ObjectID ExampleWithNamespace::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleWithNamespace::operator==(const ConstExampleWithNamespace& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleWithNamespace::
+operator==(const ConstExampleWithNamespace &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithNamespace& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " data : " << value.data() << std::endl ;
-  o << " x : " << value.x() << std::endl ;
-  o << " y : " << value.y() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithNamespace &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " data : " << value.data() << std::endl;
+  o << " x : " << value.x() << std::endl;
+  o << " y : " << value.y() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleWithNamespace& p1, const ExampleWithNamespace& p2 ) {
+// bool operator< (const ExampleWithNamespace& p1, const ExampleWithNamespace&
+// p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {

--- a/tests/src/ExampleWithNamespaceCollection.cc
+++ b/tests/src/ExampleWithNamespaceCollection.cc
@@ -1,30 +1,32 @@
 // standard includes
 #include <stdexcept>
 
-
 #include "ExampleWithNamespaceCollection.h"
 
 namespace ex {
 
-ExampleWithNamespaceCollection::ExampleWithNamespaceCollection() : m_isValid(false), m_collectionID(0), m_entries() ,m_data(new ExampleWithNamespaceDataContainer() ) {
-  
-}
+ExampleWithNamespaceCollection::ExampleWithNamespaceCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_data(new ExampleWithNamespaceDataContainer()) {}
 
 ExampleWithNamespaceCollection::~ExampleWithNamespaceCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-  
+  if (m_data != nullptr)
+    delete m_data;
 }
 
-const ExampleWithNamespace ExampleWithNamespaceCollection::operator[](unsigned int index) const {
+const ExampleWithNamespace ExampleWithNamespaceCollection::
+operator[](unsigned int index) const {
   return ExampleWithNamespace(m_entries[index]);
 }
 
-const ExampleWithNamespace ExampleWithNamespaceCollection::at(unsigned int index) const {
+const ExampleWithNamespace
+ExampleWithNamespaceCollection::at(unsigned int index) const {
   return ExampleWithNamespace(m_entries.at(index));
 }
 
-ExampleWithNamespace ExampleWithNamespaceCollection::operator[](unsigned int index) {
+ExampleWithNamespace ExampleWithNamespaceCollection::
+operator[](unsigned int index) {
   return ExampleWithNamespace(m_entries[index]);
 }
 
@@ -32,96 +34,104 @@ ExampleWithNamespace ExampleWithNamespaceCollection::at(unsigned int index) {
   return ExampleWithNamespace(m_entries.at(index));
 }
 
-int  ExampleWithNamespaceCollection::size() const {
-  return m_entries.size();
-}
+int ExampleWithNamespaceCollection::size() const { return m_entries.size(); }
 
-ExampleWithNamespace ExampleWithNamespaceCollection::create(){
+ExampleWithNamespace ExampleWithNamespaceCollection::create() {
   auto obj = new ExampleWithNamespaceObj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleWithNamespace(obj);
 }
 
-void ExampleWithNamespaceCollection::clear(){
+void ExampleWithNamespaceCollection::clear() {
   m_data->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleWithNamespaceCollection::prepareForWrite(){
+void ExampleWithNamespaceCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
+  }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
   }
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
 }
 
-void ExampleWithNamespaceCollection::prepareAfterRead(){
+void ExampleWithNamespaceCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleWithNamespaceObj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj = new ExampleWithNamespaceObj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleWithNamespaceCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleWithNamespaceCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleWithNamespaceCollection::push_back(ConstExampleWithNamespace object){
+void ExampleWithNamespaceCollection::push_back(
+    ConstExampleWithNamespace object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleWithNamespaceCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleWithNamespaceDataContainer*>(address);
+void ExampleWithNamespaceCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleWithNamespaceDataContainer *>(address);
 }
 
-
-const ExampleWithNamespace ExampleWithNamespaceCollectionIterator::operator* () const {
+const ExampleWithNamespace ExampleWithNamespaceCollectionIterator::
+operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleWithNamespace* ExampleWithNamespaceCollectionIterator::operator-> () const {
+const ExampleWithNamespace *ExampleWithNamespaceCollectionIterator::
+operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleWithNamespaceCollectionIterator& ExampleWithNamespaceCollectionIterator::operator++() const {
+const ExampleWithNamespaceCollectionIterator &
+ExampleWithNamespaceCollectionIterator::operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithNamespaceCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          data [y,x,]:                " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].data() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithNamespaceCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          data [y,x,]:                " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].data() << " " << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
 
 } // namespace ex

--- a/tests/src/ExampleWithNamespaceConst.cc
+++ b/tests/src/ExampleWithNamespaceConst.cc
@@ -1,36 +1,42 @@
 // datamodel specific includes
-#include "ExampleWithNamespace.h"
 #include "ExampleWithNamespaceConst.h"
-#include "ExampleWithNamespaceObj.h"
-#include "ExampleWithNamespaceData.h"
+#include "ExampleWithNamespace.h"
 #include "ExampleWithNamespaceCollection.h"
+#include "ExampleWithNamespaceData.h"
+#include "ExampleWithNamespaceObj.h"
 #include <iostream>
-
 
 namespace ex {
 
-ConstExampleWithNamespace::ConstExampleWithNamespace() : m_obj(new ExampleWithNamespaceObj()) {
- m_obj->acquire();
-}
-
-ConstExampleWithNamespace::ConstExampleWithNamespace(ex2::NamespaceStruct data) : m_obj(new ExampleWithNamespaceObj()){
- m_obj->acquire();
-   m_obj->data.data = data;
-}
-
-
-ConstExampleWithNamespace::ConstExampleWithNamespace(const ConstExampleWithNamespace& other) : m_obj(other.m_obj) {
+ConstExampleWithNamespace::ConstExampleWithNamespace()
+    : m_obj(new ExampleWithNamespaceObj()) {
   m_obj->acquire();
 }
 
-ConstExampleWithNamespace& ConstExampleWithNamespace::operator=(const ConstExampleWithNamespace& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithNamespace::ConstExampleWithNamespace(ex2::NamespaceStruct data)
+    : m_obj(new ExampleWithNamespaceObj()) {
+  m_obj->acquire();
+  m_obj->data.data = data;
+}
+
+ConstExampleWithNamespace::ConstExampleWithNamespace(
+    const ConstExampleWithNamespace &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleWithNamespace &ConstExampleWithNamespace::
+operator=(const ConstExampleWithNamespace &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleWithNamespace::ConstExampleWithNamespace(ExampleWithNamespaceObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleWithNamespace::ConstExampleWithNamespace(
+    ExampleWithNamespaceObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,18 +44,19 @@ ConstExampleWithNamespace ConstExampleWithNamespace::clone() const {
   return {new ExampleWithNamespaceObj(*m_obj)};
 }
 
-ConstExampleWithNamespace::~ConstExampleWithNamespace(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithNamespace::~ConstExampleWithNamespace() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  const int& ConstExampleWithNamespace::x() const { return m_obj->data.data.x; }
-  const int& ConstExampleWithNamespace::y() const { return m_obj->data.data.y; }
-  /// Access the  a component
-  const ex2::NamespaceStruct& ConstExampleWithNamespace::data() const { return m_obj->data.data; }
+const int &ConstExampleWithNamespace::x() const { return m_obj->data.data.x; }
+const int &ConstExampleWithNamespace::y() const { return m_obj->data.data.y; }
+/// Access the  a component
+const ex2::NamespaceStruct &ConstExampleWithNamespace::data() const {
+  return m_obj->data.data;
+}
 
-
-
-bool  ConstExampleWithNamespace::isAvailable() const {
+bool ConstExampleWithNamespace::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -57,17 +64,19 @@ bool  ConstExampleWithNamespace::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleWithNamespace::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleWithNamespace::operator==(const ExampleWithNamespace& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleWithNamespace::
+operator==(const ExampleWithNamespace &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleWithNamespace& p1, const ExampleWithNamespace& p2 ) {
+// bool operator< (const ExampleWithNamespace& p1, const ExampleWithNamespace&
+// p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {

--- a/tests/src/ExampleWithNamespaceObj.cc
+++ b/tests/src/ExampleWithNamespaceObj.cc
@@ -1,26 +1,21 @@
 #include "ExampleWithNamespaceObj.h"
 
-
 namespace ex {
-ExampleWithNamespaceObj::ExampleWithNamespaceObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data()
-{ }
+ExampleWithNamespaceObj::ExampleWithNamespaceObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data() {}
 
-ExampleWithNamespaceObj::ExampleWithNamespaceObj(const podio::ObjectID id, ExampleWithNamespaceData data) :
-    ObjBase{id,0}, data(data)
-{ }
+ExampleWithNamespaceObj::ExampleWithNamespaceObj(const podio::ObjectID id,
+                                                 ExampleWithNamespaceData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleWithNamespaceObj::ExampleWithNamespaceObj(const ExampleWithNamespaceObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
-{
-
-}
+ExampleWithNamespaceObj::ExampleWithNamespaceObj(
+    const ExampleWithNamespaceObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data) {}
 
 ExampleWithNamespaceObj::~ExampleWithNamespaceObj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-
 }
 } // namespace ex

--- a/tests/src/ExampleWithOneRelation.cc
+++ b/tests/src/ExampleWithOneRelation.cc
@@ -1,33 +1,34 @@
 // datamodel specific includes
 #include "ExampleWithOneRelation.h"
-#include "ExampleWithOneRelationConst.h"
-#include "ExampleWithOneRelationObj.h"
-#include "ExampleWithOneRelationData.h"
-#include "ExampleWithOneRelationCollection.h"
-#include <iostream>
 #include "ExampleCluster.h"
+#include "ExampleWithOneRelationCollection.h"
+#include "ExampleWithOneRelationConst.h"
+#include "ExampleWithOneRelationData.h"
+#include "ExampleWithOneRelationObj.h"
+#include <iostream>
 
-
-
-
-ExampleWithOneRelation::ExampleWithOneRelation() : m_obj(new ExampleWithOneRelationObj()){
- m_obj->acquire();
-}
-
-
-
-ExampleWithOneRelation::ExampleWithOneRelation(const ExampleWithOneRelation& other) : m_obj(other.m_obj) {
+ExampleWithOneRelation::ExampleWithOneRelation()
+    : m_obj(new ExampleWithOneRelationObj()) {
   m_obj->acquire();
 }
 
-ExampleWithOneRelation& ExampleWithOneRelation::operator=(const ExampleWithOneRelation& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithOneRelation::ExampleWithOneRelation(
+    const ExampleWithOneRelation &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleWithOneRelation &ExampleWithOneRelation::
+operator=(const ExampleWithOneRelation &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleWithOneRelation::ExampleWithOneRelation(ExampleWithOneRelationObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleWithOneRelation::ExampleWithOneRelation(ExampleWithOneRelationObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -35,26 +36,28 @@ ExampleWithOneRelation ExampleWithOneRelation::clone() const {
   return {new ExampleWithOneRelationObj(*m_obj)};
 }
 
-ExampleWithOneRelation::~ExampleWithOneRelation(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithOneRelation::~ExampleWithOneRelation() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleWithOneRelation::operator ConstExampleWithOneRelation() const {return ConstExampleWithOneRelation(m_obj);}
+ExampleWithOneRelation::operator ConstExampleWithOneRelation() const {
+  return ConstExampleWithOneRelation(m_obj);
+}
 
-  const ::ConstExampleCluster ExampleWithOneRelation::cluster() const {
-    if (m_obj->m_cluster == nullptr) {
-      return ::ConstExampleCluster(nullptr);
-    }
-    return ::ConstExampleCluster(*(m_obj->m_cluster));
+const ::ConstExampleCluster ExampleWithOneRelation::cluster() const {
+  if (m_obj->m_cluster == nullptr) {
+    return ::ConstExampleCluster(nullptr);
   }
+  return ::ConstExampleCluster(*(m_obj->m_cluster));
+}
 void ExampleWithOneRelation::cluster(::ConstExampleCluster value) {
-  if (m_obj->m_cluster != nullptr) delete m_obj->m_cluster;
+  if (m_obj->m_cluster != nullptr)
+    delete m_obj->m_cluster;
   m_obj->m_cluster = new ConstExampleCluster(value);
 }
 
-
-
-bool  ExampleWithOneRelation::isAvailable() const {
+bool ExampleWithOneRelation::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -62,29 +65,29 @@ bool  ExampleWithOneRelation::isAvailable() const {
 }
 
 const podio::ObjectID ExampleWithOneRelation::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleWithOneRelation::operator==(const ConstExampleWithOneRelation& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleWithOneRelation::
+operator==(const ConstExampleWithOneRelation &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithOneRelation& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " cluster : " << value.cluster().id() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithOneRelation &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " cluster : " << value.cluster().id() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleWithOneRelation& p1, const ExampleWithOneRelation& p2 ) {
+// bool operator< (const ExampleWithOneRelation& p1, const
+// ExampleWithOneRelation& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithOneRelationCollection.cc
+++ b/tests/src/ExampleWithOneRelationCollection.cc
@@ -1,152 +1,174 @@
 // standard includes
-#include <stdexcept>
 #include "ExampleClusterCollection.h"
-
+#include <stdexcept>
 
 #include "ExampleWithOneRelationCollection.h"
 
-
-
-ExampleWithOneRelationCollection::ExampleWithOneRelationCollection() : m_isValid(false), m_collectionID(0), m_entries() , m_rel_cluster(new std::vector<::ConstExampleCluster>()),m_data(new ExampleWithOneRelationDataContainer() ) {
-    m_refCollections.push_back(new std::vector<podio::ObjectID>());
-
+ExampleWithOneRelationCollection::ExampleWithOneRelationCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_rel_cluster(new std::vector<::ConstExampleCluster>()),
+      m_data(new ExampleWithOneRelationDataContainer()) {
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
 }
 
 ExampleWithOneRelationCollection::~ExampleWithOneRelationCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-    for (auto& pointer : m_refCollections) { if (pointer != nullptr) delete pointer; }
-  if (m_rel_cluster != nullptr) { delete m_rel_cluster; }
-
+  if (m_data != nullptr)
+    delete m_data;
+  for (auto &pointer : m_refCollections) {
+    if (pointer != nullptr)
+      delete pointer;
+  }
+  if (m_rel_cluster != nullptr) {
+    delete m_rel_cluster;
+  }
 }
 
-const ExampleWithOneRelation ExampleWithOneRelationCollection::operator[](unsigned int index) const {
+const ExampleWithOneRelation ExampleWithOneRelationCollection::
+operator[](unsigned int index) const {
   return ExampleWithOneRelation(m_entries[index]);
 }
 
-const ExampleWithOneRelation ExampleWithOneRelationCollection::at(unsigned int index) const {
+const ExampleWithOneRelation
+ExampleWithOneRelationCollection::at(unsigned int index) const {
   return ExampleWithOneRelation(m_entries.at(index));
 }
 
-ExampleWithOneRelation ExampleWithOneRelationCollection::operator[](unsigned int index) {
+ExampleWithOneRelation ExampleWithOneRelationCollection::
+operator[](unsigned int index) {
   return ExampleWithOneRelation(m_entries[index]);
 }
 
-ExampleWithOneRelation ExampleWithOneRelationCollection::at(unsigned int index) {
+ExampleWithOneRelation
+ExampleWithOneRelationCollection::at(unsigned int index) {
   return ExampleWithOneRelation(m_entries.at(index));
 }
 
-int  ExampleWithOneRelationCollection::size() const {
-  return m_entries.size();
-}
+int ExampleWithOneRelationCollection::size() const { return m_entries.size(); }
 
-ExampleWithOneRelation ExampleWithOneRelationCollection::create(){
+ExampleWithOneRelation ExampleWithOneRelationCollection::create() {
   auto obj = new ExampleWithOneRelationObj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleWithOneRelation(obj);
 }
 
-void ExampleWithOneRelationCollection::clear(){
+void ExampleWithOneRelationCollection::clear() {
   m_data->clear();
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-  for (auto& item : (*m_rel_cluster)) { item.unlink(); }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+  for (auto &item : (*m_rel_cluster)) {
+    item.unlink();
+  }
   m_rel_cluster->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleWithOneRelationCollection::prepareForWrite(){
+void ExampleWithOneRelationCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
   }
-  for (auto& obj : m_entries) {
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
+  for (auto &obj : m_entries) {
     if (obj->m_cluster != nullptr) {
       m_refCollections[0]->emplace_back(obj->m_cluster->getObjectID());
     } else {
-      m_refCollections[0]->push_back({-2,-2});
+      m_refCollections[0]->push_back({-2, -2});
     }
   }
-
 }
 
-void ExampleWithOneRelationCollection::prepareAfterRead(){
+void ExampleWithOneRelationCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleWithOneRelationObj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj = new ExampleWithOneRelationObj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleWithOneRelationCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleWithOneRelationCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-  for(unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
+  for (unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
     auto id = (*m_refCollections[0])[i];
     if (id.index != podio::ObjectID::invalid) {
-      CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID,coll);
-      ExampleClusterCollection* tmp_coll = static_cast<ExampleClusterCollection*>(coll);
+      CollectionBase *coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      ExampleClusterCollection *tmp_coll =
+          static_cast<ExampleClusterCollection *>(coll);
       m_entries[i]->m_cluster = new ConstExampleCluster((*tmp_coll)[id.index]);
     } else {
       m_entries[i]->m_cluster = nullptr;
     }
   }
 
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleWithOneRelationCollection::push_back(ConstExampleWithOneRelation object){
+void ExampleWithOneRelationCollection::push_back(
+    ConstExampleWithOneRelation object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleWithOneRelationCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleWithOneRelationDataContainer*>(address);
+void ExampleWithOneRelationCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleWithOneRelationDataContainer *>(address);
 }
 
-
-const ExampleWithOneRelation ExampleWithOneRelationCollectionIterator::operator* () const {
+const ExampleWithOneRelation ExampleWithOneRelationCollectionIterator::
+operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleWithOneRelation* ExampleWithOneRelationCollectionIterator::operator-> () const {
+const ExampleWithOneRelation *ExampleWithOneRelationCollectionIterator::
+operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleWithOneRelationCollectionIterator& ExampleWithOneRelationCollectionIterator::operator++() const {
+const ExampleWithOneRelationCollectionIterator &
+ExampleWithOneRelationCollectionIterator::operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithOneRelationCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "   << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithOneRelationCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::endl;
+    o << "     cluster : ";
+    o << v[i].cluster().id() << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleWithOneRelationConst.cc
+++ b/tests/src/ExampleWithOneRelationConst.cc
@@ -1,33 +1,35 @@
 // datamodel specific includes
-#include "ExampleWithOneRelation.h"
 #include "ExampleWithOneRelationConst.h"
-#include "ExampleWithOneRelationObj.h"
-#include "ExampleWithOneRelationData.h"
-#include "ExampleWithOneRelationCollection.h"
-#include <iostream>
 #include "ExampleCluster.h"
+#include "ExampleWithOneRelation.h"
+#include "ExampleWithOneRelationCollection.h"
+#include "ExampleWithOneRelationData.h"
+#include "ExampleWithOneRelationObj.h"
+#include <iostream>
 
-
-
-
-ConstExampleWithOneRelation::ConstExampleWithOneRelation() : m_obj(new ExampleWithOneRelationObj()) {
- m_obj->acquire();
-}
-
-
-
-ConstExampleWithOneRelation::ConstExampleWithOneRelation(const ConstExampleWithOneRelation& other) : m_obj(other.m_obj) {
+ConstExampleWithOneRelation::ConstExampleWithOneRelation()
+    : m_obj(new ExampleWithOneRelationObj()) {
   m_obj->acquire();
 }
 
-ConstExampleWithOneRelation& ConstExampleWithOneRelation::operator=(const ConstExampleWithOneRelation& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithOneRelation::ConstExampleWithOneRelation(
+    const ConstExampleWithOneRelation &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleWithOneRelation &ConstExampleWithOneRelation::
+operator=(const ConstExampleWithOneRelation &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleWithOneRelation::ConstExampleWithOneRelation(ExampleWithOneRelationObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleWithOneRelation::ConstExampleWithOneRelation(
+    ExampleWithOneRelationObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -35,19 +37,20 @@ ConstExampleWithOneRelation ConstExampleWithOneRelation::clone() const {
   return {new ExampleWithOneRelationObj(*m_obj)};
 }
 
-ConstExampleWithOneRelation::~ConstExampleWithOneRelation(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithOneRelation::~ConstExampleWithOneRelation() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  a particular cluster
-  const ::ConstExampleCluster ConstExampleWithOneRelation::cluster() const {
-    if (m_obj->m_cluster == nullptr) {
-      return ::ConstExampleCluster(nullptr);
-    }
-    return ::ConstExampleCluster(*(m_obj->m_cluster));}
+/// Access the  a particular cluster
+const ::ConstExampleCluster ConstExampleWithOneRelation::cluster() const {
+  if (m_obj->m_cluster == nullptr) {
+    return ::ConstExampleCluster(nullptr);
+  }
+  return ::ConstExampleCluster(*(m_obj->m_cluster));
+}
 
-
-bool  ConstExampleWithOneRelation::isAvailable() const {
+bool ConstExampleWithOneRelation::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -55,22 +58,22 @@ bool  ConstExampleWithOneRelation::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleWithOneRelation::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleWithOneRelation::operator==(const ExampleWithOneRelation& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleWithOneRelation::
+operator==(const ExampleWithOneRelation &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleWithOneRelation& p1, const ExampleWithOneRelation& p2 ) {
+// bool operator< (const ExampleWithOneRelation& p1, const
+// ExampleWithOneRelation& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithOneRelationObj.cc
+++ b/tests/src/ExampleWithOneRelationObj.cc
@@ -1,32 +1,28 @@
 #include "ExampleWithOneRelationObj.h"
 #include "ExampleClusterConst.h"
 
+ExampleWithOneRelationObj::ExampleWithOneRelationObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(), m_cluster(nullptr)
 
+{}
 
-ExampleWithOneRelationObj::ExampleWithOneRelationObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_cluster(nullptr)
+ExampleWithOneRelationObj::ExampleWithOneRelationObj(
+    const podio::ObjectID id, ExampleWithOneRelationData data)
+    : ObjBase{id, 0}, data(data) {}
 
-{ }
-
-ExampleWithOneRelationObj::ExampleWithOneRelationObj(const podio::ObjectID id, ExampleWithOneRelationData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleWithOneRelationObj::ExampleWithOneRelationObj(const ExampleWithOneRelationObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_cluster(nullptr)
-{
+ExampleWithOneRelationObj::ExampleWithOneRelationObj(
+    const ExampleWithOneRelationObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data), m_cluster(nullptr) {
   if (other.m_cluster != nullptr) {
-     m_cluster = new ConstExampleCluster(*(other.m_cluster));
+    m_cluster = new ConstExampleCluster(*(other.m_cluster));
   }
-
 }
 
 ExampleWithOneRelationObj::~ExampleWithOneRelationObj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-    if (m_cluster != nullptr) delete m_cluster;
-
+  if (m_cluster != nullptr)
+    delete m_cluster;
 }
-

--- a/tests/src/ExampleWithString.cc
+++ b/tests/src/ExampleWithString.cc
@@ -1,36 +1,36 @@
 // datamodel specific includes
 #include "ExampleWithString.h"
-#include "ExampleWithStringConst.h"
-#include "ExampleWithStringObj.h"
-#include "ExampleWithStringData.h"
 #include "ExampleWithStringCollection.h"
+#include "ExampleWithStringConst.h"
+#include "ExampleWithStringData.h"
+#include "ExampleWithStringObj.h"
 #include <iostream>
 
-
-
-
-ExampleWithString::ExampleWithString() : m_obj(new ExampleWithStringObj()){
- m_obj->acquire();
-}
-
-ExampleWithString::ExampleWithString(std::string theString) : m_obj(new ExampleWithStringObj()) {
-  m_obj->acquire();
-    m_obj->data.theString = theString;
-}
-
-
-ExampleWithString::ExampleWithString(const ExampleWithString& other) : m_obj(other.m_obj) {
+ExampleWithString::ExampleWithString() : m_obj(new ExampleWithStringObj()) {
   m_obj->acquire();
 }
 
-ExampleWithString& ExampleWithString::operator=(const ExampleWithString& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithString::ExampleWithString(std::string theString)
+    : m_obj(new ExampleWithStringObj()) {
+  m_obj->acquire();
+  m_obj->data.theString = theString;
+}
+
+ExampleWithString::ExampleWithString(const ExampleWithString &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleWithString &ExampleWithString::
+operator=(const ExampleWithString &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleWithString::ExampleWithString(ExampleWithStringObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleWithString::ExampleWithString(ExampleWithStringObj *obj) : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,19 +38,24 @@ ExampleWithString ExampleWithString::clone() const {
   return {new ExampleWithStringObj(*m_obj)};
 }
 
-ExampleWithString::~ExampleWithString(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithString::~ExampleWithString() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleWithString::operator ConstExampleWithString() const {return ConstExampleWithString(m_obj);}
+ExampleWithString::operator ConstExampleWithString() const {
+  return ConstExampleWithString(m_obj);
+}
 
-  const std::string& ExampleWithString::theString() const { return m_obj->data.theString; }
+const std::string &ExampleWithString::theString() const {
+  return m_obj->data.theString;
+}
 
-void ExampleWithString::theString(std::string value) { m_obj->data.theString = value; }
+void ExampleWithString::theString(std::string value) {
+  m_obj->data.theString = value;
+}
 
-
-
-bool  ExampleWithString::isAvailable() const {
+bool ExampleWithString::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -58,29 +63,26 @@ bool  ExampleWithString::isAvailable() const {
 }
 
 const podio::ObjectID ExampleWithString::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleWithString::operator==(const ConstExampleWithString& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleWithString::operator==(const ConstExampleWithString &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithString& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " theString : " << value.theString() << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o, const ConstExampleWithString &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " theString : " << value.theString() << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleWithString& p1, const ExampleWithString& p2 ) {
+// bool operator< (const ExampleWithString& p1, const ExampleWithString& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithStringCollection.cc
+++ b/tests/src/ExampleWithStringCollection.cc
@@ -1,26 +1,25 @@
 // standard includes
 #include <stdexcept>
 
-
 #include "ExampleWithStringCollection.h"
 
-
-
-ExampleWithStringCollection::ExampleWithStringCollection() : m_isValid(false), m_collectionID(0), m_entries() ,m_data(new ExampleWithStringDataContainer() ) {
-  
-}
+ExampleWithStringCollection::ExampleWithStringCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_data(new ExampleWithStringDataContainer()) {}
 
 ExampleWithStringCollection::~ExampleWithStringCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-  
+  if (m_data != nullptr)
+    delete m_data;
 }
 
-const ExampleWithString ExampleWithStringCollection::operator[](unsigned int index) const {
+const ExampleWithString ExampleWithStringCollection::
+operator[](unsigned int index) const {
   return ExampleWithString(m_entries[index]);
 }
 
-const ExampleWithString ExampleWithStringCollection::at(unsigned int index) const {
+const ExampleWithString
+ExampleWithStringCollection::at(unsigned int index) const {
   return ExampleWithString(m_entries.at(index));
 }
 
@@ -32,96 +31,100 @@ ExampleWithString ExampleWithStringCollection::at(unsigned int index) {
   return ExampleWithString(m_entries.at(index));
 }
 
-int  ExampleWithStringCollection::size() const {
-  return m_entries.size();
-}
+int ExampleWithStringCollection::size() const { return m_entries.size(); }
 
-ExampleWithString ExampleWithStringCollection::create(){
+ExampleWithString ExampleWithStringCollection::create() {
   auto obj = new ExampleWithStringObj();
   m_entries.emplace_back(obj);
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleWithString(obj);
 }
 
-void ExampleWithStringCollection::clear(){
+void ExampleWithStringCollection::clear() {
   m_data->clear();
 
-  for (auto& obj : m_entries) { delete obj; }
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleWithStringCollection::prepareForWrite(){
+void ExampleWithStringCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  for(int i=0, size = m_data->size(); i != size; ++i){
-
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
+  }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
   }
 
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  }
 }
 
-void ExampleWithStringCollection::prepareAfterRead(){
+void ExampleWithStringCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleWithStringObj({index,m_collectionID}, data);
-    
+  for (auto &data : *m_data) {
+    auto obj = new ExampleWithStringObj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleWithStringCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleWithStringCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleWithStringCollection::push_back(ConstExampleWithString object){
+void ExampleWithStringCollection::push_back(ConstExampleWithString object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleWithStringCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleWithStringDataContainer*>(address);
+void ExampleWithStringCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleWithStringDataContainer *>(address);
 }
 
-
-const ExampleWithString ExampleWithStringCollectionIterator::operator* () const {
+const ExampleWithString ExampleWithStringCollectionIterator::operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleWithString* ExampleWithStringCollectionIterator::operator-> () const {
+const ExampleWithString *ExampleWithStringCollectionIterator::
+operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleWithStringCollectionIterator& ExampleWithStringCollectionIterator::operator++() const {
+const ExampleWithStringCollectionIterator &ExampleWithStringCollectionIterator::
+operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithStringCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          theString:    " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].theString() << " "  << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithStringCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          theString:    " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::setw(12) << v[i].theString() << " " << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleWithStringConst.cc
+++ b/tests/src/ExampleWithStringConst.cc
@@ -1,36 +1,39 @@
 // datamodel specific includes
-#include "ExampleWithString.h"
 #include "ExampleWithStringConst.h"
-#include "ExampleWithStringObj.h"
-#include "ExampleWithStringData.h"
+#include "ExampleWithString.h"
 #include "ExampleWithStringCollection.h"
+#include "ExampleWithStringData.h"
+#include "ExampleWithStringObj.h"
 #include <iostream>
 
-
-
-
-ConstExampleWithString::ConstExampleWithString() : m_obj(new ExampleWithStringObj()) {
- m_obj->acquire();
-}
-
-ConstExampleWithString::ConstExampleWithString(std::string theString) : m_obj(new ExampleWithStringObj()){
- m_obj->acquire();
-   m_obj->data.theString = theString;
-}
-
-
-ConstExampleWithString::ConstExampleWithString(const ConstExampleWithString& other) : m_obj(other.m_obj) {
+ConstExampleWithString::ConstExampleWithString()
+    : m_obj(new ExampleWithStringObj()) {
   m_obj->acquire();
 }
 
-ConstExampleWithString& ConstExampleWithString::operator=(const ConstExampleWithString& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithString::ConstExampleWithString(std::string theString)
+    : m_obj(new ExampleWithStringObj()) {
+  m_obj->acquire();
+  m_obj->data.theString = theString;
+}
+
+ConstExampleWithString::ConstExampleWithString(
+    const ConstExampleWithString &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleWithString &ConstExampleWithString::
+operator=(const ConstExampleWithString &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleWithString::ConstExampleWithString(ExampleWithStringObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleWithString::ConstExampleWithString(ExampleWithStringObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -38,16 +41,17 @@ ConstExampleWithString ConstExampleWithString::clone() const {
   return {new ExampleWithStringObj(*m_obj)};
 }
 
-ConstExampleWithString::~ConstExampleWithString(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithString::~ConstExampleWithString() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-  /// Access the  the string
-  const std::string& ConstExampleWithString::theString() const { return m_obj->data.theString; }
+/// Access the  the string
+const std::string &ConstExampleWithString::theString() const {
+  return m_obj->data.theString;
+}
 
-
-
-bool  ConstExampleWithString::isAvailable() const {
+bool ConstExampleWithString::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -55,22 +59,20 @@ bool  ConstExampleWithString::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleWithString::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleWithString::operator==(const ExampleWithString& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleWithString::operator==(const ExampleWithString &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleWithString& p1, const ExampleWithString& p2 ) {
+// bool operator< (const ExampleWithString& p1, const ExampleWithString& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithStringObj.cc
+++ b/tests/src/ExampleWithStringObj.cc
@@ -1,26 +1,18 @@
 #include "ExampleWithStringObj.h"
 
+ExampleWithStringObj::ExampleWithStringObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data() {}
 
+ExampleWithStringObj::ExampleWithStringObj(const podio::ObjectID id,
+                                           ExampleWithStringData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleWithStringObj::ExampleWithStringObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data()
-{ }
-
-ExampleWithStringObj::ExampleWithStringObj(const podio::ObjectID id, ExampleWithStringData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleWithStringObj::ExampleWithStringObj(const ExampleWithStringObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data)
-{
-
-}
+ExampleWithStringObj::ExampleWithStringObj(const ExampleWithStringObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data) {}
 
 ExampleWithStringObj::~ExampleWithStringObj() {
   if (id.index == podio::ObjectID::untracked) {
-
   }
-
 }
-

--- a/tests/src/ExampleWithVectorMember.cc
+++ b/tests/src/ExampleWithVectorMember.cc
@@ -1,32 +1,34 @@
 // datamodel specific includes
 #include "ExampleWithVectorMember.h"
-#include "ExampleWithVectorMemberConst.h"
-#include "ExampleWithVectorMemberObj.h"
-#include "ExampleWithVectorMemberData.h"
 #include "ExampleWithVectorMemberCollection.h"
+#include "ExampleWithVectorMemberConst.h"
+#include "ExampleWithVectorMemberData.h"
+#include "ExampleWithVectorMemberObj.h"
 #include <iostream>
 
-
-
-
-ExampleWithVectorMember::ExampleWithVectorMember() : m_obj(new ExampleWithVectorMemberObj()){
- m_obj->acquire();
-}
-
-
-
-ExampleWithVectorMember::ExampleWithVectorMember(const ExampleWithVectorMember& other) : m_obj(other.m_obj) {
+ExampleWithVectorMember::ExampleWithVectorMember()
+    : m_obj(new ExampleWithVectorMemberObj()) {
   m_obj->acquire();
 }
 
-ExampleWithVectorMember& ExampleWithVectorMember::operator=(const ExampleWithVectorMember& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithVectorMember::ExampleWithVectorMember(
+    const ExampleWithVectorMember &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ExampleWithVectorMember &ExampleWithVectorMember::
+operator=(const ExampleWithVectorMember &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ExampleWithVectorMember::ExampleWithVectorMember(ExampleWithVectorMemberObj* obj) : m_obj(obj){
-  if(m_obj != nullptr)
+ExampleWithVectorMember::ExampleWithVectorMember(
+    ExampleWithVectorMemberObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -34,13 +36,14 @@ ExampleWithVectorMember ExampleWithVectorMember::clone() const {
   return {new ExampleWithVectorMemberObj(*m_obj)};
 }
 
-ExampleWithVectorMember::~ExampleWithVectorMember(){
-  if ( m_obj != nullptr) m_obj->release();
+ExampleWithVectorMember::~ExampleWithVectorMember() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-ExampleWithVectorMember::operator ConstExampleWithVectorMember() const {return ConstExampleWithVectorMember(m_obj);}
-
-
+ExampleWithVectorMember::operator ConstExampleWithVectorMember() const {
+  return ConstExampleWithVectorMember(m_obj);
+}
 
 std::vector<int>::const_iterator ExampleWithVectorMember::count_begin() const {
   auto ret_value = m_obj->m_count->begin();
@@ -60,18 +63,17 @@ void ExampleWithVectorMember::addcount(int component) {
 }
 
 unsigned int ExampleWithVectorMember::count_size() const {
-  return (m_obj->data.count_end-m_obj->data.count_begin);
+  return (m_obj->data.count_end - m_obj->data.count_begin);
 }
 
 int ExampleWithVectorMember::count(unsigned int index) const {
   if (count_size() > index) {
-    return m_obj->m_count->at(m_obj->data.count_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_count->at(m_obj->data.count_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ExampleWithVectorMember::isAvailable() const {
+bool ExampleWithVectorMember::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -79,32 +81,32 @@ bool  ExampleWithVectorMember::isAvailable() const {
 }
 
 const podio::ObjectID ExampleWithVectorMember::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ExampleWithVectorMember::operator==(const ConstExampleWithVectorMember& other) const {
-  return (m_obj==other.m_obj);
+bool ExampleWithVectorMember::
+operator==(const ConstExampleWithVectorMember &other) const {
+  return (m_obj == other.m_obj);
 }
 
-std::ostream& operator<<( std::ostream& o,const ConstExampleWithVectorMember& value ){
-  o << " id : " << value.id() << std::endl ;
-  o << " count : " ;
-  for(unsigned i=0,N=value.count_size(); i<N ; ++i)
-    o << value.count(i) << " " ; 
-  o << std::endl ;
-  return o ;
+std::ostream &operator<<(std::ostream &o,
+                         const ConstExampleWithVectorMember &value) {
+  o << " id : " << value.id() << std::endl;
+  o << " count : ";
+  for (unsigned i = 0, N = value.count_size(); i < N; ++i)
+    o << value.count(i) << " ";
+  o << std::endl;
+  return o;
 }
 
-
-//bool operator< (const ExampleWithVectorMember& p1, const ExampleWithVectorMember& p2 ) {
+// bool operator< (const ExampleWithVectorMember& p1, const
+// ExampleWithVectorMember& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithVectorMemberCollection.cc
+++ b/tests/src/ExampleWithVectorMemberCollection.cc
@@ -1,133 +1,138 @@
 // standard includes
 #include <stdexcept>
 
-
 #include "ExampleWithVectorMemberCollection.h"
 
-
-
-ExampleWithVectorMemberCollection::ExampleWithVectorMemberCollection() : m_isValid(false), m_collectionID(0), m_entries() ,m_data(new ExampleWithVectorMemberDataContainer()),  m_vec_count( new std::vector<int>()) {
-  m_vecmem_info.push_back( std::make_pair( "int", &m_vec_count )) ; 
-}
+ExampleWithVectorMemberCollection::ExampleWithVectorMemberCollection()
+    : m_isValid(false), m_collectionID(0), m_entries(),
+      m_data(new ExampleWithVectorMemberDataContainer()) {}
 
 ExampleWithVectorMemberCollection::~ExampleWithVectorMemberCollection() {
   clear();
-  if (m_data != nullptr) delete m_data;
-  if(m_vec_count != nullptr) delete m_vec_count;
+  if (m_data != nullptr)
+    delete m_data;
 }
 
-const ExampleWithVectorMember ExampleWithVectorMemberCollection::operator[](unsigned int index) const {
+const ExampleWithVectorMember ExampleWithVectorMemberCollection::
+operator[](unsigned int index) const {
   return ExampleWithVectorMember(m_entries[index]);
 }
 
-const ExampleWithVectorMember ExampleWithVectorMemberCollection::at(unsigned int index) const {
+const ExampleWithVectorMember
+ExampleWithVectorMemberCollection::at(unsigned int index) const {
   return ExampleWithVectorMember(m_entries.at(index));
 }
 
-ExampleWithVectorMember ExampleWithVectorMemberCollection::operator[](unsigned int index) {
+ExampleWithVectorMember ExampleWithVectorMemberCollection::
+operator[](unsigned int index) {
   return ExampleWithVectorMember(m_entries[index]);
 }
 
-ExampleWithVectorMember ExampleWithVectorMemberCollection::at(unsigned int index) {
+ExampleWithVectorMember
+ExampleWithVectorMemberCollection::at(unsigned int index) {
   return ExampleWithVectorMember(m_entries.at(index));
 }
 
-int  ExampleWithVectorMemberCollection::size() const {
-  return m_entries.size();
-}
+int ExampleWithVectorMemberCollection::size() const { return m_entries.size(); }
 
-ExampleWithVectorMember ExampleWithVectorMemberCollection::create(){
+ExampleWithVectorMember ExampleWithVectorMemberCollection::create() {
   auto obj = new ExampleWithVectorMemberObj();
   m_entries.emplace_back(obj);
-  m_vecs_count.push_back(obj->m_count) ;
 
-  obj->id = {int(m_entries.size()-1),m_collectionID};
+  obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleWithVectorMember(obj);
 }
 
-void ExampleWithVectorMemberCollection::clear(){
+void ExampleWithVectorMemberCollection::clear() {
   m_data->clear();
-  m_vec_count->clear() ;
-  m_vecs_count.clear() ;
-  for (auto& obj : m_entries) { delete obj; }
+
+  for (auto &obj : m_entries) {
+    delete obj;
+  }
   m_entries.clear();
 }
 
-void ExampleWithVectorMemberCollection::prepareForWrite(){
+void ExampleWithVectorMemberCollection::prepareForWrite() {
   auto size = m_entries.size();
   m_data->reserve(size);
-  for (auto& obj : m_entries) {m_data->push_back(obj->data); }
-  for (auto& pointer : m_refCollections) {pointer->clear(); } 
-  int count_index =0  ;
-  for(int i=0, size = m_data->size(); i != size; ++i){
-    (*m_data)[i].count_begin=count_index;
-    (*m_data)[i].count_end +=count_index;
-    count_index = (*m_data)[i].count_end;
-    for(auto it : (*m_vecs_count[i])) {
-      m_vec_count->push_back(it);
-    }
+  for (auto &obj : m_entries) {
+    m_data->push_back(obj->data);
+  }
+  for (auto &pointer : m_refCollections) {
+    pointer->clear();
+  }
+
+  for (int i = 0, size = m_data->size(); i != size; ++i) {
   }
 }
 
-void ExampleWithVectorMemberCollection::prepareAfterRead(){
+void ExampleWithVectorMemberCollection::prepareAfterRead() {
   int index = 0;
-  for (auto& data : *m_data){
-    auto obj = new ExampleWithVectorMemberObj({index,m_collectionID}, data);
-    obj->m_count = m_vec_count ;
+  for (auto &data : *m_data) {
+    auto obj = new ExampleWithVectorMemberObj({index, m_collectionID}, data);
+
     m_entries.emplace_back(obj);
     ++index;
   }
   m_isValid = true;
 }
 
-bool ExampleWithVectorMemberCollection::setReferences(const podio::ICollectionProvider* collectionProvider){
+bool ExampleWithVectorMemberCollection::setReferences(
+    const podio::ICollectionProvider *collectionProvider) {
 
-
-  return true; //TODO: check success
+  return true; // TODO: check success
 }
 
-void ExampleWithVectorMemberCollection::push_back(ConstExampleWithVectorMember object){
+void ExampleWithVectorMemberCollection::push_back(
+    ConstExampleWithVectorMember object) {
   int size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-      obj->id = {size,m_collectionID};
-      m_entries.push_back(obj);
-      m_vecs_count.push_back(obj->m_count);
+    obj->id = {size, m_collectionID};
+    m_entries.push_back(obj);
+
   } else {
-    throw std::invalid_argument( "Object already in a collection. Cannot add it to a second collection " );
+    throw std::invalid_argument("Object already in a collection. Cannot add it "
+                                "to a second collection ");
   }
 }
 
-void ExampleWithVectorMemberCollection::setBuffer(void* address){
-  if (m_data != nullptr) delete m_data;
-  m_data = static_cast<ExampleWithVectorMemberDataContainer*>(address);
+void ExampleWithVectorMemberCollection::setBuffer(void *address) {
+  if (m_data != nullptr)
+    delete m_data;
+  m_data = static_cast<ExampleWithVectorMemberDataContainer *>(address);
 }
 
-
-const ExampleWithVectorMember ExampleWithVectorMemberCollectionIterator::operator* () const {
+const ExampleWithVectorMember ExampleWithVectorMemberCollectionIterator::
+operator*() const {
   m_object.m_obj = (*m_collection)[m_index];
   return m_object;
 }
 
-const ExampleWithVectorMember* ExampleWithVectorMemberCollectionIterator::operator-> () const {
+const ExampleWithVectorMember *ExampleWithVectorMemberCollectionIterator::
+operator->() const {
   m_object.m_obj = (*m_collection)[m_index];
   return &m_object;
 }
 
-const ExampleWithVectorMemberCollectionIterator& ExampleWithVectorMemberCollectionIterator::operator++() const {
+const ExampleWithVectorMemberCollectionIterator &
+ExampleWithVectorMemberCollectionIterator::operator++() const {
   ++m_index;
   return *this;
 }
 
-std::ostream& operator<<( std::ostream& o,const ExampleWithVectorMemberCollection& v){
-  std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          " << std::endl ;
-   for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "   << std::endl;
-  o.flags(old_flags) ; 
+std::ostream &operator<<(std::ostream &o,
+                         const ExampleWithVectorMemberCollection &v) {
+  std::ios::fmtflags old_flags = o.flags();
+  o << "id:          " << std::endl;
+  for (int i = 0; i < v.size(); i++) {
+    o << std::scientific << std::showpos << std::setw(12) << v[i].id() << " "
+      << std::endl;
+    o << "     count : ";
+    for (unsigned j = 0, N = v[i].count_size(); j < N; ++j)
+      o << v[i].count(j) << " ";
+    o << std::endl;
+  }
+  o.flags(old_flags);
+  return o;
 }
-  return o ;
-}
-
-
-

--- a/tests/src/ExampleWithVectorMemberCollection.cc
+++ b/tests/src/ExampleWithVectorMemberCollection.cc
@@ -5,12 +5,17 @@
 
 ExampleWithVectorMemberCollection::ExampleWithVectorMemberCollection()
     : m_isValid(false), m_collectionID(0), m_entries(),
-      m_data(new ExampleWithVectorMemberDataContainer()) {}
+      m_data(new ExampleWithVectorMemberDataContainer()) {
+  m_vecmem_info.push_back(std::make_pair("int", &m_vec_count));
+  m_vec_count = new std::vector<int>();
+}
 
 ExampleWithVectorMemberCollection::~ExampleWithVectorMemberCollection() {
   clear();
   if (m_data != nullptr)
     delete m_data;
+  if (m_vec_count != nullptr)
+    delete m_vec_count;
 }
 
 const ExampleWithVectorMember ExampleWithVectorMemberCollection::
@@ -38,6 +43,7 @@ int ExampleWithVectorMemberCollection::size() const { return m_entries.size(); }
 ExampleWithVectorMember ExampleWithVectorMemberCollection::create() {
   auto obj = new ExampleWithVectorMemberObj();
   m_entries.emplace_back(obj);
+  m_vecs_count.push_back(obj->m_count);
 
   obj->id = {int(m_entries.size() - 1), m_collectionID};
   return ExampleWithVectorMember(obj);
@@ -45,6 +51,8 @@ ExampleWithVectorMember ExampleWithVectorMemberCollection::create() {
 
 void ExampleWithVectorMemberCollection::clear() {
   m_data->clear();
+  m_vec_count->clear();
+  m_vecs_count.clear();
 
   for (auto &obj : m_entries) {
     delete obj;
@@ -61,8 +69,15 @@ void ExampleWithVectorMemberCollection::prepareForWrite() {
   for (auto &pointer : m_refCollections) {
     pointer->clear();
   }
+  int count_index = 0;
 
   for (int i = 0, size = m_data->size(); i != size; ++i) {
+    (*m_data)[i].count_begin = count_index;
+    (*m_data)[i].count_end += count_index;
+    count_index = (*m_data)[i].count_end;
+    m_vec_count->insert(m_vec_count->end(), *m_vecs_count[i]->begin(),
+                        *m_vecs_count[i]->end());
+    //   for(auto it : (*m_vecs_count[i])) { m_vec_count->push_back(it); }
   }
 }
 
@@ -70,6 +85,7 @@ void ExampleWithVectorMemberCollection::prepareAfterRead() {
   int index = 0;
   for (auto &data : *m_data) {
     auto obj = new ExampleWithVectorMemberObj({index, m_collectionID}, data);
+    obj->m_count = m_vec_count;
 
     m_entries.emplace_back(obj);
     ++index;
@@ -90,6 +106,7 @@ void ExampleWithVectorMemberCollection::push_back(
   if (obj->id.index == podio::ObjectID::untracked) {
     obj->id = {size, m_collectionID};
     m_entries.push_back(obj);
+    m_vecs_count.push_back(obj->m_count);
 
   } else {
     throw std::invalid_argument("Object already in a collection. Cannot add it "

--- a/tests/src/ExampleWithVectorMemberCollection.cc
+++ b/tests/src/ExampleWithVectorMemberCollection.cc
@@ -47,7 +47,8 @@ ExampleWithVectorMember ExampleWithVectorMemberCollection::create(){
 
 void ExampleWithVectorMemberCollection::clear(){
   m_data->clear();
-
+  m_vec_count->clear() ;
+  m_vecs_count.clear() ;
   for (auto& obj : m_entries) { delete obj; }
   m_entries.clear();
 }
@@ -57,8 +58,7 @@ void ExampleWithVectorMemberCollection::prepareForWrite(){
   m_data->reserve(size);
   for (auto& obj : m_entries) {m_data->push_back(obj->data); }
   for (auto& pointer : m_refCollections) {pointer->clear(); } 
-
-  int count_index ;
+  int count_index =0  ;
   for(int i=0, size = m_data->size(); i != size; ++i){
     (*m_data)[i].count_begin=count_index;
     (*m_data)[i].count_end +=count_index;

--- a/tests/src/ExampleWithVectorMemberCollection.cc
+++ b/tests/src/ExampleWithVectorMemberCollection.cc
@@ -1,4 +1,5 @@
 // standard includes
+#include <numeric>
 #include <stdexcept>
 
 #include "ExampleWithVectorMemberCollection.h"
@@ -69,15 +70,21 @@ void ExampleWithVectorMemberCollection::prepareForWrite() {
   for (auto &pointer : m_refCollections) {
     pointer->clear();
   }
+  int count_size =
+      std::accumulate(m_entries.begin(), m_entries.end(), 0,
+                      [](int sum, const ExampleWithVectorMemberObj *obj) {
+                        return sum + obj->m_count->size();
+                      });
+  m_vec_count->reserve(count_size);
   int count_index = 0;
 
   for (int i = 0, size = m_data->size(); i != size; ++i) {
     (*m_data)[i].count_begin = count_index;
     (*m_data)[i].count_end += count_index;
     count_index = (*m_data)[i].count_end;
-    m_vec_count->insert(m_vec_count->end(), *m_vecs_count[i]->begin(),
-                        *m_vecs_count[i]->end());
-    //   for(auto it : (*m_vecs_count[i])) { m_vec_count->push_back(it); }
+    for (auto it : (*m_vecs_count[i])) {
+      m_vec_count->push_back(it);
+    }
   }
 }
 

--- a/tests/src/ExampleWithVectorMemberConst.cc
+++ b/tests/src/ExampleWithVectorMemberConst.cc
@@ -1,32 +1,34 @@
 // datamodel specific includes
-#include "ExampleWithVectorMember.h"
 #include "ExampleWithVectorMemberConst.h"
-#include "ExampleWithVectorMemberObj.h"
-#include "ExampleWithVectorMemberData.h"
+#include "ExampleWithVectorMember.h"
 #include "ExampleWithVectorMemberCollection.h"
+#include "ExampleWithVectorMemberData.h"
+#include "ExampleWithVectorMemberObj.h"
 #include <iostream>
 
-
-
-
-ConstExampleWithVectorMember::ConstExampleWithVectorMember() : m_obj(new ExampleWithVectorMemberObj()) {
- m_obj->acquire();
-}
-
-
-
-ConstExampleWithVectorMember::ConstExampleWithVectorMember(const ConstExampleWithVectorMember& other) : m_obj(other.m_obj) {
+ConstExampleWithVectorMember::ConstExampleWithVectorMember()
+    : m_obj(new ExampleWithVectorMemberObj()) {
   m_obj->acquire();
 }
 
-ConstExampleWithVectorMember& ConstExampleWithVectorMember::operator=(const ConstExampleWithVectorMember& other) {
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithVectorMember::ConstExampleWithVectorMember(
+    const ConstExampleWithVectorMember &other)
+    : m_obj(other.m_obj) {
+  m_obj->acquire();
+}
+
+ConstExampleWithVectorMember &ConstExampleWithVectorMember::
+operator=(const ConstExampleWithVectorMember &other) {
+  if (m_obj != nullptr)
+    m_obj->release();
   m_obj = other.m_obj;
   return *this;
 }
 
-ConstExampleWithVectorMember::ConstExampleWithVectorMember(ExampleWithVectorMemberObj* obj) : m_obj(obj) {
-  if(m_obj != nullptr)
+ConstExampleWithVectorMember::ConstExampleWithVectorMember(
+    ExampleWithVectorMemberObj *obj)
+    : m_obj(obj) {
+  if (m_obj != nullptr)
     m_obj->acquire();
 }
 
@@ -34,36 +36,37 @@ ConstExampleWithVectorMember ConstExampleWithVectorMember::clone() const {
   return {new ExampleWithVectorMemberObj(*m_obj)};
 }
 
-ConstExampleWithVectorMember::~ConstExampleWithVectorMember(){
-  if ( m_obj != nullptr) m_obj->release();
+ConstExampleWithVectorMember::~ConstExampleWithVectorMember() {
+  if (m_obj != nullptr)
+    m_obj->release();
 }
 
-
-std::vector<int>::const_iterator ConstExampleWithVectorMember::count_begin() const {
+std::vector<int>::const_iterator
+ConstExampleWithVectorMember::count_begin() const {
   auto ret_value = m_obj->m_count->begin();
   std::advance(ret_value, m_obj->data.count_begin);
   return ret_value;
 }
 
-std::vector<int>::const_iterator ConstExampleWithVectorMember::count_end() const {
+std::vector<int>::const_iterator
+ConstExampleWithVectorMember::count_end() const {
   auto ret_value = m_obj->m_count->begin();
-  std::advance(ret_value, m_obj->data.count_end-1);
+  std::advance(ret_value, m_obj->data.count_end - 1);
   return ++ret_value;
 }
 
 unsigned int ConstExampleWithVectorMember::count_size() const {
-  return (m_obj->data.count_end-m_obj->data.count_begin);
+  return (m_obj->data.count_end - m_obj->data.count_begin);
 }
 
 int ConstExampleWithVectorMember::count(unsigned int index) const {
   if (count_size() > index) {
-    return m_obj->m_count->at(m_obj->data.count_begin+index);
-  }
-  else throw std::out_of_range ("index out of bounds for existing references");
+    return m_obj->m_count->at(m_obj->data.count_begin + index);
+  } else
+    throw std::out_of_range("index out of bounds for existing references");
 }
 
-
-bool  ConstExampleWithVectorMember::isAvailable() const {
+bool ConstExampleWithVectorMember::isAvailable() const {
   if (m_obj != nullptr) {
     return true;
   }
@@ -71,22 +74,22 @@ bool  ConstExampleWithVectorMember::isAvailable() const {
 }
 
 const podio::ObjectID ConstExampleWithVectorMember::getObjectID() const {
-  if (m_obj !=nullptr){
+  if (m_obj != nullptr) {
     return m_obj->id;
   }
-  return podio::ObjectID{-2,-2};
+  return podio::ObjectID{-2, -2};
 }
 
-bool ConstExampleWithVectorMember::operator==(const ExampleWithVectorMember& other) const {
-     return (m_obj==other.m_obj);
+bool ConstExampleWithVectorMember::
+operator==(const ExampleWithVectorMember &other) const {
+  return (m_obj == other.m_obj);
 }
 
-//bool operator< (const ExampleWithVectorMember& p1, const ExampleWithVectorMember& p2 ) {
+// bool operator< (const ExampleWithVectorMember& p1, const
+// ExampleWithVectorMember& p2 ) {
 //  if( p1.m_containerID == p2.m_containerID ) {
 //    return p1.m_index < p2.m_index;
 //  } else {
 //    return p1.m_containerID < p2.m_containerID;
 //  }
 //}
-
-

--- a/tests/src/ExampleWithVectorMemberObj.cc
+++ b/tests/src/ExampleWithVectorMemberObj.cc
@@ -1,27 +1,20 @@
 #include "ExampleWithVectorMemberObj.h"
 
+ExampleWithVectorMemberObj::ExampleWithVectorMemberObj()
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(), m_count(new std::vector<int>()) {}
 
+ExampleWithVectorMemberObj::ExampleWithVectorMemberObj(
+    const podio::ObjectID id, ExampleWithVectorMemberData data)
+    : ObjBase{id, 0}, data(data) {}
 
-ExampleWithVectorMemberObj::ExampleWithVectorMemberObj() :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}, data(), m_count(new std::vector<int>())
-{ }
-
-ExampleWithVectorMemberObj::ExampleWithVectorMemberObj(const podio::ObjectID id, ExampleWithVectorMemberData data) :
-    ObjBase{id,0}, data(data)
-{ }
-
-ExampleWithVectorMemberObj::ExampleWithVectorMemberObj(const ExampleWithVectorMemberObj& other) :
-    ObjBase{{podio::ObjectID::untracked,podio::ObjectID::untracked},0}
-    , data(other.data), m_count(new std::vector<int>(*(other.m_count)))
-{
-
-}
+ExampleWithVectorMemberObj::ExampleWithVectorMemberObj(
+    const ExampleWithVectorMemberObj &other)
+    : ObjBase{{podio::ObjectID::untracked, podio::ObjectID::untracked}, 0},
+      data(other.data), m_count(new std::vector<int>(*(other.m_count))) {}
 
 ExampleWithVectorMemberObj::~ExampleWithVectorMemberObj() {
   if (id.index == podio::ObjectID::untracked) {
     delete m_count;
-
   }
-
 }
-

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -190,9 +190,13 @@ int main(){
     oneRels.push_back(oneRelEmpty);
 
     auto vec = ExampleWithVectorMember();
-    vec.addcount(23);
-    vec.addcount(24);
+    vec.addcount(i);
+    vec.addcount(i+10);
     vecs.push_back(vec);
+    auto vec1 = ExampleWithVectorMember();
+    vec1.addcount(i+1);
+    vec1.addcount(i+11);
+    vecs.push_back(vec1);
 
     for (int j = 0; j < 5; j++) {
       auto rel = ex::ExampleWithARelation();


### PR DESCRIPTION

BEGINRELEASENOTES
- add code generation for I/O of vector members
       - vector members are treated analogous to the reference vectors,i.e.
          streamed as one large vector per collection
- updated tests/datamodel  accordingly  (using clang-format)

ENDRELEASENOTES