### PR TITLE
fix for macos: link edm-core library to edm-sioBlocks

### DIFF
--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -273,7 +273,7 @@ function(PODIO_ADD_SIO_IO_BLOCKS CORE_LIB HEADERS SOURCES)
   ENDIF()
 
   add_library(${CORE_LIB}SioBlocks SHARED ${SOURCES} ${HEADERS})
-  target_link_libraries(${CORE_LIB}SioBlocks PUBLIC podio::podio podio::podioSioIO)
+  target_link_libraries(${CORE_LIB}SioBlocks PUBLIC ${CORE_LIB} podio::podio podio::podioSioIO)
   target_include_directories(${CORE_LIB}SioBlocks PUBLIC
     $<BUILD_INTERFACE:${ARG_OUTPUT_FOLDER}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>


### PR DESCRIPTION

BEGINRELEASENOTES
- fix for MacOs when using SIO I/O with podio
      - need to link edm-core library to edm-sioBlocks library

ENDRELEASENOTES