### PR TITLE
Fix invalid ranges for empty relations

### DIFF
--- a/python/templates/ConstRefVector.cc.template
+++ b/python/templates/ConstRefVector.cc.template
@@ -6,8 +6,8 @@ std::vector<${relationtype}>::const_iterator Const${classname}::${relation}_begi
 
 std::vector<${relationtype}>::const_iterator Const${classname}::${relation}_end() const {
   auto ret_value = m_obj->m_${relation}->begin();
-  std::advance(ret_value, m_obj->data.${relation}_end-1);
-  return ++ret_value;
+  std::advance(ret_value, m_obj->data.${relation}_end);
+  return ret_value;
 }
 
 unsigned int Const${classname}::${relation}_size() const {

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -151,6 +151,18 @@ void write(std::string outfilename) {
   std::cout << " " << it->getObjectID().index ;
       }
       std::cout << std::endl ;
+
+      // make sure that this does not crash when we do it on a ConstExampleMC
+      ConstExampleMC constP{p};
+      std::cout << "The const particle still has the same relations: daughters: ";
+      for (auto it = constP.daughters_begin(); it != constP.daughters_end(); ++it) {
+        std::cout << " " << it->getObjectID().index;
+      }
+      std::cout << " and parents: ";
+      for (auto it = constP.parents_begin(); it != constP.parents_end(); ++it) {
+        std::cout << " " << it->getObjectID().index;
+      }
+
     }
     //-------------------------------
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix bug where `ConstObject` with empty `OneToManyRelations` give an invalid iterator range, #100 

ENDRELEASENOTES

Fixes #100 

Apparently for the non-const version this has already been fixed a long time ago by #16 . This just adds the same fix for the const versions.

In the current implementation the test is not extremely informative, but it at least fails if the iterator range is invalid.