### PR TITLE
Fix compiler warnings

### DIFF
--- a/.github/scripts/compile_and_test.sh
+++ b/.github/scripts/compile_and_test.sh
@@ -13,7 +13,7 @@ cd /Package
 source init.sh
 mkdir build install
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -DENABLE_SIO=${ENABLE_SIO} -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja .. && \
+cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -DENABLE_SIO=${ENABLE_SIO} -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror" -G Ninja .. && \
 ninja -k0 && \
 ninja install && \
 ctest --output-on-failure

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -24,7 +24,7 @@ jobs:
         source /Users/Shared/cvmfs/sft.cern.ch/lcg/views/${{ matrix.LCG }}/setup.sh
         mkdir build install
         cd build
-        cmake  -GNinja -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
+        cmake  -GNinja -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror" ..
         ninja -k 0
         ninja install
         ctest --output-on-failure

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -80,6 +80,11 @@ function(PODIO_GENERATE_DICTIONARY dictionary)
     target_sources(${dictionary} PRIVATE ${gensrcdict})
   ENDIF()
   set(gensrcdict ${dictionary}.cxx PARENT_SCOPE)
+  set_source_files_properties(${gensrcdict}
+    PROPERTIES
+    GENERATED TRUE
+    COMPILE_FLAGS "-Wno-overlength-strings"
+    )
 
   #---roottest compability---------------------------------
   if(CMAKE_ROOTTEST_DICT)

--- a/include/podio/ASCIIWriter.h
+++ b/include/podio/ASCIIWriter.h
@@ -24,6 +24,7 @@ namespace podio {
 
   struct ColWriterBase {
     virtual void writeCollection(CollectionBase*, std::ostream& )=0 ;
+    virtual ~ColWriterBase() = default;
   } ;
   
   template <class T>

--- a/include/podio/ASCIIWriter.h
+++ b/include/podio/ASCIIWriter.h
@@ -45,6 +45,10 @@ typedef std::map< std::string, ColWriterBase* > FunMap ;
     ASCIIWriter(const std::string& filename, EventStore* store);
     ~ASCIIWriter();
 
+    // non-copyable
+    ASCIIWriter(const ASCIIWriter&) = delete;
+    ASCIIWriter& operator=(const ASCIIWriter&) = delete;
+
     template<typename T>
     bool registerForWrite(const std::string& name);
     void writeEvent();

--- a/include/podio/ASCIIWriter.h
+++ b/include/podio/ASCIIWriter.h
@@ -14,7 +14,6 @@
 namespace podio {
 
   class CollectionBase;
-  class Registry;
 
   //std::function<void(CollectionBase*)> fun ;
   //std::map< std::string, std::function<void(CollectionBase*)>* > FunMap ;
@@ -59,9 +58,9 @@ typedef std::map< std::string, ColWriterBase* > FunMap ;
 
     std::ofstream* m_file;
 
-    std::vector<CollectionBase*> m_storedCollections;
-    std::vector<std::string> m_collectionNames ;
-    FunMap m_map ;
+    std::vector<CollectionBase*> m_storedCollections{};
+    std::vector<std::string> m_collectionNames{};
+    FunMap m_map{};
   };
 
   // int main () {

--- a/include/podio/BenchmarkRecorder.h
+++ b/include/podio/BenchmarkRecorder.h
@@ -22,6 +22,7 @@ public:
   // Avoid some possible issues that could arise from copying by simply
   // disallowing it
   BenchmarkRecorderTree(const BenchmarkRecorderTree&) = delete;
+  BenchmarkRecorderTree& operator=(const BenchmarkRecorderTree&) = delete;
 
   BenchmarkRecorderTree(TFile* recFile, const std::string& name, const std::vector<std::string>& steps) :
     m_stepNames(steps), m_stepTimes(steps.size()) {
@@ -62,6 +63,9 @@ public:
   BenchmarkRecorder(const std::string& recFileName="podio_benchmark_file.root") {
     m_recordFile = new TFile(recFileName.c_str(), "recreate");
   }
+
+  BenchmarkRecorder(const BenchmarkRecorder&) = delete;
+  BenchmarkRecorder operator=(const BenchmarkRecorder&) = delete;
 
   ~BenchmarkRecorder() {
     for (auto& [name, tree] : m_recordTrees) {

--- a/include/podio/BenchmarkRecorder.h
+++ b/include/podio/BenchmarkRecorder.h
@@ -98,7 +98,7 @@ public:
 private:
   TFile* m_recordFile{nullptr};
   // Stable references outside!!
-  std::deque<std::pair<std::string, BenchmarkRecorderTree>> m_recordTrees;
+  std::deque<std::pair<std::string, BenchmarkRecorderTree>> m_recordTrees{};
 };
 
 }

--- a/include/podio/BenchmarkRecorder.h
+++ b/include/podio/BenchmarkRecorder.h
@@ -68,8 +68,8 @@ public:
   BenchmarkRecorder operator=(const BenchmarkRecorder&) = delete;
 
   ~BenchmarkRecorder() {
-    for (auto& [name, tree] : m_recordTrees) {
-      tree.Write();
+    for (auto& tree : m_recordTrees) {
+      tree.second.Write();
     }
     m_recordFile->Write("", TObject::kWriteDelete);
     m_recordFile->Close();

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -13,15 +13,8 @@ namespace podio {
   class ICollectionProvider;
   class CollectionBase;
 
-  typedef std::vector<std::pair<std::string,podio::CollectionBase*>> CollRegistry;
-  typedef std::vector<std::vector<podio::ObjectID>*> CollRefCollection;
-  typedef std::vector<std::pair<std::string,void*>> VectorMembersInfo;
-
-  //class CollectionBuffer {
-  //public:
-  //  void* data;
-  //  CollRefCollection* references;
-  //};
+  using CollRefCollection = std::vector<std::vector<podio::ObjectID>*>;
+  using VectorMembersInfo = std::vector<std::pair<std::string, void*>>;
 
   class CollectionBase {
   public:

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -52,7 +52,7 @@ namespace podio {
     virtual std::string getValueTypeName() const = 0;
 
     /// destructor
-    virtual ~CollectionBase(){};
+    virtual ~CollectionBase() = default;
 
     /// clear the collection and all internal states
     virtual void clear() = 0 ;

--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -12,13 +12,11 @@ namespace podio {
   public:
 
     /// default constructor
-    CollectionIDTable() :
-      m_collectionIDs(), m_names()
-    {};
+    CollectionIDTable() = default;
 
     /// constructor from existing ID:name mapping
-    CollectionIDTable(const std::vector<int> ids, std::vector<std::string> names) :
-      m_collectionIDs(ids), m_names(names)
+    CollectionIDTable(std::vector<int>&& ids, std::vector<std::string>&& names) :
+      m_collectionIDs(std::move(ids)), m_names(std::move(names))
     {};
 
     /// return collection ID for given name
@@ -44,9 +42,9 @@ namespace podio {
     void print() const;
 
   private:
-    std::vector<int>              m_collectionIDs;
-    std::vector<std::string>      m_names;
-    mutable std::mutex  m_mutex;
+    std::vector<int>              m_collectionIDs{};
+    std::vector<std::string>      m_names{};
+    mutable std::mutex  m_mutex{};
   };
 
 

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -108,15 +108,15 @@ namespace podio {
     void setCollectionIDTable(CollectionIDTable* table) { m_table.reset(table); }
 
     // members
-    mutable std::set<int> m_retrievedIDs;
-    mutable CollContainer m_collections;
-    mutable std::vector<CollectionBase*> m_cachedCollections;
-    IReader* m_reader=nullptr;
+    mutable std::set<int> m_retrievedIDs{};
+    mutable CollContainer m_collections{};
+    mutable std::vector<CollectionBase*> m_cachedCollections{};
+    IReader* m_reader{nullptr};
     std::unique_ptr<CollectionIDTable> m_table;
 
-    mutable GenericParameters  m_evtMD ;
-    mutable RunMDMap m_runMDMap ;
-    mutable ColMDMap m_colMDMap ;
+    mutable GenericParameters m_evtMD{};
+    mutable RunMDMap m_runMDMap{};
+    mutable ColMDMap m_colMDMap{};
   };
 
 

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -59,7 +59,7 @@ namespace podio {
 
     /// fast access to cached collections
     CollectionBase* getFast(int id) const{
-      return ( m_cachedCollections.size() > id ? m_cachedCollections[id] : nullptr ) ;
+      return ( m_cachedCollections.size() > (unsigned) id ? m_cachedCollections[id] : nullptr ) ;
     }
 
     /// access a collection by ID. returns true if successful

--- a/include/podio/ObjBase.h
+++ b/include/podio/ObjBase.h
@@ -11,7 +11,7 @@ namespace podio {
   public:
 
     /// Constructor from ObjectID and initial object-count
-    ObjBase(ObjectID id, int i) : id(id) , ref_counter(i) {};
+    ObjBase(ObjectID id_, unsigned i) : id(id_) , ref_counter(i) {};
 
     /// checks whether object is "untracked" by a collection
     /// if yes, increases reference count
@@ -38,7 +38,7 @@ namespace podio {
 
   private:
     /// reference counter
-    std::atomic<int> ref_counter;
+    std::atomic<unsigned> ref_counter;
 
   };
 

--- a/include/podio/PythonEventStore.h
+++ b/include/podio/PythonEventStore.h
@@ -38,7 +38,7 @@ public:
   podio::EventStore m_store;
 
   /// set to true if input root file accessible, false otherwise
-  bool              m_isZombie;
+  bool              m_isZombie{true};
 };
 
 }

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -33,7 +33,7 @@ and to prepare collections and buffers.
 class ROOTReader : public IReader {
   friend EventStore;
   public:
-    ROOTReader() : m_eventNumber(0) {}
+    ROOTReader() = default;
     ~ROOTReader();
 
     //non-copyable
@@ -85,11 +85,11 @@ class ROOTReader : public IReader {
     std::pair<TTree*, unsigned> getLocalTreeAndEntry(const std::string& treename);
 
     typedef std::pair<CollectionBase*, std::string> Input;
-    std::vector<Input> m_inputs;
-    std::map<std::string, std::pair<TClass*,TClass*> > m_storedClasses;
-    CollectionIDTable* m_table;
-    TChain* m_chain;
-    unsigned m_eventNumber;
+    std::vector<Input> m_inputs{};
+    std::map<std::string, std::pair<TClass*,TClass*> > m_storedClasses{};
+    CollectionIDTable* m_table{nullptr};
+    TChain* m_chain{nullptr};
+    unsigned m_eventNumber{0};
 };
 
 template<typename T>

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -21,6 +21,10 @@ namespace podio {
     ROOTWriter(const std::string& filename, EventStore* store);
     ~ROOTWriter();
 
+    // non-copyable
+    ROOTWriter(const ROOTWriter&) = delete;
+    ROOTWriter& operator=(const ROOTWriter&) = delete;
+
     bool registerForWrite(const std::string& name);
     void writeEvent();
     void finish();

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -39,7 +39,6 @@ namespace podio {
     TTree* m_runMDtree;
     TTree* m_evtMDtree;
     TTree* m_colMDtree;
-    GenericParameters* m_evtMD{};
     std::vector<CollectionBase*> m_storedCollections{};
     std::vector<std::string> m_collectionsToWrite{};
     bool m_firstEvent{true};

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -39,9 +39,9 @@ namespace podio {
     TTree* m_runMDtree;
     TTree* m_evtMDtree;
     TTree* m_colMDtree;
-    GenericParameters* m_evtMD ;
-    std::vector<CollectionBase*> m_storedCollections;
-    std::vector<std::string> m_collectionsToWrite;
+    GenericParameters* m_evtMD{};
+    std::vector<CollectionBase*> m_storedCollections{};
+    std::vector<std::string> m_collectionsToWrite{};
     bool m_firstEvent{true};
   };
 

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -77,8 +77,8 @@ namespace podio {
 
   private:
     podio::EventStore* _store{nullptr};
-    podio::CollectionIDTable* _table {nullptr};
-    std::vector<std::string> _types;
+    podio::CollectionIDTable* _table{nullptr};
+    std::vector<std::string> _types{};
   };
 
 
@@ -120,10 +120,10 @@ namespace podio {
 /// factory for creating sio::blocks for a given type of EDM-collection
   class SIOBlockFactory {
   private:
-    SIOBlockFactory(){};
+    SIOBlockFactory() = default;
 
     typedef std::map<std::string, SIOBlock*> BlockMap ;
-    BlockMap  _map ;
+    BlockMap  _map{};
   public:
     void registerBlockForCollection(std::string type, SIOBlock* b){ _map[type] = b ; }
 
@@ -200,7 +200,7 @@ namespace podio {
     virtual void read(sio::read_device& device, sio::version_type version) override;
     virtual void write(sio::write_device& device) override;
 
-    SIOFileTOCRecord* record;
+    SIOFileTOCRecord* record{nullptr};
   };
 
 } // end namespace

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -32,6 +32,9 @@ namespace podio {
     SIOBlock( const std::string &nam, sio::version_type vers) :
       sio::block( nam, vers ){
     }
+    SIOBlock() = delete;
+    SIOBlock(const SIOBlock&) = delete;
+    SIOBlock& operator=(const SIOBlock&) = delete;
 
     podio::CollectionBase* getCollection() { return _col; }
 
@@ -63,6 +66,9 @@ namespace podio {
       sio::block("CollectionIDs", sio::version::encode_version(0, 1)),
       _store(store), _table(store->getCollectionIDTable()) {}
 
+    SIOCollectionIDTableBlock(const SIOCollectionIDTableBlock&) = delete;
+    SIOCollectionIDTableBlock& operator=(const SIOCollectionIDTableBlock&) = delete;
+
     virtual void read(sio::read_device& device, sio::version_type version) override;
     virtual void write(sio::write_device& device) override;
 
@@ -84,6 +90,9 @@ namespace podio {
     SIOEventMetaDataBlock() :
       sio::block("EventMetaData", sio::version::encode_version(0, 1)) {}
 
+    SIOEventMetaDataBlock(const SIOEventMetaDataBlock&) = delete;
+    SIOEventMetaDataBlock& operator=(const SIOEventMetaDataBlock&) = delete;
+
     virtual void read(sio::read_device& device, sio::version_type version) override;
     virtual void write(sio::write_device& device) override;
 
@@ -97,6 +106,9 @@ namespace podio {
   public:
     SIONumberedMetaDataBlock(const std::string& name) :
       sio::block(name, sio::version::encode_version(0, 1)) {}
+
+    SIONumberedMetaDataBlock(const SIONumberedMetaDataBlock&) = delete;
+    SIONumberedMetaDataBlock& operator=(const SIONumberedMetaDataBlock&) = delete;
 
     virtual void read(sio::read_device& device, sio::version_type version) override;
     virtual void write(sio::write_device& device) override;
@@ -171,7 +183,7 @@ namespace podio {
     size_t getNRecords(const std::string& name) const;
 
   private:
-    friend class SIOFileTOCRecordBlock;
+    friend struct SIOFileTOCRecordBlock;
 
     using RecordListType = std::pair<std::string, std::vector<PositionType>>;
     using MapType = std::vector<RecordListType>;
@@ -180,7 +192,10 @@ namespace podio {
   };
 
   struct SIOFileTOCRecordBlock : public sio::block {
-      SIOFileTOCRecordBlock() : sio::block(sio_helpers::SIOTocRecordName, sio::version::encode_version(0, 1)) {}
+    SIOFileTOCRecordBlock() : sio::block(sio_helpers::SIOTocRecordName, sio::version::encode_version(0, 1)) {}
+
+    SIOFileTOCRecordBlock(const SIOFileTOCRecordBlock&) = delete;
+    SIOFileTOCRecordBlock& operator=(const SIOFileTOCRecordBlock&) = delete;
 
     virtual void read(sio::read_device& device, sio::version_type version) override;
     virtual void write(sio::write_device& device) override;

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -80,11 +80,11 @@ namespace podio {
     void createBlocks();
 
     typedef std::pair<CollectionBase*, std::string> Input;
-    std::vector<Input> m_inputs;
+    std::vector<Input> m_inputs{};
     CollectionIDTable* m_table{nullptr}; // will be owned by the EventStore
     int m_eventNumber{0};
     int m_lastEventRead{-1};
-    std::vector<std::string> m_typeNames;
+    std::vector<std::string> m_typeNames{};
 
     std::shared_ptr<SIOEventMetaDataBlock> m_eventMetaData{};
     std::shared_ptr<SIONumberedMetaDataBlock> m_runMetaData{};

--- a/include/podio/SIOWriter.h
+++ b/include/podio/SIOWriter.h
@@ -24,6 +24,10 @@ namespace podio {
     SIOWriter(const std::string& filename, EventStore* store);
     ~SIOWriter();
 
+    // non-copyable
+    SIOWriter(const SIOWriter&) = delete;
+    SIOWriter& operator=(const SIOWriter&) = delete;
+
     void registerForWrite(const std::string& name);
     void writeEvent();
     void finish();

--- a/include/podio/SIOWriter.h
+++ b/include/podio/SIOWriter.h
@@ -45,7 +45,7 @@ namespace podio {
     std::shared_ptr<SIONumberedMetaDataBlock> m_runMetaData;
     std::shared_ptr<SIONumberedMetaDataBlock> m_collectionMetaData;
     SIOFileTOCRecord m_tocRecord{};
-    std::vector<std::string> m_collectionsToWrite;
+    std::vector<std::string> m_collectionsToWrite{};
   };
 
 } //namespace

--- a/include/podio/TimedReader.h
+++ b/include/podio/TimedReader.h
@@ -43,7 +43,7 @@ public:
 
   /// Read Collection of given name
   /// Does not set references yet.
-  virtual CollectionBase* readCollection(const std::string& name) {
+  virtual CollectionBase* readCollection(const std::string& name) override {
     const auto [result, duration] = benchmark::run_member_timed(m_reader, &IReader::readCollection, name);
     // since we cannot in general know how many collections there will be read
     // we simply sum up all the requests in an event and record that
@@ -52,30 +52,30 @@ public:
   }
 
   /// Get CollectionIDTable of read-in data
-  virtual CollectionIDTable* getCollectionIDTable() {
+  virtual CollectionIDTable* getCollectionIDTable() override {
     return runTimed(false, "read_collection_ids", &IReader::getCollectionIDTable);
   }
 
   /// read event meta data from file
-  virtual GenericParameters* readEventMetaData() {
+  virtual GenericParameters* readEventMetaData() override {
     return runTimed(true, "read_ev_md", &IReader::readEventMetaData);
   }
 
-  virtual std::map<int, GenericParameters>* readCollectionMetaData() {
+  virtual std::map<int, GenericParameters>* readCollectionMetaData() override {
     return runTimed(true, "read_coll_md", &IReader::readCollectionMetaData);
   }
 
-  virtual std::map<int, GenericParameters>* readRunMetaData() {
+  virtual std::map<int, GenericParameters>* readRunMetaData() override {
     return runTimed(true, "read_run_md", &IReader::readRunMetaData);
   }
 
   /// get the number of events available from this reader
-  virtual unsigned getEntries() const {
+  virtual unsigned getEntries() const override {
     return runTimed(false, "get_entries", &IReader::getEntries);
   }
 
   /// Prepare the reader to read the next event
-  virtual void endOfEvent() {
+  virtual void endOfEvent() override {
     runVoidTimed(true, "end_of_event", &IReader::endOfEvent);
 
     m_perEventTree.recordTime("read_collections", m_totalCollectionReadTime);
@@ -84,7 +84,7 @@ public:
   }
 
   // not benchmarking this one
-  virtual bool isValid() const { return m_reader.isValid(); }
+  virtual bool isValid() const override { return m_reader.isValid(); }
 
   virtual void openFile(const std::string& filename) override {
     runVoidTimed(false, "open_file", &IReader::openFile, filename);

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -109,7 +109,7 @@ class MemberVariable(object):
     else:
       scoped_type = self.full_type
 
-    definition = r'{} {};'.format(scoped_type, self.name)
+    definition = r'{} {}{{}};'.format(scoped_type, self.name)
     if self.description:
       definition += r' ///< {}'.format(self.description)
     return definition

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -122,13 +122,13 @@ void {{ collection_type }}::prepareForWrite() {
   int {{ relation.name }}_index = 0;
 {% endfor %}
 {% for member in VectorMembers %}
-  const int {{ member.name }}_size = std::accumulate(m_entries.begin(), m_entries.end(), 0, [](int sum, const {{ class.bare_type }}Obj* obj) { return sum + obj->m_{{ member.name }}->size(); });
+  const auto {{ member.name }}_size = std::accumulate(m_entries.begin(), m_entries.end(), 0, [](size_t sum, const {{ class.bare_type }}Obj* obj) { return sum + obj->m_{{ member.name }}->size(); });
   m_vec_{{ member.name }}->reserve({{ member.name }}_size);
   int {{ member.name }}_index = 0;
 {% endfor %}
 
 {%- if OneToManyRelations or VectorMembers %}
-  for (int i = 0, size = m_data->size(); i != size; ++i) {
+  for (size_t i = 0, size = m_data->size(); i != size; ++i) {
 {% for relation in OneToManyRelations %}
 {{ macros.prepare_for_write_multi_relation(relation, loop.index0) }}
 {% endfor %}
@@ -177,10 +177,10 @@ bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* {% i
 }
 
 void {{ collection_type }}::push_back(Const{{ class.bare_type }} object) {
-  const int size = m_entries.size();
+  const auto size = m_entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
-    obj->id = {size, m_collectionID};
+    obj->id = {(int)size, m_collectionID};
     m_entries.push_back(obj);
 
 {% for relation in OneToManyRelations %}

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -109,8 +109,7 @@ void {{ collection_type }}::clear() {
 }
 
 void {{ collection_type }}::prepareForWrite() {
-  const auto size = m_entries.size();
-  m_data->reserve(size);
+  m_data->reserve(m_entries.size());
   for (auto& obj : m_entries) { m_data->push_back(obj->data); }
 
   // if the collection has been read from a file the rest of the information is

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -19,14 +19,16 @@
   m_isValid(false), m_isReadFromFile(false), m_collectionID(0), m_entries()
 {%- for relation in OneToManyRelations + OneToOneRelations %},
   m_rel_{{ relation.name }}(new std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>())
-{%- endfor %},
+{%- endfor %}
+{%- for member in VectorMembers %},
+  m_vec_{{ member.name }}(new std::vector<{{ member.full_type }}>())
+{%- endfor -%},
   m_data(new {{ class.bare_type }}DataContainer()) {
 {% for relation in OneToManyRelations + OneToOneRelations %}
   m_refCollections.push_back(new std::vector<podio::ObjectID>());
 {% endfor %}
 {% for member in VectorMembers %}
   m_vecmem_info.emplace_back("{{ member.full_type }}", &m_vec_{{ member.name }});
-  m_vec_{{ member.name }} = new std::vector<{{ member.full_type }}>();
 {% endfor %}
 }
 

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -165,7 +165,7 @@ void {{ collection_type }}::prepareAfterRead() {
   m_isReadFromFile = true;
 }
 
-bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* collectionProvider) {
+bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* {% if OneToManyRelations or OneToOneRelations -%}collectionProvider{%- endif -%}) {
 {% for relation in OneToManyRelations %}
 {{ macros.set_references_multi_relation(relation, loop.index0) }}
 {% endfor %}

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -29,7 +29,12 @@ using {{ class.bare_type }}ObjPointerContainer = std::deque<{{ class.bare_type }
 
 class {{ class.bare_type }}CollectionIterator {
 public:
-  {{ class.bare_type }}CollectionIterator(int index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+{% with iterator_type = class.bare_type + 'CollectionIterator' %}
+  {{ iterator_type }}(int index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+
+  {{ iterator_type }}(const {{ iterator_type }}&) = delete;
+  {{ iterator_type }}& operator=(const {{ iterator_type }}&) = delete;
+{% endwith %}
 
   bool operator!=(const {{ class.bare_type }}CollectionIterator& x) const {
     return m_index != x.m_index; // TODO: may not be complete

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -50,16 +50,10 @@ private:
   const {{ class.bare_type }}ObjPointerContainer* m_collection;
 };
 
-// Cannot delete the copy-constructor, but having one triggers Weffc++ if there
-// are pointer members, so we very briefly disable it in order to suppress the
-// warning for the existing copy-constructor
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Weffc++"
 /**
 A Collection is identified by an ID.
 */
 class {{ class.bare_type }}Collection : public podio::CollectionBase {
-#pragma GCC diagnostic pop
 
 public:
   using const_iterator = const {{ class.bare_type }}CollectionIterator;

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -140,15 +140,15 @@ public:
 {% endfor %}
 
 private:
-  bool m_isValid;
+  bool m_isValid{false};
   bool m_isReadFromFile{false};
-  int m_collectionID;
+  int m_collectionID{0};
   {{ class.bare_type }}ObjPointerContainer m_entries;
 
   // members to handle 1-to-N-relations
 {% for relation in OneToManyRelations %}
   std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>* m_rel_{{ relation.name }}; ///< Relation buffer for read / write
-  std::vector<std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>*> m_rel_{{ relation.name }}_tmp; ///< Relation buffer for internal book-keeping
+  std::vector<std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>*> m_rel_{{ relation.name }}_tmp{}; ///< Relation buffer for internal book-keeping
 {% endfor %}
 {% for relation in OneToOneRelations %}
   std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>* m_rel_{{ relation.name }}; ///< Relation buffer for read / write
@@ -157,11 +157,11 @@ private:
   // members to handle vector members
 {% for member in VectorMembers %}
   std::vector<{{ member.full_type }}>* m_vec_{{ member.name }}; /// combined vector of all objects in collection
-  std::vector<std::vector<{{ member.full_type }}>*> m_vecs_{{ member.name }}; /// pointers to individual member vectors
+  std::vector<std::vector<{{ member.full_type }}>*> m_vecs_{{ member.name }}{}; /// pointers to individual member vectors
 {% endfor %}
   // members to handle streaming
-  podio::CollRefCollection m_refCollections;
-  podio::VectorMembersInfo m_vecmem_info;
+  podio::CollRefCollection m_refCollections{};
+  podio::VectorMembersInfo m_vecmem_info{};
   {{ class.bare_type }}DataContainer* m_data;
 };
 

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -65,7 +65,7 @@ public:
   using const_iterator = const {{ class.bare_type }}CollectionIterator;
 
   {{ class.bare_type }}Collection();
-  //{{ class.bare_type }}Collection(const {{ class.bare_type}}Collection& ) = delete; // deletion doesn't work w/ ROOT IO ! :-(
+  {{ class.bare_type }}Collection(const {{ class.bare_type}}Collection& ) = delete;
   {{ class.bare_type }}Collection& operator=(const {{ class.bare_type}}Collection& ) = delete;
 //  {{ class.bare_type }}Collection({{ class.bare_type }}Vector* data, int collectionID);
   ~{{ class.bare_type }}Collection();

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -50,10 +50,16 @@ private:
   const {{ class.bare_type }}ObjPointerContainer* m_collection;
 };
 
+// Cannot delete the copy-constructor, but having one triggers Weffc++ if there
+// are pointer members, so we very briefly disable it in order to suppress the
+// warning for the existing copy-constructor
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
 /**
 A Collection is identified by an ID.
 */
 class {{ class.bare_type }}Collection : public podio::CollectionBase {
+#pragma GCC diagnostic pop
 
 public:
   using const_iterator = const {{ class.bare_type }}CollectionIterator;

--- a/python/templates/Data.h.jinja2
+++ b/python/templates/Data.h.jinja2
@@ -19,8 +19,8 @@ public:
 {% endfor %}
 
 {% for member in VectorMembers + OneToManyRelations %}
-  unsigned int {{ member.name }}_begin;
-  unsigned int {{ member.name }}_end;
+  unsigned int {{ member.name }}_begin{};
+  unsigned int {{ member.name }}_end{};
 {% endfor %}
 };
 

--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -24,8 +24,8 @@
 
 {  }
 
-{{ obj_type }}::{{ obj_type }}(const podio::ObjectID id, {{ class.bare_type }}Data data) :
-  ObjBase{id, 0}, data(data)
+{{ obj_type }}::{{ obj_type }}(const podio::ObjectID id_, {{ class.bare_type }}Data data_) :
+  ObjBase{id_, 0}, data(data_)
 {  }
 
 {{ obj_type }}::{{ obj_type }}(const {{ obj_type }}& other) :

--- a/python/templates/Obj.h.jinja2
+++ b/python/templates/Obj.h.jinja2
@@ -38,10 +38,10 @@ public:
 public:
   {{ class.bare_type }}Data data;
 {% for relation in OneToOneRelations %}
-  {{ relation.relation_type }}* m_{{ relation.name }};
+  {{ relation.relation_type }}* m_{{ relation.name }}{nullptr};
 {% endfor %}
 {% for relation in OneToManyRelations + VectorMembers %}
-  std::vector<{{ relation.relation_type }}>* m_{{ relation.name }};
+  std::vector<{{ relation.relation_type }}>* m_{{ relation.name }}{nullptr};
 {% endfor %}
 };
 {% endwith %}

--- a/python/templates/Obj.h.jinja2
+++ b/python/templates/Obj.h.jinja2
@@ -31,6 +31,8 @@ public:
   /// constructor from ObjectID and {{ class.bare_type }}Data
   /// does not initialize the internal relation containers
   {{ obj_type }}(const podio::ObjectID id, {{ class.bare_type }}Data data);
+  /// No assignment operator
+  {{ obj_type }}& operator=(const {{ obj_type }}&) = delete;
   virtual ~{{ obj_type }}();
 
 public:

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -30,7 +30,7 @@ void handlePODDataSIO(devT& device, {{ class.namespace }}::{{ class.bare_type }}
 {{ utils.namespace_open(class.namespace) }}
 {% with block_class = class.bare_type + 'SIOBlock' %}
 
-void {{ block_class }}::read(sio::read_device& device, sio::version_type vers) {
+void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
 
   auto* dataVec = static_cast<{{ class.namespace }}::{{ class.bare_type }}Collection*>(_col)->_getBuffer();
 

--- a/python/templates/selection.xml.jinja2
+++ b/python/templates/selection.xml.jinja2
@@ -1,31 +1,29 @@
 {% macro class_selection(class, prefix='', postfix='') %}
-{% if class.namespace %}
-        <class name="std::vector<{{ class.namespace }}::{{ prefix }}{{ class.bare_type }}{{ postfix }}>" />
-        <class name="{{ class.namespace }}::{{ prefix }}{{ class.bare_type }}{{ postfix }}">
-{% else %}
-        <class name="std::vector<{{ prefix }}{{ class.bare_type }}{{ postfix }}>" />
-        <class name="{{ prefix }}{{ class.bare_type }}{{ postfix }}">
-{% endif %}
-            <field name="m_registry" transient="true"/>
-            <field name="m_container" transient="true"/>
-        </class>
-
+{%- if class.namespace %}
+        <class name="{{ class.namespace }}::{{ prefix }}{{ class.bare_type }}{{ postfix }}"/>
+{%- else %}
+        <class name="{{ prefix }}{{ class.bare_type }}{{ postfix }}"/>
+{%- endif %}
 {% endmacro %}
 
 <lcgdict>
     <selection>
 
+        <!-- components -->
 {% for class in components %}
 {{ class_selection(class) }}
 {% endfor %}
 
+        <!-- datatypes -->
 {% for class in datatypes %}
 {{ class_selection(class, postfix='Data') }}
+{# We need to also create the collections in the selection xml file. #}
+{# Otherwise the python interface does not work in gcc builds #}
+{# Additionally, in order to allow "direct" access to the user facing classes #}
+{# we have to declare them here, otherwise they cannot be easily imported #}
 {{ class_selection(class) }}
-{{ class_selection(class, prefix='Const') }}
 {{ class_selection(class, postfix='Collection') }}
-{{ class_selection(class, postfix='Obj') }}
-{% endfor %}
 
+{% endfor %}
     </selection>
 </lcgdict>

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -107,7 +107,6 @@ class MemberParserTest(unittest.TestCase):
     parsed = parser.parse('unsigned long long aLongWithoutDescription', False)
     self.assertEqual(parsed.full_type, 'unsigned long long')
     self.assertEqual(parsed.name, 'aLongWithoutDescription')
-    self.assertEqual(str(parsed), 'unsigned long long aLongWithoutDescription;')
 
     parsed = parser.parse('std::array<unsigned long, 123> unDescribedArray', False)
     self.assertEqual(parsed.full_type, 'std::array<unsigned long, 123>')
@@ -123,6 +122,22 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.full_type, 'NonBuiltIn')
     self.assertEqual(parsed.name, 'aType')
     self.assertEqual(parsed.description, 'descriptions are not ignored even though they are not required')
+    self.assertTrue(not parsed.is_builtin)
+
+  def test_string_representation(self):
+    """Test that the string representation that is used in the jinja2 templates
+    includes the default initialization"""
+    parser = MemberParser()
+
+    parsed = parser.parse('unsigned long long var // description')
+    self.assertEqual(str(parsed), r'unsigned long long var{}; ///< description')
+
+    # Also works without a description
+    parsed = parser.parse('SomeType memberVar', False)
+    self.assertEqual(str(parsed), r'SomeType memberVar{};')
+
+    parsed = parser.parse('Type var//with very close comment')
+    self.assertEqual(str(parsed), r'Type var{}; ///< with very close comment')
 
 
 if __name__ == '__main__':

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -7,7 +7,7 @@ what trips it up
 from __future__ import print_function, absolute_import, unicode_literals
 import unittest
 
-from podio_config_reader import MemberParser
+from podio_config_reader import MemberParser, DefinitionError
 
 
 class MemberParserTest(unittest.TestCase):
@@ -58,6 +58,10 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.full_type, r'std::array<double, 4>')
     self.assertEqual(parsed.name, r'someArray')
     self.assertEqual(parsed.description, r'a comment')
+    self.assertTrue(not parsed.is_builtin)
+    self.assertTrue(parsed.is_builtin_array)
+    self.assertEqual(int(parsed.array_size), 4)
+    self.assertEqual(parsed.array_type, r'double')
 
     # an array definition as terse as possible
     parsed = parser.parse(r'std::array<int,2>anArray//with a comment')
@@ -74,6 +78,8 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.full_type, r'std::array<::GlobalType, 1>')
     self.assertEqual(parsed.name, r'anArray')
     self.assertEqual(parsed.description, r'with a top level type')
+    self.assertTrue(not parsed.is_builtin_array)
+    self.assertEqual(parsed.array_type, r'::GlobalType')
 
   def test_parse_invalid(self):
     # setup an empty parser
@@ -98,7 +104,7 @@ class MemberParserTest(unittest.TestCase):
         ]
 
     for inp in invalid_inputs:
-      with self.assertRaises(Exception):
+      with self.assertRaises(DefinitionError):
         parser.parse(inp)
 
   def test_parse_valid_no_description(self):

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -31,9 +31,9 @@ namespace podio {
       auto name = m_table->name(id);
       success = doGet(name, collection,true);
       if( collection != nullptr ){  // cache the collection for faster retreaval later
-	if( m_cachedCollections.size() < id + 1 )
-	  m_cachedCollections.resize( id+1 ) ;
-	m_cachedCollections[id] = collection ;
+        if( m_cachedCollections.size() < (unsigned) id + 1 )
+          m_cachedCollections.resize( id+1 ) ;
+        m_cachedCollections[id] = collection ;
       }
     } else {
       // collection already requested in recursive call

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -105,7 +105,7 @@ namespace podio {
       delete tmp;
     }
     return m_runMDMap[ runID ] ;
-  } ;
+  }
   
 
   GenericParameters& EventStore::getCollectionMetaData(int colID) const {
@@ -116,7 +116,7 @@ namespace podio {
       delete tmp;
     }
     return m_colMDMap[ colID ] ;
-  } ;
+  }
 
   void EventStore::clearCollections(){
     for (auto& coll : m_collections){

--- a/src/PythonEventStore.cc
+++ b/src/PythonEventStore.cc
@@ -23,7 +23,7 @@ podio::PythonEventStore::PythonEventStore(const char* name) :
 
 podio::CollectionBase* podio::PythonEventStore::get(const char* name) {
   const podio::CollectionBase* coll(nullptr);
-  auto success = m_store.get(name, coll);
+  m_store.get(name, coll);
   return const_cast<podio::CollectionBase*>(coll);
 }
 

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -28,14 +28,14 @@ namespace podio {
   }
   std::map<int,GenericParameters>* ROOTReader::readCollectionMetaData(){
     auto* emd = new std::map<int,GenericParameters> ;
-    auto [col_metadatatree, dummy] = getLocalTreeAndEntry("col_metadata");
+    auto* col_metadatatree = getLocalTreeAndEntry("col_metadata").first;
     col_metadatatree->SetBranchAddress("colMD",&emd);
     col_metadatatree->GetEntry(0);
     return emd ;
   }
   std::map<int,GenericParameters>* ROOTReader::readRunMetaData(){
     auto* emd = new std::map<int,GenericParameters> ;
-    auto [run_metadatatree, dummy] = getLocalTreeAndEntry("run_metadata");
+    auto* run_metadatatree = getLocalTreeAndEntry("run_metadata").first;
     run_metadatatree->SetBranchAddress("runMD",&emd);
     run_metadatatree->GetEntry(0);
     return emd ;

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -91,10 +91,10 @@ void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
 
     if (auto vminfo = coll->vectorMembers()) {
       int i = 0;
-      for (auto& [type, vec] : (*vminfo)) {
+      for (const auto& info : (*vminfo)) {
         const auto brName = name + "_" + std::to_string(i);
         auto* branch = m_datatree->GetBranch(brName.c_str());
-        branch->SetAddress(vec);
+        branch->SetAddress(info.second);
         i++;
       }
     }

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -15,9 +15,9 @@ namespace podio {
     m_file(new TFile(filename.c_str(),"RECREATE","data file")),
     m_datatree(new TTree("events","Events tree")),
     m_metadatatree(new TTree("metadata", "Metadata tree")),
+    m_runMDtree(new TTree("run_metadata", "Run metadata tree")),
     m_evtMDtree(new TTree("evt_metadata", "Event metadata tree")),
-    m_colMDtree(new TTree("col_metadata", "Collection metadata tree")),
-    m_runMDtree(new TTree("run_metadata", "Run metadata tree"))
+    m_colMDtree(new TTree("col_metadata", "Collection metadata tree"))
   {
 
     m_evtMDtree->Branch("evtMD", "GenericParameters", m_store->eventMetaDataPtr() ) ;

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -12,7 +12,7 @@
 #endif
 
 namespace podio {
-  void SIOCollectionIDTableBlock::read(sio::read_device& device, sio::version_type version) {
+  void SIOCollectionIDTableBlock::read(sio::read_device& device, sio::version_type) {
     std::vector<std::string> names;
     std::vector<int> ids;
     device.data(names);
@@ -74,7 +74,7 @@ namespace podio {
   }
 
 
-  void SIOEventMetaDataBlock::read(sio::read_device& device, sio::version_type version) {
+  void SIOEventMetaDataBlock::read(sio::read_device& device, sio::version_type) {
     readGenericParameters(device, *metadata);
   }
 
@@ -83,7 +83,7 @@ namespace podio {
   }
 
 
-  void SIONumberedMetaDataBlock::read(sio::read_device& device, sio::version_type version) {
+  void SIONumberedMetaDataBlock::read(sio::read_device& device, sio::version_type) {
     int size;
     device.data(size);
     while(size--) {
@@ -199,7 +199,7 @@ namespace podio {
     return 0;
   }
 
-  void SIOFileTOCRecordBlock::read(sio::read_device& device, sio::version_type version) {
+  void SIOFileTOCRecordBlock::read(sio::read_device& device, sio::version_type) {
     int size;
     device.data(size);
     while(size--) {

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -19,7 +19,7 @@ namespace podio {
     device.data(ids);
     device.data(_types);
 
-    _table = new CollectionIDTable(ids, names);
+    _table = new CollectionIDTable(std::move(ids), std::move(names));
   }
 
   void SIOCollectionIDTableBlock::write(sio::write_device& device) {

--- a/src/SIOReader.cc
+++ b/src/SIOReader.cc
@@ -18,7 +18,7 @@ namespace podio {
     m_runMetaData(std::make_shared<SIONumberedMetaDataBlock>("RunMetaData")),
     m_collectionMetaData(std::make_shared<SIONumberedMetaDataBlock>("CollectionMetaData"))
   {
-    auto& libLoader = SIOBlockLibraryLoader::instance();
+    auto& libLoader[[maybe_unused]] = SIOBlockLibraryLoader::instance();
   }
 
   CollectionBase* SIOReader::readCollection(const std::string& name) {

--- a/src/SIOWriter.cc
+++ b/src/SIOWriter.cc
@@ -30,7 +30,7 @@ namespace podio {
     m_runMetaData->data = m_store->getRunMetaDataMap();
     m_collectionMetaData->data = m_store->getColMetaDataMap();
 
-    auto& libLoader = SIOBlockLibraryLoader::instance();
+    auto& libLoader[[maybe_unused]] = SIOBlockLibraryLoader::instance();
   }
 
   SIOWriter::~SIOWriter(){

--- a/tests/check_benchmark_outputs.cpp
+++ b/tests/check_benchmark_outputs.cpp
@@ -64,7 +64,7 @@ void verifyBMFile(const char* fileName, const StringVec& setupBranches, const St
  * We can't really make any checks on the actual execution times, but we can at
  * least verify that the expected timing points are here.
  */
-int main(int argc, char* argv[]) {
+int main(int, char* argv[]) {
   const StringVec writeBMSetupBranches = {"constructor", "finish", "register_for_write"};
   const StringVec writeBMEventBranches = {"write_event"};
   verifyBMFile(argv[1], writeBMSetupBranches, writeBMEventBranches);

--- a/tests/check_benchmark_outputs.cpp
+++ b/tests/check_benchmark_outputs.cpp
@@ -31,7 +31,7 @@ bool verifyTree(TTree* tree, int expectedEntries, const StringVec& expectedBranc
     }
   }
 
-  if (branches->GetEntries() != expectedBranches.size()) {
+  if ((unsigned) branches->GetEntries() != expectedBranches.size()) {
     std::cerr << "Tree \'" << treeName << "\' has additional, unexpected branches" << std::endl;
     return false;
   }

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -129,7 +129,7 @@ datatypes :
     Description : "Type with namespace and namespaced member"
     Author : "Joschka Lingemann"
     Members:
-      - ex2::NamespaceStruct data // a component
+      - ex2::NamespaceStruct component // a component
 
   ex42::ExampleWithARelation :
     Description : "Type with namespace and namespaced relation"

--- a/tests/read_and_write.cpp
+++ b/tests/read_and_write.cpp
@@ -21,7 +21,7 @@ int main(){
   for(unsigned i=0; i<nEvents; ++i) {
     if(i%1000==0)
       std::cout<<"reading event "<<i<<std::endl;
-    processEvent(store, true, i);
+    processEvent(store, i);
 
     writer.writeEvent() ;
     

--- a/tests/read_and_write_sio.cpp
+++ b/tests/read_and_write_sio.cpp
@@ -21,7 +21,7 @@ int main() {
   for(unsigned i=0; i<nEvents; ++i) {
     if(i%1000==0)
       std::cout<<"reading event "<<i<<std::endl;
-    processEvent(store, true, i);
+    processEvent(store, i);
 
     writer.writeEvent();
 

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -87,8 +87,6 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
     // check that we can retrieve the correct parent daughter relation
     // set in write.cpp :
 
-    // particle 0 has particles 2,3,4 and 5 as daughters:
-    auto p = mcps[0] ;
 
     //-------- print relations for debugging:
     for( auto p : mcps ){
@@ -102,6 +100,9 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
       }
       std::cout << std::endl ;
     }
+
+    // particle 0 has particles 2,3,4 and 5 as daughters:
+    auto p = mcps[0] ;
 
     auto d0 = p.daughters(0) ;
     auto d1 = p.daughters(1) ;
@@ -136,9 +137,9 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
   auto& refs = store.get<ExampleReferencingTypeCollection>("refs");
   if(refs.isValid()){
     auto ref = refs[0];
-    for (auto j = ref.Clusters_begin(), end = ref.Clusters_end(); j!=end; ++j){
-      for (auto i = j->Hits_begin(), end = j->Hits_end(); i!=end; ++i){
-        //std::cout << "  Referenced object has an energy of " << i->energy() << std::endl;
+    for (auto cluster : ref.Clusters()) {
+      for (auto hit : cluster.Hits()) {
+        //std::cout << "  Referenced object has an energy of " << hit.energy() << std::endl;
       }
     }
   } else {

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -25,7 +25,7 @@
 #include <sstream>
 
 
-void processEvent(podio::EventStore& store, unsigned eventNum) {
+void processEvent(podio::EventStore& store, int eventNum) {
 
   auto evtMD = store.getEventMetaData() ;
   float evtWeight = evtMD.getFloatVal( "UserEventWeight" ) ;
@@ -208,7 +208,7 @@ void processEvent(podio::EventStore& store, unsigned eventNum) {
   auto& copies = store.get<ex42::ExampleWithARelationCollection>("WithNamespaceRelationCopy");
   auto& cpytest = store.create<ex42::ExampleWithARelationCollection>("TestConstCopy");
   if (nmspaces.isValid() && copies.isValid()) {
-    for (int j = 0; j < nmspaces.size(); j++) {
+    for (size_t j = 0; j < nmspaces.size(); j++) {
       auto nmsp = nmspaces[j];
       auto cpy = copies[j];
       cpytest.push_back(nmsp.clone());

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -213,8 +213,8 @@ void processEvent(podio::EventStore& store, int eventNum) {
       auto cpy = copies[j];
       cpytest.push_back(nmsp.clone());
       if (nmsp.ref().isAvailable()) {
-        if (nmsp.ref().data().x != cpy.ref().data().x || nmsp.ref().data().y != cpy.ref().data().y) {
-          throw std::runtime_error("Copied item has differing data in OneToOne referenced item.");
+        if (nmsp.ref().component().x != cpy.ref().component().x || nmsp.ref().component().y != cpy.ref().component().y) {
+          throw std::runtime_error("Copied item has differing component in OneToOne referenced item.");
         }
         // check direct accessors of POD sub members
         if (nmsp.ref().x() != cpy.ref().x()) {
@@ -229,8 +229,8 @@ void processEvent(podio::EventStore& store, int eventNum) {
       }
       auto cpy_it = cpy.refs_begin();
       for (auto it = nmsp.refs_begin(); it != nmsp.refs_end(); ++it, ++cpy_it) {
-        if (it->data().x != cpy_it->data().x || it->data().y != cpy_it->data().y) {
-          throw std::runtime_error("Copied item has differing data in OneToMany referenced item.");
+        if (it->component().x != cpy_it->component().x || it->component().y != cpy_it->component().y) {
+          throw std::runtime_error("Copied item has differing component in OneToMany referenced item.");
         }
         if (!(it->getObjectID() == cpy_it->getObjectID())) {
           throw std::runtime_error("Copied item has wrong OneToMany references.");

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -25,7 +25,7 @@
 #include <sstream>
 
 
-void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
+void processEvent(podio::EventStore& store, unsigned eventNum) {
 
   auto evtMD = store.getEventMetaData() ;
   float evtWeight = evtMD.getFloatVal( "UserEventWeight" ) ;
@@ -42,7 +42,9 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
 
 
   try {
-    auto& failing = store.get<ExampleClusterCollection>("notthere");
+    // not assigning to a variable, because it will remain unused, we just want
+    // the exception here
+    store.get<ExampleClusterCollection>("notthere");
   } catch(const std::runtime_error& err) {
     if (std::string(err.what()) != "No collection \'notthere\' is present in the EventStore") {
       throw std::runtime_error("Trying to get non present collection \'notthere' should throw an exception");
@@ -183,7 +185,7 @@ void processEvent(podio::EventStore& store, bool verboser, unsigned eventNum) {
   auto& comps = store.get<ExampleWithComponentCollection>("Component");
   if (comps.isValid()) {
     auto comp = comps[0];
-    int a = comp.component().data.x + comp.component().data.z;
+    int a[[maybe_unused]] = comp.component().data.x + comp.component().data.z;
   }
 
   auto& arrays = store.get<ExampleWithArrayCollection>("arrays");
@@ -263,7 +265,7 @@ void run_read_test(podio::IReader& reader) {
     if(i%1000==0)
       std::cout<<"reading event "<<i<<std::endl;
 
-    processEvent(store, true, correctIndex(i));
+    processEvent(store, correctIndex(i));
     store.clear();
     reader.endOfEvent();
   }

--- a/tests/relation_range.cpp
+++ b/tests/relation_range.cpp
@@ -65,7 +65,7 @@ void doTestExampleMC(ExampleMCCollection const& collection)
   ASSERT_CONDITION(collection[7].daughters().size() == 0 && collection[7].parents().size() == 0,
                    "RelationRange of empty collection is not empty");
   // alternatively check if a loop is entered
-  for (const auto& p: collection[7].daughters()) {
+  for (const auto& p[[maybe_unused]]: collection[7].daughters()) {
     throw std::runtime_error("Range based for loop entered on a supposedly empty range");
   }
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -120,7 +120,7 @@ TEST_CASE("Invalid_refs") {
   cluster.addHits(hit2);
   try {
     clusters.prepareForWrite(); //should fail!
-  } catch (std::runtime_error){
+  } catch (std::runtime_error&){
     success = true;
   }
   REQUIRE(success);
@@ -278,5 +278,5 @@ TEST_CASE("Equality") {
 
 TEST_CASE("NonPresentCollection") {
   auto store = podio::EventStore();
-  REQUIRE_THROWS_AS(store.get<ExampleHitCollection>("NonPresentCollection"), std::runtime_error);
+  REQUIRE_THROWS_AS(store.get<ExampleHitCollection>("NonPresentCollection"), std::runtime_error&);
 }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+#include <type_traits>
 
 // catch
 #define CATCH_CONFIG_MAIN
@@ -167,11 +168,18 @@ TEST_CASE("OneToOneRelations") {
 }
 
 TEST_CASE("Podness") {
-  REQUIRE(std::is_pod<ExampleClusterData>());
-  REQUIRE(std::is_pod<ExampleHitData>());
-  REQUIRE(std::is_pod<ExampleWithOneRelationData>());
+  // fail this already at compile time
+  static_assert(std::is_standard_layout_v<ExampleClusterData>, "Generated data classes do not have standard layout");
+  static_assert(std::is_trivially_copyable_v<ExampleClusterData>, "Generated data classes are not trivially copyable");
+  static_assert(std::is_standard_layout_v<ExampleHitData>, "Generated data classes do not have standard layout");
+  static_assert(std::is_trivially_copyable_v<ExampleHitData>, "Generated data classes are not trivially copyable");
+  static_assert(std::is_standard_layout_v<ExampleWithOneRelationData>, "Generated data classes do not have standard layout");
+  static_assert(std::is_trivially_copyable_v<ExampleWithOneRelationData>, "Generated data classes are not trivially copyable");
+
   // just to be sure the test does what it is supposed to do
-  REQUIRE_FALSE(std::is_pod<ExampleClusterObj>());
+  static_assert(not std::is_standard_layout_v<ExampleClusterObj>);
+  static_assert(not std::is_trivially_copyable_v<ExampleClusterObj>);
+  REQUIRE(true); // just to have this also show up at runtime
 }
 
 TEST_CASE("Referencing") {

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -2,7 +2,7 @@
 #include "podio/ROOTWriter.h"
 #include "podio/EventStore.h"
 
-int main(int argc, char* argv[]){
+int main(int, char**){
   auto store = podio::EventStore();
   podio::ROOTWriter writer("example.root", &store);
   write(store, writer);

--- a/tests/write_sio.cpp
+++ b/tests/write_sio.cpp
@@ -2,7 +2,7 @@
 #include "podio/SIOWriter.h"
 #include "podio/EventStore.h"
 
-int main(int argc, char* argv[]){
+int main(int, char**){
   podio::EventStore store;
   podio::SIOWriter writer("example.sio", &store);
 

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -218,15 +218,15 @@ void write(podio::EventStore& store, WriterT& writer) {
       auto rel = ex42::ExampleWithARelation();
       rel.number(0.5*j);
       auto exWithNamesp = ex42::ExampleWithNamespace();
-      exWithNamesp.data().x = i;
-      exWithNamesp.data().y = 1000*i;
+      exWithNamesp.component().x = i;
+      exWithNamesp.component().y = 1000*i;
       namesps.push_back(exWithNamesp);
       if (j != 3) { // also check for empty relations
         rel.ref(exWithNamesp);
         for (int k = 0; k < 5; k++) {
           auto namesp = ex42::ExampleWithNamespace();
           namesp.x(3*k);
-          namesp.data().y = k;
+          namesp.component().y = k;
           namesps.push_back(namesp);
           rel.addrefs(namesp);
         }

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -233,7 +233,7 @@ void write(podio::EventStore& store, WriterT& writer) {
       }
       namesprels.push_back(rel);
     }
-    for (int j = 0; j < namesprels.size(); ++j) {
+    for (size_t j = 0; j < namesprels.size(); ++j) {
       cpytest.push_back(namesprels.at(j).clone());
     }
 

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -104,38 +104,34 @@ void write(podio::EventStore& store, WriterT& writer) {
     mcps.push_back( mcp8 ) ;
     mcps.push_back( mcp9 ) ;
 
-    // --- add some daughter relations
-    auto p = ExampleMC();
-    auto d = ExampleMC();
-
-    p = mcps[0] ;
-    p.adddaughters( mcps[2] ) ;
-    p.adddaughters( mcps[3] ) ;
-    p.adddaughters( mcps[4] ) ;
-    p.adddaughters( mcps[5] ) ;
-    p = mcps[1] ;
-    p.adddaughters( mcps[2] ) ;
-    p.adddaughters( mcps[3] ) ;
-    p.adddaughters( mcps[4] ) ;
-    p.adddaughters( mcps[5] ) ;
-    p = mcps[2] ;
-    p.adddaughters( mcps[6] ) ;
-    p.adddaughters( mcps[7] ) ;
-    p.adddaughters( mcps[8] ) ;
-    p.adddaughters( mcps[9] ) ;
-    p = mcps[3] ;
-    p.adddaughters( mcps[6] ) ;
-    p.adddaughters( mcps[7] ) ;
-    p.adddaughters( mcps[8] ) ;
-    p.adddaughters( mcps[9] ) ;
+    auto mcp = mcps[0] ;
+    mcp.adddaughters( mcps[2] ) ;
+    mcp.adddaughters( mcps[3] ) ;
+    mcp.adddaughters( mcps[4] ) ;
+    mcp.adddaughters( mcps[5] ) ;
+    mcp = mcps[1] ;
+    mcp.adddaughters( mcps[2] ) ;
+    mcp.adddaughters( mcps[3] ) ;
+    mcp.adddaughters( mcps[4] ) ;
+    mcp.adddaughters( mcps[5] ) ;
+    mcp = mcps[2] ;
+    mcp.adddaughters( mcps[6] ) ;
+    mcp.adddaughters( mcps[7] ) ;
+    mcp.adddaughters( mcps[8] ) ;
+    mcp.adddaughters( mcps[9] ) ;
+    mcp = mcps[3] ;
+    mcp.adddaughters( mcps[6] ) ;
+    mcp.adddaughters( mcps[7] ) ;
+    mcp.adddaughters( mcps[8] ) ;
+    mcp.adddaughters( mcps[9] ) ;
 
     //--- now fix the parent relations
     for( unsigned j=0,N=mcps.size();j<N;++j){
-      p = mcps[j] ;
-      for(auto it = p.daughters_begin(), end = p.daughters_end() ; it!=end ; ++it ){
-  int dIndex = it->getObjectID().index ;
-  d = mcps[ dIndex ] ;
-  d.addparents( p ) ;
+      mcp = mcps[j] ;
+      for(auto p : mcp.daughters()) {
+        int dIndex = p.getObjectID().index ;
+        auto d = mcps[ dIndex ] ;
+        d.addparents( p ) ;
       }
     }
     //-------- print relations for debugging:


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix compiler warnings, that were uncovered by #153 and described in #170. Fix them in the core classes and also in the generated ones.
- Enforce no new warnings with `Werror` in the CI builds.

ENDRELEASENOTES

Fixes #170 

These changes should fix in the core classes:
- all of the `Weffc++` warnings that are not yet covered by #156
- all of the `Wshadow-[parameter,variable]` ~not yet covered by #158 (mainly `podio::ObjBase`)~ (26.01.2021, copied relevant changes)
- the one `Wnon-virtual-dtor` warning in `ColWriterBase`
- the two `Wcatch-value=` warnings in `unittest.cpp`
- the `Wreorder` warnings in the `ROOTWriter`
- the `Wpedantic` warnings due to unnecessary semi colons

In the generated classes they should fix:
- All `Weffc++` warnings for the `Collection` classes, ~except the ones that are not fixable due to the root constraints (see #170)~(28.01.21)
- All `Weffc++` warnings for the `Obj` classes ~except for the ones covered by #158~ (26.01.2021, copied relevant changes)
- All `Weffc++` warnings about uninitialized members in the `Data` classes and in the components. (26.01.2021)
- All `Wshadow` warnings ~(partially overlapping with #158 due to a slightly different approach)~ (26.01.2021, copied the relevant changes)

~These changes **do not yet fix**~
- ~`Weffc++` warnings arising in the generated components. Here, I think we first have to think about how to best handle these.~
- ~The `Wsign-compare` warnings in the core as well as in the generated classes (see also the discussion in #170). Also this needs a bit more discussion on how to proceed.~ (26.01.2021)

Some simple statistics (via `make | sed -nr 's/.+ \[-(.*)\].*/\1/p' | sort | uniq -c`)

#### gcc statistics
Before
```
      2 Wcatch-value=
   2338 Weffc++
      1 Wnon-virtual-dtor
      2 Wpedantic
      3 Wreorder
    366 Wshadow
     97 Wsign-compare
     37 Wunused-parameter
     18 Wunused-variable
```
After
```
   468 Weffc++
```

~All of the `Wshadow` warnings and about a third of the `Weffc++` warnings are fixed by some of the changes that are present in #158 and #156.~ (26.01.2021) All of the remaining `Weffc++` warnings are fixed by #156 and #154.

#### clang statistics
(probably the easier to parse and more reliable output):
Before
```
     15 Wdeprecated-copy-dtor
     16 Winconsistent-missing-override
     22 Wmismatched-tags
      1 Wnon-virtual-dtor
      1 Woverlength-strings
      1 Wreorder-ctor
     23 Wshadow
    101 Wsign-compare
     37 Wunused-parameter
      1 Wunused-private-field
     18 Wunused-variable
```
After
```
      1 Woverlength-strings
```

These are mostly the same warnings under a slightly different name, only one or two are actually warning about things that gcc didn't warn about yet.


- [x] Check `Wsign-compare` appearance in edm4hep (i.e. user-facing code)
- [x] Fix remainging `Weffc++`
  - [x] Default initialize component and datatype members
  - [x] Disable for `Collection`s 
- [x] Fix warnings that appear in builds using llvm 