### PR TITLE
ClassGenerator: sort and uniq headers, add includeSubfolder option to…

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -158,7 +158,7 @@ class ClassGenerator(object):
                 if is_data:  # avoid having warnings twice
                     self.warnings.append("%s defines a vector member %s, that spoils the PODness" % (classname, klass))
             elif "[" in klass and is_data:  # FIXME: is this only true ofr PODs?
-                raise Exception("'%s' defines an array type. Array types are not supported yet." % (classname, klass))
+                raise Exception("'%s' defines an array type %s. Array types are not supported yet." % (classname, klass))
             else:
                 raise Exception("'%s' defines a member of a type '%s' that is not (yet) declared!" % (classname, klass))
         # get rid of duplicates:

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -1055,6 +1055,7 @@ class ClassGenerator(object):
     def fill_templates(self, category, substitutions):
       # add common include subfolder if required    
       substitutions['incfolder'] = '' if not self.includeSubfolder else self.package_name + '/'
+      substitutions['PACKAGE_NAME'] = self.package_name.upper()
       # "Data" denotes the real class;
       # only headers and the FN should not contain Data
       if category == "Data":

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -146,7 +146,10 @@ class PodioConfigReader(object):
             # should getters / setters be prefixed with get / set?
             "getSyntax": False,
             # should POD members be exposed with getters/setters in classes that have them as members?
-            "exposePODMembers": True}
+            "exposePODMembers": True,
+            # use subfolder when including package header files
+            "includeSubfolder": False,
+            }
 
     @staticmethod
     def handle_extracode(definition):

--- a/python/templates/Collection.cc.template
+++ b/python/templates/Collection.cc.template
@@ -2,7 +2,7 @@
 #include <stdexcept>
 ${includes}
 
-#include "${name}Collection.h"
+#include "${incfolder}${name}Collection.h"
 
 ${namespace_open}
 

--- a/python/templates/Collection.h.template
+++ b/python/templates/Collection.h.template
@@ -1,7 +1,7 @@
 //AUTOMATICALLY GENERATED - DO NOT EDIT
 
-#ifndef ${name}Collection_H
-#define  ${name}Collection_H
+#ifndef ${PACKAGE_NAME}_${name}Collection_H
+#define ${PACKAGE_NAME}_${name}Collection_H
 
 #include <string>
 #include <vector>

--- a/python/templates/Collection.h.template
+++ b/python/templates/Collection.h.template
@@ -17,9 +17,9 @@
 #include "podio/CollectionIDTable.h"
 
 // datamodel specific includes
-#include "${name}Data.h"
-#include "${name}.h"
-#include "${name}Obj.h"
+#include "${incfolder}${name}Data.h"
+#include "${incfolder}${name}.h"
+#include "${incfolder}${name}Obj.h"
 
 ${namespace_open}
 typedef std::vector<${name}Data> ${name}DataContainer;

--- a/python/templates/Component.h.template
+++ b/python/templates/Component.h.template
@@ -1,5 +1,5 @@
-#ifndef ${name}_H
-#define ${name}_H
+#ifndef ${PACKAGE_NAME}_${name}_H
+#define ${PACKAGE_NAME}_${name}_H
 $includes
 
 #include <iostream>

--- a/python/templates/ConstObject.cc.template
+++ b/python/templates/ConstObject.cc.template
@@ -1,9 +1,9 @@
 // datamodel specific includes
-#include "${name}.h"
-#include "${name}Const.h"
-#include "${name}Obj.h"
-#include "${name}Data.h"
-#include "${name}Collection.h"
+#include "${incfolder}${name}.h"
+#include "${incfolder}${name}Const.h"
+#include "${incfolder}${name}Obj.h"
+#include "${incfolder}${name}Data.h"
+#include "${incfolder}${name}Collection.h"
 #include <iostream>
 $includes_cc
 

--- a/python/templates/ConstObject.h.template
+++ b/python/templates/ConstObject.h.template
@@ -1,5 +1,5 @@
-#ifndef Const${name}_H
-#define Const${name}_H
+#ifndef ${PACKAGE_NAME}_Const${name}_H
+#define ${PACKAGE_NAME}_Const${name}_H
 $includes
 #include <vector>
 #include "podio/ObjectID.h"

--- a/python/templates/ConstObject.h.template
+++ b/python/templates/ConstObject.h.template
@@ -7,7 +7,7 @@ $includes
 //forward declarations
 $forward_declarations
 
-#include "${name}Obj.h"
+#include "${incfolder}${name}Obj.h"
 
 ${namespace_open}
 

--- a/python/templates/Data.h.template
+++ b/python/templates/Data.h.template
@@ -1,5 +1,5 @@
-#ifndef ${name}DATA_H
-#define ${name}DATA_H
+#ifndef ${PACKAGE_NAME}_${name}DATA_H
+#define ${PACKAGE_NAME}_${name}DATA_H
 
 $includes
 

--- a/python/templates/Obj.cc.template
+++ b/python/templates/Obj.cc.template
@@ -1,4 +1,4 @@
-#include "${name}Obj.h"
+#include "${incfolder}${name}Obj.h"
 $includes_cc
 
 ${namespace_open}

--- a/python/templates/Obj.h.template
+++ b/python/templates/Obj.h.template
@@ -1,5 +1,5 @@
-#ifndef ${name}OBJ_H
-#define ${name}OBJ_H
+#ifndef ${PACKAGE_NAME}_${name}OBJ_H
+#define ${PACKAGE_NAME}_${name}OBJ_H
 
 // std includes
 #include <atomic>

--- a/python/templates/Obj.h.template
+++ b/python/templates/Obj.h.template
@@ -7,7 +7,7 @@
 
 // data model specific includes
 #include "podio/ObjBase.h"
-#include "${name}Data.h"
+#include "${incfolder}${name}Data.h"
 
 $includes
 

--- a/python/templates/Object.cc.template
+++ b/python/templates/Object.cc.template
@@ -1,9 +1,9 @@
 // datamodel specific includes
-#include "${name}.h"
-#include "${name}Const.h"
-#include "${name}Obj.h"
-#include "${name}Data.h"
-#include "${name}Collection.h"
+#include "${incfolder}${name}.h"
+#include "${incfolder}${name}Const.h"
+#include "${incfolder}${name}Obj.h"
+#include "${incfolder}${name}Data.h"
+#include "${incfolder}${name}Collection.h"
 #include <iostream>
 $includes_cc
 

--- a/python/templates/Object.h.template
+++ b/python/templates/Object.h.template
@@ -1,5 +1,5 @@
-#ifndef ${name}_H
-#define ${name}_H
+#ifndef ${PACKAGE_NAME}_${name}_H
+#define ${PACKAGE_NAME}_${name}_H
 $includes
 #include <vector>
 #include <iostream>

--- a/python/templates/Object.h.template
+++ b/python/templates/Object.h.template
@@ -9,8 +9,8 @@ $includes
 //forward declarations
 $forward_declarations
 
-#include "${name}Const.h"
-#include "${name}Obj.h"
+#include "${incfolder}${name}Const.h"
+#include "${incfolder}${name}Obj.h"
 
 ${namespace_open}
 

--- a/python/templates/PrintInfo.h.template
+++ b/python/templates/PrintInfo.h.template
@@ -1,6 +1,6 @@
 
-#ifndef  ${name}PrintInfo_h
-#define  ${name}PrintInfo_h
+#ifndef  ${PACKAGE_NAME}_${name}PrintInfo_h
+#define  ${PACKAGE_NAME}_${name}PrintInfo_h
 
 #include "${incfolder}${name}Collection.h"
 

--- a/python/templates/PrintInfo.h.template
+++ b/python/templates/PrintInfo.h.template
@@ -2,7 +2,7 @@
 #ifndef  ${name}PrintInfo_h
 #define  ${name}PrintInfo_h
 
-#include "${name}Collection.h"
+#include "${incfolder}${name}Collection.h"
 
 class ${name}PrintInfo{
 

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -4,6 +4,7 @@ options :
   getSyntax: False
   # should POD members be exposed with getters/setters in classes that have them as members?
   exposePODMembers: True
+  includeSubfolder: False
 
 components :
   SimpleStruct:


### PR DESCRIPTION
… include package files from subfolder

BEGINRELEASENOTES
- ClassGenerator: add option "includeSubfolder", to always use `#include "\<packagename\>/\<object\>.h" etc. if set to "True"
- Added sorting and "uniquing" of include lists. Some duplicates still occur because two different lists are used on occasion 
- Added $PACKAGE_NAME_ to include guards

ENDRELEASENOTES