### PR TITLE
Update README to reflect the changes of the install process

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Please submit feature requests and bugs to
  - [Advanced Topics](./doc/advanced_topics.md)
  - [Contributing](./doc/contributing.md)
 
-Browse the API documentation created with Doxygen at
+<!-- Browse the API documentation created with Doxygen at -->
 
-[http://fccsw.web.cern.ch/fccsw/podio/index.html](http://fccsw.web.cern.ch/fccsw/podio/index.html).
+<!-- [http://fccsw.web.cern.ch/fccsw/podio/index.html](http://fccsw.web.cern.ch/fccsw/podio/index.html). -->
 
 ## Prerequisites
 
@@ -90,15 +90,36 @@ To see a list of options, do this in the build-directory:
 
 The examples are for creating a file "example.root",
 
-    ../install/tests/write
+    tests/write
 
-reading it again in C++,
+and reading it again in C++,
 
-    ../install/tests/read
+    tests/read
 
-and reading it again in python,
+It is also possible to read the file again using the
+[`tests/read.py`](tests/read.py) script. Make sure to have run `init.sh`
+and `env.sh` first. Additionally you have to make `ROOT` aware of
+`libTestDataModel.so` to be able to read in the data types defined there. There
+are two ways to do that. First it is possible to add the directory to the
+`LD_LIBRARY_PATH`
 
-    python ../tests/read.py
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)/tests
+
+Secondly it is also possible to explicitly load the library via `ROOT` in the
+script by adding the following lines *after* the imports from `__future__`
+
+```python
+import os
+BUILD_PATH = os.getcwd()
+
+import ROOT
+ROOT.gSystem.Load(os.path.join(BUILD_PATH, 'tests/libTestDataModel.so'))
+```
+
+Either of the two versions allows you to now read the `example.root` file again
+using
+
+     python ../tests/read.py
 
 ## Installing using SPACK
 
@@ -106,7 +127,6 @@ A recipe for building podio is included with the [spack package manager](https:/
 
 ```
 spack install podio
-
 ```
 
 Note that if you do not have any previous installations or registered system packages, this will compile ROOT and all its dependencies, which may be time-consuming.
@@ -131,6 +151,6 @@ The generation script has the following additional options:
 - `--dryrun` (`-d`): Only run the generation logic and validate yaml, do not write files to disk
 
 ## Running tests
-After compilation and installation (!) you can run rudimentary tests with
+After compilation you can run rudimentary tests with
 
     make test

--- a/env.sh
+++ b/env.sh
@@ -11,7 +11,12 @@ unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
 	echo $LD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
 	if [ $? == "1" ]; then
-		export LD_LIBRARY_PATH=$PODIO/lib:$LD_LIBRARY_PATH
+    # RedHat based put the libraries into lib64
+    if [ -d $PODIO/lib64 ]; then
+      export LD_LIBRARY_PATH=$PODIO/lib64:$LD_LIBRARY_PATH
+    else
+      export LD_LIBRARY_PATH=$PODIO/lib:$LD_LIBRARY_PATH
+    fi
 	fi
 elif [[ "$unamestr" == 'Darwin' ]]; then
   # This currenty does not work on OS X as DYLD_LIBRARY_PATH is ignored

--- a/env.sh
+++ b/env.sh
@@ -11,14 +11,14 @@ unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
 	echo $LD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
 	if [ $? == "1" ]; then
-		export LD_LIBRARY_PATH=$PODIO/tests:$PODIO/lib:$LD_LIBRARY_PATH
+		export LD_LIBRARY_PATH=$PODIO/lib:$LD_LIBRARY_PATH
 	fi
 elif [[ "$unamestr" == 'Darwin' ]]; then
   # This currenty does not work on OS X as DYLD_LIBRARY_PATH is ignored
   # in recent OS X versions
 	echo $DYLD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
 	if [ $? == "1" ]; then
-    	export DYLD_LIBRARY_PATH=$PODIO/tests:$PODIO/lib:$DYLD_LIBRARY_PATH
+    	export DYLD_LIBRARY_PATH=$PODIO/lib:$DYLD_LIBRARY_PATH
     fi
 fi
 echo $PYTHONPATH | grep $PODIO/python >& /dev/null


### PR DESCRIPTION

BEGINRELEASENOTES
- Updated README and env.sh to reflect changes in install process

ENDRELEASENOTES

The README instructions and the setup done in `env.sh` was still assuming the install directory structure used previously, where the `tests` directory was also moved to the install directory. This is no longer the case and it broke some of the instructions which should now work again.

I have also for the moment commented out the dead link to the Doxygen documentation. If this is now placed somewhere else this could also be changed before merging.