### PR TITLE
Make EventStore metadata access const correct

### DIFF
--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -87,17 +87,17 @@ namespace podio {
     virtual bool isValid() const final;
 
     /// return the event meta data for the current event
-    virtual GenericParameters& getEventMetaData() const override ;
+    GenericParameters& getEventMetaData() override ;
 
     /// return the run meta data for the given runID
-    virtual GenericParameters& getRunMetaData(int runID) const override ;
+    GenericParameters& getRunMetaData(int runID) override ;
 
     /// return the collection meta data for the given colID
-    virtual GenericParameters& getCollectionMetaData(int colID) const override ;
+    GenericParameters& getCollectionMetaData(int colID) override ;
 
-    RunMDMap* getRunMetaDataMap() const {return &m_runMDMap ; }
-    ColMDMap* getColMetaDataMap() const {return &m_colMDMap ; }
-    GenericParameters* eventMetaDataPtr() const {return &m_evtMD; }
+    RunMDMap* getRunMetaDataMap() { return &m_runMDMap ; }
+    ColMDMap* getColMetaDataMap() { return &m_colMDMap ; }
+    GenericParameters* eventMetaDataPtr() { return &m_evtMD; }
 
    private:
 
@@ -114,9 +114,9 @@ namespace podio {
     IReader* m_reader{nullptr};
     std::unique_ptr<CollectionIDTable> m_table;
 
-    mutable GenericParameters m_evtMD{};
-    mutable RunMDMap m_runMDMap{};
-    mutable ColMDMap m_colMDMap{};
+    GenericParameters m_evtMD{};
+    RunMDMap m_runMDMap{};
+    ColMDMap m_colMDMap{};
   };
 
 

--- a/include/podio/IMetaDataProvider.h
+++ b/include/podio/IMetaDataProvider.h
@@ -17,13 +17,13 @@ namespace podio {
     virtual ~IMetaDataProvider(){};
 
     /// return the event meta data for the current event
-    virtual GenericParameters& getEventMetaData() const = 0;
+    virtual GenericParameters& getEventMetaData() = 0;
 
     /// return the run meta data for the given runID
-    virtual GenericParameters& getRunMetaData(int runID) const = 0;
+    virtual GenericParameters& getRunMetaData(int runID) = 0;
 
     /// return the collection meta data for the given colID
-    virtual GenericParameters& getCollectionMetaData(int colID) const = 0;
+    virtual GenericParameters& getCollectionMetaData(int colID) = 0;
   };
 
 } // namespace

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -86,7 +86,7 @@ namespace podio {
     return false;
   }
 
-  GenericParameters& EventStore::getEventMetaData() const {
+  GenericParameters& EventStore::getEventMetaData() {
 
     if( m_reader != nullptr ){
       m_evtMD.clear() ;
@@ -97,7 +97,7 @@ namespace podio {
     return m_evtMD ;
   }
   
-  GenericParameters& EventStore::getRunMetaData(int runID) const {
+  GenericParameters& EventStore::getRunMetaData(int runID) {
 
     if( m_runMDMap.empty() && m_reader != nullptr ){
       RunMDMap* tmp = m_reader->readRunMetaData() ;
@@ -108,7 +108,7 @@ namespace podio {
   }
   
 
-  GenericParameters& EventStore::getCollectionMetaData(int colID) const {
+  GenericParameters& EventStore::getCollectionMetaData(int colID) {
 
     if( m_colMDMap.empty() && m_reader != nullptr ){
       ColMDMap* tmp = m_reader->readCollectionMetaData() ;


### PR DESCRIPTION
Cherry-picked from #177
Fixes #136 

BEGINRELEASENOTES
- Fix const-correctness problems of meta data access via EventStore.

ENDRELEASENOTES

Since we never have access to a `const EventStore` we also do not need to mark any member functions as `const`. This at least makes it obvious that meta data access is really not thread safe at the moment, even though it does not really fix the underlying problem of making it thread safe.