### PR TITLE
make EventStore non-copyable

### DIFF
--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -35,7 +35,9 @@ namespace podio {
   typedef std::map<int,GenericParameters>    ColMDMap;
 
   class EventStore : public ICollectionProvider, public IMetaDataProvider {
-
+    /// Make non-copyable
+    EventStore( const EventStore & ) = delete;
+    EventStore& operator=( const EventStore & ) = delete;
   public:
     /// Collection entry. Each collection is identified by a name
     typedef std::pair<std::string, CollectionBase*> CollPair;


### PR DESCRIPTION

BEGINRELEASENOTES
- Make EventStore non-copyable

ENDRELEASENOTES