### PR TITLE
Use SIO::sio target in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,17 @@ include(cmake/podioMacros.cmake)
 # optionally build with SIO -------------------------------------------------
 if(ENABLE_SIO)
   find_package( SIO REQUIRED)
+  # Targets from SIO only become available with v00-01 so we rig them here to be
+  # able to use them
+  if (SIO_VERSION VERSION_LESS 0.1)
+    message(STATUS "Found SIO without Targets, creating them on the fly")
+    add_library(SIO::sio SHARED IMPORTED)
+    set_target_properties(SIO::sio PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${SIO_INCLUDE_DIRS}
+      INTERFACE_LINK_LIBRARIES ${SIO_LIBRARIES}
+      IMPORTED_LOCATION ${SIO_LIBRARIES})
+  endif()
+
   PODIO_CHECK_CPP_FS(PODIO_FS_LIBS)
   if (SIO_FOUND)
     MESSAGE( STATUS "Found SIO library - will build SIO I/O support" )

--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -28,6 +28,16 @@ find_dependency(ROOT @ROOT_VERSION@)
 
 if(@ENABLE_SIO@)
   find_dependency(SIO)
+  # Targets from SIO only become available with v00-01 so we rig them here to be
+  # able to use them
+  if (SIO_VERSION VERSION_LESS 0.1)
+    message(STATUS "Found SIO without Targets, creating them on the fly")
+    add_library(SIO::sio SHARED IMPORTED)
+    set_target_properties(SIO::sio PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${SIO_INCLUDE_DIRS}
+      INTERFACE_LINK_LIBRARIES ${SIO_LIBRARIES}
+      IMPORTED_LOCATION ${SIO_LIBRARIES})
+  endif()
 endif()
 
 if(NOT TARGET podio::podio)

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -278,12 +278,10 @@ function(PODIO_ADD_SIO_IO_BLOCKS CORE_LIB HEADERS SOURCES)
   ENDIF()
 
   add_library(${CORE_LIB}SioBlocks SHARED ${SOURCES} ${HEADERS})
-  target_link_libraries(${CORE_LIB}SioBlocks PUBLIC ${CORE_LIB} podio::podio podio::podioSioIO)
+  target_link_libraries(${CORE_LIB}SioBlocks PUBLIC ${CORE_LIB} podio::podio podio::podioSioIO SIO::sio)
   target_include_directories(${CORE_LIB}SioBlocks PUBLIC
     $<BUILD_INTERFACE:${ARG_OUTPUT_FOLDER}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${SIO_INCLUDE_DIRS}
-    )
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 endfunction()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,9 +63,8 @@ if(ENABLE_SIO)
 
   target_include_directories(podioSioIO PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${SIO_INCLUDE_DIRS})
-  target_link_libraries(podioSioIO PUBLIC podio::podio ${SIO_LIBRARIES} ${CMAKE_DL_LIBS} ${PODIO_FS_LIBS})
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  target_link_libraries(podioSioIO PUBLIC podio::podio SIO::sio ${CMAKE_DL_LIBS} ${PODIO_FS_LIBS})
 
   LIST(APPEND INSTALL_LIBRARIES podioSioIO)
 endif()


### PR DESCRIPTION

BEGINRELEASENOTES
- Use SIO targets in cmake, which are exported starting with v00-01 (iLCSoft/SIO#15)

ENDRELEASENOTES