### PR TITLE
Root performance degradation fixes

### DIFF
--- a/include/podio/CollectionBranches.h
+++ b/include/podio/CollectionBranches.h
@@ -1,0 +1,22 @@
+#ifndef PODIO_COLLECTION_BRANCHES_H
+#define PODIO_COLLECTION_BRANCHES_H
+
+#include "TBranch.h"
+
+#include <vector>
+
+namespace podio::root_utils {
+/**
+ * Small helper struct to collect all branches that are necessary to read or
+ * write a collection. Needed to cache the branch pointers and avoid having to
+ * get them from a TTree/TChain for every event.
+ */
+struct CollectionBranches {
+  TBranch* data{nullptr};
+  std::vector<TBranch*> refs{};
+  std::vector<TBranch*> vecs{};
+};
+
+}
+
+#endif

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -86,6 +86,7 @@ class ROOTReader : public IReader {
     using CollectionInfo = std::tuple<const TClass*, const TClass*, size_t>;
 
     CollectionBase* getCollection(const std::pair<std::string, CollectionInfo>& collInfo);
+    CollectionBase* readCollectionData(const root_utils::CollectionBranches& branches, CollectionBase* collection, Long64_t entry, const std::string& name);
 
     typedef std::pair<CollectionBase*, std::string> Input;
     std::vector<Input> m_inputs{};

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -83,19 +83,30 @@ class ROOTReader : public IReader {
 
   private:
     std::pair<TTree*, unsigned> getLocalTreeAndEntry(const std::string& treename);
+    // Information about the data vector as wall as the collection class type
+    // and the index in the collection branches cache vector
     using CollectionInfo = std::tuple<const TClass*, const TClass*, size_t>;
 
     CollectionBase* getCollection(const std::pair<std::string, CollectionInfo>& collInfo);
     CollectionBase* readCollectionData(const root_utils::CollectionBranches& branches, CollectionBase* collection, Long64_t entry, const std::string& name);
 
+    // cache collections that have been read already in a given event
     typedef std::pair<CollectionBase*, std::string> Input;
     std::vector<Input> m_inputs{};
 
+    // cache the necessary information to more quickly construct and read each
+    // collection after it has been read the very first time
     std::map<std::string, CollectionInfo> m_storedClasses{};
+
     CollectionIDTable* m_table{nullptr};
     TChain* m_chain{nullptr};
     unsigned m_eventNumber{0};
 
+    // Similar to writing we cache the branches that belong to each collection
+    // in order to not having to look them up every event. However, for the
+    // reader we cannot guarantee a fixed order of collections as they are read
+    // on demand. Hence, we give each collection an index the first time it is
+    // read and we start caching the branches.
     size_t m_collectionIndex = 0;
     std::vector<root_utils::CollectionBranches> m_collectionBranches{};
 };

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -1,7 +1,9 @@
 #ifndef ROOTREADER_H
 #define ROOTREADER_H
 
-#include "podio/rootUtils.h"
+#include "podio/ICollectionProvider.h"
+#include "podio/IReader.h"
+#include "podio/CollectionBranches.h"
 
 #include <algorithm>
 #include <map>
@@ -16,10 +18,6 @@ class TClass;
 class TFile;
 class TTree;
 class TChain;
-
-
-#include "podio/ICollectionProvider.h"
-#include "podio/IReader.h"
 
 
 namespace podio {

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -1,12 +1,15 @@
 #ifndef ROOTREADER_H
 #define ROOTREADER_H
 
+#include "podio/rootUtils.h"
+
 #include <algorithm>
 #include <map>
 #include <string>
 #include <vector>
 #include <iostream>
 #include <utility>
+#include <tuple>
 
 // forward declarations
 class TClass;
@@ -48,10 +51,6 @@ class ROOTReader : public IReader {
     /// Read all collections requested
     void readEvent();
 
-    /// get collection of name/type; returns true if successfull
-    template<typename T>
-    bool getCollection(const std::string& name, T*& collection);
-
     /// Read CollectionIDTable from ROOT file
     CollectionIDTable* getCollectionIDTable() override final {return m_table;}
 
@@ -81,26 +80,24 @@ class ROOTReader : public IReader {
   /// read the run meta data
     std::map<int,GenericParameters>* readRunMetaData() override final ;
 
+
   private:
     std::pair<TTree*, unsigned> getLocalTreeAndEntry(const std::string& treename);
+    using CollectionInfo = std::tuple<const TClass*, const TClass*, size_t>;
+
+    CollectionBase* getCollection(const std::pair<std::string, CollectionInfo>& collInfo);
 
     typedef std::pair<CollectionBase*, std::string> Input;
     std::vector<Input> m_inputs{};
-    std::map<std::string, std::pair<TClass*,TClass*> > m_storedClasses{};
+
+    std::map<std::string, CollectionInfo> m_storedClasses{};
     CollectionIDTable* m_table{nullptr};
     TChain* m_chain{nullptr};
     unsigned m_eventNumber{0};
-};
 
-template<typename T>
-bool ROOTReader::getCollection(const std::string& name, T*& collection){
-  collection = dynamic_cast<T*>(readCollection(name));
-  if (collection != nullptr) {
-    return true;
-  } else {
-    return false;
-  }
-}
+    size_t m_collectionIndex = 0;
+    std::vector<root_utils::CollectionBranches> m_collectionBranches{};
+};
 
 } // namespace
 

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -48,6 +48,11 @@ namespace podio {
     TTree* m_evtMDtree;
     TTree* m_colMDtree;
     std::vector<std::string> m_collectionsToWrite{};
+    // In order to avoid having to look up the branches from the datatree for
+    // every event, we cache them in this vector, that is populated the first
+    // time we write an event. Since the collections and their order do not
+    // change between events, the assocation between the collections to write
+    // and their branches is simply index based
     std::vector<root_utils::CollectionBranches> m_collectionBranches{};
 
     bool m_firstEvent{true};

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -3,6 +3,9 @@
 
 #include "podio/CollectionBase.h"
 #include "podio/EventStore.h"
+#include "podio/rootUtils.h"
+
+#include "TBranch.h"
 
 #include <string>
 #include <vector>
@@ -30,6 +33,7 @@ namespace podio {
     void finish();
 
   private:
+
     using StoreCollection = std::pair<const std::string&, podio::CollectionBase*>;
     void createBranches(const std::vector<StoreCollection>& collections);
     void setBranches(const std::vector<StoreCollection>& collections);
@@ -43,8 +47,9 @@ namespace podio {
     TTree* m_runMDtree;
     TTree* m_evtMDtree;
     TTree* m_colMDtree;
-    std::vector<CollectionBase*> m_storedCollections{};
     std::vector<std::string> m_collectionsToWrite{};
+    std::vector<root_utils::CollectionBranches> m_collectionBranches{};
+
     bool m_firstEvent{true};
   };
 

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -3,7 +3,7 @@
 
 #include "podio/CollectionBase.h"
 #include "podio/EventStore.h"
-#include "podio/rootUtils.h"
+#include "podio/CollectionBranches.h"
 
 #include "TBranch.h"
 

--- a/include/podio/rootUtils.h
+++ b/include/podio/rootUtils.h
@@ -1,8 +1,11 @@
 #ifndef PODIO_ROOT_UTILS_H__
 #define PODIO_ROOT_UTILS_H__
 
+#include "podio/CollectionBase.h"
+
 #include "TBranch.h"
 #include "TChain.h"
+#include "TClass.h"
 
 #include <vector>
 #include <string>
@@ -28,6 +31,34 @@ inline std::string refBranch(const std::string& name, size_t index) {
 inline std::string vecBranch(const std::string& name, size_t index) {
   return name + "_" + std::to_string(index);
 }
+
+
+inline void setCollectionAddresses(podio::CollectionBase* collection, const CollectionBranches& branches) {
+  auto refCollections = collection->referenceCollections();
+  auto vecMembers = collection->vectorMembers();
+
+  branches.data->SetAddress(collection->getBufferAddress());
+
+  if (refCollections) {
+    for (size_t i = 0; i < refCollections->size(); ++i) {
+      branches.refs[i]->SetAddress(&(*refCollections)[i]);
+    }
+  }
+
+  if (vecMembers) {
+    for (size_t i = 0; i < vecMembers->size(); ++i) {
+      branches.vecs[i]->SetAddress((*vecMembers)[i].second);
+    }
+  }
+}
+
+inline CollectionBase* prepareCollection(const TClass* dataClass, const TClass* collectionClass) {
+  auto* buffer = dataClass->New();
+  auto* collection = static_cast<CollectionBase*>(collectionClass->New());
+  collection->setBuffer(buffer);
+  return collection;
+}
+
 
 }
 

--- a/include/podio/rootUtils.h
+++ b/include/podio/rootUtils.h
@@ -12,7 +12,7 @@
 
 namespace podio::root_utils {
 // test workaround function for 6.22/06 performance degradation
-  // see: https://root-forum.cern.ch/t/serious-degradation-of-i-o-performance-from-6-20-04-to-6-22-06/43584/10
+// see: https://root-forum.cern.ch/t/serious-degradation-of-i-o-performance-from-6-20-04-to-6-22-06/43584/10
 template<class Tree>
 TBranch* getBranch(Tree* chain, const char* name) {
   return static_cast<TBranch*>(chain->GetListOfBranches()->FindObject(name));

--- a/include/podio/rootUtils.h
+++ b/include/podio/rootUtils.h
@@ -1,0 +1,34 @@
+#ifndef PODIO_ROOT_UTILS_H__
+#define PODIO_ROOT_UTILS_H__
+
+#include "TBranch.h"
+#include "TChain.h"
+
+#include <vector>
+#include <string>
+
+namespace podio::root_utils {
+// test workaround function for 6.22/06 performance degradation
+  // see: https://root-forum.cern.ch/t/serious-degradation-of-i-o-performance-from-6-20-04-to-6-22-06/43584/10
+template<class Tree>
+TBranch* getBranch(Tree* chain, const char* name) {
+  return static_cast<TBranch*>(chain->GetListOfBranches()->FindObject(name));
+}
+
+struct CollectionBranches {
+  TBranch* data{nullptr};
+  std::vector<TBranch*> refs{};
+  std::vector<TBranch*> vecs{};
+};
+
+inline std::string refBranch(const std::string& name, size_t index) {
+  return name + "#" + std::to_string(index);
+}
+
+inline std::string vecBranch(const std::string& name, size_t index) {
+  return name + "_" + std::to_string(index);
+}
+
+}
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 # target usage requirements
 
 file(GLOB sources *.cc)
+LIST(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/rootUtils.h)
 SET(root_sources ${sources})
 
 # --- Store the sources for sio into a separate list
@@ -12,8 +13,8 @@ endif()
 
 # Remove SIO and ROOT related things from the core library
 LIST(FILTER sources EXCLUDE REGEX SIO.*)
-LIST(FILTER sources EXCLUDE REGEX ROOT.*|PythonEventStore.* )
-LIST(FILTER root_sources INCLUDE REGEX ROOT.*|PythonEventStore.* )
+LIST(FILTER sources EXCLUDE REGEX ROOT.*|PythonEventStore.*|root.* )
+LIST(FILTER root_sources INCLUDE REGEX ROOT.*|PythonEventStore.*|root.* )
 
 # Main Library, no external dependencies
 add_library(podio SHARED ${sources})

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -1,3 +1,5 @@
+#include "rootUtils.h"
+
 // podio specific includes
 #include "podio/ROOTReader.h"
 #include "podio/CollectionIDTable.h"

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -10,14 +10,11 @@
 #include "podio/CollectionIDTable.h"
 #include "podio/CollectionBase.h"
 #include "podio/GenericParameters.h"
+#include "podio/rootUtils.h"
+
 
 namespace podio {
-  // test workaround function for 6.22/06 performance degradation
-  // see: https://root-forum.cern.ch/t/serious-degradation-of-i-o-performance-from-6-20-04-to-6-22-06/43584/10
-  template<class Tree>
-  TBranch* getBranch(Tree* chain, const char* name) {
-    return static_cast<TBranch*>(chain->GetListOfBranches()->FindObject(name));
-  }
+  using root_utils::getBranch;
 
   std::pair<TTree*, unsigned> ROOTReader::getLocalTreeAndEntry(const std::string& treename) {
     auto localEntry = m_chain->LoadTree(m_eventNumber);

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -1,3 +1,9 @@
+// podio specific includes
+#include "podio/ROOTReader.h"
+#include "podio/CollectionIDTable.h"
+#include "podio/CollectionBase.h"
+#include "podio/GenericParameters.h"
+
 // ROOT specific includes
 #include "TFile.h"
 #include "TTree.h"
@@ -5,16 +11,8 @@
 #include "TROOT.h"
 #include "TTreeCache.h"
 
-// podio specific includes
-#include "podio/ROOTReader.h"
-#include "podio/CollectionIDTable.h"
-#include "podio/CollectionBase.h"
-#include "podio/GenericParameters.h"
-#include "podio/rootUtils.h"
-
 
 namespace podio {
-  using root_utils::getBranch;
 
   std::pair<TTree*, unsigned> ROOTReader::getLocalTreeAndEntry(const std::string& treename) {
     auto localEntry = m_chain->LoadTree(m_eventNumber);
@@ -25,7 +23,7 @@ namespace podio {
   GenericParameters* ROOTReader::readEventMetaData(){
     GenericParameters* emd = new GenericParameters() ;
     auto [evt_metadatatree, entry] = getLocalTreeAndEntry("evt_metadata");
-    auto* branch = getBranch(evt_metadatatree, "evtMD");
+    auto* branch = root_utils::getBranch(evt_metadatatree, "evtMD");
     branch->SetAddress(&emd);
     evt_metadatatree->GetEntry(entry);
     return emd ;
@@ -33,7 +31,7 @@ namespace podio {
   std::map<int,GenericParameters>* ROOTReader::readCollectionMetaData(){
     auto* emd = new std::map<int,GenericParameters> ;
     auto* col_metadatatree = getLocalTreeAndEntry("col_metadata").first;
-    auto* branch = getBranch(col_metadatatree, "colMD");
+    auto* branch = root_utils::getBranch(col_metadatatree, "colMD");
     branch->SetAddress(&emd);
     col_metadatatree->GetEntry(0);
     return emd ;
@@ -41,21 +39,20 @@ namespace podio {
   std::map<int,GenericParameters>* ROOTReader::readRunMetaData(){
     auto* emd = new std::map<int,GenericParameters> ;
     auto* run_metadatatree = getLocalTreeAndEntry("run_metadata").first;
-    auto* branch = getBranch(run_metadatatree, "runMD");
+    auto* branch = root_utils::getBranch(run_metadatatree, "runMD");
     branch->SetAddress(&emd);
     run_metadatatree->GetEntry(0);
     return emd ;
   }
+
+
 
   CollectionBase* ROOTReader::getCollection(const std::pair<std::string, CollectionInfo>& collInfo) {
     const auto name = collInfo.first;
     const auto [theClass, collectionClass, index] = collInfo.second;
     auto& branches = m_collectionBranches[index];
 
-    auto* buffer = theClass->New();
-    auto* collection = static_cast<CollectionBase*>(collectionClass->New());
-    // connect collection and branch
-    collection->setBuffer(buffer);
+    auto* collection = root_utils::prepareCollection(theClass, collectionClass);
 
     auto refCollections = collection->referenceCollections();
     auto vecMembers = collection->vectorMembers();
@@ -63,15 +60,15 @@ namespace podio {
     const auto localEntry = m_chain->LoadTree(m_eventNumber);
     // After switching trees in the chain, branch pointers get invalidated so
     // they need to be reassigned.
-    // NOTE: passing the pointer to branch pointer as third argument
-    // automatically takes care of updating the branch pointer as necessary
+    // NOTE: root 6.22/06 requires that we get completely new branches here,
+    // with 6.20/04 we could just re-set them
     if (localEntry == 0) {
-      m_chain->SetBranchAddress(name.c_str(), collection->getBufferAddress(), &branches.data);
+      branches.data = root_utils::getBranch(m_chain, name.c_str());
       // reference collections
       if (refCollections) {
         for (size_t i = 0; i < refCollections->size(); ++i) {
           const auto brName = root_utils::refBranch(name, i);
-          m_chain->SetBranchAddress(brName.c_str(), &(*refCollections)[i], &branches.refs[i]);
+          branches.refs[i] = root_utils::getBranch(m_chain, brName.c_str());
         }
       }
 
@@ -79,39 +76,15 @@ namespace podio {
       if (vecMembers) {
         for (size_t i = 0; i < vecMembers->size(); ++i) {
           const auto brName = root_utils::vecBranch(name, i);
-          m_chain->SetBranchAddress(brName.c_str(), (*vecMembers)[i].second, &branches.vecs[i]);
-        }
-      }
-    } else {
-      // Otherwise we simply set the addresses on the known branches
-      branches.data->SetAddress(collection->getBufferAddress());
-
-      if (refCollections) {
-        for (size_t i = 0; i < refCollections->size(); ++i) {
-          branches.refs[i]->SetAddress(&(*refCollections)[i]);
-        }
-      }
-
-      if (vecMembers) {
-        for (size_t i = 0; i < vecMembers->size(); ++i) {
-          branches.vecs[i]->SetAddress((*vecMembers)[i].second);
+          branches.vecs[i] = root_utils::getBranch(m_chain, brName.c_str());
         }
       }
     }
 
-    // Read all data
-    branches.data->GetEntry(localEntry);
-    for (auto* br : branches.refs) br->GetEntry(localEntry);
-    for (auto* br : branches.vecs) br->GetEntry(localEntry);
+    // set the addresses
+    root_utils::setCollectionAddresses(collection, branches);
 
-    // do the unpacking
-    const auto id = m_table->collectionID(name);
-    collection->setID(id);
-    collection->prepareAfterRead();
-
-    m_inputs.emplace_back(std::make_pair(collection, name));
-
-    return collection;
+    return readCollectionData(branches, collection, localEntry, name);
   }
 
 
@@ -129,8 +102,8 @@ namespace podio {
       return getCollection(*info);
     }
 
-    // Otherwise do some setup first
-    if (auto branch = getBranch(m_chain, name.c_str())) {
+    // Otherwise do some setup first and then directly read the collection
+    if (auto branch = root_utils::getBranch(m_chain, name.c_str())) {
       const std::string dataClassName = branch->GetClassName();
       const auto* theClass = gROOT->GetClass(dataClassName.c_str());
       if (theClass == nullptr) return nullptr;
@@ -145,20 +118,22 @@ namespace podio {
       const auto* collectionClass = gROOT->GetClass(collectionClassName.c_str());
       if (collectionClass == nullptr) return nullptr;
 
+      // create the branches and cache them
       root_utils::CollectionBranches branches;
       branches.data = branch;
 
-      auto* collection = static_cast<CollectionBase*>(collectionClass->New());
+      auto* collection = root_utils::prepareCollection(theClass, collectionClass);
+
       if (auto refCollections = collection->referenceCollections()) {
         for (size_t i = 0; i < refCollections->size(); ++i) {
           const auto brName = root_utils::refBranch(name, i);
-          branches.refs.push_back(getBranch(m_chain, brName.c_str()));
+          branches.refs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
         }
       }
       if (auto vecMembers = collection->vectorMembers()) {
         for (size_t i = 0; i < vecMembers->size(); ++i) {
           const auto brName = root_utils::vecBranch(name, i);
-          branches.vecs.push_back(getBranch(m_chain, brName.c_str()));
+          branches.vecs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
         }
       }
 
@@ -167,10 +142,28 @@ namespace podio {
       m_storedClasses[name] = collInfo;
       m_collectionBranches.push_back(branches);
 
-      return getCollection(std::make_pair(name, collInfo));
+      // connect the branches and the buffers
+      root_utils::setCollectionAddresses(collection, branches);
+
+      return readCollectionData(branches, collection, 0, name);
     }
 
     return nullptr;
+  }
+
+  CollectionBase* ROOTReader::readCollectionData(const root_utils::CollectionBranches& branches, CollectionBase* collection, Long64_t entry, const std::string& name) {
+    // Read all data
+    branches.data->GetEntry(entry);
+    for (auto* br : branches.refs) br->GetEntry(entry);
+    for (auto* br : branches.vecs) br->GetEntry(entry);
+
+    // do the unpacking
+    const auto id = m_table->collectionID(name);
+    collection->setID(id);
+    collection->prepareAfterRead();
+
+    m_inputs.emplace_back(std::make_pair(collection, name));
+    return collection;
   }
 
   void ROOTReader::openFile(const std::string& filename){

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -81,9 +81,9 @@ void ROOTWriter::createBranches(const std::vector<StoreCollection>& collections)
 
 void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
   size_t iCollection = 0;
-  for (auto& [name, coll] : collections) {
+  for (auto& coll : collections) {
     const auto& branches = m_collectionBranches[iCollection];
-    root_utils::setCollectionAddresses(coll, branches);
+    root_utils::setCollectionAddresses(coll.second, branches);
 
     iCollection++;
   }

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -1,3 +1,5 @@
+#include "rootUtils.h"
+
 // podio specific includes
 #include "podio/CollectionBase.h"
 #include "podio/EventStore.h"
@@ -6,7 +8,6 @@
 // ROOT specifc includes
 #include "TFile.h"
 #include "TTree.h"
-#include "podio/rootUtils.h"
 
 namespace podio {
   ROOTWriter::ROOTWriter(const std::string& filename, EventStore* store) :

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -6,6 +6,7 @@
 // ROOT specifc includes
 #include "TFile.h"
 #include "TTree.h"
+#include "podio/rootUtils.h"
 
 namespace podio {
   ROOTWriter::ROOTWriter(const std::string& filename, EventStore* store) :
@@ -82,23 +83,7 @@ void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
   size_t iCollection = 0;
   for (auto& [name, coll] : collections) {
     const auto& branches = m_collectionBranches[iCollection];
-    branches.data->SetAddress(coll->getBufferAddress());
-
-    if (auto refColls = coll->referenceCollections()) {
-      int i = 0;
-      for (auto& c : (*refColls)) {
-        branches.refs[i]->SetAddress(&c);
-        i++;
-      }
-    }
-
-    if (auto vminfo = coll->vectorMembers()) {
-      int i = 0;
-      for (const auto& info : (*vminfo)) {
-        branches.vecs[i]->SetAddress(info.second);
-        i++;
-      }
-    }
+    root_utils::setCollectionAddresses(coll, branches);
 
     iCollection++;
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve the branch look-up logic in ROOTReader and ROOTWriter. Triggered by a performance degradation in v6.22/06, where this logic was changed inside ROOT and our use case was affected badly. All ROOT versions profit from these changes as it is in general more efficient than the previous implementation.

ENDRELEASENOTES

Need to discuss which of the proposed solutions in https://root-forum.cern.ch/t/serious-degradation-of-i-o-performance-from-6-20-04-to-6-22-06/43584/10 we would like to have in the end. ~Currently this PR only implements the first proposal, but this is something that probably needs to be touched again in the redesign, so this might be fine.~

~Also contains changes from #171. **Do not merge before that**~

Fixes #179 