### PR TITLE
Add empty member function to RelationRange

### DIFF
--- a/include/podio/RelationRange.h
+++ b/include/podio/RelationRange.h
@@ -13,6 +13,9 @@ namespace podio {
   class RelationRange {
   public:
     using ConstIteratorType = typename std::vector<ReferenceType>::const_iterator;
+
+    RelationRange() = delete;
+
     RelationRange(ConstIteratorType begin, ConstIteratorType end) : m_begin(begin), m_end(end) {}
 
     /// begin of the range (necessary for range-based for loop)
@@ -21,6 +24,8 @@ namespace podio {
     ConstIteratorType end() const { return m_end; }
     /// convenience overload for size
     size_t size() const { return std::distance(m_begin, m_end); }
+    /// convenience overload to check if the range is empty
+    bool empty() const { return m_begin == m_end; }
   private:
     ConstIteratorType m_begin;
     ConstIteratorType m_end;

--- a/tests/relation_range.cpp
+++ b/tests/relation_range.cpp
@@ -129,7 +129,7 @@ void testExampleWithVectorMember()
   ex.addcount(2);
   ex.addcount(10);
 
-  ASSERT_EQUAL(ex.count().size(), 3, "vector member ragnehas wrong size");
+  ASSERT_EQUAL(ex.count().size(), 3, "vector member range has wrong size");
 
   std::vector<int> expected = {1, 2, 10};
   int index = 0;
@@ -160,6 +160,9 @@ void testExampleReferencingType()
 
     index++;
   }
+
+  ASSERT_CONDITION(!ex.Refs().empty(), "Relation range of element with relations should not be empty");
+  ASSERT_CONDITION(ex1.Refs().empty(), "Relation range of element with no relations should be empty");
 }
 
 void testWithIO()


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a convenience `RelationRange::emtpy` function for easily checking whether a range is empty.

ENDRELEASENOTES

The same could be achieved with `size() != 0`, but in order to be somewhat similar to the STL, I think an `empty()` function is nice to have and also allows for (an ever so) slightly more efficient implementation. 