### PR TITLE
Remove python unittests from installed files

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -3,6 +3,7 @@ SET(podio_PYTHON_INSTALLDIR ${podio_PYTHON_INSTALLDIR} PARENT_SCOPE)
 SET(podio_PYTHON_DIR ${CMAKE_CURRENT_LIST_DIR} PARENT_SCOPE)
 
 file(GLOB to_install *py figure.txt)
+LIST(FILTER to_install EXCLUDE REGEX "test_.*\\.py$" )
 install(FILES ${to_install} DESTINATION ${podio_PYTHON_INSTALLDIR})
 
 #--- install templates ---------------------------------------------------------


### PR DESCRIPTION

BEGINRELEASENOTES
- No longer install python unittest files

ENDRELEASENOTES