### PR TITLE
[cmake] fix test dependencies for read_and_write

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 #--- set some dependencies between the different tests to ensure input generating ones are run first
 set_property(TEST read PROPERTY DEPENDS write)
 set_property(TEST read-multiple PROPERTY DEPENDS write)
+set_property(TEST read_and_write PROPERTY DEPENDS write)
 set_property(TEST read_timed PROPERTY DEPENDS write_timed)
 
 add_executable(check_benchmark_outputs check_benchmark_outputs.cpp)


### PR DESCRIPTION
`read_and_write.cpp` reads the file `example.root` that is created by the write test. If the dependency is not declared, running the tests concurrently can lead to spurious test failures.



BEGINRELEASENOTES
- [cmake] fix test dependencies: `read_and_write.cpp` reads the file `example.root` that is created by the write test. If the dependency is not declared, running the tests concurrently can lead to spurious test failures.

ENDRELEASENOTES