### PR TITLE
Clear the data buffer after constructing the Objects in a collection

### DIFF
--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -150,6 +150,10 @@ void {{ collection_type }}::prepareAfterRead() {
     m_entries.emplace_back(obj);
     ++index;
   }
+
+  // at this point we are done with the I/O buffer and can safely clear it to not
+  // have a redundant (but now useless) copy of the data
+  m_data->clear();
   m_isValid = true;
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Reduce memory footprint by clearing intermediately used I/O buffers.

ENDRELEASENOTES

Since the data are copied into the Objs from the m_data buffer that is
filled by I/O there is no use to keep the second copy of the data around
any longer.

It would probably be possible to slightly change the layout of the `Obj` classes from using a `Data data` member (as value) to a `Data* data` member which could then point directly into the I/O buffer of the collections. We would then not need the copy of the data that is currently done in `prepareAfterRead`. Keeping track of the data would then be a bit more work as it is at the moment, but to the actual user classes this should be completely transparent. However, I am not actually sure how this would impact performance. Both for I/O and for later usage.

In any case this small fix here at least cleans up the I/O buffer after all its contents have been copied into the actual `Obj`s, which should improve the memory footprint. The factor by which it is improved depends on how many different relations a given datatype has.