### PR TITLE
add <sstream> to write.cpp

### DIFF
--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -16,6 +16,7 @@
 // STL
 #include <iostream>
 #include <vector>
+#include <sstream>
 
 // podio specific includes
 #include "podio/EventStore.h"


### PR DESCRIPTION
BEGINRELEASENOTES
- minor bug fix for macos:
      - add `<sstream>` to write.cpp
      - fixes #123 


ENDRELEASENOTES