### PR TITLE
update CI to use use newer LCG views

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -3,21 +3,38 @@ name: mac
 on: [push, pull_request]
 
 jobs:
-  test:
+  compile:
     runs-on: macos-10.15
+    strategy:
+      matrix:
+        LCG: ["LCG_98python3/x86_64-mac1015-clang110-opt","LCG_97apython3/x86_64-mac1015-clang110-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Download ROOT
+    - name: Install CVMFS
       run: |
-        curl -O https://lcd-data.web.cern.ch/lcd-data/ROOT/root_v6.20.02.macosx64-10.15-clang110_Xcode113_19D76.tar.gz
-        tar xf root_v6.20.02.macosx64-10.15-clang110_Xcode113_19D76.tar.gz
-        pip install -r requirements.txt
+        brew install ninja
+        brew cask install osxfuse
+        curl -L -o cvmfs-2.7.3.pkg https://ecsft.cern.ch/dist/cvmfs/cvmfs-2.7.3/cvmfs-2.7.3.pkg
+        sudo installer -package cvmfs-2.7.3.pkg -target /
+        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
+        sudo mv default.local /etc/cvmfs/default.local
+        sudo cvmfs_config setup
+        brew cask install gfortran
+        brew cask install xquartz
+    - name: Mount CVMFS
+      run: |
+        mkdir -p /Users/Shared/cvmfs/sft.cern.ch
+        mkdir -p /Users/Shared/cvmfs/geant4.cern.ch
+        sudo mount -t cvmfs sft.cern.ch /Users/Shared/cvmfs/sft.cern.ch
+        sudo mount -t cvmfs geant4.cern.ch /Users/Shared/cvmfs/geant4.cern.ch
+        ls /Users/Shared/cvmfs/sft.cern.ch
+        ls /Users/Shared/cvmfs/geant4.cern.ch
     - name: Compile and test
       run: |
-        source root/bin/thisroot.sh
+        source /Users/Shared/cvmfs/sft.cern.ch/lcg/views/${{ matrix.LCG }}/setup.sh
         mkdir build install
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
-        make -j4 --keep-going
-        make install
+        cmake  -GNinja -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
+        ninja -k 0
+        ninja install
         ctest --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         ls /cvmfs/geant4.cern.ch
     - name: Start container
       run: |
-        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d clicdp/cc7-lcg96b /bin/bash
+        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d ghcr.io/aidasoft/centos7:latest /bin/bash
     - name: Compile and test
       run: |
         docker exec CI_container /bin/bash -c "./Package/.github/scripts/compile_and_test.sh"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,11 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        LCG: ["LCG_96b/x86_64-centos7-gcc9-opt","LCG_96b/x86_64-centos7-gcc8-opt","LCG_96b/x86_64-centos7-clang8-opt","LCG_96bpython3/x86_64-centos7-gcc8-opt"]
+        LCG: ["LCG_96b/x86_64-centos7-gcc8-opt",
+              "LCG_97a/x86_64-centos7-gcc9-opt",
+              "LCG_98/x86_64-centos7-clang10-opt",
+              "LCG_98python3/x86_64-centos7-gcc9-opt",
+              "LCG_98python3/x86_64-centos7-gcc10-opt"]
     steps:
     - uses: actions/checkout@v2
     - name: Install CVMFS

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,21 +3,28 @@ name: ubuntu
 on: [push, pull_request]
 
 jobs:
-  test-ubuntu:
-    runs-on: ubuntu-latest
-    container: rootproject/root-ubuntu
+  test:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        LCG: ["LCG_98/x86_64-ubuntu1804-gcc7-opt", "LCG_98/x86_64-ubuntu1804-gcc8-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Dependencies
+    - name: Install CVMFS
       run: |
-        apt update
-        apt -y install python3-yaml python-is-python3 python3-pip
-        pip3 install -r requirements.txt
+        wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+        sudo dpkg -i cvmfs-release-latest_all.deb
+        sudo apt-get update
+        sudo apt-get install cvmfs cvmfs-config-default
+        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
+        sudo mkdir -p /etc/cvmfs
+        sudo mv default.local /etc/cvmfs/default.local
+        sudo cvmfs_config setup
+        ls /cvmfs/sft.cern.ch
+        ls /cvmfs/geant4.cern.ch
+    - name: Start container
+      run: |
+        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d ghcr.io/aidasoft/ubuntu18:latest /bin/bash
     - name: Compile and test
       run: |
-        mkdir build install
-        cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=../install
-        make -j `getconf _NPROCESSORS_ONLN`
-        make install
-        ctest --output-on-failure
+        docker exec CI_container /bin/bash -c "./Package/.github/scripts/compile_and_test.sh"


### PR DESCRIPTION
BEGINRELEASENOTES
- Update CI actions to use LCG 96, 97, 98 for mac, centos7 and ubuntu1804

ENDRELEASENOTES
Should resolve the issue caused by the update of the virtual enviroment #137 