### PR TITLE
Build setup fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,25 @@ Check that you can now import the yaml module in python.
 
 ## Preparing the environment
 
-Before building and installing this package, and everytime you need to use it, do:
+Full use of PODIO requires you to set the `PODIO` environment variable
+and modify `LD_LIBRARY_PATH` and `PYTHONPATH`. Some convenience scripts
+are provided:
 
+    # Set PODIO install area to `./install` and setup environment accordingly
     source ./init.sh
 
+or
+
+    # Setup environment based on current value of `PODIO`
+    source ./env.sh
+
+Or you can setup the environment entirely under your control: see `init.sh`
+and `env.sh`.
 
 ## Compiling
 
-Set up separate build and install areas, and trigger the build:
+If you are using the easy setup from `init.sh` then create separate build
+and install areas, and trigger the build:
 
     mkdir build
     mkdir install

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Browse the API documentation created with Doxygen at
 
 ## Prerequisites
 
-If you are on lxplus, all the necessary software is preinstalled.
+If you are on lxplus, all the necessary software is preinstalled if you
+use a recent LCG or FCC stack release.
 
 On Mac OS or Ubuntu, you need to install the following software.
 

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,27 @@
+# Adjust environment setting to enable PODIO at runtime
+#
+# The PODIO environment variable must be set to use this
+# script
+if [ -z "$PODIO" ]; then
+  echo "Please set the PODIO enviroment variable to the install location before sourcing this script."
+  return
+fi
+
+unamestr=`uname`
+if [[ "$unamestr" == 'Linux' ]]; then
+	echo $LD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
+	if [ $? == "1" ]; then
+		export LD_LIBRARY_PATH=$PODIO/tests:$PODIO/lib:$LD_LIBRARY_PATH
+	fi
+elif [[ "$unamestr" == 'Darwin' ]]; then
+  # This currenty does not work on OS X as DYLD_LIBRARY_PATH is ignored
+  # in recent OS X versions
+	echo $DYLD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
+	if [ $? == "1" ]; then
+    	export DYLD_LIBRARY_PATH=$PODIO/tests:$PODIO/lib:$DYLD_LIBRARY_PATH
+    fi
+fi
+echo $PYTHONPATH | grep $PODIO/python >& /dev/null
+if [ $? == "1" ]; then
+	export PYTHONPATH=$PODIO/python:$PYTHONPATH
+fi

--- a/init.sh
+++ b/init.sh
@@ -1,10 +1,24 @@
-# Detect os
-TOOLSPATH=/cvmfs/fcc.cern.ch/sw/0.8.3/tools/
-OS=`python $TOOLSPATH/hsf_get_platform.py --get os`
+# Initialisation script for PODIO build environment
+#
+# The important variable to come out of the script is PODIO,
+# which is needed by some PODIO clients. Usually users will
+# set PODIO to the install area for PODIO after it is built,
+# but this script provides a "canned" option that can be
+# used for bootstrapping and testing.
+#
+# Script options are:
+#  -r - Reset value of PODIO even if it's currently set
 
-# source FCC externals
-source /cvmfs/fcc.cern.ch/sw/views/releases/externals/94.0.0/x86_64-$OS-gcc62-opt/setup.sh
+# First see if PODIO is already set
+if [ -n "$PODIO" -a "$1" != "-r" ]; then
+	echo "PODIO already set - use '-r' if you want to reinitialise it"
+	return
+fi
 
-# Define path to podio
-# CMakeLists.txt relies on some environment variables
-export PODIO=$FCCVIEW
+PODIO=$(pwd)/install
+
+if [ -e env.sh ]; then
+	source ./env.sh
+else
+	echo "To complete PODIO setup please source the 'env.sh' script"
+fi

--- a/init.sh
+++ b/init.sh
@@ -15,7 +15,7 @@ if [ -n "$PODIO" -a "$1" != "-r" ]; then
 	return
 fi
 
-PODIO=$(pwd)/install
+export PODIO=$(pwd)/install
 
 if [ -e env.sh ]; then
 	source ./env.sh


### PR DESCRIPTION
Remove FCC specific code from the `init.sh` script (which breaks things for other users). This was discussed with @JavierCVilla and we agreed that any special FCC setup should be controlled by FCC directly (e.g. in the CI).

Made the convenience scripts more generic and updated the instructions in `README.md`.

Factorised the environment setup to `env.sh` as this allows user to set `PODIO` then use the script to set the requisite environment.

BEGINRELEASENOTES
- Improve convenience setup scripts and build instructions
       - remove FCC specific code from init.sh
       - factorise environment setup to env.sh
       - updated README.md

ENDRELEASENOTES