### PR TITLE
RootIO: ensure podioDict is linked also when linker has as-needed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,9 +46,38 @@ PODIO_GENERATE_DICTIONARY(podioDict ${headers} SELECTION selection.xml
 # prevent generating dictionary twice
 set_target_properties(podioDict-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
+# check if the linker supports as needed or not
+set(STORE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+include(CheckCCompilerFlag)
+set(CMAKE_REQUIRED_FLAGS "-Wl,--no-as-needed")
+check_c_compiler_flag("" TEST_NO_AS_NEEDED)
+if(TEST_NO_AS_NEEDED)
+    message(STATUS "Linker supports: -Wl,--no-as-needed")
+else()
+    message(STATUS "Linker does not support: -Wl,--no-as-needed")
+endif()
+set(CMAKE_REQUIRED_FLAGS "-Wl,--as-needed")
+check_c_compiler_flag("" TEST_AS_NEEDED)
+if(TEST_AS_NEEDED)
+    message(STATUS "Linker supports: -Wl,--as-needed")
+else()
+    message(STATUS "Linker does not support: -Wl,--as-needed")
+endif()
+set(CMAKE_REQUIRED_FLAGS ${STORE_REQUIRED_FLAGS})
+
 target_sources(podioDict PRIVATE podioDict.cxx)
 # ROOT IO without the Dict does not work, so we link RootIO against the Dict
-target_link_libraries(podioRootIO PUBLIC podioDict)
+# need to disable as needed if linker supports it
+if(TEST_NO_AS_NEEDED AND TEST_AS_NEEDED)
+  target_link_libraries(podioRootIO
+    PRIVATE
+      -Wl,--push-state,--no-as-needed podioDict -Wl,--pop-state
+    INTERFACE
+      podioDict
+     )
+ else()
+   target_link_libraries(podioRootIO PUBLIC podioDict)
+ endif()
 
 # Install the Targets and Headers
 install(TARGETS podio podioDict podioRootIO


### PR DESCRIPTION
@tmadlener, can you test this, please

BEGINRELEASENOTES
- Ensure podioRootIO is linked against podioDict even when linker uses as-needed by default, fixes #90 

ENDRELEASENOTES