### PR TITLE
Fix a possible nullptr access in the Writers

### DIFF
--- a/include/podio/ASCIIWriter.h
+++ b/include/podio/ASCIIWriter.h
@@ -74,12 +74,12 @@ typedef std::map< std::string, ColWriterBase* > FunMap ;
   template<typename T>
   void ASCIIWriter::registerForWrite(const std::string& name){
     const T* tmp_coll(nullptr);
-    m_store->get(name, tmp_coll);
+    if(!m_store->get(name, tmp_coll)) {
+      std::cerr<<"no such collection to write, throw exception."<<std::endl;
+      return;
+    }
     T* coll = const_cast<T*>(tmp_coll);
 
-    if(coll==nullptr) {
-      std::cerr<<"no such collection to write, throw exception."<<std::endl;
-    }
     m_storedCollections.emplace_back(coll);
     m_collectionNames.emplace_back(name) ;
     m_map[ name ] = new ColWriter<T> ;

--- a/include/podio/ASCIIWriter.h
+++ b/include/podio/ASCIIWriter.h
@@ -46,7 +46,7 @@ typedef std::map< std::string, ColWriterBase* > FunMap ;
     ~ASCIIWriter();
 
     template<typename T>
-    void registerForWrite(const std::string& name);
+    bool registerForWrite(const std::string& name);
     void writeEvent();
     void finish();
 
@@ -72,17 +72,18 @@ typedef std::map< std::string, ColWriterBase* > FunMap ;
   //}
 
   template<typename T>
-  void ASCIIWriter::registerForWrite(const std::string& name){
+  bool ASCIIWriter::registerForWrite(const std::string& name){
     const T* tmp_coll(nullptr);
     if(!m_store->get(name, tmp_coll)) {
       std::cerr<<"no such collection to write, throw exception."<<std::endl;
-      return;
+      return false;
     }
     T* coll = const_cast<T*>(tmp_coll);
 
     m_storedCollections.emplace_back(coll);
     m_collectionNames.emplace_back(name) ;
     m_map[ name ] = new ColWriter<T> ;
+    return true;
   }
 
 } //namespace

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -23,7 +23,7 @@ namespace podio {
     ROOTWriter(const std::string& filename, EventStore* store);
     ~ROOTWriter();
 
-    void registerForWrite(const std::string& name);
+    bool registerForWrite(const std::string& name);
     void writeEvent();
     void finish();
 

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -50,11 +50,11 @@ namespace podio {
     m_file->Close();
   }
 
- void ROOTWriter::registerForWrite(const std::string& name){
+ bool ROOTWriter::registerForWrite(const std::string& name) {
     const podio::CollectionBase* tmp_coll(nullptr);
     if (!m_store->get(name, tmp_coll)) {
-      return;
       std::cerr << "no such collection to write, throw exception." << std::endl;
+      return false;
     }
 
     podio::CollectionBase* coll = const_cast<CollectionBase*>(tmp_coll);
@@ -84,6 +84,7 @@ namespace podio {
       }
     }
     m_storedCollections.emplace_back(coll);
+    return true;
  }
 
 } // namespace

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -52,40 +52,38 @@ namespace podio {
 
  void ROOTWriter::registerForWrite(const std::string& name){
     const podio::CollectionBase* tmp_coll(nullptr);
-    m_store->get(name, tmp_coll);
+    if (!m_store->get(name, tmp_coll)) {
+      return;
+      std::cerr << "no such collection to write, throw exception." << std::endl;
+    }
 
     podio::CollectionBase* coll = const_cast<CollectionBase*>(tmp_coll);
     std::string className( coll->getValueTypeName() ) ;
     std::string collClassName = "vector<"+className+"Data>";
 
-    if(coll==nullptr) {
-      std::cerr<<"no such collection to write, throw exception."<<std::endl;
-    }
-    else {
-      m_datatree->Branch(name.c_str(),  collClassName.c_str(), coll->getBufferAddress());
-      auto colls = coll->referenceCollections();
-      if (colls != nullptr){
+    m_datatree->Branch(name.c_str(),  collClassName.c_str(), coll->getBufferAddress());
+    auto colls = coll->referenceCollections();
+    if (colls != nullptr){
       int i = 0;
       for(auto& c : (*colls)){
         m_datatree->Branch((name+"#"+std::to_string(i)).c_str(),c);
         ++i;
       }
-      }
-// ---- vector members
-      auto vminfo = coll->vectorMembers();
-      if (vminfo != nullptr){
-      	int i = 0;
-      	for(auto& c : (*vminfo)){
-      	  std::string typeName = "vector<"+c.first+">" ;
-      	  void* add = c.second ;
-      	  m_datatree->Branch((name+"_"+std::to_string(i)).c_str(),
-      			     typeName.c_str(),
-      			     add);
-      	  ++i;
-      	}
-      }
-      m_storedCollections.emplace_back(coll);
     }
+// ---- vector members
+    auto vminfo = coll->vectorMembers();
+    if (vminfo != nullptr){
+      int i = 0;
+      for(auto& c : (*vminfo)){
+        std::string typeName = "vector<"+c.first+">" ;
+        void* add = c.second ;
+        m_datatree->Branch((name+"_"+std::to_string(i)).c_str(),
+                           typeName.c_str(),
+                           add);
+        ++i;
+      }
+    }
+    m_storedCollections.emplace_back(coll);
  }
 
 } // namespace


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a possible nullptr access in the Writers and make registerForWrite return a boolean to make it easier to check from the calling site.

ENDRELEASENOTES

Previously it was possible that `temp_coll` and subsequently `coll` are nullptrs if no collection is stored in the `EventStore` under the given name. A nullptr check was in place, but a few lines too late to actually catch it before the first dereference and additionally it didn't prevent any later dereferences and just printed an error message. Reusing the return value from `EventStore::get` makes it possible to omit the nullptr check completely.

To see whether the registering was successful, I have also changed the return value to `bool`. This shouldn't break anything, but allows to check it in the future.