### PR TITLE
make readers/writers non-copyable

### DIFF
--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -35,6 +35,11 @@ class ROOTReader : public IReader {
   public:
     ROOTReader() : m_eventNumber(0) {}
     ~ROOTReader();
+
+    //non-copyable
+    ROOTReader(const ROOTReader &) = delete;
+    ROOTReader& operator=(const ROOTReader &) = delete;
+
     void openFile(const std::string& filename) override;
     void openFiles(const std::vector<std::string>& filenames);
     void closeFile() override;

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -34,6 +34,11 @@ namespace podio {
   public:
     SIOReader();
     ~SIOReader();
+
+    //make non-copyable
+    SIOReader(const SIOReader &) = delete;
+    SIOReader& operator=(const SIOReader &) = delete;
+
     void openFile(const std::string& filename) override;
     void closeFile() override;
 


### PR DESCRIPTION
Since the readers/writers have pointers to internal state,
they should not be copied.



BEGINRELEASENOTES
- Readers/writers are now noncopyable
ENDRELEASENOTES