### PR TITLE
Fix possible infinite loops in ostream operator

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -478,7 +478,10 @@ class ClassGenerator(object):
       relnamespace, reltype, _, __ = self.demangle_classname(refvector["type"])
       relationtype = refvector["type"]
       if relationtype not in self.buildin_types and relationtype not in self.reader.components:
-        relationtype = relnamespace + "::Const" + reltype
+        relationtype = relnamespace
+        if relnamespace:
+          relationtype += "::"
+        relationtype += "Const" + reltype
 
       relationName = refvector["name"]
       get_relation = relationName

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -493,7 +493,13 @@ class ClassGenerator(object):
 
       ostream_implementation += ('  o << " %s : " ;\n' % relationName)
       ostream_implementation += ('  for(unsigned i=0,N=value.%s_size(); i<N ; ++i)\n' % relationName)
-      ostream_implementation += ('    o << value.%s(i) << " " ; \n' % get_relation)
+      # If the reference is of the same type as the class we have to avoid
+      # running into a possible infinite loop when printing. Hence, print only
+      # the id instead of the whole referenced object
+      if reltype == classname:
+        ostream_implementation += ('    o << value.%s(i).id() << " " ; \n' % get_relation)
+      else:
+        ostream_implementation += ('    o << value.%s(i) << " " ; \n' % get_relation)
       ostream_implementation += '  o << std::endl ;\n'
 
       substitutions = {"relation": relationName,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,4 +58,9 @@ set_property(TEST pyunittest
                       ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/tests/datamodel:${ROOT_INCLUDE_PATH})
 set_property(TEST pyunittest PROPERTY DEPENDS write)
 
+add_test(NAME ostream_operator COMMAND ostream_operator)
+set_property(TEST ostream_operator PROPERTY ENVIRONMENT
+  LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH}
+  ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/tests/datamodel:${ROOT_INCLUDE_PATH})
+
 add_test(NAME unittest COMMAND unittest)

--- a/tests/ostream_operator.cpp
+++ b/tests/ostream_operator.cpp
@@ -1,0 +1,41 @@
+#include "datamodel/ExampleMC.h"
+#include "datamodel/ExampleForCyclicDependency1.h"
+#include "datamodel/ExampleForCyclicDependency2.h"
+#include "datamodel/ExampleReferencingType.h"
+
+#include <iostream>
+
+// When using CTest for unit testing it is enough for this test to eventually
+// segfault
+int main(int, char**)
+{
+  ExampleMC mcp1;
+  ExampleMC mcp2;
+
+  mcp1.adddaughters(mcp2);
+  mcp2.addparents(mcp1);
+
+  // This will lead to an infinite loop and a core dump eventually
+  std::cout << mcp1 << std::endl;
+
+  // Make sure everything still works if the relation is not of the same type
+  ExampleForCyclicDependency1 cyc1;
+  ExampleForCyclicDependency2 cyc2;
+
+  cyc1.ref(cyc2);
+  cyc2.ref(cyc1);
+
+  std::cout << cyc1 << cyc2 << std::endl;
+
+  // Non-cyclical references
+  ExampleReferencingType ref1;
+  ExampleReferencingType ref2;
+  ExampleReferencingType ref3;
+
+  ref1.addRefs(ref2);
+  ref2.addRefs(ref3);
+
+  std::cout << ref1 << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix the possibility of running into infinite loops in the ostream operator with cyclical references

ENDRELEASENOTES

The current approach simply refrains from printing the complete object and falls back to the `id` in case the referred to class is the same as the class that is printed.

This has the advantage, that it removes the possibility of running into infinite loops when cyclical references exist. The disadvantage is that for reference structures, where no such cycles exist the information content is reduced to only the `id`s instead of the full objects.

Fixes #105 