### PR TITLE
[WIP] Add "RunParameters" branch to metadata tree

### DIFF
--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <type_traits>
 #include <set>
+#include <map>
 
 // podio specific includes
 #include "podio/CollectionIDTable.h"
@@ -74,6 +75,8 @@ namespace podio {
 
     CollectionIDTable* getCollectionIDTable() const {return m_table;};
 
+    std::map<std::string, std::string>* getRunParameters() const {return m_runparameters;};
+
     virtual bool isValid() const final;
 
   private:
@@ -91,6 +94,7 @@ namespace podio {
     mutable std::vector<CollectionBase*> m_cachedCollections;
     IReader* m_reader;
     CollectionIDTable* m_table;
+    std::map<std::string, std::string>* m_runparameters;
   };
 
 

--- a/include/podio/IReader.h
+++ b/include/podio/IReader.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <map>
 
 #include <iostream>
 
@@ -27,6 +28,8 @@ class IReader {
     virtual CollectionBase* readCollection(const std::string& name) = 0;
     /// Get CollectionIDTable of read-in data
     virtual CollectionIDTable* getCollectionIDTable() = 0;
+    /// Get RunParameters of read-in data
+    virtual std::map<std::string, std::string>* getRunParameters() = 0;
     //TODO: decide on smart-pointers for passing of objects
     /// Check if reader is valid
     virtual bool isValid() const = 0;

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -49,6 +49,9 @@ class ROOTReader : public IReader {
     /// Read CollectionIDTable from ROOT file
     CollectionIDTable* getCollectionIDTable() override final {return m_table;}
 
+    /// Return RunParameters read from ROOT file
+    std::map<std::string, std::string>* getRunParameters() override final {return m_runparameters;}
+
     /// Returns number of entries in the TTree
     unsigned getEntries() const;
 
@@ -71,6 +74,7 @@ class ROOTReader : public IReader {
     std::vector<Input> m_inputs;
     std::map<std::string, std::pair<TClass*,TClass*> > m_storedClasses;
     CollectionIDTable* m_table;
+    std::map<std::string, std::string>* m_runparameters;
     TChain* m_chain;
     unsigned m_eventNumber;
 };

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -8,7 +8,8 @@ namespace podio {
 
   EventStore::EventStore() :
     m_reader(nullptr),
-    m_table(new CollectionIDTable())
+    m_table(new CollectionIDTable()),
+    m_runparameters(new std::map<std::string, std::string>())
   {
     m_cachedCollections.resize(128) ; // allow for a sufficiently large initial number of collections
   }
@@ -125,6 +126,7 @@ namespace podio {
   void EventStore::setReader(IReader* reader){
     m_reader = reader;
     setCollectionIDTable(reader->getCollectionIDTable());
+    m_runparameters = reader->getRunParameters();
   }
 
 

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -101,8 +101,10 @@ namespace podio {
       m_chain->Add(filename.c_str());
     }
     CollectionIDTable* l_table = new CollectionIDTable();
+    std::map<std::string, std::string>* l_runparameters = new std::map<std::string, std::string>();
     auto metadatatree = static_cast<TTree*>(m_chain->GetFile()->Get("metadata"));
     metadatatree->SetBranchAddress("CollectionIDs",&l_table);
+    metadatatree->SetBranchAddress("RunParameters",&l_runparameters);
     metadatatree->GetEntry(0);
     auto l_names = l_table->names();
     std::vector<int> l_collectionIDs;
@@ -111,6 +113,7 @@ namespace podio {
 
     }
     m_table = new CollectionIDTable(l_collectionIDs, l_names);
+    m_runparameters = l_runparameters;
   }
 
   void ROOTReader::closeFile(){

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -32,6 +32,7 @@ namespace podio {
   void ROOTWriter::finish(){
     // now we want to safe the metadata
     m_metadatatree->Branch("CollectionIDs",m_store->getCollectionIDTable());
+    m_metadatatree->Branch("RunParameters",m_store->getRunParameters());
     m_metadatatree->Fill();
     m_file->Write();
     m_file->Close();

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -26,6 +26,11 @@ int glob = 0;
 
 void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
 
+  auto params = store.getRunParameters();
+  if ((*params)["RunNumber"] != "1") {
+    throw std::runtime_error("Expected RunParameter 'RunNumber' to be '1'");
+  }
+
   auto& failing = store.get<ExampleClusterCollection>("notthere");
   if(failing.isValid() == true) {
     throw std::runtime_error("Collection 'notthere' should not be valid");

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -27,6 +27,9 @@ void write(std::string outfilename) {
 
   auto store = podio::EventStore();
   auto writer = podio::ROOTWriter(outfilename, &store);
+  // write run-level parameters
+  auto params = store.getRunParameters();
+  params->insert({"RunNumber", "1"});
 
   auto& info       = store.create<EventInfoCollection>("info");
   auto& mcps       = store.create<ExampleMCCollection>("mcparticles");


### PR DESCRIPTION
This adds a branch with a  `std::map<std::string, std::string>` to the metadata tree and adds the necessary methods to the EventStore in order that MetaData can be saved. Would be a straightforward,  but a bit minimalistic solution to #49. 
BEGINRELEASENOTES
- Add RunParameters Branch to Metadata Tree
ENDRELEASENOTES