### PR TITLE
Fix deprecated brew cask install

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Install LCG dependencies
       run: |
         brew install ninja
-        brew cask install gfortran
-        brew cask install xquartz
+        brew install --cask gfortran
+        brew install --cask xquartz
     - name: Compile and test
       run: |
         source /Users/Shared/cvmfs/sft.cern.ch/lcg/views/${{ matrix.LCG }}/setup.sh

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install LCG dependencies
       run: |
         brew install ninja
-        brew install --cask gfortran
+        brew install gfortran
         brew install --cask xquartz
     - name: Compile and test
       run: |


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix deprecated `brew install` commands in mac workflow

ENDRELEASENOTES

`brew cask install` has been deprecated in 2.6.0 and removed in 2.7.0. See https://brew.sh/2020/12/01/homebrew-2.6.0/ and Homebrew/brew/pull/8899

Together with a similar fix in the cvmfs-github-action (cvmfs-contrib/github-action-cvmfs#10) this should fix the mac CI workflows.