### PR TITLE
Fix memory leaks in EventStore and Reader/Writer interplay

### DIFF
--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -4,9 +4,9 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <type_traits>
 #include <set>
 #include <iostream>
+#include <memory>
 
 // podio specific includes
 #include "podio/CollectionIDTable.h"
@@ -80,7 +80,7 @@ namespace podio {
     /// set the reader
     void setReader(IReader* reader);
 
-    CollectionIDTable* getCollectionIDTable() const {return m_table;};
+    CollectionIDTable* getCollectionIDTable() const { return m_table.get(); }
 
     virtual bool isValid() const final;
 
@@ -103,14 +103,14 @@ namespace podio {
     bool doGet(const std::string& name, CollectionBase*& collection, bool setReferences = true) const;
     /// check if a collection of given name already exists
     bool collectionRegistered(const std::string& name) const;
-    void setCollectionIDTable(CollectionIDTable* table){if (m_table!=nullptr) delete m_table; m_table=table;};
+    void setCollectionIDTable(CollectionIDTable* table) { m_table.reset(table); }
 
     // members
     mutable std::set<int> m_retrievedIDs;
     mutable CollContainer m_collections;
     mutable std::vector<CollectionBase*> m_cachedCollections;
     IReader* m_reader=nullptr;
-    CollectionIDTable* m_table;
+    std::unique_ptr<CollectionIDTable> m_table;
 
     mutable GenericParameters  m_evtMD ;
     mutable RunMDMap m_runMDMap ;

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -98,6 +98,7 @@ void {{ collection_type }}::clear() {
 {% endfor %}
 {% for member in VectorMembers %}
   m_vec_{{ member.name }}->clear();
+  for (auto& vec : m_vecs_{{ member.name }}) { delete vec; }
   m_vecs_{{ member.name }}.clear();
 
 {% endfor %}

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -91,7 +91,8 @@ namespace podio {
     if( m_reader != nullptr ){
       m_evtMD.clear() ;
       GenericParameters* tmp = m_reader->readEventMetaData() ;
-      m_evtMD = *tmp ;
+      m_evtMD = std::move(*tmp);
+      delete tmp;
     }
     return m_evtMD ;
   }
@@ -100,7 +101,8 @@ namespace podio {
 
     if( m_runMDMap.empty() && m_reader != nullptr ){
       RunMDMap* tmp = m_reader->readRunMetaData() ;
-      m_runMDMap = *tmp ;
+      m_runMDMap = std::move(*tmp) ;
+      delete tmp;
     }
     return m_runMDMap[ runID ] ;
   } ;
@@ -110,7 +112,8 @@ namespace podio {
 
     if( m_colMDMap.empty() && m_reader != nullptr ){
       ColMDMap* tmp = m_reader->readCollectionMetaData() ;
-      m_colMDMap = *tmp ;
+      m_colMDMap = std::move(*tmp) ;
+      delete tmp;
     }
     return m_colMDMap[ colID ] ;
   } ;


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the EventStore actually take ownership of the metadata passed to it by the readers. (see #139)
- Make the collections properly clean up data of VectorMembers (see #139)
- Fix small memory leak in the EventStore for the CollectionIDTable.

ENDRELEASENOTES

The `m_table` pointer to the collection ID table is not deleted in the deconstructor even though it is acquired via `new` in the constructor. Using a `unique_ptr` to make clear that the `EventStore` owns this table (which it seems to do at least following the logic in `setCollectionIDTable`)

Fixes #139 