### PR TITLE
Add meta data for collections, events and runs

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -122,6 +122,49 @@ Collections can be retrieved explicitly:
 
 Or implicitly when following an object reference. In both cases the access to data that has been retrieved is `const`.
 
+
+### User defined Meta Data
+
+Sometimes it is necessary or useful to store additional data that is not directly foreseen in the EDM.
+This could be configuration parameters of simulation jobs, or parameter descriptions like cell-ID encoding etc. PODIO currently allows to store such meta data in terms of a `GenericParameters` class that
+holds an arbitrary number of named parameters of type `int, float, string` or vectors if these.
+Meta data can be stored and retrieved from the `EventStore` for runs, collections and events via
+the three methods:
+```
+virtual GenericParameters& EventStore::getRunMetaData(int runID);
+virtual GenericParameters& EventStore::getEventMetaData();
+virtual GenericParameters& EventStore::getCollectionMetaData(int colID);
+```
+
+- example for writing event data:
+```
+auto& evtMD = store.getEventMetaData() ;
+evtMD.setValue( "UserEventWeight" , (float) 100.*i ) ;
+```
+- example for reading event data:
+```
+auto& evtMD = store.getEventMetaData() ;
+float evtWeight = evtMD.getFloatVal( "UserEventWeight" ) ;
+
+```
+
+- example for writing collection meta data:
+
+```
+auto& hits = store.create<ExampleHitCollection>("hits");
+// ...
+auto& colMD = store.getCollectionMetaData( hits.getID() );
+colMD.setValue("CellIDEncodingString","system:8,barrel:3,layer:6,slice:5,x:-16,y:-16");
+```
+
+- example for reading collection meta data
+
+```
+auto colMD = store.getCollectionMetaData( hits.getID() );
+std::string es = colMD.getStringVal("CellIDEncodingString") ;
+```
+
+
 #### Python Interface
 
 The class `EventStore` provides all the necessary (read) access to event files. It can be used as follows:

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -38,7 +38,10 @@ namespace podio {
     virtual bool  setReferences(const ICollectionProvider* collectionProvider) = 0;
 
     /// set collection ID
-    virtual void  setID(unsigned id) = 0;
+    virtual void setID(unsigned id) = 0;
+
+    /// get collection ID
+    virtual unsigned getID() const = 0;
 
     /// set I/O buffer
     virtual void  setBuffer(void*) = 0;

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -35,7 +35,7 @@ namespace podio {
     virtual void  prepareAfterRead() = 0;
 
     /// initialize references after read
-    virtual bool  setReferences(const ICollectionProvider* collectionProvider) = 0;
+    virtual bool setReferences(const ICollectionProvider* collectionProvider) = 0;
 
     /// set collection ID
     virtual void setID(unsigned id) = 0;

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -29,6 +29,11 @@ namespace podio {
   class CollectionBase;
   class IReader;
 
+  typedef std::pair<int,int> ipair ;
+  typedef std::map<int,GenericParameters*>    RunMDMap;
+  typedef std::map<ipair,GenericParameters*>  EvtMDMap;
+  typedef std::map<int,GenericParameters*>    ColMDMap;
+
   class EventStore : public ICollectionProvider, public IMetaDataProvider {
 
   public:
@@ -79,14 +84,17 @@ namespace podio {
 
     virtual bool isValid() const final;
 
-    virtual GenericParameters* getRunMetaData(int runID) const override ;
+    /// return the event meta data for the current event
+    virtual GenericParameters* getEventMetaData() const override ;
 
-    /// return the event meta data for the event with runID and evtID
-    virtual GenericParameters* getEventMetaData(int runID, int evtID) const override ;
+    /// return the run meta data for the given runID
+    virtual GenericParameters* getRunMetaData(int runID) const override ;
 
     /// return the collection meta data for the given colID
     virtual GenericParameters* getCollectionMetaData(int colID) const override ;
 
+    RunMDMap* getRunMetaDataMap() const {return &m_runMDMap ; }
+    ColMDMap* getColMetaDataMap() const {return &m_colMDMap ; }
 
   private:
 
@@ -101,12 +109,12 @@ namespace podio {
     mutable CollContainer m_collections;
     mutable std::vector<const CollectionBase*> m_failedRetrieves;
     mutable std::vector<CollectionBase*> m_cachedCollections;
-    IReader* m_reader;
+    IReader* m_reader=nullptr;
     CollectionIDTable* m_table;
-    typedef std::pair<int,int> ipair ;
-    mutable std::map<int,GenericParameters*>   m_runMD ;
-    mutable std::map<ipair,GenericParameters*> m_evtMD ;
-    mutable std::map<int,GenericParameters*>   m_colMD ;
+
+    mutable GenericParameters  m_evtMD ;
+    mutable RunMDMap m_runMDMap ;
+    mutable ColMDMap m_colMDMap ;
   };
 
 

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -29,10 +29,8 @@ namespace podio {
   class CollectionBase;
   class IReader;
 
-  typedef std::pair<int,int> ipair ;
-  typedef std::map<int,GenericParameters*>    RunMDMap;
-  typedef std::map<ipair,GenericParameters*>  EvtMDMap;
-  typedef std::map<int,GenericParameters*>    ColMDMap;
+  typedef std::map<int,GenericParameters>    RunMDMap;
+  typedef std::map<int,GenericParameters>    ColMDMap;
 
   class EventStore : public ICollectionProvider, public IMetaDataProvider {
 

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -83,18 +83,19 @@ namespace podio {
     virtual bool isValid() const final;
 
     /// return the event meta data for the current event
-    virtual GenericParameters* getEventMetaData() const override ;
+    virtual GenericParameters& getEventMetaData() const override ;
 
     /// return the run meta data for the given runID
-    virtual GenericParameters* getRunMetaData(int runID) const override ;
+    virtual GenericParameters& getRunMetaData(int runID) const override ;
 
     /// return the collection meta data for the given colID
-    virtual GenericParameters* getCollectionMetaData(int colID) const override ;
+    virtual GenericParameters& getCollectionMetaData(int colID) const override ;
 
     RunMDMap* getRunMetaDataMap() const {return &m_runMDMap ; }
     ColMDMap* getColMetaDataMap() const {return &m_colMDMap ; }
+    GenericParameters* eventMetaDataPtr() const {return &m_evtMD; }
 
-  private:
+   private:
 
     /// get the collection of given name; returns true if successfull
     bool doGet(const std::string& name, CollectionBase*& collection, bool setReferences = true) const;

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -9,6 +9,9 @@
 // podio specific includes
 #include "podio/CollectionIDTable.h"
 #include "podio/ICollectionProvider.h"
+#include "podio/IMetaDataProvider.h"
+#include "podio/GenericParameters.h"
+
 
 /**
 This is an *example* event store
@@ -26,7 +29,7 @@ namespace podio {
   class CollectionBase;
   class IReader;
 
-  class EventStore : public ICollectionProvider {
+  class EventStore : public ICollectionProvider, public IMetaDataProvider {
 
   public:
     /// Collection entry. Each collection is identified by a name
@@ -76,6 +79,15 @@ namespace podio {
 
     virtual bool isValid() const final;
 
+    virtual GenericParameters* getRunMetaData(int runID) const override ;
+
+    /// return the event meta data for the event with runID and evtID
+    virtual GenericParameters* getEventMetaData(int runID, int evtID) const override ;
+
+    /// return the collection meta data for the given colID
+    virtual GenericParameters* getCollectionMetaData(int colID) const override ;
+
+
   private:
 
     /// get the collection of given name; returns true if successfull
@@ -91,6 +103,10 @@ namespace podio {
     mutable std::vector<CollectionBase*> m_cachedCollections;
     IReader* m_reader;
     CollectionIDTable* m_table;
+    typedef std::pair<int,int> ipair ;
+    mutable std::map<int,GenericParameters*>   m_runMD ;
+    mutable std::map<ipair,GenericParameters*> m_evtMD ;
+    mutable std::map<int,GenericParameters*>   m_colMD ;
   };
 
 

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -109,6 +109,12 @@ namespace podio {
      */
     virtual void setValues(const std::string & key, const StringVec & values);
 
+    /// erase all elements
+    void clear() {
+      _intMap.clear();
+      _floatMap.clear();
+      _stringMap.clear();
+    }
 
   protected:
 

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -1,0 +1,121 @@
+// -*- C++ -*-
+#ifndef GenericParameters_H
+#define GenericParameters_H 1
+
+#include <map>
+#include <vector>
+#include <string>
+
+namespace podio {
+
+  typedef std::vector<int> IntVec ;
+  typedef std::vector<float> FloatVec ;
+  typedef std::vector<std::string> StringVec ;
+  typedef std::map< std::string, IntVec >    IntMap ;
+  typedef std::map< std::string, FloatVec >  FloatMap ;
+  typedef std::map< std::string, StringVec > StringMap ;
+  
+
+  /** GenericParameters objects allow to store generic named parameters of type
+   *  int, float and string or vectors of these types. 
+   *  They can be used  to store (user) meta data that is 
+   *  run, event or collection dependent. 
+   *  (based on lcio::LCParameters)
+   * 
+   * @author F. Gaede, DESY 
+   * @date Apr 2020
+   */
+  
+  class GenericParameters {
+
+  public: 
+    
+    GenericParameters() = default; 
+    /// Destructor.
+    virtual ~GenericParameters() = default;
+    
+    /** Returns the first integer value for the given key.
+     */
+    virtual int getIntVal(const std::string & key) const  ;
+    
+    /** Returns the first float value for the given key.
+     */
+    virtual float getFloatVal(const std::string & key) const ;
+    
+    /** Returns the first string value for the given key.
+     */
+    virtual const std::string & getStringVal(const std::string & key) const ;
+    
+    /** Adds all integer values for the given key to values.
+     *  Returns a reference to values for convenience.
+     */
+    virtual IntVec & getIntVals(const std::string & key, IntVec & values) const ;
+    
+    /** Adds all float values for the given key to values.
+     *  Returns a reference to values for convenience.
+     */
+    virtual FloatVec & getFloatVals(const std::string & key, FloatVec & values) const ;
+    
+    /** Adds all float values for the given key to values.
+     *  Returns a reference to values for convenience.
+     */
+    virtual  StringVec & getStringVals(const std::string & key, StringVec & values) const ;
+    
+    /** Returns a list of all keys of integer parameters.
+     */
+    virtual const StringVec & getIntKeys( StringVec & keys) const  ;
+
+    /** Returns a list of all keys of float parameters.
+     */
+    virtual const StringVec & getFloatKeys(StringVec & keys)  const ;
+
+    /** Returns a list of all keys of string parameters.
+     */
+    virtual const StringVec & getStringKeys(StringVec & keys)  const ;
+    
+    /** The number of integer values stored for this key.
+     */ 
+    virtual int getNInt(const std::string & key) const ;
+    
+    /** The number of float values stored for this key.
+     */ 
+    virtual int getNFloat(const std::string & key) const ;
+    
+    /** The number of string values stored for this key.
+     */ 
+    virtual int getNString(const std::string & key) const ;
+    
+    /** Set integer value for the given key.
+     */
+    virtual void setValue(const std::string & key, int value) ;
+
+    /** Set float value for the given key.
+     */
+    virtual void setValue(const std::string & key, float value) ;
+
+    /** Set string value for the given key.
+     */
+    virtual void setValue(const std::string & key, const std::string & value) ;
+
+    /** Set integer values for the given key.
+     */
+    virtual void setValues(const std::string & key, const IntVec & values);
+
+    /** Set float values for the given key.
+     */
+    virtual void setValues(const std::string & key, const FloatVec & values);
+
+    /** Set string values for the given key.
+     */
+    virtual void setValues(const std::string & key, const StringVec & values);
+
+
+  protected:
+
+    mutable IntMap _intMap{} ;
+    mutable FloatMap _floatMap{} ;
+    mutable StringMap _stringMap{} ;
+    
+  }; // class
+} // namespace podio
+#endif

--- a/include/podio/IMetaDataProvider.h
+++ b/include/podio/IMetaDataProvider.h
@@ -16,11 +16,11 @@ namespace podio {
     /// destructor
     virtual ~IMetaDataProvider(){};
 
+    /// return the event meta data for the current event
+    virtual GenericParameters* getEventMetaData() const = 0;
+
     /// return the run meta data for the given runID
     virtual GenericParameters* getRunMetaData(int runID) const = 0;
-
-    /// return the event meta data for the event with runID and evtID
-    virtual GenericParameters* getEventMetaData(int runID, int evtID) const = 0;
 
     /// return the collection meta data for the given colID
     virtual GenericParameters* getCollectionMetaData(int colID) const = 0;

--- a/include/podio/IMetaDataProvider.h
+++ b/include/podio/IMetaDataProvider.h
@@ -1,0 +1,31 @@
+#ifndef IMETADATAPROVIDER_H
+#define IMETADATAPROVIDER_H
+
+#include "podio/GenericParameters.h"
+
+namespace podio {
+  
+
+   /** Inteface to access meta data for runs, events and collections.
+   * @author F. Gaede, DESY 
+   * @date Apr 2020
+   */
+  class IMetaDataProvider {
+
+  public:
+    /// destructor
+    virtual ~IMetaDataProvider(){};
+
+    /// return the run meta data for the given runID
+    virtual GenericParameters* getRunMetaData(int runID) const = 0;
+
+    /// return the event meta data for the event with runID and evtID
+    virtual GenericParameters* getEventMetaData(int runID, int evtID) const = 0;
+
+    /// return the collection meta data for the given colID
+    virtual GenericParameters* getCollectionMetaData(int colID) const = 0;
+  };
+
+} // namespace
+
+#endif

--- a/include/podio/IMetaDataProvider.h
+++ b/include/podio/IMetaDataProvider.h
@@ -17,13 +17,13 @@ namespace podio {
     virtual ~IMetaDataProvider(){};
 
     /// return the event meta data for the current event
-    virtual GenericParameters* getEventMetaData() const = 0;
+    virtual GenericParameters& getEventMetaData() const = 0;
 
     /// return the run meta data for the given runID
-    virtual GenericParameters* getRunMetaData(int runID) const = 0;
+    virtual GenericParameters& getRunMetaData(int runID) const = 0;
 
     /// return the collection meta data for the given colID
-    virtual GenericParameters* getCollectionMetaData(int colID) const = 0;
+    virtual GenericParameters& getCollectionMetaData(int colID) const = 0;
   };
 
 } // namespace

--- a/include/podio/IReader.h
+++ b/include/podio/IReader.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <map>
 
 #include <iostream>
 
@@ -30,6 +31,8 @@ class IReader {
     virtual CollectionIDTable* getCollectionIDTable() = 0;
     /// read event meta data from file
     virtual GenericParameters* readEventMetaData()=0 ;
+    virtual std::map<int,GenericParameters>* readCollectionMetaData()=0 ;
+    virtual std::map<int,GenericParameters>* readRunMetaData()=0 ;
     //TODO: decide on smart-pointers for passing of objects
     /// Check if reader is valid
     virtual bool isValid() const = 0;

--- a/include/podio/IReader.h
+++ b/include/podio/IReader.h
@@ -18,6 +18,7 @@ namespace podio {
 
 class CollectionBase;
 class CollectionIDTable;
+class GenericParameters;
 
 class IReader {
   public:
@@ -27,6 +28,8 @@ class IReader {
     virtual CollectionBase* readCollection(const std::string& name) = 0;
     /// Get CollectionIDTable of read-in data
     virtual CollectionIDTable* getCollectionIDTable() = 0;
+    /// read event meta data from file
+    virtual GenericParameters* readEventMetaData()=0 ;
     //TODO: decide on smart-pointers for passing of objects
     /// Check if reader is valid
     virtual bool isValid() const = 0;

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -24,7 +24,7 @@ class EventStore;
 class CollectionBase;
 class Registry;
 class CollectionIDTable;
-
+class GenericParameters;
 /**
 This class has the function to read available data from disk
 and to prepare collections and buffers.
@@ -65,6 +65,9 @@ class ROOTReader : public IReader {
 
     /// Implementation for collection reading
     CollectionBase* readCollection(const std::string& name) override final;
+
+    /// read event meta data for current event
+    GenericParameters* readEventMetaData() override final ;
 
   private:
     typedef std::pair<CollectionBase*, std::string> Input;

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -69,6 +69,12 @@ class ROOTReader : public IReader {
     /// read event meta data for current event
     GenericParameters* readEventMetaData() override final ;
 
+  /// read the collection meta data
+    std::map<int,GenericParameters>* readCollectionMetaData() override final ;
+
+  /// read the run meta data
+    std::map<int,GenericParameters>* readRunMetaData() override final ;
+
   private:
     typedef std::pair<CollectionBase*, std::string> Input;
     std::vector<Input> m_inputs;

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -34,6 +34,10 @@ namespace podio {
     TFile* m_file;
     TTree* m_datatree;
     TTree* m_metadatatree;
+    TTree* m_runMDtree;
+    TTree* m_evtMDtree;
+    TTree* m_colMDtree;
+    GenericParameters* m_evtMD ;
     std::vector<CollectionBase*> m_storedCollections;
 
   };

--- a/python/EventStore.py
+++ b/python/EventStore.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 from ROOT import gSystem
 gSystem.Load("libpodioRootIO")  # noqa: E402
+gSystem.Load("libpodioDict")  # noqa: E402
+gSystem.Load("libTestDataModel.so")
 from ROOT import podio
 
 

--- a/python/EventStore.py
+++ b/python/EventStore.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 from ROOT import gSystem
 gSystem.Load("libpodioRootIO")  # noqa: E402
-gSystem.Load("libpodioDict")  # noqa: E402
-gSystem.Load("libTestDataModel.so")
 from ROOT import podio
 
 

--- a/python/templates/Collection.h.template
+++ b/python/templates/Collection.h.template
@@ -106,6 +106,10 @@ public:
     );
   };
 
+  unsigned getID() const override final {
+    return m_collectionID ;
+  }
+
   bool isValid() const override final {
     return m_isValid;
   }

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -100,26 +100,22 @@ namespace podio {
   }
   
   GenericParameters* EventStore::getRunMetaData(int runID) const {
-    auto it = m_runMDMap.find( runID ) ;
-    if( it != m_runMDMap.end() )
-      return it->second ;
 
-    GenericParameters* tmp=new GenericParameters ;
-    m_runMDMap.insert( std::make_pair(runID , tmp )  ) ;
-
-    return tmp ;
+    if( m_runMDMap.empty() && m_reader != nullptr ){
+      RunMDMap* tmp = m_reader->readRunMetaData() ;
+      m_runMDMap = *tmp ;
+    }
+    return &m_runMDMap[ runID ] ;
   } ;
   
 
   GenericParameters* EventStore::getCollectionMetaData(int colID) const {
-    auto it = m_colMDMap.find( colID ) ;
-    if( it != m_colMDMap.end() )
-      return it->second ;
 
-    GenericParameters* tmp=new GenericParameters ;
-    m_colMDMap.insert( std::make_pair(colID , tmp )  ) ;
-
-    return tmp ;
+    if( m_colMDMap.empty() && m_reader != nullptr ){
+      ColMDMap* tmp = m_reader->readCollectionMetaData() ;
+      m_colMDMap = *tmp ;
+    }
+    return &m_colMDMap[ colID ] ;
   } ;
 
   void EventStore::clearCollections(){

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -89,6 +89,30 @@ namespace podio {
     }
     return false;
   }
+  
+  GenericParameters* EventStore::getRunMetaData(int runID) const {
+    auto it = m_runMD.find( runID ) ;
+    if( it != m_runMD.end() )
+      return it->second ;
+
+    GenericParameters* tmp=new GenericParameters ;
+    m_runMD.insert( std::make_pair(runID , tmp )  ) ;
+    
+    if( m_reader != nullptr ){
+      // read event from file
+      // ...
+    } 
+
+    return tmp ;
+  } ;
+  
+  GenericParameters* EventStore::getEventMetaData(int runID, int evtID) const {
+    return nullptr ;
+  } ;
+
+  GenericParameters* EventStore::getCollectionMetaData(int colID) const {
+    return nullptr ;
+  } ;
 
   void EventStore::clearCollections(){
     for (auto& coll : m_collections){

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -89,33 +89,33 @@ namespace podio {
     return false;
   }
 
-  GenericParameters* EventStore::getEventMetaData() const {
+  GenericParameters& EventStore::getEventMetaData() const {
 
     if( m_reader != nullptr ){
       m_evtMD.clear() ;
       GenericParameters* tmp = m_reader->readEventMetaData() ;
       m_evtMD = *tmp ;
     }
-    return &m_evtMD ;
+    return m_evtMD ;
   }
   
-  GenericParameters* EventStore::getRunMetaData(int runID) const {
+  GenericParameters& EventStore::getRunMetaData(int runID) const {
 
     if( m_runMDMap.empty() && m_reader != nullptr ){
       RunMDMap* tmp = m_reader->readRunMetaData() ;
       m_runMDMap = *tmp ;
     }
-    return &m_runMDMap[ runID ] ;
+    return m_runMDMap[ runID ] ;
   } ;
   
 
-  GenericParameters* EventStore::getCollectionMetaData(int colID) const {
+  GenericParameters& EventStore::getCollectionMetaData(int colID) const {
 
     if( m_colMDMap.empty() && m_reader != nullptr ){
       ColMDMap* tmp = m_reader->readCollectionMetaData() ;
       m_colMDMap = *tmp ;
     }
-    return &m_colMDMap[ colID ] ;
+    return m_colMDMap[ colID ] ;
   } ;
 
   void EventStore::clearCollections(){

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -1,0 +1,165 @@
+#include "podio/GenericParameters.h"
+
+#include <algorithm>
+
+namespace podio{
+
+
+  int GenericParameters::getIntVal(const std::string & key) const {
+    
+    IntMap::iterator it = _intMap.find( key ) ;
+
+    if( it == _intMap.end() )  return 0 ;
+
+    IntVec &  iv =  it->second ;
+
+    return iv[0] ;
+  }
+
+  float GenericParameters::getFloatVal(const std::string & key) const {
+
+    FloatMap::iterator it = _floatMap.find( key ) ;
+
+    if( it == _floatMap.end() )  return 0 ;
+
+    FloatVec &  fv =  it->second ;
+
+    return fv[0] ;
+  }
+
+  const std::string & GenericParameters::getStringVal(const std::string & key) const {
+
+    static std::string empty("") ;
+    
+    StringMap::iterator it = _stringMap.find( key ) ;
+    
+    if( it == _stringMap.end() )  return empty ;
+    
+    StringVec &  sv =  it->second ;
+    
+    return sv[0] ;
+  }
+
+  IntVec & GenericParameters::getIntVals(const std::string & key, IntVec & values) const {
+
+    IntMap::iterator it = _intMap.find( key ) ;
+
+    if( it != _intMap.end() ) {
+      values.insert( values.end() , it->second.begin() , it->second.end() ) ;
+    }
+
+    return values ;
+  }
+
+  FloatVec & GenericParameters::getFloatVals(const std::string & key, FloatVec & values) const {
+
+    FloatMap::iterator it = _floatMap.find( key ) ;
+
+    if( it != _floatMap.end() ) {
+      values.insert( values.end() , it->second.begin() , it->second.end() ) ;
+    }
+    return values ;
+  }
+
+  StringVec & GenericParameters::getStringVals(const std::string & key, StringVec & values) const {
+
+    StringMap::iterator it = _stringMap.find( key ) ;
+
+    if( it != _stringMap.end() ) {
+      values.insert( values.end() , it->second.begin() , it->second.end() ) ;
+    }
+    return values ;
+  }
+
+
+  const StringVec & GenericParameters::getIntKeys(StringVec & keys) const  {
+
+    std::transform( _intMap.begin() , _intMap.end() , back_inserter( keys )  ,
+		[](auto const& pair){ return pair.first; }) ;
+
+    return keys ;
+  }
+
+  const StringVec & GenericParameters::getFloatKeys(StringVec & keys) const  {
+    
+    std::transform( _floatMap.begin() , _floatMap.end() , back_inserter( keys )  ,
+		[](auto const& pair){ return pair.first; }) ;
+
+    return keys ;
+  }
+
+  const StringVec & GenericParameters::getStringKeys(StringVec & keys) const  {
+
+    std::transform( _stringMap.begin() , _stringMap.end() , back_inserter( keys ),
+		    [](auto const& pair){ return pair.first; }) ;
+		    
+    return keys ;
+  }
+  
+  int GenericParameters::getNInt(const std::string & key) const {
+
+    IntMap::iterator it = _intMap.find( key ) ;
+
+    if( it == _intMap.end() )
+      return 0 ;
+    else
+      return it->second.size() ;
+  }
+
+  int GenericParameters::getNFloat(const std::string & key) const {
+
+    FloatMap::iterator it = _floatMap.find( key ) ;
+
+    if( it == _floatMap.end() )  
+      return 0 ;
+    else
+      return it->second.size() ;
+  }
+
+  int GenericParameters::getNString(const std::string & key) const {
+
+    StringMap::iterator it = _stringMap.find( key ) ;
+
+    if( it == _stringMap.end() )  
+      return 0 ;
+    else
+      return it->second.size() ;
+  }
+
+  void GenericParameters::setValue(const std::string & key, int value){
+
+    _intMap[ key ].clear() ;
+    _intMap[ key ].push_back( value ) ;
+  }
+
+  void GenericParameters::setValue(const std::string & key, float value){
+
+    _floatMap[ key ].clear() ;
+    _floatMap[ key ].push_back( value ) ;
+  }
+
+  void GenericParameters::setValue(const std::string & key, const std::string & value) {
+
+    _stringMap[ key ].clear() ;
+    _stringMap[ key ].push_back( value ) ;
+
+  }
+
+
+
+  void GenericParameters::setValues(const std::string & key,const IntVec & values){
+    
+    _intMap[ key ].assign(  values.begin() , values.end() ) ;
+  }
+  
+  void GenericParameters::setValues(const std::string & key,const  FloatVec & values){
+
+    _floatMap[ key ].assign(  values.begin() , values.end() ) ;
+  }
+  
+  void GenericParameters::setValues(const std::string & key, const StringVec & values){
+
+    _stringMap[ key ].assign(  values.begin() , values.end() ) ;
+  }
+
+} // namespace 

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -20,6 +20,21 @@ namespace podio {
     evt_metadatatree->GetEntry(m_eventNumber);
     return emd ;
   }
+  std::map<int,GenericParameters>* ROOTReader::readCollectionMetaData(){
+    auto* emd = new std::map<int,GenericParameters> ;
+    auto col_metadatatree = static_cast<TTree*>(m_chain->GetFile()->Get("col_metadata"));
+    col_metadatatree->SetBranchAddress("colMD",&emd);
+    col_metadatatree->GetEntry(0);
+    return emd ;
+  }
+  std::map<int,GenericParameters>* ROOTReader::readRunMetaData(){
+    auto* emd = new std::map<int,GenericParameters> ;
+    auto run_metadatatree = static_cast<TTree*>(m_chain->GetFile()->Get("run_metadata"));
+    run_metadatatree->SetBranchAddress("runMD",&emd);
+    run_metadatatree->GetEntry(0);
+    return emd ;
+  }
+
 
   CollectionBase* ROOTReader::readCollection(const std::string& name) {
     // has the collection already been constructed?
@@ -116,13 +131,7 @@ namespace podio {
     std::vector<int> l_collectionIDs;
     for (auto name: l_names) {
       l_collectionIDs.push_back(l_table->collectionID(name));
-
     }
-
-    // auto evtMDtree = static_cast<TTree*>(m_chain->GetFile()->Get("eventmetadata"));
-    // evtMDtree->SetBranchAddress("evtMD", m_store->getEvtMetaDataMap() );
-    // evtMDtree->GetEntry(0);
-
 
     m_table = new CollectionIDTable(l_collectionIDs, l_names);
   }

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -9,9 +9,17 @@
 #include "podio/ROOTReader.h"
 #include "podio/CollectionIDTable.h"
 #include "podio/CollectionBase.h"
+#include "podio/GenericParameters.h"
 
 namespace podio {
 
+  GenericParameters* ROOTReader::readEventMetaData(){
+    GenericParameters* emd = new GenericParameters() ;
+    auto evt_metadatatree = static_cast<TTree*>(m_chain->GetFile()->Get("evt_metadata"));
+    evt_metadatatree->SetBranchAddress("evtMD",&emd);
+    evt_metadatatree->GetEntry(m_eventNumber);
+    return emd ;
+  }
 
   CollectionBase* ROOTReader::readCollection(const std::string& name) {
     // has the collection already been constructed?
@@ -110,6 +118,12 @@ namespace podio {
       l_collectionIDs.push_back(l_table->collectionID(name));
 
     }
+
+    // auto evtMDtree = static_cast<TTree*>(m_chain->GetFile()->Get("eventmetadata"));
+    // evtMDtree->SetBranchAddress("evtMD", m_store->getEvtMetaDataMap() );
+    // evtMDtree->GetEntry(0);
+
+
     m_table = new CollectionIDTable(l_collectionIDs, l_names);
   }
 

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -41,6 +41,11 @@ namespace podio {
     m_metadatatree->Branch("CollectionIDs",m_store->getCollectionIDTable());
     m_metadatatree->Fill();
 
+    m_colMDtree->Branch("colMD", "std::map<int,podio::GenericParameters>", m_store->getColMetaDataMap() ) ;
+    m_colMDtree->Fill();
+    m_runMDtree->Branch("runMD", "std::map<int,podio::GenericParameters>", m_store->getRunMetaDataMap() ) ;
+    m_runMDtree->Fill();
+
     m_file->Write();
     m_file->Close();
   }

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -21,7 +21,7 @@ namespace podio {
     m_runMDtree(new TTree("run_metadata", "Run metadata tree"))
   {
 
-    m_evtMDtree->Branch("evtMD", "GenericParameters", m_store->getEventMetaData() ) ;
+    m_evtMDtree->Branch("evtMD", "GenericParameters", m_store->eventMetaDataPtr() ) ;
   }
 
   ROOTWriter::~ROOTWriter(){

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -15,8 +15,14 @@ namespace podio {
     m_store(store),
     m_file(new TFile(filename.c_str(),"RECREATE","data file")),
     m_datatree(new TTree("events","Events tree")),
-    m_metadatatree(new TTree("metadata", "Metadata tree"))
-  {}
+    m_metadatatree(new TTree("metadata", "Metadata tree")),
+    m_evtMDtree(new TTree("evt_metadata", "Event metadata tree")),
+    m_colMDtree(new TTree("col_metadata", "Collection metadata tree")),
+    m_runMDtree(new TTree("run_metadata", "Run metadata tree"))
+  {
+
+    m_evtMDtree->Branch("evtMD", "GenericParameters", m_store->getEventMetaData() ) ;
+  }
 
   ROOTWriter::~ROOTWriter(){
     delete m_file;
@@ -27,12 +33,14 @@ namespace podio {
       coll->prepareForWrite();
     }
     m_datatree->Fill();
+    m_evtMDtree->Fill();
   }
 
   void ROOTWriter::finish(){
     // now we want to safe the metadata
     m_metadatatree->Branch("CollectionIDs",m_store->getCollectionIDTable());
     m_metadatatree->Fill();
+
     m_file->Write();
     m_file->Close();
   }

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -1,5 +1,13 @@
 <lcgdict>
-    <selection>
+  <selection>
+    <class name="podio::GenericParameters"/>
+    <class name="podio::IntVec"/>
+    <class name="podio::FloatVec"/>
+    <class name="podio::StringVec"/>
+    <class name="podio::IntMap"/>
+    <class name="podio::FloatMap"/>
+    <class name="podio::StringMap"/>
+    <class name="podio::EvtMDMap"/>
     <class name="podio::CollectionBase"/>
     <class name="podio::CollectionIDTable">
         <field name="m_mutex" transient="true"/>

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -7,7 +7,7 @@
     <class name="podio::IntMap"/>
     <class name="podio::FloatMap"/>
     <class name="podio::StringMap"/>
-    <class name="podio::EvtMDMap"/>
+    <class name="std::map<int,podio::GenericParameters>"/>
     <class name="podio::CollectionBase"/>
     <class name="podio::CollectionIDTable">
         <field name="m_mutex" transient="true"/>

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -27,14 +27,14 @@ int glob = 0;
 
 void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
 
-  auto* evtMD = store.getEventMetaData() ;
-  float evtWeight = evtMD->getFloatVal( "UserEventWeight" ) ;
+  auto evtMD = store.getEventMetaData() ;
+  float evtWeight = evtMD.getFloatVal( "UserEventWeight" ) ;
   if( evtWeight != (float) 100.*eventNum ){
     std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << (float) 100.*eventNum << std::endl ;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
   }
   std::stringstream ss ; ss << " event_number_" << eventNum ;
-  std::string evtName = evtMD->getStringVal( "UserEventName" ) ;
+  std::string evtName = evtMD.getStringVal( "UserEventName" ) ;
   if( evtName != ss.str() ){
     std::cout << " read UserEventName: " << evtName << " - expected : " << ss.str() << std::endl ;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventName'");
@@ -59,8 +59,8 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
 
   // read collection meta data
   auto& hits = store.get<ExampleHitCollection>("hits");
-  auto* colMD = store.getCollectionMetaData( hits.getID() );
-  std::string es = colMD->getStringVal("CellIDEncodingString") ;
+  auto colMD = store.getCollectionMetaData( hits.getID() );
+  std::string es = colMD.getStringVal("CellIDEncodingString") ;
   if( es != std::string("system:8,barrel:3,layer:6,slice:5,x:-16,y:-16") ){
     std::cout << " meta data from collection 'hits' with id = " <<  hits.getID()
 	      << " read CellIDEncodingString: " << es << " - expected : system:8,barrel:3,layer:6,slice:5,x:-16,y:-16"

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -57,6 +57,18 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
     throw std::runtime_error("Collection 'strings' should be present.");
   }
 
+  // read collection meta data
+  auto& hits = store.get<ExampleHitCollection>("hits");
+  auto* colMD = store.getCollectionMetaData( hits.getID() );
+  std::string es = colMD->getStringVal("CellIDEncodingString") ;
+  if( es != std::string("system:8,barrel:3,layer:6,slice:5,x:-16,y:-16") ){
+    std::cout << " meta data from collection 'hits' with id = " <<  hits.getID()
+	      << " read CellIDEncodingString: " << es << " - expected : system:8,barrel:3,layer:6,slice:5,x:-16,y:-16"
+	      << std::endl ;
+    throw std::runtime_error("Couldn't read event meta data parameters 'CellIDEncodingString'");
+  }
+
+
   auto& clusters = store.get<ExampleClusterCollection>("clusters");
   if(clusters.isValid()){
     auto cluster = clusters[0];

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <exception>
 #include <cassert>
+#include <sstream>
 
 // podio specific includes
 #include "podio/EventStore.h"
@@ -25,6 +26,21 @@ int glob = 0;
 
 
 void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
+
+  auto* evtMD = store.getEventMetaData() ;
+  float evtWeight = evtMD->getFloatVal( "UserEventWeight" ) ;
+  if( evtWeight != (float) 100.*eventNum ){
+    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << (float) 100.*eventNum << std::endl ;
+    throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
+  }
+  std::stringstream ss ; ss << " event_number_" << eventNum ;
+  std::string evtName = evtMD->getStringVal( "UserEventName" ) ;
+  if( evtName != ss.str() ){
+    std::cout << " read UserEventName: " << evtName << " - expected : " << ss.str() << std::endl ;
+    throw std::runtime_error("Couldn't read event meta data parameters 'UserEventName'");
+  }
+
+
 
   auto& failing = store.get<ExampleClusterCollection>("notthere");
   if(failing.isValid() == true) {

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -73,6 +73,10 @@ void write(std::string outfilename) {
     std::stringstream ss ; ss << " event_number_" << i ;
     evtMD->setValue( "UserEventName" , ss.str() ) ;
 
+
+    auto* colMD = store.getCollectionMetaData( hits.getID() );
+    colMD->setValue("CellIDEncodingString","system:8,barrel:3,layer:6,slice:5,x:-16,y:-16");
+
     auto hit1 = ExampleHit( 0xbad, 0.,0.,0.,23.+i);
     auto hit2 = ExampleHit( 0xcaffee,1.,0.,0.,12.+i);
 

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -68,14 +68,14 @@ void write(std::string outfilename) {
     item1.Number(i);
     info.push_back(item1);
 
-    auto* evtMD = store.getEventMetaData() ;
-    evtMD->setValue( "UserEventWeight" , (float) 100.*i ) ;
+    auto& evtMD = store.getEventMetaData() ;
+    evtMD.setValue( "UserEventWeight" , (float) 100.*i ) ;
     std::stringstream ss ; ss << " event_number_" << i ;
-    evtMD->setValue( "UserEventName" , ss.str() ) ;
+    evtMD.setValue( "UserEventName" , ss.str() ) ;
 
 
-    auto* colMD = store.getCollectionMetaData( hits.getID() );
-    colMD->setValue("CellIDEncodingString","system:8,barrel:3,layer:6,slice:5,x:-16,y:-16");
+    auto& colMD = store.getCollectionMetaData( hits.getID() );
+    colMD.setValue("CellIDEncodingString","system:8,barrel:3,layer:6,slice:5,x:-16,y:-16");
 
     auto hit1 = ExampleHit( 0xbad, 0.,0.,0.,23.+i);
     auto hit2 = ExampleHit( 0xcaffee,1.,0.,0.,12.+i);

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -67,6 +67,12 @@ void write(std::string outfilename) {
     auto item1 = EventInfo();
     item1.Number(i);
     info.push_back(item1);
+
+    auto* evtMD = store.getEventMetaData() ;
+    evtMD->setValue( "UserEventWeight" , (float) 100.*i ) ;
+    std::stringstream ss ; ss << " event_number_" << i ;
+    evtMD->setValue( "UserEventName" , ss.str() ) ;
+
     auto hit1 = ExampleHit( 0xbad, 0.,0.,0.,23.+i);
     auto hit2 = ExampleHit( 0xcaffee,1.,0.,0.,12.+i);
 


### PR DESCRIPTION
BEGINRELEASENOTES
- implement reading/writing of meta data for runs, events and collections
     - based on GenericParameters that hold named parameters of type `int, float, string` or vectors if these (copied from `lcio::LCParameters`)
     - meta data for the three types is always written 
     - it is read only on request
- example for writing:
```
   auto& evtMD = store.getEventMetaData() ;
    evtMD.setValue( "UserEventWeight" , (float) 100.*i ) ;
```
- example for reading:
```
  auto& evtMD = store.getEventMetaData() ;
  float evtWeight = evtMD.getFloatVal( "UserEventWeight" ) ;

```
- addresses #49 

ENDRELEASENOTES