### PR TITLE
[CMake] remove need for directory properties set includes, links opti…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,14 @@ option(CREATE_DOC "Whether or not to create doxygen doc target." OFF)
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(ROOT REQUIRED COMPONENTS RIO Tree)
-include_directories(${ROOT_INCLUDE_DIR})
-include(${ROOT_USE_FILE})
+# ROOT only sets usage requirements from 6.14, so for
+# earlier versions need to hack in INTERFACE_INCLUDE_DIRECTORIES
+if(ROOT_VERSION VERSION_LESS 6.14)
+  set_property(TARGET ROOT::Core APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${ROOT_INCLUDE_DIRS}")
+endif()
 
-add_definitions(-Wno-unused-variable -Wno-unused-parameter -pthread)
+#--- enable podio macros--------------------------------------------------------
+include(cmake/podioMacros.cmake)
 
 #--- enable unit testing capabilities ------------------------------------------
 include(CTest)

--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -8,6 +8,7 @@ find_dependency(ROOT @ROOT_VERSION@)
 
 if(NOT TARGET podio::podio)
   include("${CMAKE_CURRENT_LIST_DIR}/podioTargets.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/podioMacros.cmake")
 
   # ROOT only sets usage requirements from 6.14, so for
   # earlier versions need to hack in INTERFACE_INCLUDE_DIRECTORIES

--- a/cmake/podioCreateConfig.cmake
+++ b/cmake/podioCreateConfig.cmake
@@ -19,6 +19,7 @@ configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/podioConfig.cmake.in
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/podioConfig.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/podioConfigVersion.cmake
+              ${CMAKE_SOURCE_DIR}/cmake/podioMacros.cmake
               DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/${PROJECT_NAME} )
 install(EXPORT podioTargets
   DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/${PROJECT_NAME}

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -1,0 +1,95 @@
+#---------------------------------------------------------------------------------------------------
+#---PODIO_GENERATE_DICTIONARY( dictionary headerfiles SELECTION selectionfile OPTIONS opt1 opt2 ...
+#                              DEPENDS dependency1 dependency2 ...
+#                              USES target1 target2 ...
+#                            )
+#
+#  USES takes a list of targets. From the targets the properties INCLUDE_DIRECTORIES
+#     and COMPILE_DEFINITIONS are used to create the appropriate -I and -D flags
+#
+#---------------------------------------------------------------------------------------------------
+macro(PODIO_GENERATE_DICTIONARY dictionary)
+  CMAKE_PARSE_ARGUMENTS(ARG "" "SELECTION" "OPTIONS;DEPENDS;USES" ${ARGN})
+  #---Get List of header files---------------
+  set(headerfiles)
+  foreach(fp ${ARG_UNPARSED_ARGUMENTS})
+    file(GLOB files inc/${fp})
+    if(files)
+      foreach(f ${files})
+        if(NOT f MATCHES LinkDef)
+          set(headerfiles ${headerfiles} ${f})
+        endif()
+      endforeach()
+    elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${fp})
+      set(headerfiles ${headerfiles} ${CMAKE_CURRENT_SOURCE_DIR}/${fp})
+    else()
+      set(headerfiles ${headerfiles} ${fp})
+    endif()
+  endforeach()
+  #---Get Selection file------------------------------------
+  if(IS_ABSOLUTE ${ARG_SELECTION})
+    set(selectionfile ${ARG_SELECTION})
+  else()
+    set(selectionfile ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SELECTION})
+  endif()
+
+  set(gensrcdict ${dictionary}.cxx)
+
+  #---roottest compability---------------------------------
+  if(CMAKE_ROOTTEST_NOROOTMAP)
+    set(rootmapname )
+    set(rootmapopts )
+  elseif(DEFINED CMAKE_ROOTTEST_NOROOTMAP)  # Follow the roottest dictionary library naming
+    set(rootmapname ${dictionary}.rootmap)
+    set(rootmapopts --rootmap=${rootmapname} --rootmap-lib=${libprefix}${dictionary}_dictrflx)
+  else()
+    set(rootmapname ${dictionary}Dict.rootmap)
+    set(rootmapopts --rootmap=${rootmapname} --rootmap-lib=${libprefix}${dictionary}Dict)
+  endif()
+
+  set(include_dirs ${CMAKE_CURRENT_SOURCE_DIR})
+  get_directory_property(incdirs INCLUDE_DIRECTORIES)
+  foreach(d ${incdirs})
+    if(NOT "${d}" MATCHES "^(AFTER|BEFORE|INTERFACE|PRIVATE|PUBLIC|SYSTEM)$")
+      list(APPEND include_dirs ${d})
+    endif()
+  endforeach()
+
+  set(definitions)
+  get_directory_property(defs COMPILE_DEFINITIONS)
+  foreach( d ${defs})
+   list(APPEND definitions ${d})
+  endforeach()
+
+  foreach(DEP ${ARG_USES})
+    LIST(APPEND include_dirs $<TARGET_PROPERTY:${DEP},INCLUDE_DIRECTORIES>)
+    LIST(APPEND definitions $<TARGET_PROPERTY:${DEP},COMPILE_DEFINITIONS>)
+  endforeach()
+
+  add_custom_command(
+    OUTPUT ${gensrcdict} ${rootmapname}
+    COMMAND ${ROOT_genreflex_CMD}
+    ARGS ${headerfiles} -o ${gensrcdict} ${rootmapopts} --select=${selectionfile}
+         --gccxmlpath=${GCCXML_home}/bin ${ARG_OPTIONS}
+         "-I$<JOIN:${include_dirs},;-I>"
+         "$<$<BOOL:$<JOIN:${definitions},>>:-D$<JOIN:${definitions},;-D>>"
+    DEPENDS ${headerfiles} ${selectionfile} ${ARG_DEPENDS}
+
+    COMMAND_EXPAND_LISTS
+    )
+
+  #---roottest compability---------------------------------
+  if(CMAKE_ROOTTEST_DICT)
+    ROOTTEST_TARGETNAME_FROM_FILE(targetname ${dictionary})
+
+    set(targetname "${targetname}-dictgen")
+
+    add_custom_target(${targetname} DEPENDS ${gensrcdict} ${ROOT_LIBRARIES})
+  else()
+    set(targetname "${dictionary}-dictgen")
+    # Creating this target at ALL level enables the possibility to generate dictionaries (genreflex step)
+    # well before the dependent libraries of the dictionary are build
+    add_custom_target(${targetname} ALL DEPENDS ${gensrcdict})
+  endif()
+
+endmacro()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 # This is needed for older ROOTs which do not understand
 # target usage requirements
-include_directories(${PROJECT_SOURCE_DIR}/include)
 
 file(GLOB sources *.cc)
 file(GLOB headers ${CMAKE_SOURCE_DIR}/include/podio/*.h)
@@ -10,16 +9,20 @@ add_library(podio SHARED ${headers} ${sources})
 target_include_directories(podio PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_link_libraries(podio PUBLIC ROOT::RIO ROOT::Tree)
+target_link_libraries(podio PUBLIC ROOT::Core ROOT::RIO ROOT::Tree)
+target_compile_options(podio PRIVATE -Wno-unused-variable -Wno-unused-parameter -pthread)
 
 # Add alias target to ease "subproject" usage
 add_library(podio::podio ALIAS podio)
 
+
 # Dict Library
-REFLEX_GENERATE_DICTIONARY(podio ${headers} SELECTION selection.xml)
+PODIO_GENERATE_DICTIONARY(podio ${headers} SELECTION selection.xml
+  USES podio)
 add_library(podioDict SHARED podio.cxx)
 add_dependencies(podioDict podio-dictgen)
 target_link_libraries(podioDict podio ROOT::Core)
+
 
 # Install the Targets and Headers
 install(TARGETS podio podioDict

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,3 @@
-include_directories(
-  ${CMAKE_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/datamodel
-)
-
 foreach( _conf ${CMAKE_CONFIGURATION_TYPES} )
   string(TOUPPER ${_conf} _conf )
   set( CMAKE_RUNTIME_OUTPUT_DIRECTORY_${_conf} ${CMAKE_CURRENT_BINARY_DIR} )
@@ -17,8 +12,12 @@ file(GLOB headers_utils utilities/*.h)
 
 add_library(TestDataModel SHARED ${sources} ${sources_utils} ${headers} ${headers_utils})
 target_link_libraries(TestDataModel podio )
+target_include_directories(TestDataModel PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/datamodel
+)
 
-REFLEX_GENERATE_DICTIONARY(TestDataModel ${headers} SELECTION src/selection.xml)
+PODIO_GENERATE_DICTIONARY(TestDataModel ${headers} SELECTION src/selection.xml USES TestDataModel)
 add_library(TestDataModelDict SHARED TestDataModel.cxx)
 add_dependencies(TestDataModelDict TestDataModel-dictgen)
 target_link_libraries(TestDataModelDict TestDataModel podio )


### PR DESCRIPTION
…ons directly for targets, add PODIO_GENERATE_DICTIONARY macro to allow this

This is somewhat temporary until root supports the use of targets directly.
These changes are necessary to allow one to use properties of targets instead of directory properties. It is also necessary if one has include_directories properties that contain a list of include directories, not just individual entries.


BEGINRELEASENOTES
- Add podioMacros.cmake to contain PODIO_GENERATE_DICTIONARY

ENDRELEASENOTES