### PR TITLE
Add coverity scan based on run-lcg-view action

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,7 +2,7 @@ name: coverity
 
 on:
   schedule:
-    - cron:  '0 0 * * 0'
+    - cron:  '0 0 * * *'
 
 jobs:
   run-coverity:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: aidasoft/run-lcg-view@v2
       with:
-        coverity-cmake-command: 'cmake -DCMAKE_CXX_STANDARD=17 ..'
+        coverity-cmake-command: 'cmake -DCMAKE_CXX_STANDARD=17  -DENABLE_SIO=ON ..'
         coverity-project: 'AIDASoft%2Fpodio'
         coverity-project-token: ${{ secrets.PODIO_COVERITY_TOKEN }}
         github-pat: ${{ secrets.READ_COVERITY_IMAGE }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,20 @@
+name: coverity
+
+on:
+  schedule:
+    - cron:  '0 0 * * 0'
+
+jobs:
+  run-coverity:
+    runs-on: ubuntu-latest
+    if: github.repository == 'AIDASoft/podio'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v2
+      with:
+        coverity-cmake-command: 'cmake -DCMAKE_CXX_STANDARD=17 ..'
+        coverity-project: 'AIDASoft%2Fpodio'
+        coverity-project-token: ${{ secrets.PODIO_COVERITY_TOKEN }}
+        github-pat: ${{ secrets.READ_COVERITY_IMAGE }}
+        release-platform: "LCG_99/x86_64-centos7-gcc10-opt"


### PR DESCRIPTION

BEGINRELEASENOTES
- Add coverity nightly scan based on `run-lcg-view` action

ENDRELEASENOTES

I have been working on the action, and used podio as an example. @andresailer can give access to the project to whom it is needed.