### PR TITLE
Add support for fixed width integers

### DIFF
--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -28,10 +28,11 @@ A component is just a flat struct containing data. it can be defined via:
     components:
       # My example component
       MyComponent:
-        x : float
-        y : float
-        z : float
-        a : AnotherComponent
+        Members:
+          - float x
+          - float y
+          - float z
+          - AnotherComponent a
 ```
 
 ## Definition of custom data classes
@@ -113,7 +114,8 @@ Some customization of the generated code is possible through flags. These flags 
     components:
       # My simple component
       ExampleComponent:
-        x : int
+        Members:
+          - int x
     datatypes:
       ExampleType:
         Description: "My datatype with a component member"

--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -13,7 +13,9 @@ Instead, users can combine multiple `components` to build a to be used `datatype
 To allow the datatypes to be real PODs, the data stored within the data model are constrained to be
 POD-compatible data. Those are
 
- 1. basic types like int, double, etc
+ 1. basic types like int, double, etc as well as a limited set of fixed width
+    integers from `<cstdint>` (the `_leastN` or `_fastN` types as well as all
+    `8` bit types are not allowed).
  1. components built up from basic types or other components
  1. Fixed sized arrays of those types
 

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -53,6 +53,32 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.name, r'uInt')
     self.assertEqual(parsed.description, r'an unsigned integer')
 
+    # Fixed width integers in their various forms that they can be spelled out
+    # and be considered valid in our case
+    parsed = parser.parse(r'std::int16_t qualified // qualified fixed width ints work')
+    self.assertEqual(parsed.full_type, r'std::int16_t')
+    self.assertEqual(parsed.name, r'qualified')
+    self.assertEqual(parsed.description, r'qualified fixed width ints work')
+    self.assertTrue(parsed.is_builtin)
+
+    parsed = parser.parse(r'std::uint64_t bits // fixed width integer types should work')
+    self.assertEqual(parsed.full_type, r'std::uint64_t')
+    self.assertEqual(parsed.name, r'bits')
+    self.assertEqual(parsed.description, r'fixed width integer types should work')
+    self.assertTrue(parsed.is_builtin)
+
+    parsed = parser.parse(r'int32_t fixedInt // fixed width signed integer should work')
+    self.assertEqual(parsed.full_type, r'std::int32_t')
+    self.assertEqual(parsed.name, r'fixedInt')
+    self.assertEqual(parsed.description, r'fixed width signed integer should work')
+    self.assertTrue(parsed.is_builtin)
+
+    parsed = parser.parse(r'uint16_t fixedUInt // fixed width unsigned int with 16 bits')
+    self.assertEqual(parsed.full_type, r'std::uint16_t')
+    self.assertEqual(parsed.name, r'fixedUInt')
+    self.assertEqual(parsed.description, r'fixed width unsigned int with 16 bits')
+    self.assertTrue(parsed.is_builtin)
+
     # an array definition with space everywhere it is allowed
     parsed = parser.parse(r'  std::array < double , 4 >   someArray   // a comment  ')
     self.assertEqual(parsed.full_type, r'std::array<double, 4>')
@@ -98,9 +124,15 @@ class MemberParserTest(unittest.TestCase):
         r'int another ill formed name // some comment'
 
         # Some examples of valid c++ that are rejected by the validation
-        r'unsigned long int uLongInt // technically valid c++, but not in our builtin list'
-        r'::std::array<float, 2> a // technically valid c++, but breaks class generation'
-        r':: std :: array<int, 3> arr // also technically valid c++ but not in our case'
+        r'unsigned long int uLongInt // technically valid c++, but not in our builtin list',
+        r'::std::array<float, 2> a // technically valid c++, but breaks class generation',
+        r':: std :: array<int, 3> arr // also technically valid c++ but not in our case',
+        r'int8_t disallowed // fixed width ints with 8 bits are often aliased to signed char',
+        r'uint8_t disallowed // fixed width unsigned ints with 8 bits are often aliased to unsigned char',
+        r'int_least32_t disallowed // only allow fixed width integers with exact widths',
+        r'uint_fast64_t disallowed // only allow fixed width integers with exact widths',
+        r'std::int_least16_t disallowed // also adding a std namespace here does not make these allowed',
+        r'std::uint_fast16_t disallowed // also adding a std namespace here does not make these allowed',
         ]
 
     for inp in invalid_inputs:

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -34,6 +34,12 @@ components :
     Members:
       - ex2::NamespaceStruct data
 
+  StructWithFixedWithTypes:
+    Members:
+      - uint16_t fixedUnsigned16 // unsigned int with exactly 16 bits
+      - std::int64_t fixedInteger64 // int with exactly 64 bits
+      - int32_t fixedInteger32 // int with exactly 32 bits
+
 datatypes :
 
   EventInfo:
@@ -151,3 +157,12 @@ datatypes :
       - std::array<int, 4> snail_case_array // snail case to test regex
       - std::array<int, 4> snail_case_Array3 // mixing things up for regex
       - std::array<ex2::NamespaceStruct, 4> structArray // an array containing structs
+
+  ExampleWithFixedWidthIntegers:
+    Description: "Datatype using fixed width integer types as members"
+    Author: "Thomas Madlener"
+    Members:
+      - std::int16_t fixedI16 // some integer with exactly 16 bits
+      - uint64_t fixedU64 // unsigned int with exactly 64 bits
+      - uint32_t fixedU32 // unsigned int with exactly 32 bits
+      - StructWithFixedWithTypes fixedWidthStruct // struct with more fixed width types


### PR DESCRIPTION
BEGINRELEASENOTES
- Add support for [fixed width integer type](https://en.cppreference.com/w/cpp/types/integer) members in components and datatypes.
  - Now possible to use `int16_t`, `int32_t`, `int64_t`, `uint16_t`, `uint32_t` and `uint64_t` as members. Other fixed width integer types that are potentially defined in `<cstdint>` are not considered valid as the intended use case is really only fixed width integers for now. These are rejected at the datamodel validation step.
  - Fixed width integers are considered to be "builtin" types for podio.

ENDRELEASENOTES

See key4hep/EDM4hep#112 for a possible use case.

The actually necessary changes are confined to the `generator_utils.py`, the rest is adding a bunch of tests that should cover the major use (and non-use) cases.