### PR TITLE
disable explicit assignment operator - implement #111

### DIFF
--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -54,7 +54,8 @@ public:
   using const_iterator = const {{ class.bare_type }}CollectionIterator;
 
   {{ class.bare_type }}Collection();
-//  {{ class.bare_type }}Collection(const {{ class.bare_type}}Collection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
+  //{{ class.bare_type }}Collection(const {{ class.bare_type}}Collection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
+  {{ class.bare_type }}Collection& operator=(const {{ class.bare_type}}Collection& ) = delete;
 //  {{ class.bare_type }}Collection({{ class.bare_type }}Vector* data, int collectionID);
   ~{{ class.bare_type }}Collection();
 


### PR DESCRIPTION
This disables the explicit assignment operator to enforce copy
constraints.  The copy constructor is not disabled since this
interferes with root adapters.



BEGINRELEASENOTES

- Disable operator = for collections so that it maintains one copy of collections, fixes #111

ENDRELEASENOTES