### PR TITLE
Generate an additional cmake lists file containing the generated source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ spack*
 # Tooling
 /.clangd/
 /compile_commands.json
+
+# Generated files
+*podio_generated_files.cmake

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -147,12 +147,17 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     ${podio_PYTHON_DIR}/podio_config_reader.py
   )
 
+  message(STATUS "Creating '${datamodel}' datamodel")
   # we need to boostrap the data model, so this has to be executed in the cmake run
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E echo "Creating \"${datamodel}\" data model"
     COMMAND python ${podio_PYTHON_DIR}/podio_class_generator.py ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE podio_generate_command_retval
     )
+
+  IF(NOT ${podio_generate_command_retval} EQUAL 0)
+    message(FATAL_ERROR "Could not generate datamodel '${datamodel}'. Check your definition in '${YAML_FILE}'")
+  ENDIF()
 
   # Get the generated headers and source files
   include(${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake)

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -142,6 +142,9 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
     ${YAML_FILE}
     ${PODIO_TEMPLATES}
+    ${podio_PYTHON_DIR}/podio_class_generator.py
+    ${podio_PYTHON_DIR}/generator_utils.py
+    ${podio_PYTHON_DIR}/podio_config_reader.py
   )
 
   # we need to boostrap the data model, so this has to be executed in the cmake run

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -134,6 +134,7 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     # At least build the ROOT selection.xml by default for now
     SET(ARG_IO_BACKEND_HANDLERS "ROOT")
   ENDIF()
+
   # we need to boostrap the data model, so this has to be executed in the cmake run
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E echo "Creating \"${datamodel}\" data model"
@@ -141,19 +142,18 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
-  file(GLOB headers ${ARG_OUTPUT_FOLDER}/${datamodel}/*.h)
-  file(GLOB sources ${ARG_OUTPUT_FOLDER}/src/*.cc)
-
-  set (${RETURN_HEADERS} ${headers} PARENT_SCOPE)
-  set (${RETURN_SOURCES} ${sources} PARENT_SCOPE)
-
   add_custom_target(create_${datamodel}
     COMMENT "Re-Creating \"${datamodel}\" data model"
     DEPENDS ${YAML_FILE}
-    BYPRODUCTS ${sources} ${headers}
+    BYPRODUCTS ${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake
     COMMAND python ${podio_PYTHON_DIR}/podio_class_generator.py --quiet ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
+
+  include(${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake)
+
+  set (${RETURN_HEADERS} ${headers} PARENT_SCOPE)
+  set (${RETURN_SOURCES} ${sources} PARENT_SCOPE)
 
 endfunction()
 

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -135,6 +135,15 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     SET(ARG_IO_BACKEND_HANDLERS "ROOT")
   ENDIF()
 
+  # Make sure that we re run the generation process everytime either the
+  # templates or the yaml file changes.
+  include(${podio_PYTHON_DIR}/templates/CMakeLists.txt)
+  set_property(
+    DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+    ${YAML_FILE}
+    ${PODIO_TEMPLATES}
+  )
+
   # we need to boostrap the data model, so this has to be executed in the cmake run
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E echo "Creating \"${datamodel}\" data model"
@@ -142,14 +151,7 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
-  add_custom_target(create_${datamodel}
-    COMMENT "Re-Creating \"${datamodel}\" data model"
-    DEPENDS ${YAML_FILE}
-    BYPRODUCTS ${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake
-    COMMAND python ${podio_PYTHON_DIR}/podio_class_generator.py --quiet ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
+  # Get the generated headers and source files
   include(${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake)
 
   set (${RETURN_HEADERS} ${headers} PARENT_SCOPE)

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals, absolute_import, print_function
 
 import os
-import errno
 import sys
 import subprocess
 from io import open
@@ -56,6 +55,24 @@ def get_clang_format():
     return []
 
 
+def write_file_if_changed(filename, content, force_write=False):
+  """Write the file contents only if it has changed or if the file does not exist
+  yet. Return whether the file has been written or not"""
+  try:
+    with open(filename, 'r') as f:
+      existing_content = f.read()
+      changed = existing_content != content
+  except FileNotFoundError:
+    changed = True
+
+  if changed or force_write:
+    with open(filename, 'w') as f:
+      f.write(content)
+    return True
+
+  return False
+
+
 class ClassGenerator(object):
   def __init__(self, yamlfile, install_dir, package_name, io_handlers, verbose, dryrun):
     self.install_dir = install_dir
@@ -85,6 +102,7 @@ class ClassGenerator(object):
 
     self.clang_format = []
     self.generated_files = []
+    self.any_changes = False
 
   def process(self):
     for name, component in self.reader.components.items():
@@ -134,22 +152,8 @@ class ClassGenerator(object):
         cfproc = subprocess.Popen(self.clang_format, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         content = cfproc.communicate(input=content.encode())[0].decode()
 
-      try:
-        with open(fullname, 'r') as f:
-          existing_content = f.read()
-          changed = existing_content != content
-
-      except EnvironmentError as e:
-        # If we deprecate python2 support, FileNotFoundError becomes available
-        # and this can be using it. For now we keep it compatible with both
-        # versions
-        if e.errno != errno.ENOENT:
-          raise
-        changed = True
-
-      if changed:
-        with open(fullname, 'w') as f:
-          f.write(content)
+      changed = write_file_if_changed(fullname, content)
+      self.any_changes = changed or self.any_changes
 
   @staticmethod
   def _get_filenames_templates(template_base, name):
@@ -385,29 +389,35 @@ class ClassGenerator(object):
     src_files = (f for f in self.generated_files if f.endswith('.cc'))
     xml_files = (f for f in self.generated_files if f.endswith('.xml'))
 
-    def _write_list(list_file, name, target_folder, files, comment):
+    def _write_list(name, target_folder, files, comment):
       """Write all files into a cmake variable using the target_folder as path to the
       file"""
-      list_file.write(f'# {comment}\n')
-      list_file.write(f'SET({name}\n')
+      list_cont = []
+
+      list_cont.append(f'# {comment}')
+      list_cont.append(f'SET({name}')
       for full_file in files:
         fname = os.path.basename(full_file)
-        list_file.write(f'  {os.path.join(target_folder, fname)}\n')
+        list_cont.append(f'  {os.path.join(target_folder, fname)}')
 
-      list_file.write(')\n')
+      list_cont.append(')')
+      list_cont.append(f'SET_PROPERTY(SOURCE ${{{name}}} PROPERTY GENERATED TRUE)\n')
 
-    with open(f'{self.install_dir}/podio_generated_files.cmake', 'w') as list_file:
-      list_file.write('# AUTOMATICALLY GENERATED FILE - DO NOT EDIT\n\n')
+      return '\n'.join(list_cont)
 
-      _write_list(list_file, 'headers', r'${ARG_OUTPUT_FOLDER}/${datamodel}',
-                  header_files, 'Generated header files')
+    full_contents = ['#-- AUTOMATICALLY GENERATED FILE - DO NOT EDIT -- \n']
+    full_contents.append(_write_list('headers', r'${ARG_OUTPUT_FOLDER}/${datamodel}',
+                                     header_files, 'Generated header files'))
 
-      _write_list(list_file, 'sources', r'${ARG_OUTPUT_FOLDER}/src',
-                  src_files, 'Generated source files')
+    full_contents.append(_write_list('sources', r'${ARG_OUTPUT_FOLDER}/src',
+                                     src_files, 'Generated source files'))
 
-      _write_list(list_file, 'selection_xml', r'${ARG_OUTPUT_FOLDER}/src',
-                  xml_files, 'Generated xml files')
+    full_contents.append(_write_list('selection_xml', r'${ARG_OUTPUT_FOLDER}/src',
+                                     xml_files, 'Generated xml files'))
 
+    write_file_if_changed(f'{self.install_dir}/podio_generated_files.cmake',
+                          '\n'.join(full_contents),
+                          self.any_changes)
 
   @staticmethod
   def _is_pod_type(members):

--- a/python/templates/CMakeLists.txt
+++ b/python/templates/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(PODIO_TEMPLATES
+  ${CMAKE_CURRENT_LIST_DIR}/Collection.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Collection.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/CollectionData.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/CollectionData.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Component.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/ConstObject.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/ConstObject.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Data.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Obj.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Object.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Object.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Obj.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/selection.xml.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/SIOBlock.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/SIOBlock.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/collections.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/declarations.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/implementations.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/iterator.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/sioblocks.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/utils.jinja2
+)


### PR DESCRIPTION
BEGINRELEASENOTES
- Generate an additional `podio_generated_files.cmake` file containing all generated source files as a `header` and `sources` list and make the code generation macro include this file to get the headers and source files.
  - Now only the files generated for the current settings are picked up by cmake
  - Makes it possible to have additional files in the folders where the generated files are placed, since these are no longer globbed over.

ENDRELEASENOTES

This now makes it possible to seamlessly switch between branches of podio that generate different files :)

The contents of the generated file are the following

```cmake
SET(headers
  # all header files in the format
  ${ARG_OUTPUT_FOLDER}/${datamodel}/FooObj.h
)
SET_PROPERTY(SOURCE ${headers} PROPERTY GENERATED TRUE)

SET(sources
  # All source files in the format
  ${ARG_OUTPUT_FOLDER}/src/FooObj.cc
)
SET_PROPERTY(SOURCE ${sources} PROPERTY GENERATED TRUE)


SET(selection_xml
  ${ARG_OUTPUT_FOLDER}/src/selection.xml
)
SET_PROPERTY(SOURCE ${selection_xml} PROPERTY GENERATED TRUE)
```

The `selection_xml` variable is not used at the moment, but since it is a generated file I put it there.