### PR TITLE
Make internal maps non-mutable

### DIFF
--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -32,86 +32,82 @@ namespace podio {
     using FloatMap = MapType<float>;
     using StringMap = MapType<std::string>;
 
-  public: 
-    
-    GenericParameters() = default; 
-    /// Destructor.
-    virtual ~GenericParameters() = default;
-    
+  public:
+   
     /** Returns the first integer value for the given key.
      */
-    virtual int getIntVal(const std::string & key) const  ;
+    int getIntVal(const std::string & key) const  ;
     
     /** Returns the first float value for the given key.
      */
-    virtual float getFloatVal(const std::string & key) const ;
+    float getFloatVal(const std::string & key) const ;
     
     /** Returns the first string value for the given key.
      */
-    virtual const std::string & getStringVal(const std::string & key) const ;
+    const std::string & getStringVal(const std::string & key) const ;
     
     /** Adds all integer values for the given key to values.
      *  Returns a reference to values for convenience.
      */
-    virtual IntVec & getIntVals(const std::string & key, IntVec & values) const ;
+    IntVec & getIntVals(const std::string & key, IntVec & values) const ;
     
     /** Adds all float values for the given key to values.
      *  Returns a reference to values for convenience.
      */
-    virtual FloatVec & getFloatVals(const std::string & key, FloatVec & values) const ;
+    FloatVec & getFloatVals(const std::string & key, FloatVec & values) const ;
     
     /** Adds all float values for the given key to values.
      *  Returns a reference to values for convenience.
      */
-    virtual  StringVec & getStringVals(const std::string & key, StringVec & values) const ;
+     StringVec & getStringVals(const std::string & key, StringVec & values) const ;
     
     /** Returns a list of all keys of integer parameters.
      */
-    virtual const StringVec & getIntKeys( StringVec & keys) const  ;
+    const StringVec & getIntKeys( StringVec & keys) const  ;
 
     /** Returns a list of all keys of float parameters.
      */
-    virtual const StringVec & getFloatKeys(StringVec & keys)  const ;
+    const StringVec & getFloatKeys(StringVec & keys)  const ;
 
     /** Returns a list of all keys of string parameters.
      */
-    virtual const StringVec & getStringKeys(StringVec & keys)  const ;
+    const StringVec & getStringKeys(StringVec & keys)  const ;
     
     /** The number of integer values stored for this key.
      */ 
-    virtual int getNInt(const std::string & key) const ;
+    int getNInt(const std::string & key) const ;
     
     /** The number of float values stored for this key.
      */ 
-    virtual int getNFloat(const std::string & key) const ;
+    int getNFloat(const std::string & key) const ;
     
     /** The number of string values stored for this key.
      */ 
-    virtual int getNString(const std::string & key) const ;
+    int getNString(const std::string & key) const ;
     
     /** Set integer value for the given key.
      */
-    virtual void setValue(const std::string & key, int value) ;
+    void setValue(const std::string & key, int value) ;
 
     /** Set float value for the given key.
      */
-    virtual void setValue(const std::string & key, float value) ;
+    void setValue(const std::string & key, float value) ;
 
     /** Set string value for the given key.
      */
-    virtual void setValue(const std::string & key, const std::string & value) ;
+    void setValue(const std::string & key, const std::string & value) ;
 
     /** Set integer values for the given key.
      */
-    virtual void setValues(const std::string & key, const IntVec & values);
+    void setValues(const std::string & key, const IntVec & values);
 
     /** Set float values for the given key.
      */
-    virtual void setValues(const std::string & key, const FloatVec & values);
+    void setValues(const std::string & key, const FloatVec & values);
 
     /** Set string values for the given key.
      */
-    virtual void setValues(const std::string & key, const StringVec & values);
+    void setValues(const std::string & key, const StringVec & values);
 
     /// erase all elements
     void clear() {

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -118,9 +118,9 @@ namespace podio {
 
   protected:
 
-    mutable IntMap _intMap{} ;
-    mutable FloatMap _floatMap{} ;
-    mutable StringMap _stringMap{} ;
+    IntMap _intMap{} ;
+    FloatMap _floatMap{} ;
+    StringMap _stringMap{} ;
     
   }; // class
 } // namespace podio

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -11,10 +11,6 @@ namespace podio {
   typedef std::vector<int> IntVec ;
   typedef std::vector<float> FloatVec ;
   typedef std::vector<std::string> StringVec ;
-  typedef std::map< std::string, IntVec >    IntMap ;
-  typedef std::map< std::string, FloatVec >  FloatMap ;
-  typedef std::map< std::string, StringVec > StringMap ;
-  
 
   /** GenericParameters objects allow to store generic named parameters of type
    *  int, float and string or vectors of these types. 
@@ -27,6 +23,14 @@ namespace podio {
    */
   
   class GenericParameters {
+  public:
+    template<typename T>
+    using MapType = std::map<std::string, std::vector<T>>;
+
+  private:
+    using IntMap = MapType<int>;
+    using FloatMap = MapType<float>;
+    using StringMap = MapType<std::string>;
 
   public: 
     
@@ -121,7 +125,7 @@ namespace podio {
     IntMap _intMap{} ;
     FloatMap _floatMap{} ;
     StringMap _stringMap{} ;
-    
+
   }; // class
 } // namespace podio
 #endif

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -7,22 +7,22 @@ namespace podio{
 
   int GenericParameters::getIntVal(const std::string & key) const {
     
-    IntMap::iterator it = _intMap.find( key ) ;
+    const auto it = _intMap.find( key ) ;
 
     if( it == _intMap.end() )  return 0 ;
 
-    IntVec &  iv =  it->second ;
+    const auto &  iv =  it->second ;
 
     return iv[0] ;
   }
 
   float GenericParameters::getFloatVal(const std::string & key) const {
 
-    FloatMap::iterator it = _floatMap.find( key ) ;
+    const auto it = _floatMap.find( key ) ;
 
     if( it == _floatMap.end() )  return 0 ;
 
-    FloatVec &  fv =  it->second ;
+    const auto &  fv =  it->second ;
 
     return fv[0] ;
   }
@@ -31,18 +31,18 @@ namespace podio{
 
     static std::string empty("") ;
     
-    StringMap::iterator it = _stringMap.find( key ) ;
+    const auto it = _stringMap.find( key ) ;
     
     if( it == _stringMap.end() )  return empty ;
     
-    StringVec &  sv =  it->second ;
+    const auto &  sv =  it->second ;
     
     return sv[0] ;
   }
 
   IntVec & GenericParameters::getIntVals(const std::string & key, IntVec & values) const {
 
-    IntMap::iterator it = _intMap.find( key ) ;
+    const auto it = _intMap.find( key ) ;
 
     if( it != _intMap.end() ) {
       values.insert( values.end() , it->second.begin() , it->second.end() ) ;
@@ -53,7 +53,7 @@ namespace podio{
 
   FloatVec & GenericParameters::getFloatVals(const std::string & key, FloatVec & values) const {
 
-    FloatMap::iterator it = _floatMap.find( key ) ;
+    const auto it = _floatMap.find( key ) ;
 
     if( it != _floatMap.end() ) {
       values.insert( values.end() , it->second.begin() , it->second.end() ) ;
@@ -63,7 +63,7 @@ namespace podio{
 
   StringVec & GenericParameters::getStringVals(const std::string & key, StringVec & values) const {
 
-    StringMap::iterator it = _stringMap.find( key ) ;
+    const auto it = _stringMap.find( key ) ;
 
     if( it != _stringMap.end() ) {
       values.insert( values.end() , it->second.begin() , it->second.end() ) ;
@@ -98,7 +98,7 @@ namespace podio{
   
   int GenericParameters::getNInt(const std::string & key) const {
 
-    IntMap::iterator it = _intMap.find( key ) ;
+    const auto it = _intMap.find( key ) ;
 
     if( it == _intMap.end() )
       return 0 ;
@@ -108,7 +108,7 @@ namespace podio{
 
   int GenericParameters::getNFloat(const std::string & key) const {
 
-    FloatMap::iterator it = _floatMap.find( key ) ;
+    const auto it = _floatMap.find( key ) ;
 
     if( it == _floatMap.end() )  
       return 0 ;
@@ -118,7 +118,7 @@ namespace podio{
 
   int GenericParameters::getNString(const std::string & key) const {
 
-    StringMap::iterator it = _stringMap.find( key ) ;
+    const auto it = _stringMap.find( key ) ;
 
     if( it == _stringMap.end() )  
       return 0 ;

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -4,126 +4,94 @@
 
 namespace podio{
 
+  template<typename T>
+  T getValFromMap(const GenericParameters::MapType<T>& map, const std::string& key) {
+    const auto it = map.find(key);
+    if (it == map.end()) return T{};
+    const auto& iv = it->second;
+    return iv[0];
+  }
+
+  // overload for string such that return by const ref is preferred
+  const std::string& getValFromMap(const GenericParameters::MapType<std::string>& map, const std::string& key) {
+    static const std::string empty("");
+    auto it = map.find(key);
+    if (it == map.end()) return empty;
+    const auto& iv = it->second;
+    return iv[0];
+  }
 
   int GenericParameters::getIntVal(const std::string & key) const {
-    
-    const auto it = _intMap.find( key ) ;
-
-    if( it == _intMap.end() )  return 0 ;
-
-    const auto &  iv =  it->second ;
-
-    return iv[0] ;
+    return getValFromMap(_intMap, key);
   }
 
   float GenericParameters::getFloatVal(const std::string & key) const {
-
-    const auto it = _floatMap.find( key ) ;
-
-    if( it == _floatMap.end() )  return 0 ;
-
-    const auto &  fv =  it->second ;
-
-    return fv[0] ;
+    return getValFromMap(_floatMap, key);
   }
 
   const std::string & GenericParameters::getStringVal(const std::string & key) const {
+    return getValFromMap(_stringMap, key);
+  }
 
-    static std::string empty("") ;
-    
-    const auto it = _stringMap.find( key ) ;
-    
-    if( it == _stringMap.end() )  return empty ;
-    
-    const auto &  sv =  it->second ;
-    
-    return sv[0] ;
+  template<typename T>
+  std::vector<T>& fillValsFromMap(const GenericParameters::MapType<T>& map, const std::string& key, std::vector<T>& values) {
+    auto it = map.find(key);
+    if (it != map.end()) {
+      values.insert(values.end(), it->second.begin(), it->second.end());
+    }
+    return values;
   }
 
   IntVec & GenericParameters::getIntVals(const std::string & key, IntVec & values) const {
-
-    const auto it = _intMap.find( key ) ;
-
-    if( it != _intMap.end() ) {
-      values.insert( values.end() , it->second.begin() , it->second.end() ) ;
-    }
-
-    return values ;
+    return fillValsFromMap(_intMap, key, values);
   }
 
   FloatVec & GenericParameters::getFloatVals(const std::string & key, FloatVec & values) const {
-
-    const auto it = _floatMap.find( key ) ;
-
-    if( it != _floatMap.end() ) {
-      values.insert( values.end() , it->second.begin() , it->second.end() ) ;
-    }
-    return values ;
+    return fillValsFromMap(_floatMap, key, values);
   }
 
   StringVec & GenericParameters::getStringVals(const std::string & key, StringVec & values) const {
-
-    const auto it = _stringMap.find( key ) ;
-
-    if( it != _stringMap.end() ) {
-      values.insert( values.end() , it->second.begin() , it->second.end() ) ;
-    }
-    return values ;
+    return fillValsFromMap(_stringMap, key, values);
   }
 
+  template<typename T>
+  const StringVec& getKeys(const GenericParameters::MapType<T>& map, StringVec& keys) {
+    std::transform(map.begin(), map.end(), std::back_inserter(keys),
+                   [] (auto const& pair) { return pair.first; });
+    return keys;
+  }
 
   const StringVec & GenericParameters::getIntKeys(StringVec & keys) const  {
-
-    std::transform( _intMap.begin() , _intMap.end() , back_inserter( keys )  ,
-		[](auto const& pair){ return pair.first; }) ;
-
-    return keys ;
+    return getKeys(_intMap, keys);
   }
 
   const StringVec & GenericParameters::getFloatKeys(StringVec & keys) const  {
-    
-    std::transform( _floatMap.begin() , _floatMap.end() , back_inserter( keys )  ,
-		[](auto const& pair){ return pair.first; }) ;
-
-    return keys ;
+    return getKeys(_floatMap, keys);
   }
 
   const StringVec & GenericParameters::getStringKeys(StringVec & keys) const  {
-
-    std::transform( _stringMap.begin() , _stringMap.end() , back_inserter( keys ),
-		    [](auto const& pair){ return pair.first; }) ;
-		    
-    return keys ;
+    return getKeys(_stringMap, keys);
   }
-  
-  int GenericParameters::getNInt(const std::string & key) const {
 
-    const auto it = _intMap.find( key ) ;
-
-    if( it == _intMap.end() )
+  template<typename T>
+  int getStoredElements(const GenericParameters::MapType<T>& map, const std::string& key) {
+    auto it = map.find( key ) ;
+    if( it == map.end() )
       return 0 ;
     else
       return it->second.size() ;
+  }
+
+  int GenericParameters::getNInt(const std::string & key) const {
+    return getStoredElements(_intMap, key);
   }
 
   int GenericParameters::getNFloat(const std::string & key) const {
-
-    const auto it = _floatMap.find( key ) ;
-
-    if( it == _floatMap.end() )  
-      return 0 ;
-    else
-      return it->second.size() ;
+    return getStoredElements(_floatMap, key);
   }
 
   int GenericParameters::getNString(const std::string & key) const {
-
-    const auto it = _stringMap.find( key ) ;
-
-    if( it == _stringMap.end() )  
-      return 0 ;
-    else
-      return it->second.size() ;
+    return getStoredElements(_stringMap, key);
   }
 
   void GenericParameters::setValue(const std::string & key, int value){

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -4,9 +4,9 @@
     <class name="podio::IntVec"/>
     <class name="podio::FloatVec"/>
     <class name="podio::StringVec"/>
-    <class name="podio::IntMap"/>
-    <class name="podio::FloatMap"/>
-    <class name="podio::StringMap"/>
+    <class name="podio::GenericParameters::MapType<int>"/>
+    <class name="podio::GenericParameters::MapType<float>"/>
+    <class name="podio::GenericParameters::MapType<std::string>"/>
     <class name="std::map<int,podio::GenericParameters>"/>
     <class name="podio::CollectionBase"/>
     <class name="podio::CollectionIDTable">


### PR DESCRIPTION
BEGINRELEASENOTES
 - cleanup of `GenericParameters` for meta data
      - remove mutable from internal maps
ENDRELEASENOTES

By using a map<K, V>::const_iterator as return type from map::find()
there is no longer a need to mark the internal maps as mutable.

With these changes in place a refactoring to not have so much code repetition is almost trivial. I could do it in this PR, or it could be put up as a "good first issue" as we have discussed some time ago, if we still want to compile such a list to point newcomers to.