### PR TITLE
[WIP] Implement reference collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ spack*
 *.exe
 *.out
 *.app
+
+# clangd cache and other LSP related files
+/.clangd/
+compile_commands.json

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -51,6 +51,9 @@ namespace podio {
     /// fully qualified type name of elements - with namespace
     virtual std::string getValueTypeName() const = 0;
 
+    /// Is this a reference collection
+    virtual bool isReferenceCollection() const = 0;
+
     /// destructor
     virtual ~CollectionBase() = default;
 

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -80,6 +80,8 @@ class ROOTReader : public IReader {
 
 
   private:
+    void createCollectionBranches(const std::vector<std::tuple<int, std::string, std::string>>& collInfo);
+
     std::pair<TTree*, unsigned> getLocalTreeAndEntry(const std::string& treename);
     // Information about the data vector as wall as the collection class type
     // and the index in the collection branches cache vector

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -47,7 +47,7 @@ namespace podio {
     virtual SIOBlock* create(const std::string& name) const=0 ;
 
     // create a new collection for this block
-    virtual void createCollection() = 0;
+    virtual void createCollection(const bool referenceCollection=false) = 0;
 
   protected:
 
@@ -74,11 +74,13 @@ namespace podio {
 
     podio::CollectionIDTable* getTable() { return _table; }
     const std::vector<std::string>& getTypeNames() const { return _types; }
+    const std::vector<short>& getRefCollectionBits() const { return _isRefColl; }
 
   private:
     podio::EventStore* _store{nullptr};
     podio::CollectionIDTable* _table{nullptr};
     std::vector<std::string> _types{};
+    std::vector<short> _isRefColl{};
   };
 
 
@@ -130,7 +132,7 @@ namespace podio {
     std::shared_ptr<SIOBlock> createBlock( const podio::CollectionBase* col, const std::string& name) const;
 
     // return a block with a new collection (used for reading )
-    std::shared_ptr<SIOBlock> createBlock( const std::string& typeStr, const std::string& name) const;
+    std::shared_ptr<SIOBlock> createBlock( const std::string& typeStr, const std::string& name, const bool isRefColl=false) const;
 
     static SIOBlockFactory& instance() {
       static SIOBlockFactory me ;

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -85,6 +85,7 @@ namespace podio {
     int m_eventNumber{0};
     int m_lastEventRead{-1};
     std::vector<std::string> m_typeNames{};
+    std::vector<short> m_refCollectionBits{};
 
     std::shared_ptr<SIOEventMetaDataBlock> m_eventMetaData{};
     std::shared_ptr<SIONumberedMetaDataBlock> m_runMetaData{};

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -207,6 +207,7 @@ class ClassGenerator(object):
     self._fill_templates('ConstObject', datatype)
     self._fill_templates('Obj', datatype)
     self._fill_templates('Collection', datatype)
+    self._fill_templates('RefCollection', datatype)
 
     if 'SIO' in self.io_handlers:
       self._fill_templates('SIOBlock', datatype)

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -65,6 +65,8 @@ public:
   /// fully qualified type name of elements - with namespace
   std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
 
+  bool isReferenceCollection() const override { return false; }
+
   /// Returns the const object of given index
   Const{{ class.bare_type }} operator[](unsigned int index) const;
   /// Returns the object of a given index

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -14,7 +14,6 @@
 // podio specific includes
 #include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
-#include "podio/CollectionIDTable.h"
 
 #include <string>
 #include <vector>
@@ -130,6 +129,8 @@ public:
 {% endfor %}
 
 private:
+  friend class {{ class.bare_type }}RefCollection;
+
   bool m_isValid{false};
   bool m_isReadFromFile{false};
   int m_collectionID{0};

--- a/python/templates/ConstObject.h.jinja2
+++ b/python/templates/ConstObject.h.jinja2
@@ -21,6 +21,7 @@ class Const{{ class.bare_type }} {
 
   friend class {{ class.bare_type }};
   friend class {{ class.bare_type }}Collection;
+  friend class {{ class.bare_type }}RefCollection;
   friend class {{ class.bare_type }}ConstCollectionIterator;
 
 public:

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -22,6 +22,7 @@
 class {{ class.bare_type }} {
 
   friend class {{ class.bare_type }}Collection;
+  friend class {{ class.bare_type }}RefCollection;
   friend class {{ class.bare_type }}CollectionIterator;
   friend class Const{{ class.bare_type }};
 

--- a/python/templates/RefCollection.cc.jinja2
+++ b/python/templates/RefCollection.cc.jinja2
@@ -1,0 +1,79 @@
+{% import "macros/utils.jinja2" as utils %}
+{% import "macros/collections.jinja2" as macros %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#include "{{ incfolder }}{{ class.bare_type }}RefCollection.h"
+
+{{ utils.namespace_open(class.namespace) }}
+
+{% with collection_type = class.bare_type + 'RefCollection' %}
+{{ collection_type }}::{{ collection_type }}() {
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
+}
+
+{{ collection_type }}::~{{ collection_type }}() {
+  clear();
+  // we don't own these objects, so we do not have to clean them up
+  m_entries.clear();
+
+  for (auto& pointer : m_refCollections) { if (pointer) delete pointer; }
+}
+
+Const{{ class.bare_type }} {{ collection_type }}::operator[](unsigned int index) const {
+  return Const{{ class.bare_type }}(m_entries[index]);
+}
+
+Const{{ class.bare_type }} {{ collection_type }}::at(unsigned int index) const {
+  return Const{{ class.bare_type }}(m_entries.at(index));
+}
+
+{{ class.bare_type }} {{ collection_type }}::operator[](unsigned int index) {
+  return {{ class.bare_type }}(m_entries[index]);
+}
+
+{{ class.bare_type }} {{ collection_type }}::at(unsigned int index) {
+  return {{ class.bare_type }}(m_entries.at(index));
+}
+
+void {{ collection_type }}::clear() {
+  m_entries.clear();
+  for (auto& pointer : m_refCollections) { pointer->clear(); }
+}
+
+void {{ collection_type }}::prepareForWrite() {
+  // if this collection has been read from file there is nothing to do
+  if (m_isReadFromFile) return;
+  for (auto& pointer : m_refCollections) { pointer->clear(); }
+
+  for (const auto* obj : m_entries) {
+    m_refCollections[0]->emplace_back(obj->id);
+  }
+}
+
+void {{ collection_type }}::prepareAfterRead() {
+  // really nothing to do here, since we have no data to operate on
+  m_isValid = true;
+  m_isReadFromFile = true;
+}
+
+bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* collectionProvider) {
+  for (const auto& id : *m_refCollections[0]) {
+    {{ macros.get_collection(class.full_type) }}
+    m_entries.push_back(tmp_coll->m_entries[id.index]);
+  }
+
+  return true; // TODO: actually do something to determine this
+}
+
+void {{ collection_type }}::push_back(Const{{ class.bare_type }} object) {
+  const auto obj = object.m_obj;
+  if (obj->id.index < 0) {
+    throw std::invalid_argument("Object needs to be tracked by another collection in order for it to be storable in a RefCollection");
+  } else {
+    m_entries.push_back(obj);
+  }
+}
+
+{% endwith %}
+
+{{ utils.namespace_close(class.namespace) }}

--- a/python/templates/RefCollection.h.jinja2
+++ b/python/templates/RefCollection.h.jinja2
@@ -57,6 +57,8 @@ public:
   /// fully qualified type name of elements - with namespace
   std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
 
+  bool isReferenceCollection() const override { return true; }
+
   void prepareForWrite() override final;
   void prepareAfterRead() override final;
   void setBuffer(void*) override final { /* nothing to do. collection doesn't store any data */ };

--- a/python/templates/RefCollection.h.jinja2
+++ b/python/templates/RefCollection.h.jinja2
@@ -1,0 +1,89 @@
+{% import "macros/utils.jinja2" as utils %}
+{% import "macros/collections.jinja2" as coll_macros %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#ifndef {{ package_name.upper() }}_{{ class.bare_type }}RefCollection_H
+#define {{ package_name.upper() }}_{{ class.bare_type }}RefCollection_H
+
+// datamodel specific includes
+#include "{{ incfolder }}{{ class.bare_type }}.h"
+#include "{{ incfolder }}{{ class.bare_type }}Obj.h"
+#include "{{ incfolder }}{{ class.bare_type }}Collection.h"
+
+// podio specific includes
+#include "podio/ICollectionProvider.h"
+#include "podio/CollectionBase.h"
+
+#include <vector>
+
+{{ utils.namespace_open(class.namespace) }}
+
+/**
+ * A collection referencing objects in other collections
+ */
+{% with collection_type = class.bare_type + 'RefCollection' %}
+class {{ class.bare_type }}RefCollection : public podio::CollectionBase {
+public:
+
+  {{ collection_type }}();
+  {{ collection_type }}& operator=(const {{ collection_type }}&) = delete;
+  {{ collection_type }}(const {{ collection_type }}&) = delete;
+  ~{{ collection_type }}();
+
+  /// indexex access
+  Const{{ class.bare_type }} operator[](unsigned int index) const;
+  Const{{ class.bare_type }} at(unsigned int index) const;
+
+  {{ class.bare_type }} operator[](unsigned int index);
+  {{ class.bare_type }} at(unsigned int index);
+
+  // support for range-based for loops
+  using iterator = {{ class.bare_type }}CollectionIterator;
+  iterator begin() { return iterator(0, &m_entries); }
+  iterator end() { return iterator(m_entries.size(), &m_entries); }
+
+  using const_iterator = {{ class.bare_type }}ConstCollectionIterator;
+  const_iterator begin() const { return const_iterator(0, &m_entries); }
+  const_iterator end() const { return const_iterator(m_entries.size(), &m_entries); }
+
+  /// Append object to the collection
+  void push_back(Const{{ class.bare_type }} object);
+
+  void clear() override final;
+
+  /// number of elements in the collection
+  size_t size() const override final { return m_entries.size(); }
+
+  /// fully qualified type name of elements - with namespace
+  std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
+
+  void prepareForWrite() override final;
+  void prepareAfterRead() override final;
+  void setBuffer(void*) override final { /* nothing to do. collection doesn't store any data */ };
+  bool setReferences(const podio::ICollectionProvider* collectionProvider) override final;
+  podio::CollRefCollection* referenceCollections() override final { return &m_refCollections; }
+  podio::VectorMembersInfo* vectorMembers() override final { return nullptr; }
+
+  void setID(unsigned ID) override final { m_collectionID = ID; }
+
+  unsigned getID() const override final { return m_collectionID; }
+  bool isValid() const override final { return m_isValid; }
+
+  void* getBufferAddress() override final { return nullptr; /*  no data, no buffer */ }
+
+private:
+  bool m_isReadFromFile{false};
+  bool m_isValid{false};
+  int m_collectionID{0};
+
+  podio::CollRefCollection m_refCollections{};
+
+  // could be a vector here, but if we make it a deque we can re-use the
+  // CollectionIterator
+  std::deque<{{ class.bare_type }}Obj*> m_entries{};
+};
+{% endwith %}
+
+{{ utils.namespace_close(class.namespace) }}
+
+#endif

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -3,6 +3,8 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
 #include "{{ incfolder }}{{ class.bare_type }}SIOBlock.h"
+#include "{{ incfolder }}{{ class.bare_type }}Collection.h"
+#include "{{ incfolder }}{{ class.bare_type }}RefCollection.h"
 
 #include <sio/block.h>
 #include <sio/io_device.h>
@@ -32,17 +34,19 @@ void handlePODDataSIO(devT& device, {{ class.namespace }}::{{ class.bare_type }}
 
 void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
 
-  auto* dataVec = static_cast<{{ class.namespace }}::{{ class.bare_type }}Collection*>(_col)->_getBuffer();
+  if (not _col->isReferenceCollection()) {
+    auto* dataVec = static_cast<{{ class.namespace }}::{{ class.bare_type }}Collection*>(_col)->_getBuffer();
+    unsigned size(0);
+    device.data( size );
+    dataVec->resize(size);
 
-  unsigned size(0);
-  device.data( size );
-  dataVec->resize(size);
-
-  podio::handlePODDataSIO(device, &(*dataVec)[0], size);
+    podio::handlePODDataSIO(device, &(*dataVec)[0], size);
+  }
 
   //---- read ref collections -----
   podio::CollRefCollection* refCols = _col->referenceCollections() ;
   for( auto* refC : *refCols ){
+    unsigned size{0};
     device.data( size ) ;
     refC->resize(size) ;
     podio::handlePODDataSIO( device ,  &((*refC)[0]), size ) ;
@@ -61,17 +65,18 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
 void {{ block_class }}::write(sio::write_device& device) {
   _col->prepareForWrite() ;
 
-  auto * dataVec = static_cast<{{ class.namespace }}::{{ class.bare_type}}Collection*>(_col)->_getBuffer() ;
+  if (not _col->isReferenceCollection()) {
+    auto * dataVec = static_cast<{{ class.namespace }}::{{ class.bare_type}}Collection*>(_col)->_getBuffer() ;
+    unsigned size = dataVec->size() ;
+    device.data( size ) ;
 
-  unsigned size = dataVec->size() ;
-  device.data( size ) ;
-
-  podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
+    podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
+  }
 
   //---- write ref collections -----
   podio::CollRefCollection* refCols = _col->referenceCollections() ;
   for( auto* refC : *refCols ){
-    size = refC->size() ;
+    unsigned size = refC->size() ;
     device.data( size ) ;
     podio::handlePODDataSIO( device ,  &((*refC)[0]), size ) ;
   }
@@ -84,6 +89,14 @@ void {{ block_class }}::write(sio::write_device& device) {
 {{ macros.vector_member_write(member, loop.index0) }}
 {% endfor %}
 {% endif %}
+}
+
+void {{ block_class }}::createCollection(const bool referenceCollection) {
+  if (referenceCollection) {
+    setCollection(new {{ class.bare_type }}RefCollection);
+  } else {
+    setCollection(new {{ class.bare_type }}Collection);
+  }
 }
 
 {% endwith %}

--- a/python/templates/SIOBlock.h.jinja2
+++ b/python/templates/SIOBlock.h.jinja2
@@ -4,8 +4,6 @@
 #ifndef {{ package_name.upper() }}_{{ class.bare_type }}SIOBlock_H
 #define {{ package_name.upper() }}_{{ class.bare_type }}SIOBlock_H
 
-#include "{{ incfolder}}{{ class.bare_type }}Collection.h"
-
 #include "podio/SIOBlock.h"
 
 #include <sio/api.h>
@@ -35,9 +33,7 @@ public:
   // Write the particle data to the device
   virtual void write(sio::write_device& device) override;
 
-  virtual void createCollection() override {
-    setCollection(new {{ class.bare_type }}Collection);
-  }
+  virtual void createCollection(const bool referenceCollection=false) override;
 
   SIOBlock* create(const std::string& name) const override { return new {{ block_class }}(name); }
 };

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -51,7 +51,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   }
 {% endmacro %}
 
-{% macro _get_collection(type) %}
+{% macro get_collection(type) %}
       CollectionBase* coll = nullptr;
       collectionProvider->get(id.collectionID, coll);
       {{ type }}Collection* tmp_coll = static_cast<{{ type }}Collection*>(coll);
@@ -61,7 +61,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   for (unsigned int i = 0, size = m_refCollections[{{ index }}]->size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
-{{ _get_collection(relation.full_type) }}
+{{ get_collection(relation.full_type) }}
       const auto tmp = (*tmp_coll)[id.index];
       m_rel_{{ relation.name }}->emplace_back(tmp);
     } else {
@@ -76,7 +76,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   for (unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ real_index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
-  {{ _get_collection(relation.full_type) }}
+  {{ get_collection(relation.full_type) }}
       m_entries[i]->m_{{ relation.name }} = new Const{{ relation.bare_type }}((*tmp_coll)[id.index]);
     } else {
       m_entries[i]->m_{{ relation.name }} = nullptr;

--- a/python/templates/macros/sioblocks.jinja2
+++ b/python/templates/macros/sioblocks.jinja2
@@ -1,6 +1,6 @@
 {% macro vector_member_write(member, index) %}
     auto* vec{{ index }} = *reinterpret_cast<std::vector<{{ member.full_type }}>**>(vecMemInfo->at({{ index }}).second);
-    size = vec{{ index }}->size();
+    unsigned size = vec{{ index }}->size();
     device.data(size);
     podio::handlePODDataSIO(device, &(*vec{{ index }})[0], size);
 
@@ -9,6 +9,7 @@
 
 {% macro vector_member_read(member, index) %}
     auto* vec{{ index }} = *reinterpret_cast<std::vector<{{ member.full_type }}>**>(vecMemInfo->at({{ index }}).second);
+    unsigned size{0};
     device.data(size);
     vec{{ index }}->resize(size);
     podio::handlePODDataSIO(device, &(*vec{{ index }})[0], size);

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -18,6 +18,7 @@ namespace podio {
     device.data(names);
     device.data(ids);
     device.data(_types);
+    device.data(_isRefColl);
 
     _table = new CollectionIDTable(std::move(ids), std::move(names));
   }
@@ -27,6 +28,7 @@ namespace podio {
     device.data(_table->ids());
 
     std::vector<std::string> typeNames;
+    std::vector<short> isRefColl;
     typeNames.reserve(_table->ids().size());
     for (const int id : _table->ids()) {
       CollectionBase* tmp;
@@ -34,8 +36,10 @@ namespace podio {
         std::cerr << "ERROR during writing of CollectionID table" << std::endl;
       }
       typeNames.push_back(tmp->getValueTypeName());
+      isRefColl.push_back(tmp->isReferenceCollection());
     }
     device.data(typeNames);
+    device.data(isRefColl);
   }
 
   template<typename MappedT>
@@ -105,12 +109,12 @@ namespace podio {
   }
 
 
-  std::shared_ptr<SIOBlock> SIOBlockFactory::createBlock(const std::string& typeStr, const std::string& name) const {
+  std::shared_ptr<SIOBlock> SIOBlockFactory::createBlock(const std::string& typeStr, const std::string& name, const bool isRefColl) const {
     const auto it = _map.find(typeStr) ;
 
     if( it != _map.end() ){
       auto blk = std::shared_ptr<SIOBlock>(it->second->create( name ));
-      blk->createCollection() ;
+      blk->createCollection(isRefColl) ;
       return blk;
     } else {
       return nullptr;

--- a/src/SIOReader.cc
+++ b/src/SIOReader.cc
@@ -125,7 +125,7 @@ namespace podio {
     m_blocks.push_back(m_eventMetaData);
 
     for (size_t i = 0; i < m_typeNames.size(); ++i) {
-      auto blk = podio::SIOBlockFactory::instance().createBlock(m_typeNames[i], m_table->names()[i]);
+      auto blk = podio::SIOBlockFactory::instance().createBlock(m_typeNames[i], m_table->names()[i], m_refCollectionBits[i]);
       m_blocks.push_back(blk);
       m_inputs.emplace_back(blk->getCollection(), m_table->names()[i]);
     }
@@ -147,6 +147,7 @@ namespace podio {
     auto* idTableBlock = static_cast<SIOCollectionIDTableBlock*>(blocks[0].get());
     m_table = idTableBlock->getTable();
     m_typeNames = idTableBlock->getTypeNames();
+    m_refCollectionBits = idTableBlock->getRefCollectionBits();
   }
 
   void SIOReader::readMetaDataRecord(std::shared_ptr<SIONumberedMetaDataBlock> mdBlock) {

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -32,10 +32,9 @@ inline void setCollectionAddresses(podio::CollectionBase* collection, const Coll
     branches.data->SetAddress(buffer);
   }
 
-  if (auto refCollections = collection->referenceCollections()) {
-    for (size_t i = 0; i < refCollections->size(); ++i) {
-      branches.refs[i]->SetAddress(&(*refCollections)[i]);
-    }
+  auto refCollections = collection->referenceCollections();
+  for (size_t i = 0; i < refCollections->size(); ++i) {
+    branches.refs[i]->SetAddress(&(*refCollections)[i]);
   }
 
   if (auto vecMembers = collection->vectorMembers()) {
@@ -46,9 +45,11 @@ inline void setCollectionAddresses(podio::CollectionBase* collection, const Coll
 }
 
 inline CollectionBase* prepareCollection(const TClass* dataClass, const TClass* collectionClass) {
-  auto* buffer = dataClass->New();
   auto* collection = static_cast<CollectionBase*>(collectionClass->New());
-  collection->setBuffer(buffer);
+  if (dataClass) {
+    auto* buffer = dataClass->New();
+    collection->setBuffer(buffer);
+  }
   return collection;
 }
 

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -8,6 +8,7 @@
     <class name="podio::GenericParameters::MapType<float>"/>
     <class name="podio::GenericParameters::MapType<std::string>"/>
     <class name="std::map<int,podio::GenericParameters>"/>
+    <class name="std::vector<std::tuple<int, std::string, std::string>>"/>
     <class name="podio::CollectionBase"/>
     <class name="podio::CollectionIDTable">
         <field name="m_mutex" transient="true"/>

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -3,7 +3,7 @@
 
 // Data model
 #include "datamodel/EventInfoCollection.h"
-#include "datamodel/ExampleMCCollection.h"
+#include "datamodel/ExampleMCRefCollection.h"
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/ExampleClusterCollection.h"
 #include "datamodel/ExampleReferencingTypeCollection.h"
@@ -30,6 +30,7 @@ void write(podio::EventStore& store, WriterT& writer) {
 
   auto& info       = store.create<EventInfoCollection>("info");
   auto& mcps       = store.create<ExampleMCCollection>("mcparticles");
+  auto& mcpsRefs   = store.create<ExampleMCRefCollection>("mcParticleRefs");
   auto& hits       = store.create<ExampleHitCollection>("hits");
   auto& clusters   = store.create<ExampleClusterCollection>("clusters");
   auto& refs       = store.create<ExampleReferencingTypeCollection>("refs");
@@ -46,6 +47,7 @@ void write(podio::EventStore& store, WriterT& writer) {
 
   writer.registerForWrite("info");
   writer.registerForWrite("mcparticles");
+  writer.registerForWrite("mcParticleRefs");
   writer.registerForWrite("hits");
   writer.registerForWrite("clusters");
   writer.registerForWrite("refs");
@@ -163,6 +165,18 @@ void write(podio::EventStore& store, WriterT& writer) {
         std::cout << " " << it->getObjectID().index;
       }
 
+    }
+    //-------------------------------
+
+    // ----------------- add all "odd" mc particles into a reference collection
+    for (auto p : mcps) {
+      if (p.id() % 2) {
+        mcpsRefs.push_back(p);
+      }
+    }
+
+    if (mcpsRefs.size() != mcps.size() / 2) {
+      throw std::runtime_error("The mcParticleRefs collection should now contain half as many elements as the mcparticles collection");
     }
     //-------------------------------
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Implement true reference collections, that can collect objects that are already tracked by another collection. Each datatype now gets a `RefCollection` class that behaves similar to a `Collection` with the major difference, that it does not own its elements, and does not offer `create` functionality. It can only store elements that are already tracked by a "proper" `Collection`.

ENDRELEASENOTES

~~**Contains all changes of #180 !**~~


### reference collections
The basic idea is to generate an additional `RefCollection` class, which only holds a container of `Obj*` and gives similar access as a normal `Collection`. All objects that are stored in a `RefCollection` have to be already tracked by a `Collection`, as the `RefCollection` does no management of resources in any form. Since it doesn't manage any resources, it is also lacking the `create` functionality. To persist it's contents it simply fills a vector of `podio::ObjectID`, following the same approach as `OneToOneRelation`s.

~~### const correct collection access~~
~~Introduce appropriate overloads for `operator[]` and `at` functions. Additionally introduce a new `ConstCollectionIterator` alongside the `CollectionIterator`. The former only gives access to `Const` classes, while the latter gives access to the normal classes.~~ Moved to #193

~~### const correct meta data handling in EventStore~~
~~Since the `EventStore` is never const at the moment, I have removed all the `const` qualifiers from the methods giving access to any kind of metadata. This makes it impossible to use metadata from a `const EventStore`, but we do not have that anywhere at the moment. I think this is the better solution that giving the wrong impression that we have actually handled metadata in a const-correct way.~~ Moved to #192

fixes #146

- [x] generate additional `RefCollection` classes.
- [x] Enable all readers / writers to read and write these collections again
