### PR TITLE
Make CollectionIDTable use a std::mutex

### DIFF
--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -43,7 +43,7 @@ namespace podio {
   private:
     std::vector<int>              m_collectionIDs;
     std::vector<std::string>      m_names;
-    mutable std::recursive_mutex  m_mutex;
+    mutable std::mutex  m_mutex;
   };
 
 

--- a/src/CollectionIDTable.cc
+++ b/src/CollectionIDTable.cc
@@ -6,22 +6,22 @@
 namespace podio {
 
   const std::string CollectionIDTable::name(int ID) const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    auto result = std::find(begin(m_collectionIDs), end(m_collectionIDs), ID);
-    auto index = result - m_collectionIDs.begin();
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const auto result = std::find(begin(m_collectionIDs), end(m_collectionIDs), ID);
+    const auto index = std::distance(m_collectionIDs.begin(), result);
     return m_names[index];
   }
 
   int CollectionIDTable::collectionID(const std::string& name) const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    auto result = std::find(begin(m_names), end(m_names), name);
-    auto index = result - m_names.begin();
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const auto result = std::find(begin(m_names), end(m_names), name);
+    const auto index = std::distance(m_names.begin(), result);
     return m_collectionIDs[index];
   }
 
 
   void CollectionIDTable::print() const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     std::cout<<"CollectionIDTable"<<std::endl;
     for(unsigned i=0; i<m_names.size(); ++i ) {
       std::cout<<"\t"
@@ -30,21 +30,21 @@ namespace podio {
   }
 
   bool CollectionIDTable::present(const std::string& name) const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    auto result = std::find(begin(m_names), end(m_names), name);
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const auto result = std::find(begin(m_names), end(m_names), name);
     return result != end(m_names);
   }
 
   int CollectionIDTable::add(const std::string& name) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    auto result = std::find(begin(m_names), end(m_names), name);
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const auto result = std::find(begin(m_names), end(m_names), name);
     int ID = 0;
     if (result == m_names.end()) {
       m_names.emplace_back(name);
       ID = m_names.size();
       m_collectionIDs.emplace_back( ID );
     } else {
-        auto index = result - m_names.begin();
+        const auto index = std::distance(m_names.begin(), result);
         ID = m_collectionIDs[index];
     }
     return ID;


### PR DESCRIPTION
BEGINRELEASENOTES
- improve CollectionIDTable
       - previously used a std::recursive_mutex which is unnecessary in this case
        - made whatever can be made const const and now use std::distance to calculate the index.
ENDRELEASENOTES
