### PR TITLE
Make Ubuntu CI pip install all requirements

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,7 +11,8 @@ jobs:
     - name: Setup Dependencies
       run: |
         apt update
-        apt -y install python3-yaml python-is-python3
+        apt -y install python3-yaml python-is-python3 python3-pip
+        pip3 install -r requirements.txt
     - name: Compile and test
       run: |
         mkdir build install


### PR DESCRIPTION

BEGINRELEASENOTES
- Update Ubuntu CI script to install the python requirements via pip.

ENDRELEASENOTES

I have factored this change out of #120 where it is necessary to get the `jinja2` for successfully running the CI. I think it is nicer to have this in a separate PR to avoid that these changes are missed in a larger diff.