### PR TITLE
Split root dependencies into separate library

### DIFF
--- a/.podio-ci.d/compile_and_test.sh
+++ b/.podio-ci.d/compile_and_test.sh
@@ -6,7 +6,7 @@ cd /podio
 source init.sh
 mkdir build install
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 .. && \
-make -j4 && \
-make install && \
-ctest --output-on-failure
+cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja .. && \
+    ninja -k0 && \
+    ninja install && \
+    ctest --output-on-failure

--- a/python/EventStore.py
+++ b/python/EventStore.py
@@ -1,5 +1,5 @@
 from ROOT import gSystem
-gSystem.Load("libpodio")
+gSystem.Load("libpodioRootIO")
 from ROOT import podio
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,35 +2,61 @@
 # target usage requirements
 
 file(GLOB sources *.cc)
-file(GLOB headers ${CMAKE_SOURCE_DIR}/include/podio/*.h)
+SET(root_sources ${sources})
 
-# Main Library
-add_library(podio SHARED ${headers} ${sources})
+LIST(FILTER sources EXCLUDE REGEX ROOT.*|PythonEventStore.* )
+LIST(FILTER root_sources INCLUDE REGEX ROOT.*|PythonEventStore.* )
+
+# Main Library, no external dependencies
+add_library(podio SHARED ${sources})
+add_library(podio::podio ALIAS podio)
 target_include_directories(podio PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_link_libraries(podio PUBLIC ROOT::Core ROOT::RIO ROOT::Tree)
-target_compile_options(podio PRIVATE -Wno-unused-variable -Wno-unused-parameter -pthread)
+target_compile_options(podio PRIVATE -pthread)
 
-# Add alias target to ease "subproject" usage
-add_library(podio::podio ALIAS podio)
-
+# Root dependency, mostly IO
+add_library(podioRootIO SHARED ${root_sources})
+add_library(podio::podioRootIO ALIAS podioRootIO)
+target_link_libraries(podioRootIO PUBLIC podio::podio ROOT::Core ROOT::RIO ROOT::Tree)
+target_include_directories(podioRootIO PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # Dict Library
-PODIO_GENERATE_DICTIONARY(podio ${headers} SELECTION selection.xml
-  USES podio)
-add_library(podioDict SHARED podio.cxx)
-add_dependencies(podioDict podio-dictgen)
-target_link_libraries(podioDict podio ROOT::Core)
+add_library(podioDict SHARED)
+add_library(podio::podioDict ALIAS podioDict)
+target_include_directories(podioDict PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(podioDict PUBLIC podio::podio ROOT::Core ROOT::Tree)
 
+SET(headers
+  ${CMAKE_SOURCE_DIR}/include/podio/CollectionBase.h
+  ${CMAKE_SOURCE_DIR}/include/podio/CollectionIDTable.h
+  ${CMAKE_SOURCE_DIR}/include/podio/EventStore.h
+  ${CMAKE_SOURCE_DIR}/include/podio/ICollectionProvider.h
+  ${CMAKE_SOURCE_DIR}/include/podio/IReader.h
+  ${CMAKE_SOURCE_DIR}/include/podio/ObjectID.h
+  ${CMAKE_SOURCE_DIR}/include/podio/PythonEventStore.h
+  )
+PODIO_GENERATE_DICTIONARY(podioDict ${headers} SELECTION selection.xml
+  OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}podio${CMAKE_SHARED_LIBRARY_SUFFIX}
+  )
+# prevent generating dictionary twice
+set_target_properties(podioDict-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+target_sources(podioDict PRIVATE podioDict.cxx)
+# ROOT IO without the Dict does not work, so we link RootIO against the Dict
+target_link_libraries(podioRootIO PUBLIC podioDict)
 
 # Install the Targets and Headers
-install(TARGETS podio podioDict
+install(TARGETS podio podioDict podioRootIO
   EXPORT podioTargets
   DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/podio DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/podioDict.rootmap
-  ${CMAKE_CURRENT_BINARY_DIR}/podio_rdict.pcm
+  ${CMAKE_CURRENT_BINARY_DIR}/podioDictDict.rootmap
+  ${CMAKE_CURRENT_BINARY_DIR}/libpodio_rdict.pcm
   DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,23 +11,23 @@ file(GLOB sources_utils utilities/*.cc)
 file(GLOB headers_utils utilities/*.h)
 
 add_library(TestDataModel SHARED ${sources} ${sources_utils} ${headers} ${headers_utils})
-target_link_libraries(TestDataModel podio )
+target_link_libraries(TestDataModel podio::podio)
 target_include_directories(TestDataModel PUBLIC
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/datamodel
-)
-
-PODIO_GENERATE_DICTIONARY(TestDataModel ${headers} SELECTION src/selection.xml USES TestDataModel)
-add_library(TestDataModelDict SHARED TestDataModel.cxx)
-add_dependencies(TestDataModelDict TestDataModel-dictgen)
-target_link_libraries(TestDataModelDict TestDataModel podio )
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/datamodel
+  )
+PODIO_GENERATE_DICTIONARY(TestDataModel ${headers} SELECTION src/selection.xml
+  OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}TestDataModel${CMAKE_SHARED_LIBRARY_SUFFIX}
+  )
+set_target_properties(TestDataModel-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
+target_sources(TestDataModel PRIVATE TestDataModel.cxx)
 
 file(GLOB executables RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
 foreach( sourcefile ${executables} )
   string( REPLACE ".cpp" "" name ${sourcefile} )
   add_executable( ${name} ${sourcefile} )
-  target_link_libraries( ${name} TestDataModelDict podio)
+  target_link_libraries( ${name} TestDataModel podio::podioRootIO)
 endforeach( sourcefile ${executables} )
 
 #--- Adding tests --------------------------------------------------------------
@@ -38,7 +38,7 @@ add_test(NAME generate-edm
 
 add_test(NAME write COMMAND write)
 # The following directories need to be added to the LD_LIBRARY_PATH:
-# - CMAKE_CURRENT_BINARY_DIR: contains the root dictionary and pcm files for TestDataModelDict
+# - CMAKE_CURRENT_BINARY_DIR: contains the root dictionary and pcm files for TestDataModel
 # - CMAKE_BINARY_DIR/src: contains the root dictionary and pcm files for podio
 set_property(TEST write PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH})
 


### PR DESCRIPTION
BEGINRELEASENOTES
-  Move all Root dependencies (RootReader, RootWriter) of the podio Library into podioRootIO, rename podioDict to podioDict

ENDRELEASENOTES