### PR TITLE
[cmake] add find_package_handle_standard_args to podio config

### DIFF
--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -42,3 +42,7 @@ if(NOT TARGET podio::podio)
 endif()
 
 check_required_components(podio)
+
+get_property(TEST_PODIO_LIBRARY TARGET podio::podio PROPERTY LOCATION)
+find_package_handle_standard_args(podio DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_PODIO_LIBRARY)
+

--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -43,6 +43,8 @@ endif()
 
 check_required_components(podio)
 
+# Print the default "Found" message and check library location
+include(FindPackageHandleStandardArgs)
 get_property(TEST_PODIO_LIBRARY TARGET podio::podio PROPERTY LOCATION)
 find_package_handle_standard_args(podio DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_PODIO_LIBRARY)
 


### PR DESCRIPTION

BEGINRELEASENOTES
- [cmake] add find_package_handle_standard_args() to podio config

ENDRELEASENOTES

This PR will add the standard printout

```
  -- Found podio: /cvmfs/sw.hsf.org/spackages/linux-ubuntu20.04-broadwell/gcc-9.3.0/podio-0.12.0-4fjxdaczkubcuz5fb23uou2rbn3pj3i4/lib/cmake/podio/podioConfig.cmake
```
when downstream packages call `find_package(podio)` (unless QUIET is added). It's inspired by an issue in the edm4hep CI, which turned out to be due to the wrong podio install being picked up, which was not obvious from the build logs.