### PR TITLE
rpath, linker, compiler flags and find python fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,22 +49,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 message(STATUS "Setting C++ standard: '${CMAKE_CXX_STANDARD}'.")
 
-if (${APPLE})
-    set(CPP_STANDARD_FLAGS "-std=c++${CMAKE_CXX_STANDARD}\ -stdlib=libc++")
-    set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CPP_STANDARD_FLAGS}")
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
 
+option(PODIO_SET_RPATH "Link libraries with built-in RPATH (run-time search path)" OFF)
+include(cmake/podioBuild.cmake)
+podio_set_compiler_flags()
+podio_set_rpath()
 
-# allow undefined symbols in shared library - needed for PythonEventStore/ROOTReader 
-#
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-    SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,dynamic_lookup")
-elseif ( ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" ))
-    SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--allow-shlib-undefined")
-else()
-    MESSAGE( WARNING "We do not test with the ${CMAKE_CXX_COMPILER_ID} compiler, use at your own discretion" )
-endif()
 
 #--- Declare options -----------------------------------------------------------
 option(CREATE_DOC "Whether or not to create doxygen doc target." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,15 +72,21 @@ get_target_property(ROOT_COMPILE_FEATURES ROOT::Core INTERFACE_COMPILE_FEATURES)
 if (NOT "cxx_std_17" IN_LIST ROOT_COMPILE_FEATURES)
   message(FATAL_ERROR "You are trying to build podio against a version of ROOT that has not been built with a sufficient c++ standard. podio requires c++17")
 endif()
-# Also verify that it has been built against the same python version as we are
-# using (that is if ROOT gives us the necessary tools)
-if (${ROOT_VERSION} VERSION_GREATER_EQUAL 6.19)
-  set(Python_FIND_FRAMEWORK LAST)
-  find_package(Python COMPONENTS Development)
-  if (NOT ${Python_VERSION} EQUAL ${ROOT_PYTHON_VERSION})
-    message(WARNING "Python version used for buildig ROOT is different than the current python version: " ${ROOT_PYTHON_VERSION} " vs " ${Python_VERSION})
-  endif()
-endif()
+#Check if Python version detected matches the version used to build ROOT
+SET(Python_FIND_FRAMEWORK LAST)
+IF((TARGET ROOT::PyROOT OR TARGET ROOT::ROOTTPython) AND ${ROOT_VERSION} VERSION_GREATER_EQUAL 6.19)
+  # cmake 3.17.1 and 3.17.2 don't include python patch level in PYTHON_VERSION
+  IF(CMAKE_VERSION VERSION_EQUAL 3.17.1 OR CMAKE_VERSION VERSION_EQUAL 3.17.2)
+    string(REGEX MATCH [23]\.[0-9]+ REQUIRE_PYTHON_VERSION ${ROOT_PYTHON_VERSION})
+  ELSE()
+    SET(REQUIRE_PYTHON_VERSION ${ROOT_PYTHON_VERSION})
+  ENDIF()
+  message( STATUS "Python version used for building ROOT ${ROOT_PYTHON_VERSION}" )
+  message( STATUS "Required python version ${REQUIRE_PYTHON_VERSION}")
+  FIND_PACKAGE(Python ${REQUIRE_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Development)
+ELSE()
+  FIND_PACKAGE(Python COMPONENTS Development)
+ENDIF()
 
 # ROOT only sets usage requirements from 6.14, so for
 # earlier versions need to hack in INTERFACE_INCLUDE_DIRECTORIES

--- a/cmake/podioBuild.cmake
+++ b/cmake/podioBuild.cmake
@@ -50,7 +50,7 @@ macro(podio_set_compiler_flags)
   endif()
 
   FOREACH( FLAG ${COMPILER_FLAGS} )
-    ## meed to replace the minus or plus signs from the variables, because it is passed
+    ## need to replace the minus or plus signs from the variables, because it is passed
     ## as a macro to g++ which causes a warning about no whitespace after macro
     ## definition
     STRING(REPLACE "-" "_" FLAG_WORD ${FLAG} )

--- a/cmake/podioBuild.cmake
+++ b/cmake/podioBuild.cmake
@@ -1,0 +1,92 @@
+#---------------------------------------------------------------------------------------------------
+#---podio_set_rpath
+#
+#  Set optional rpath on linux and mandatory rpath on mac
+#
+#---------------------------------------------------------------------------------------------------
+macro(podio_set_rpath)
+  #  When building, don't use the install RPATH already (but later on when installing)
+  set(CMAKE_SKIP_BUILD_RPATH FALSE)         # don't skip the full RPATH for the build tree
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) # use always the build RPATH for the build tree
+  set(CMAKE_MACOSX_RPATH TRUE)              # use RPATH for MacOSX
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) # point to directories outside the build tree to the install RPATH
+
+  # Check whether to add RPATH to the installation (the build tree always has the RPATH enabled)
+  if(APPLE)
+    set(CMAKE_INSTALL_NAME_DIR "@rpath")
+    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")    # self relative LIBDIR
+    # the RPATH to be used when installing, but only if it's not a system directory
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+    if("${isSystemDir}" STREQUAL "-1")
+      set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
+    endif("${isSystemDir}" STREQUAL "-1")
+  elseif(PODIO_SET_RPATH)
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIBDIR}") # install LIBDIR
+    # the RPATH to be used when installing, but only if it's not a system directory
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+    if("${isSystemDir}" STREQUAL "-1")
+      set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIBDIR}")
+    endif("${isSystemDir}" STREQUAL "-1")
+  else()
+    set(CMAKE_SKIP_INSTALL_RPATH TRUE)           # skip the full RPATH for the install tree
+  endif()
+endmacro(podio_set_rpath)
+
+#---------------------------------------------------------------------------------------------------
+#---podio_set_compiler_flags
+#
+#  Set compiler and linker flags
+#
+#---------------------------------------------------------------------------------------------------
+
+macro(podio_set_compiler_flags)
+  include(CheckCXXCompilerFlag)
+
+  SET(COMPILER_FLAGS -Wshadow -Wformat-security -Wno-long-long -Wdeprecated -fdiagnostics-color=auto -Wall -Wextra -pedantic -Weffc++)
+
+  # AppleClang/Clang specific warning flags
+  if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+    set ( COMPILER_FLAGS ${COMPILER_FLAGS} -Winconsistent-missing-override -Wheader-hygiene )
+  endif()
+
+  FOREACH( FLAG ${COMPILER_FLAGS} )
+    ## meed to replace the minus or plus signs from the variables, because it is passed
+    ## as a macro to g++ which causes a warning about no whitespace after macro
+    ## definition
+    STRING(REPLACE "-" "_" FLAG_WORD ${FLAG} )
+    STRING(REPLACE "+" "P" FLAG_WORD ${FLAG_WORD} )
+
+    CHECK_CXX_COMPILER_FLAG( "${FLAG}" CXX_FLAG_WORKS_${FLAG_WORD} )
+    IF( ${CXX_FLAG_WORKS_${FLAG_WORD}} )
+      message( STATUS "Adding ${FLAG} to CXX_FLAGS" )
+      SET ( CMAKE_CXX_FLAGS "${FLAG} ${CMAKE_CXX_FLAGS} ")
+    ELSE()
+      message( STATUS "NOT Adding ${FLAG} to CXX_FLAGS" )
+    ENDIF()
+  ENDFOREACH()
+  
+  # resolve which linker we use
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -Wl,--version OUTPUT_VARIABLE stdout ERROR_QUIET)
+  if("${stdout}" MATCHES "GNU ")
+    set(LINKER_TYPE "GNU")
+    message( STATUS "Detected GNU compatible linker" )
+  else()
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -Wl,-v ERROR_VARIABLE stderr )
+    if(("${stderr}" MATCHES "PROGRAM:ld") AND ("${stderr}" MATCHES "PROJECT:ld64"))
+      set(LINKER_TYPE "APPLE")
+      message( STATUS "Detected Apple linker" )
+    else()
+      set(LINKER_TYPE "unknown")
+      message( STATUS "Detected unknown linker" )
+    endif()
+  endif()
+
+  if("${LINKER_TYPE}" STREQUAL "APPLE")
+    SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,dynamic_lookup")
+  elseif("${LINKER_TYPE}" STREQUAL "GNU")
+    SET ( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--allow-shlib-undefined")
+  else()
+    MESSAGE( WARNING "No known linker (GNU or Apple) has been detected, pass no flags to linker" )
+  endif()
+
+endmacro(podio_set_compiler_flags)


### PR DESCRIPTION
resolves #145 
resolves #76
BEGINRELEASENOTES
- Set rpath for macOS and externalize compiler and linker flags
- Search for the same version of python as was used for building ROOT

ENDRELEASENOTES

the compiler flags are only a suggestion