### PR TITLE
Fix python bindings for root 6.22 and update CI

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -6,6 +6,7 @@ jobs:
   compile:
     runs-on: macos-10.15
     strategy:
+      fail-fast: false
       matrix:
         LCG: ["LCG_98python3/x86_64-mac1015-clang110-opt","LCG_97apython3/x86_64-mac1015-clang110-opt"]
     steps:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -3,21 +3,38 @@ name: mac
 on: [push, pull_request]
 
 jobs:
-  test:
+  compile:
     runs-on: macos-10.15
+    strategy:
+      matrix:
+        LCG: ["LCG_98python3/x86_64-mac1015-clang110-opt","LCG_97apython3/x86_64-mac1015-clang110-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Download ROOT
+    - name: Install CVMFS
       run: |
-        curl -O https://lcd-data.web.cern.ch/lcd-data/ROOT/root_v6.20.02.macosx64-10.15-clang110_Xcode113_19D76.tar.gz
-        tar xf root_v6.20.02.macosx64-10.15-clang110_Xcode113_19D76.tar.gz
-        pip install -r requirements.txt
+        brew install ninja
+        brew cask install osxfuse
+        curl -L -o cvmfs-2.7.3.pkg https://ecsft.cern.ch/dist/cvmfs/cvmfs-2.7.3/cvmfs-2.7.3.pkg
+        sudo installer -package cvmfs-2.7.3.pkg -target /
+        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
+        sudo mv default.local /etc/cvmfs/default.local
+        sudo cvmfs_config setup
+        brew cask install gfortran
+        brew cask install xquartz
+    - name: Mount CVMFS
+      run: |
+        mkdir -p /Users/Shared/cvmfs/sft.cern.ch
+        mkdir -p /Users/Shared/cvmfs/geant4.cern.ch
+        sudo mount -t cvmfs sft.cern.ch /Users/Shared/cvmfs/sft.cern.ch
+        sudo mount -t cvmfs geant4.cern.ch /Users/Shared/cvmfs/geant4.cern.ch
+        ls /Users/Shared/cvmfs/sft.cern.ch
+        ls /Users/Shared/cvmfs/geant4.cern.ch
     - name: Compile and test
       run: |
-        source root/bin/thisroot.sh
+        source /Users/Shared/cvmfs/sft.cern.ch/lcg/views/${{ matrix.LCG }}/setup.sh
         mkdir build install
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
-        make -j4 --keep-going
-        make install
+        cmake  -GNinja -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
+        ninja -k 0
+        ninja install
         ctest --output-on-failure

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,7 @@ jobs:
   python:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         LCG: ["LCG_96b/x86_64-centos7-gcc9-opt"]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         ls /cvmfs/geant4.cern.ch
     - name: Start container
       run: |
-        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d clicdp/cc7-lcg96b /bin/bash
+        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d ghcr.io/aidasoft/centos7:latest /bin/bash
     - name: Compile and test
       run: |
         docker exec CI_container /bin/bash -c "./Package/.github/scripts/compile_and_test.sh"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,11 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        LCG: ["LCG_96b/x86_64-centos7-gcc9-opt","LCG_96b/x86_64-centos7-gcc8-opt","LCG_96b/x86_64-centos7-clang8-opt","LCG_96bpython3/x86_64-centos7-gcc8-opt"]
+        LCG: ["LCG_96b/x86_64-centos7-gcc8-opt",
+              "LCG_97a/x86_64-centos7-gcc9-opt",
+              "LCG_98/x86_64-centos7-clang10-opt",
+              "LCG_98python3/x86_64-centos7-gcc9-opt",
+              "LCG_98python3/x86_64-centos7-gcc10-opt"]
     steps:
     - uses: actions/checkout@v2
     - name: Install CVMFS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         LCG: ["LCG_96b/x86_64-centos7-gcc8-opt",
               "LCG_97a/x86_64-centos7-gcc9-opt",

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,21 +3,28 @@ name: ubuntu
 on: [push, pull_request]
 
 jobs:
-  test-ubuntu:
-    runs-on: ubuntu-latest
-    container: rootproject/root-ubuntu
+  test:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        LCG: ["LCG_98/x86_64-ubuntu1804-gcc7-opt", "LCG_98/x86_64-ubuntu1804-gcc8-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Dependencies
+    - name: Install CVMFS
       run: |
-        apt update
-        apt -y install python3-yaml python-is-python3 python3-pip
-        pip3 install -r requirements.txt
+        wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+        sudo dpkg -i cvmfs-release-latest_all.deb
+        sudo apt-get update
+        sudo apt-get install cvmfs cvmfs-config-default
+        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
+        sudo mkdir -p /etc/cvmfs
+        sudo mv default.local /etc/cvmfs/default.local
+        sudo cvmfs_config setup
+        ls /cvmfs/sft.cern.ch
+        ls /cvmfs/geant4.cern.ch
+    - name: Start container
+      run: |
+        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d ghcr.io/aidasoft/ubuntu18:latest /bin/bash
     - name: Compile and test
       run: |
-        mkdir build install
-        cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=../install
-        make -j `getconf _NPROCESSORS_ONLN`
-        make install
-        ctest --output-on-failure
+        docker exec CI_container /bin/bash -c "./Package/.github/scripts/compile_and_test.sh"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         LCG: ["LCG_98/x86_64-ubuntu1804-gcc7-opt", "LCG_98/x86_64-ubuntu1804-gcc8-opt"]
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,22 @@ option(CREATE_DOC "Whether or not to create doxygen doc target." OFF)
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(ROOT REQUIRED COMPONENTS RIO Tree)
+
+# Check that root is compiled with a modern enough c++ standard
+get_target_property(ROOT_COMPILE_FEATURES ROOT::Core INTERFACE_COMPILE_FEATURES)
+if (NOT "cxx_std_17" IN_LIST ROOT_COMPILE_FEATURES)
+  message(FATAL_ERROR "You are trying to build podio against a version of ROOT that has not been built with a sufficient c++ standard. podio requires c++17")
+endif()
+# Also verify that it has been built against the same python version as we are
+# using (that is if ROOT gives us the necessary tools)
+if (${ROOT_VERSION} VERSION_GREATER_EQUAL 6.19)
+  set(Python_FIND_FRAMEWORK LAST)
+  find_package(Python COMPONENTS Development)
+  if (NOT ${Python_VERSION} EQUAL ${ROOT_PYTHON_VERSION})
+    message(WARNING "Python version used for buildig ROOT is different than the current python version: " ${ROOT_PYTHON_VERSION} " vs " ${Python_VERSION})
+  endif()
+endif()
+
 # ROOT only sets usage requirements from 6.14, so for
 # earlier versions need to hack in INTERFACE_INCLUDE_DIRECTORIES
 if(ROOT_VERSION VERSION_LESS 6.14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # HSF recommends 3.3 to support C/C++ compile features for C/C++11 across all
 # platforms
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.12)
 
 #--- Project name --------------------------------------------------------------
 project(podio)

--- a/python/EventStore.py
+++ b/python/EventStore.py
@@ -7,13 +7,6 @@ gSystem.Load("libpodioRootIO")  # noqa: E402
 from ROOT import podio
 
 
-def iterator(self):
-  '''dynamically added iterator'''
-  entries = self.size()
-  for entry in range(entries):
-    yield self.at(entry)
-
-
 def size(self):
   return self.size()
 
@@ -67,12 +60,15 @@ class EventStore(object):
        name: name of the collection in the podio root file.
     '''
     coll = self.current_store.get(name)
-    # adding iterator generator to be able to loop on the collection
-    coll.__iter__ = iterator
     # adding length function
     coll.__len__ = size
     # enabling the use of [] notation on the collection
-    coll.__getitem__ = getitem
+    # cppyy defines the __getitem__ method if the underlying c++ class has an operator[]
+    # method. For some reason they do not conform to the usual signature and only
+    # pass one argument to the function they call. Here we simply check if we have to
+    # define the __getitem__ for the collection.
+    if not hasattr(coll, '__getitem__'):
+      coll.__getitem__ = getitem
     return coll
 
   def isValid(self):


### PR DESCRIPTION
BEGINRELEASENOTES
- Update CI actions to use LCG 96, 97, 98 for mac, centos7 and ubuntu1804
- Make python bindings work with root 6.22 (and onwards)
- Make sure that root has been built with c++17 at the cmake stage
- Require at least CMake 3.12

ENDRELEASENOTES

For some reason cppyy seems to be calling the `__getitem__` method with
only one argument instead of the usual two. Starting from root 6.22 this
breaks our python access to the collections. By only overriding it if it
is not already defined we can get it to work with root <= 6.20 and root
> 6.22.

Also removed the `__iter__` overload, because that is not necessary to
loop over a collection, specifically because the iterator protocol would
also require a `__next__` (or `next` in python2) method for actually
advancing.

Fixes #137 