### PR TITLE
fix code generation for 'long long' et al members

### DIFF
--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -87,8 +87,10 @@ class ClassDefinitionValidator(object):
                 typ=typ, length=array_match.group(2)
             )
         else:
-            klass, name = string.split()[:2]
             comment = string.split("//")[1]
+            rest    = string.split("//")[0].split()
+            name = rest[ len(rest)-1 ]
+            klass = ' '.join( rest[:len(rest)-1] )
         return {"name": name,
                 "type": klass,
                 "description": comment

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ endforeach( sourcefile ${executables} )
 #--- Adding tests --------------------------------------------------------------
 # uncomment this to actually run the EDM generation in the tests
 add_test(NAME generate-edm
-	 COMMAND python ${CMAKE_SOURCE_DIR}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel --dryrun
+	 COMMAND python ${CMAKE_SOURCE_DIR}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel #--dryrun
 	 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 add_test(NAME write COMMAND write)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ endforeach( sourcefile ${executables} )
 #--- Adding tests --------------------------------------------------------------
 # uncomment this to actually run the EDM generation in the tests
 add_test(NAME generate-edm
-	 COMMAND python ${CMAKE_SOURCE_DIR}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel #--dryrun
+	 COMMAND python ${CMAKE_SOURCE_DIR}/python/podio_class_generator.py tests/datalayout.yaml tests datamodel --dryrun
 	 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 add_test(NAME write COMMAND write)

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -44,6 +44,7 @@ datatypes :
     Description : "Example Hit"
     Author : "B. Hegner"
     Members:
+     - unsigned long long cellID      // cellID
      - double x      // x-coordinate
      - double y      // y-coordinate
      - double z      // z-coordinate

--- a/tests/datamodel/ExampleHit.h
+++ b/tests/datamodel/ExampleHit.h
@@ -32,7 +32,7 @@ public:
 
   /// default constructor
   ExampleHit();
-  ExampleHit(double x,double y,double z,double energy);
+  ExampleHit(unsigned long long cellID,double x,double y,double z,double energy);
 
   /// constructor from existing ExampleHitObj
   ExampleHit(ExampleHitObj* obj);
@@ -50,6 +50,8 @@ public:
 
 public:
 
+  /// Access the  cellID
+  const unsigned long long& cellID() const;
   /// Access the  x-coordinate
   const double& x() const;
   /// Access the  y-coordinate
@@ -58,6 +60,9 @@ public:
   const double& z() const;
   /// Access the  measured energy deposit
   const double& energy() const;
+
+  /// Set the  cellID
+  void cellID(unsigned long long value);
 
   /// Set the  x-coordinate
   void x(double value);

--- a/tests/datamodel/ExampleHitCollection.h
+++ b/tests/datamodel/ExampleHitCollection.h
@@ -125,6 +125,8 @@ public:
   std::vector<ExampleHitData>* _getBuffer() { return m_data;};
 
     template<size_t arraysize>
+  const std::array<unsigned long long,arraysize> cellID() const;
+  template<size_t arraysize>
   const std::array<double,arraysize> x() const;
   template<size_t arraysize>
   const std::array<double,arraysize> y() const;
@@ -159,6 +161,15 @@ ExampleHit  ExampleHitCollection::create(Args&&... args){
   return ExampleHit(obj);
 }
 
+template<size_t arraysize>
+const std::array<unsigned long long,arraysize> ExampleHitCollection::cellID() const {
+  std::array<unsigned long long,arraysize> tmp;
+  auto valid_size = std::min(arraysize,m_entries.size());
+  for (unsigned i = 0; i<valid_size; ++i){
+    tmp[i] = m_entries[i]->data.cellID;
+ }
+ return tmp;
+}
 template<size_t arraysize>
 const std::array<double,arraysize> ExampleHitCollection::x() const {
   std::array<double,arraysize> tmp;

--- a/tests/datamodel/ExampleHitConst.h
+++ b/tests/datamodel/ExampleHitConst.h
@@ -31,7 +31,7 @@ public:
 
   /// default constructor
   ConstExampleHit();
-  ConstExampleHit(double x,double y,double z,double energy);
+  ConstExampleHit(unsigned long long cellID,double x,double y,double z,double energy);
 
   /// constructor from existing ExampleHitObj
   ConstExampleHit(ExampleHitObj* obj);
@@ -47,6 +47,8 @@ public:
 
 public:
 
+  /// Access the  cellID
+  const unsigned long long& cellID() const;
   /// Access the  x-coordinate
   const double& x() const;
   /// Access the  y-coordinate

--- a/tests/datamodel/ExampleHitData.h
+++ b/tests/datamodel/ExampleHitData.h
@@ -11,6 +11,7 @@
 
 class ExampleHitData {
 public:
+  unsigned long long cellID;  ///< cellID
   double x;  ///< x-coordinate
   double y;  ///< y-coordinate
   double z;  ///< z-coordinate

--- a/tests/src/ExampleHit.cc
+++ b/tests/src/ExampleHit.cc
@@ -13,9 +13,9 @@ ExampleHit::ExampleHit() : m_obj(new ExampleHitObj()){
  m_obj->acquire();
 }
 
-ExampleHit::ExampleHit(double x,double y,double z,double energy) : m_obj(new ExampleHitObj()) {
+ExampleHit::ExampleHit(unsigned long long cellID,double x,double y,double z,double energy) : m_obj(new ExampleHitObj()) {
   m_obj->acquire();
-    m_obj->data.x = x;  m_obj->data.y = y;  m_obj->data.z = z;  m_obj->data.energy = energy;
+    m_obj->data.cellID = cellID;  m_obj->data.x = x;  m_obj->data.y = y;  m_obj->data.z = z;  m_obj->data.energy = energy;
 }
 
 
@@ -44,11 +44,13 @@ ExampleHit::~ExampleHit(){
 
 ExampleHit::operator ConstExampleHit() const {return ConstExampleHit(m_obj);}
 
+  const unsigned long long& ExampleHit::cellID() const { return m_obj->data.cellID; }
   const double& ExampleHit::x() const { return m_obj->data.x; }
   const double& ExampleHit::y() const { return m_obj->data.y; }
   const double& ExampleHit::z() const { return m_obj->data.z; }
   const double& ExampleHit::energy() const { return m_obj->data.energy; }
 
+void ExampleHit::cellID(unsigned long long value) { m_obj->data.cellID = value; }
 void ExampleHit::x(double value) { m_obj->data.x = value; }
 void ExampleHit::y(double value) { m_obj->data.y = value; }
 void ExampleHit::z(double value) { m_obj->data.z = value; }
@@ -76,6 +78,7 @@ bool ExampleHit::operator==(const ConstExampleHit& other) const {
 
 std::ostream& operator<<( std::ostream& o,const ConstExampleHit& value ){
   o << " id : " << value.id() << std::endl ;
+  o << " cellID : " << value.cellID() << std::endl ;
   o << " x : " << value.x() << std::endl ;
   o << " y : " << value.y() << std::endl ;
   o << " z : " << value.z() << std::endl ;

--- a/tests/src/ExampleHitCollection.cc
+++ b/tests/src/ExampleHitCollection.cc
@@ -115,9 +115,9 @@ const ExampleHitCollectionIterator& ExampleHitCollectionIterator::operator++() c
 
 std::ostream& operator<<( std::ostream& o,const ExampleHitCollection& v){
   std::ios::fmtflags old_flags = o.flags() ; 
-  o << "id:          x:            y:            z:            energy:       " << std::endl ;
+  o << "id:          cellID:       x:            y:            z:            energy:       " << std::endl ;
    for(int i = 0; i < v.size(); i++){
-     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].x() << " " << std::setw(12) << v[i].y() << " " << std::setw(12) << v[i].z() << " " << std::setw(12) << v[i].energy() << " "  << std::endl;
+     o << std::scientific << std::showpos  << std::setw(12)  << v[i].id() << " "  << std::setw(12) << v[i].cellID() << " " << std::setw(12) << v[i].x() << " " << std::setw(12) << v[i].y() << " " << std::setw(12) << v[i].z() << " " << std::setw(12) << v[i].energy() << " "  << std::endl;
   }
 o.flags(old_flags);
   return o ;

--- a/tests/src/ExampleHitConst.cc
+++ b/tests/src/ExampleHitConst.cc
@@ -13,9 +13,9 @@ ConstExampleHit::ConstExampleHit() : m_obj(new ExampleHitObj()) {
  m_obj->acquire();
 }
 
-ConstExampleHit::ConstExampleHit(double x,double y,double z,double energy) : m_obj(new ExampleHitObj()){
+ConstExampleHit::ConstExampleHit(unsigned long long cellID,double x,double y,double z,double energy) : m_obj(new ExampleHitObj()){
  m_obj->acquire();
-   m_obj->data.x = x;  m_obj->data.y = y;  m_obj->data.z = z;  m_obj->data.energy = energy;
+   m_obj->data.cellID = cellID;  m_obj->data.x = x;  m_obj->data.y = y;  m_obj->data.z = z;  m_obj->data.energy = energy;
 }
 
 
@@ -42,6 +42,8 @@ ConstExampleHit::~ConstExampleHit(){
   if ( m_obj != nullptr) m_obj->release();
 }
 
+  /// Access the  cellID
+  const unsigned long long& ConstExampleHit::cellID() const { return m_obj->data.cellID; }
   /// Access the  x-coordinate
   const double& ConstExampleHit::x() const { return m_obj->data.x; }
   /// Access the  y-coordinate

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Basics") {
   auto store = podio::EventStore();
   // Adding
   auto& collection = store.create<ExampleHitCollection>("name");
-  auto hit1 = collection.create(0.,0.,0.,0.); //initialize w/ value
+  auto hit1 = collection.create(0xcaffeeULL,0.,0.,0.,0.); //initialize w/ value
   auto hit2 = collection.create(); //default initialize
   hit2.energy(12.5);
   // Retrieving
@@ -111,7 +111,7 @@ TEST_CASE("Invalid_refs") {
   bool success = false;
   auto store = podio::EventStore();
   auto& hits  = store.create<ExampleHitCollection>("hits");
-  auto hit1 = hits.create(0.,0.,0.,0.);
+  auto hit1 = hits.create(0xcaffeeULL,0.,0.,0.,0.);
   auto hit2 = ExampleHit();
   auto& clusters  = store.create<ExampleClusterCollection>("clusters");
   auto  cluster  = clusters.create();
@@ -129,8 +129,8 @@ TEST_CASE("Looping") {
   bool success = true;
   auto store = podio::EventStore();
   auto& coll  = store.create<ExampleHitCollection>("name");
-  auto hit1 = coll.create(0.,0.,0.,0.);
-  auto hit2 = coll.create(1.,1.,1.,1.);
+  auto hit1 = coll.create(0xbadULL,0.,0.,0.,0.);
+  auto hit2 = coll.create(0xcaffeeULL,1.,1.,1.,1.);
   for(auto i = coll.begin(), end = coll.end(); i != end; ++i) {
     auto energy = i->energy();
   }
@@ -146,7 +146,7 @@ TEST_CASE("Notebook") {
   auto store = podio::EventStore();
   auto& hits  = store.create<ExampleHitCollection>("hits");
   for(unsigned i=0; i<12; ++i){
-    auto hit = hits.create(0.,0.,0.,double(i));
+    auto hit = hits.create(0xcaffeeULL,0.,0.,0.,double(i));
   }
   auto energies = hits.energy<10>();
   int index = 0;
@@ -177,8 +177,8 @@ TEST_CASE("Referencing") {
   bool success = true;
   auto store = podio::EventStore();
   auto& hits  = store.create<ExampleHitCollection>("hits");
-  auto hit1 = hits.create(0.,0.,0.,0.);
-  auto hit2 = hits.create(1.,1.,1.,1.);
+  auto hit1 = hits.create(0x42ULL,0.,0.,0.,0.);
+  auto hit2 = hits.create(0x42ULL,1.,1.,1.,1.);
   auto& clusters  = store.create<ExampleClusterCollection>("clusters");
   auto  cluster  = clusters.create();
   cluster.addHits(hit1);
@@ -195,8 +195,8 @@ TEST_CASE("write_buffer") {
   bool success = true;
   auto store = podio::EventStore();
   auto& coll  = store.create<ExampleHitCollection>("data");
-  auto hit1 = coll.create(0.,0.,0.,0.);
-  auto hit2 = coll.create(1.,1.,1.,1.);
+  auto hit1 = coll.create(0x42ULL,0.,0.,0.,0.);
+  auto hit2 = coll.create(0x42ULL,1.,1.,1.,1.);
   auto& clusters  = store.create<ExampleClusterCollection>("clusters");
   auto cluster  = clusters.create();
   clusters.prepareForWrite();

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -67,8 +67,8 @@ void write(std::string outfilename) {
     auto item1 = EventInfo();
     item1.Number(i);
     info.push_back(item1);
-    auto hit1 = ExampleHit(0.,0.,0.,23.+i);
-    auto hit2 = ExampleHit(1.,0.,0.,12.+i);
+    auto hit1 = ExampleHit( 0xbad, 0.,0.,0.,23.+i);
+    auto hit2 = ExampleHit( 0xcaffee,1.,0.,0.,12.+i);
 
     hits.push_back(hit1);
     hits.push_back(hit2);

--- a/tests/write_ascii.cpp
+++ b/tests/write_ascii.cpp
@@ -61,8 +61,8 @@ int main(){
     auto item1 = EventInfo();
     item1.Number(i);
     info.push_back(item1);
-    auto hit1 = ExampleHit(0.,0.,0.,23.+i);
-    auto hit2 = ExampleHit(1.,0.,0.,12.+i);
+    auto hit1 = ExampleHit( 0xbad, 0.,0.,0.,23.+i);
+    auto hit2 = ExampleHit( 0xcaffee,1.,0.,0.,12.+i);
 
     hits.push_back(hit1);
     hits.push_back(hit2);


### PR DESCRIPTION
   - add example to ExampleHit:
     unsigned long long cellID // cellID



BEGINRELEASENOTES
- fixed the code generation for members with multi word types (long long, unsigned long,...) 
      - add example to ExampleHit:
        `- unsigned long long cellID // cellID`



ENDRELEASENOTES