### PR TITLE
Use cvmfs github action

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -11,25 +11,14 @@ jobs:
         LCG: ["LCG_98python3/x86_64-mac1015-clang110-opt","LCG_97apython3/x86_64-mac1015-clang110-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Install CVMFS
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+      with:
+        cvmfs_repositories: 'sft.cern.ch,geant4.cern.ch'
+    - name: Install LCG dependencies
       run: |
         brew install ninja
-        brew cask install osxfuse
-        curl -L -o cvmfs-2.7.3.pkg https://ecsft.cern.ch/dist/cvmfs/cvmfs-2.7.3/cvmfs-2.7.3.pkg
-        sudo installer -package cvmfs-2.7.3.pkg -target /
-        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
-        sudo mv default.local /etc/cvmfs/default.local
-        sudo cvmfs_config setup
         brew cask install gfortran
         brew cask install xquartz
-    - name: Mount CVMFS
-      run: |
-        mkdir -p /Users/Shared/cvmfs/sft.cern.ch
-        mkdir -p /Users/Shared/cvmfs/geant4.cern.ch
-        sudo mount -t cvmfs sft.cern.ch /Users/Shared/cvmfs/sft.cern.ch
-        sudo mount -t cvmfs geant4.cern.ch /Users/Shared/cvmfs/geant4.cern.ch
-        ls /Users/Shared/cvmfs/sft.cern.ch
-        ls /Users/Shared/cvmfs/geant4.cern.ch
     - name: Compile and test
       run: |
         source /Users/Shared/cvmfs/sft.cern.ch/lcg/views/${{ matrix.LCG }}/setup.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,21 +11,10 @@ jobs:
         LCG: ["LCG_96b/x86_64-centos7-gcc9-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Install CVMFS
-      run: |
-        wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
-        sudo dpkg -i cvmfs-release-latest_all.deb
-        sudo apt-get update
-        sudo apt-get install cvmfs cvmfs-config-default
-        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
-        sudo mkdir -p /etc/cvmfs
-        sudo mv default.local /etc/cvmfs/default.local
-        sudo cvmfs_config setup
-        ls /cvmfs/sft.cern.ch
-        ls /cvmfs/geant4.cern.ch
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
     - name: Start container
       run: |
-        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d clicdp/cc7-lcg96b /bin/bash
+        docker run -it --privileged --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash
     - name: Run Python Checks
       run: |
         docker exec CI_container /bin/bash -c "./Package/.github/scripts/runPythonChecks.sh"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   python:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,21 +15,10 @@ jobs:
               "LCG_98python3/x86_64-centos7-gcc10-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Install CVMFS
-      run: |
-        wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
-        sudo dpkg -i cvmfs-release-latest_all.deb
-        sudo apt-get update
-        sudo apt-get install cvmfs cvmfs-config-default
-        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
-        sudo mkdir -p /etc/cvmfs
-        sudo mv default.local /etc/cvmfs/default.local
-        sudo cvmfs_config setup
-        ls /cvmfs/sft.cern.ch
-        ls /cvmfs/geant4.cern.ch
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
     - name: Start container
       run: |
-        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d ghcr.io/aidasoft/centos7:latest /bin/bash
+        docker run -it --privileged --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash
     - name: Compile and test
       run: |
         docker exec CI_container /bin/bash -c "./Package/.github/scripts/compile_and_test.sh"

--- a/.github/workflows/test_with_sio.yml
+++ b/.github/workflows/test_with_sio.yml
@@ -10,22 +10,10 @@ jobs:
         ILCSoft: ["lcg/97/nightly/x86_64-centos7-gcc9-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Install CVMFS
-      run: |
-        wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
-        sudo dpkg -i cvmfs-release-latest_all.deb
-        sudo apt-get update
-        sudo apt-get install cvmfs cvmfs-config-default
-        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
-        sudo mkdir -p /etc/cvmfs
-        sudo mv default.local /etc/cvmfs/default.local
-        sudo cvmfs_config setup
-        ls /cvmfs/sft.cern.ch
-        ls /cvmfs/geant4.cern.ch
-        ls /cvmfs/clicdp.cern.ch
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
     - name: Start container
       run: |
-        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.ILCSoft }} -e USE_SIO=ON -v /cvmfs:/cvmfs -d clicdp/cc7-lcg /bin/bash
+        docker run -it --privileged --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.ILCSoft }} -e USE_SIO=ON -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash
     - name: Compile and test
       run: |
         docker exec CI_container /bin/bash -c "./Package/.github/scripts/compile_and_test.sh"

--- a/.github/workflows/test_with_sio.yml
+++ b/.github/workflows/test_with_sio.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ILCSoft: ["lcg/97/nightly/x86_64-centos7-gcc9-opt"]

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,21 +11,10 @@ jobs:
         LCG: ["LCG_98/x86_64-ubuntu1804-gcc7-opt", "LCG_98/x86_64-ubuntu1804-gcc8-opt"]
     steps:
     - uses: actions/checkout@v2
-    - name: Install CVMFS
-      run: |
-        wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
-        sudo dpkg -i cvmfs-release-latest_all.deb
-        sudo apt-get update
-        sudo apt-get install cvmfs cvmfs-config-default
-        wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
-        sudo mkdir -p /etc/cvmfs
-        sudo mv default.local /etc/cvmfs/default.local
-        sudo cvmfs_config setup
-        ls /cvmfs/sft.cern.ch
-        ls /cvmfs/geant4.cern.ch
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
     - name: Start container
       run: |
-        docker run -it --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs -d ghcr.io/aidasoft/ubuntu18:latest /bin/bash
+        docker run -it --privileged --name CI_container -v /home/runner/work/podio/podio:/Package -e VIEW=${{ matrix.LCG }} -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/ubuntu18:latest /bin/bash
     - name: Compile and test
       run: |
         docker exec CI_container /bin/bash -c "./Package/.github/scripts/compile_and_test.sh"


### PR DESCRIPTION
- Update actions to use `cvmfs-contrib/github-action-cvmfs` action to install cvmfs
- Don't mount each repo separately into container but use `-v /cvmfs:/cvmfs:shared`

Fixes #163