### PR TITLE
some fixes: namespace, array getters, include in components,... 

### DIFF
--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -49,6 +49,9 @@ namespace podio {
     /// check for validity of the container after read
     virtual bool isValid() const = 0;
 
+    /// number of elements in the collection
+    virtual int size() const = 0;
+
     /// destructor
     virtual ~CollectionBase(){};
 

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -317,6 +317,11 @@ class ClassGenerator(object):
           getter_declarations += declarations["array_member_getter"].format(type=item_class, name=name, fname=gname, description=desc)
           getter_implementations += implementations["array_member_getter"].format(type=item_class, classname=rawclassname, name=name, fname=gname)
           ConstGetter_implementations += implementations["const_array_member_getter"].format(type=item_class, classname=rawclassname, name=name, fname=gname, description=desc)
+          arrsize = klass[ klass.rfind(',')+1 : klass.rfind('>') ]
+          ostream_implementation += ( '  o << " %s : " ;\n' % (name) )
+          ostream_implementation +=    '  for(int i=0,N='+arrsize+';i<N;++i)\n'
+          ostream_implementation +=  ( '      o << value.%s()[i] << "|" ;\n' %  gname  )
+          ostream_implementation +=    '  o << std::endl ;\n'
         else:
           ostream_implementation += ( '  o << " %s : " << value.%s() << std::endl ;\n' % (name,gname) )
           setter_declarations += declarations["member_class_refsetter"].format(type=klass, name=name, description=desc)
@@ -858,8 +863,12 @@ class ClassGenerator(object):
         if( name != "ExtraCode"):
 
           if not klass.startswith("std::array"):
-            ostreamComponents +=  ( '  o << value.%s << " " ;\n' %  name  ) 
-
+            ostreamComponents +=  ( '  o << value.%s << " " ;\n' %  name  )
+          else:
+            arrsize = klass[ klass.rfind(',')+1 : klass.rfind('>') ]
+            ostreamComponents +=    '  for(int i=0,N='+arrsize+';i<N;++i)\n'
+            ostreamComponents +=  ( '      o << value.%s[i] << "|" ;\n' %  name  )
+            ostreamComponents +=    '  o << "  " ;\n'
           klassname = klass
           mnamespace = ""
           if "::" in klass:

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -314,9 +314,9 @@ class ClassGenerator(object):
           item_class = klass.split("<")[1].split(",")[0].strip()
           setter_declarations += declarations["array_builtin_setter"].format(type=item_class, name=name, fname=sname, description=desc)
           setter_implementations += implementations["array_builtin_setter"].format(type=item_class, classname=rawclassname, name=name, fname=sname)
-          getter_declarations += declarations["array_member_getter"].format(type=item_class, name=name, fname=sname, description=desc)
-          getter_implementations += implementations["array_member_getter"].format(type=item_class, classname=rawclassname, name=name, fname=sname)
-          ConstGetter_implementations += implementations["const_array_member_getter"].format(type=item_class, classname=rawclassname, name=name, fname=sname, description=desc)
+          getter_declarations += declarations["array_member_getter"].format(type=item_class, name=name, fname=gname, description=desc)
+          getter_implementations += implementations["array_member_getter"].format(type=item_class, classname=rawclassname, name=name, fname=gname)
+          ConstGetter_implementations += implementations["const_array_member_getter"].format(type=item_class, classname=rawclassname, name=name, fname=gname, description=desc)
         else:
           ostream_implementation += ( '  o << " %s : " << value.%s() << std::endl ;\n' % (name,gname) )
           setter_declarations += declarations["member_class_refsetter"].format(type=klass, name=name, description=desc)

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -883,6 +883,8 @@ class ClassGenerator(object):
           # handle user provided extra code
           if klass.has_key("declaration"):
             extracode_declarations = klass["declaration"]
+          if klass.has_key("includes"):
+             includes.append(klass["includes"])
 
       ostreamComponents +=  "  return o ;\n"
       ostreamComponents +=  "}\n"

--- a/templates/Collection.h.template
+++ b/templates/Collection.h.template
@@ -70,7 +70,9 @@ public:
   /// Initialized with the parameters given
   template<typename... Args>
   ${name} create(Args&&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final ;
 
   /// Returns the const object of given index
   const ${name} operator[](unsigned int index) const;

--- a/templates/Obj.h.template
+++ b/templates/Obj.h.template
@@ -12,11 +12,14 @@
 $includes
 
 // forward declarations
-class ${name};
-class Const${name};
 $forward_declarations
 
 ${namespace_open}
+
+class ${name};
+class Const${name};
+
+
 class ${name}Obj : public podio::ObjBase {
 public:
   /// constructor

--- a/tests/datamodel/EventInfoCollection.h
+++ b/tests/datamodel/EventInfoCollection.h
@@ -71,7 +71,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> EventInfo create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const EventInfo operator[](unsigned int index) const;

--- a/tests/datamodel/EventInfoObj.h
+++ b/tests/datamodel/EventInfoObj.h
@@ -10,6 +10,7 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+
 class EventInfo;
 class ConstEventInfo;
 

--- a/tests/datamodel/ExampleClusterCollection.h
+++ b/tests/datamodel/ExampleClusterCollection.h
@@ -73,7 +73,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleCluster create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleCluster operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleClusterObj.h
+++ b/tests/datamodel/ExampleClusterObj.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 // forward declarations
+
 class ExampleCluster;
 class ConstExampleCluster;
 

--- a/tests/datamodel/ExampleForCyclicDependency1Collection.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Collection.h
@@ -80,7 +80,9 @@ public:
   /// Initialized with the parameters given
   template <typename... Args>
   ExampleForCyclicDependency1 create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleForCyclicDependency1 operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleForCyclicDependency1Obj.h
+++ b/tests/datamodel/ExampleForCyclicDependency1Obj.h
@@ -10,9 +10,10 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+class ConstExampleForCyclicDependency2;
+
 class ExampleForCyclicDependency1;
 class ConstExampleForCyclicDependency1;
-class ConstExampleForCyclicDependency2;
 
 class ExampleForCyclicDependency1Obj : public podio::ObjBase {
 public:

--- a/tests/datamodel/ExampleForCyclicDependency2Collection.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Collection.h
@@ -80,7 +80,9 @@ public:
   /// Initialized with the parameters given
   template <typename... Args>
   ExampleForCyclicDependency2 create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleForCyclicDependency2 operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleForCyclicDependency2Obj.h
+++ b/tests/datamodel/ExampleForCyclicDependency2Obj.h
@@ -10,9 +10,10 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+class ConstExampleForCyclicDependency1;
+
 class ExampleForCyclicDependency2;
 class ConstExampleForCyclicDependency2;
-class ConstExampleForCyclicDependency1;
 
 class ExampleForCyclicDependency2Obj : public podio::ObjBase {
 public:

--- a/tests/datamodel/ExampleHitCollection.h
+++ b/tests/datamodel/ExampleHitCollection.h
@@ -71,7 +71,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleHit create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleHit operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleHitObj.h
+++ b/tests/datamodel/ExampleHitObj.h
@@ -10,6 +10,7 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+
 class ExampleHit;
 class ConstExampleHit;
 

--- a/tests/datamodel/ExampleMCCollection.h
+++ b/tests/datamodel/ExampleMCCollection.h
@@ -71,7 +71,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleMC create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleMC operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleMCObj.h
+++ b/tests/datamodel/ExampleMCObj.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 // forward declarations
+
 class ExampleMC;
 class ConstExampleMC;
 

--- a/tests/datamodel/ExampleReferencingTypeCollection.h
+++ b/tests/datamodel/ExampleReferencingTypeCollection.h
@@ -76,7 +76,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleReferencingType create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleReferencingType operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleReferencingTypeObj.h
+++ b/tests/datamodel/ExampleReferencingTypeObj.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 // forward declarations
+
 class ExampleReferencingType;
 class ConstExampleReferencingType;
 

--- a/tests/datamodel/ExampleWithARelationCollection.h
+++ b/tests/datamodel/ExampleWithARelationCollection.h
@@ -76,7 +76,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleWithARelation create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleWithARelation operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleWithARelationObj.h
+++ b/tests/datamodel/ExampleWithARelationObj.h
@@ -13,13 +13,15 @@
 #include <vector>
 
 // forward declarations
-class ExampleWithARelation;
-class ConstExampleWithARelation;
 namespace ex {
 class ConstExampleWithNamespace;
 }
 
 namespace ex {
+
+class ExampleWithARelation;
+class ConstExampleWithARelation;
+
 class ExampleWithARelationObj : public podio::ObjBase {
 public:
   /// constructor

--- a/tests/datamodel/ExampleWithArrayCollection.h
+++ b/tests/datamodel/ExampleWithArrayCollection.h
@@ -74,7 +74,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleWithArray create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleWithArray operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleWithArrayObj.h
+++ b/tests/datamodel/ExampleWithArrayObj.h
@@ -10,6 +10,7 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+
 class ExampleWithArray;
 class ConstExampleWithArray;
 

--- a/tests/datamodel/ExampleWithComponentCollection.h
+++ b/tests/datamodel/ExampleWithComponentCollection.h
@@ -75,7 +75,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleWithComponent create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleWithComponent operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleWithComponentObj.h
+++ b/tests/datamodel/ExampleWithComponentObj.h
@@ -10,6 +10,7 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+
 class ExampleWithComponent;
 class ConstExampleWithComponent;
 

--- a/tests/datamodel/ExampleWithNamespaceCollection.h
+++ b/tests/datamodel/ExampleWithNamespaceCollection.h
@@ -76,7 +76,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleWithNamespace create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleWithNamespace operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleWithNamespaceObj.h
+++ b/tests/datamodel/ExampleWithNamespaceObj.h
@@ -10,10 +10,12 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+
+namespace ex {
+
 class ExampleWithNamespace;
 class ConstExampleWithNamespace;
 
-namespace ex {
 class ExampleWithNamespaceObj : public podio::ObjBase {
 public:
   /// constructor

--- a/tests/datamodel/ExampleWithOneRelationCollection.h
+++ b/tests/datamodel/ExampleWithOneRelationCollection.h
@@ -76,7 +76,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleWithOneRelation create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleWithOneRelation operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleWithOneRelationObj.h
+++ b/tests/datamodel/ExampleWithOneRelationObj.h
@@ -10,9 +10,10 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+class ConstExampleCluster;
+
 class ExampleWithOneRelation;
 class ConstExampleWithOneRelation;
-class ConstExampleCluster;
 
 class ExampleWithOneRelationObj : public podio::ObjBase {
 public:

--- a/tests/datamodel/ExampleWithStringCollection.h
+++ b/tests/datamodel/ExampleWithStringCollection.h
@@ -74,7 +74,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleWithString create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleWithString operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleWithStringObj.h
+++ b/tests/datamodel/ExampleWithStringObj.h
@@ -10,6 +10,7 @@
 #include "podio/ObjBase.h"
 
 // forward declarations
+
 class ExampleWithString;
 class ConstExampleWithString;
 

--- a/tests/datamodel/ExampleWithVectorMemberCollection.h
+++ b/tests/datamodel/ExampleWithVectorMemberCollection.h
@@ -76,7 +76,9 @@ public:
   /// Append a new object to the collection, and return this object.
   /// Initialized with the parameters given
   template <typename... Args> ExampleWithVectorMember create(Args &&... args);
-  int size() const;
+
+  /// number of elements in the collection
+  int size() const override final;
 
   /// Returns the const object of given index
   const ExampleWithVectorMember operator[](unsigned int index) const;

--- a/tests/datamodel/ExampleWithVectorMemberObj.h
+++ b/tests/datamodel/ExampleWithVectorMemberObj.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 // forward declarations
+
 class ExampleWithVectorMember;
 class ConstExampleWithVectorMember;
 

--- a/tests/datamodel/SimpleStruct.h
+++ b/tests/datamodel/SimpleStruct.h
@@ -16,6 +16,9 @@ public:
 };
 
 inline std::ostream &operator<<(std::ostream &o, const SimpleStruct &value) {
+  for (int i = 0, N = 4; i < N; ++i)
+    o << value.p[i] << "|";
+  o << "  ";
   o << value.x << " ";
   o << value.y << " ";
   o << value.z << " ";

--- a/tests/src/ExampleWithArray.cc
+++ b/tests/src/ExampleWithArray.cc
@@ -156,6 +156,26 @@ std::ostream &operator<<(std::ostream &o, const ConstExampleWithArray &value) {
   o << " id : " << value.id() << std::endl;
   o << " arrayStruct : " << value.arrayStruct() << std::endl;
   o << " data : " << value.data() << std::endl;
+  o << " myArray : ";
+  for (int i = 0, N = 4; i < N; ++i)
+    o << value.myArray()[i] << "|";
+  o << std::endl;
+  o << " anotherArray2 : ";
+  for (int i = 0, N = 4; i < N; ++i)
+    o << value.anotherArray2()[i] << "|";
+  o << std::endl;
+  o << " snail_case_array : ";
+  for (int i = 0, N = 4; i < N; ++i)
+    o << value.snail_case_array()[i] << "|";
+  o << std::endl;
+  o << " snail_case_Array3 : ";
+  for (int i = 0, N = 4; i < N; ++i)
+    o << value.snail_case_Array3()[i] << "|";
+  o << std::endl;
+  o << " structArray : ";
+  for (int i = 0, N = 4; i < N; ++i)
+    o << value.structArray()[i] << "|";
+  o << std::endl;
   return o;
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- add some fixes and improvements
     - fix forward declarations in Object template when using a namespace for the EDM
     - fix array getter names when using the get/set syntax
     -  add missing treatment for include statements  in component's header files
     - handle array members in ostream operators
 - add CollectionBase::size() member function
      - allows to access collection size w/o knowing the concrete type
      - method is already generated in implementation classes

ENDRELEASENOTES