### PR TITLE
Const correct collection access

### DIFF
--- a/include/podio/PythonEventStore.h
+++ b/include/podio/PythonEventStore.h
@@ -13,7 +13,7 @@ public:
   PythonEventStore(const char* filename);
 
   /// access a collection.
-  podio::CollectionBase* get(const char* name);
+  const podio::CollectionBase* get(const char* name);
 
   /// signify end of event
   void endOfEvent();

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -1,5 +1,6 @@
 {% import "macros/utils.jinja2" as utils %}
 {% import "macros/collections.jinja2" as macros %}
+{% from "macros/iterator.jinja2" import iterator_definitions %}
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
 #include "{{ incfolder }}{{ class.bare_type }}Collection.h"
@@ -199,23 +200,10 @@ void {{ collection_type }}::setBuffer(void* address) {
 }
 {% endwith %}
 
-{% with iterator_type = class.bare_type + 'CollectionIterator' %}
-const {{ class.bare_type }} {{ iterator_type }}::operator*() const {
-  m_object.m_obj = (*m_collection)[m_index];
-  return m_object;
-}
+{{ iterator_definitions(class) }}
 
-const {{ class.bare_type }}* {{ iterator_type }}::operator->() const {
-  m_object.m_obj = (*m_collection)[m_index];
-  return &m_object;
-}
+{{ iterator_definitions(class, prefix='Const' ) }}
 
-const {{ iterator_type}}& {{ iterator_type }}::operator++() const {
-  ++m_index;
-  return *this;
-}
-
-{% endwith %}
 {{ macros.ostream_operator(class, Members, OneToOneRelations, OneToManyRelations, VectorMembers, use_get_syntax, ostream_collection_settings) }}
 
 {{ utils.namespace_close(class.namespace) }}

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -46,12 +46,12 @@
 {% endfor %}
 }
 
-const {{ class.bare_type }} {{ collection_type }}::operator[](unsigned int index) const {
-  return {{ class.bare_type }}(m_entries[index]);
+Const{{ class.bare_type }} {{ collection_type }}::operator[](unsigned int index) const {
+  return Const{{ class.bare_type }}(m_entries[index]);
 }
 
-const {{ class.bare_type }} {{ collection_type }}::at(unsigned int index) const {
-  return {{ class.bare_type }}(m_entries.at(index));
+Const{{ class.bare_type }} {{ collection_type }}::at(unsigned int index) const {
+  return Const{{ class.bare_type }}(m_entries.at(index));
 }
 
 {{ class.bare_type }} {{ collection_type }}::operator[](unsigned int index) {

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -84,11 +84,11 @@ public:
   std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
 
   /// Returns the const object of given index
-  const {{ class.bare_type }} operator[](unsigned int index) const;
+  Const{{ class.bare_type }} operator[](unsigned int index) const;
   /// Returns the object of a given index
   {{ class.bare_type }} operator[](unsigned int index);
   /// Returns the const object of given index
-  const {{ class.bare_type }} at(unsigned int index) const;
+  Const{{ class.bare_type }} at(unsigned int index) const;
   /// Returns the object of given index
   {{ class.bare_type }} at(unsigned int index);
 

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -1,5 +1,6 @@
 {% import "macros/utils.jinja2" as utils %}
 {% import "macros/collections.jinja2" as macros %}
+{% from "macros/iterator.jinja2" import iterator_declaration %}
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
 #ifndef {{ package_name.upper() }}_{{ class.bare_type }}Collection_H
@@ -27,28 +28,9 @@
 using {{ class.bare_type }}DataContainer = std::vector<{{ class.bare_type }}Data>;
 using {{ class.bare_type }}ObjPointerContainer = std::deque<{{ class.bare_type }}Obj*>;
 
-class {{ class.bare_type }}CollectionIterator {
-public:
-{% with iterator_type = class.bare_type + 'CollectionIterator' %}
-  {{ iterator_type }}(int index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+{{ iterator_declaration(class) }}
 
-  {{ iterator_type }}(const {{ iterator_type }}&) = delete;
-  {{ iterator_type }}& operator=(const {{ iterator_type }}&) = delete;
-{% endwith %}
-
-  bool operator!=(const {{ class.bare_type }}CollectionIterator& x) const {
-    return m_index != x.m_index; // TODO: may not be complete
-  }
-
-  const {{ class.bare_type }} operator*() const;
-  const {{ class.bare_type }}* operator->() const;
-  const {{ class.bare_type }}CollectionIterator& operator++() const;
-
-private:
-  mutable int m_index;
-  mutable {{ class.bare_type }} m_object;
-  const {{ class.bare_type }}ObjPointerContainer* m_collection;
-};
+{{ iterator_declaration(class, prefix='Const') }}
 
 /**
 A Collection is identified by an ID.
@@ -56,7 +38,8 @@ A Collection is identified by an ID.
 class {{ class.bare_type }}Collection : public podio::CollectionBase {
 
 public:
-  using const_iterator = const {{ class.bare_type }}CollectionIterator;
+  using const_iterator = {{ class.bare_type }}ConstCollectionIterator;
+  using iterator = {{ class.bare_type }}CollectionIterator;
 
   {{ class.bare_type }}Collection();
   {{ class.bare_type }}Collection(const {{ class.bare_type}}Collection& ) = delete;
@@ -122,10 +105,16 @@ public:
   }
 
   // support for the iterator protocol
-  const const_iterator begin() const {
+  iterator begin() {
+    return iterator(0, &m_entries);
+  }
+  const_iterator begin() const {
     return const_iterator(0, &m_entries);
   }
-  const const_iterator end() const {
+  iterator end() {
+    return iterator(m_entries.size(), &m_entries);
+  }
+  const_iterator end() const {
     return const_iterator(m_entries.size(), &m_entries);
   }
 

--- a/python/templates/ConstObject.h.jinja2
+++ b/python/templates/ConstObject.h.jinja2
@@ -16,16 +16,12 @@
 
 {{ utils.namespace_open(class.namespace) }}
 
-class {{ class.bare_type }};
-class {{ class.bare_type }}Collection;
-class {{ class.bare_type }}CollectionIterator;
-
 {{ macros.class_description(class.bare_type, Description, Author, prefix='Const') }}
 class Const{{ class.bare_type }} {
 
-  friend {{ class.bare_type }};
-  friend {{ class.bare_type }}Collection;
-  friend {{ class.bare_type }}CollectionIterator;
+  friend class {{ class.bare_type }};
+  friend class {{ class.bare_type }}Collection;
+  friend class {{ class.bare_type }}ConstCollectionIterator;
 
 public:
 {{ macros.constructors_destructors(class.bare_type, Members, prefix='Const') }}

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -18,16 +18,12 @@
 
 {{ utils.namespace_open(class.namespace) }}
 
-class {{ class.bare_type }}Collection;
-class {{ class.bare_type }}CollectionIterator;
-class Const{{ class.bare_type }};
-
 {{ macros.class_description(class.bare_type, Description, Author) }}
 class {{ class.bare_type }} {
 
-  friend {{ class.bare_type }}Collection;
-  friend {{ class.bare_type }}CollectionIterator;
-  friend Const{{ class.bare_type }};
+  friend class {{ class.bare_type }}Collection;
+  friend class {{ class.bare_type }}CollectionIterator;
+  friend class Const{{ class.bare_type }};
 
 public:
 

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -1,0 +1,45 @@
+{% macro iterator_declaration(class, prefix='') %}
+{% with iterator_type = class.bare_type + prefix + 'CollectionIterator' %}
+class {{ iterator_type }} {
+public:
+  {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object(nullptr), m_collection(collection) {}
+
+  {{ iterator_type }}(const {{ iterator_type }}&) = delete;
+  {{ iterator_type }}& operator=(const {{ iterator_type }}&) = delete;
+
+  bool operator!=(const {{ iterator_type}}& x) const {
+    return m_index != x.m_index; // TODO: may not be complete
+  }
+
+  {{ prefix }}{{ class.bare_type }} operator*();
+  {{ prefix }}{{ class.bare_type }}* operator->();
+  {{ iterator_type }}& operator++();
+
+private:
+  size_t m_index;
+  {{ prefix }}{{ class.bare_type }} m_object;
+  const {{ class.bare_type }}ObjPointerContainer* m_collection;
+};
+{% endwith %}
+{% endmacro %}
+
+
+{% macro iterator_definitions(class, prefix='') %}
+{% with iterator_type = class.bare_type + prefix + 'CollectionIterator' %}
+{{ prefix }}{{ class.bare_type }} {{ iterator_type }}::operator*() {
+  m_object.m_obj = (*m_collection)[m_index];
+  return m_object;
+}
+
+{{ prefix }}{{ class.bare_type }}* {{ iterator_type }}::operator->() {
+  m_object.m_obj = (*m_collection)[m_index];
+  return &m_object;
+}
+
+{{ iterator_type }}& {{ iterator_type }}::operator++() {
+  ++m_index;
+  return *this;
+}
+
+{% endwith %}
+{% endmacro %}

--- a/src/PythonEventStore.cc
+++ b/src/PythonEventStore.cc
@@ -21,10 +21,10 @@ podio::PythonEventStore::PythonEventStore(const char* name) :
   }
 }
 
-podio::CollectionBase* podio::PythonEventStore::get(const char* name) {
+const podio::CollectionBase* podio::PythonEventStore::get(const char* name) {
   const podio::CollectionBase* coll(nullptr);
   m_store.get(name, coll);
-  return const_cast<podio::CollectionBase*>(coll);
+  return coll;
 }
 
 void podio::PythonEventStore::endOfEvent() {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -134,13 +134,25 @@ TEST_CASE("Looping") {
   auto hit1 = coll.create(0xbadULL,0.,0.,0.,0.);
   auto hit2 = coll.create(0xcaffeeULL,1.,1.,1.,1.);
   for(auto i = coll.begin(), end = coll.end(); i != end; ++i) {
-    auto energy = i->energy();
+    i->energy(42); // make sure that we can indeed change the energy here for
+                   // non-const collections
   }
+  REQUIRE(hit1.energy() == 42);
+  REQUIRE(hit2.energy() == 42);
+
   for(int i = 0, end = coll.size(); i != end; ++i) {
-    auto energy = coll[i].energy();
+    coll[i].energy(i); // reset it back to the original value
   }
-  if ((coll[0].energy() != 0) || (coll[1].energy() != 1)) success = false;
-  REQUIRE(success);
+
+  REQUIRE(coll[0].energy() == 0);
+  REQUIRE(coll[1].energy() == 1);
+
+  auto& constColl = store.get<ExampleHitCollection>("name");
+  int index = 0;
+  for (auto hit : constColl) {
+    auto energy = hit.energy();
+    REQUIRE(energy == index++);
+  }
 }
 
 TEST_CASE("Notebook") {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -300,3 +300,108 @@ TEST_CASE("NonPresentCollection") {
   auto store = podio::EventStore();
   REQUIRE_THROWS_AS(store.get<ExampleHitCollection>("NonPresentCollection"), std::runtime_error&);
 }
+
+TEST_CASE("const correct indexed access to const collections", "[const-correctness]") {
+  static_assert(std::is_same_v<
+                decltype(std::declval<const ExampleClusterCollection>()[0]),
+                ConstExampleCluster>,
+                "const collections should only have indexed access to Const objects");
+
+  static_assert(std::is_same_v<
+                decltype(std::declval<const ExampleClusterCollection>().at(0)),
+                ConstExampleCluster>,
+                "const collections should only have indexed access to Const objects");
+
+  REQUIRE(true);
+}
+
+TEST_CASE("const correct indexed access to collections", "[const-correctness]") {
+  auto store = podio::EventStore();
+  auto& collection = store.create<ExampleHitCollection>("irrelevant name");
+
+  static_assert(std::is_same_v<decltype(collection), ExampleHitCollection&>, "collection created by store should not be const");
+
+  static_assert(std::is_same_v<decltype(collection[0]), ExampleHit>,"non-const collections should have indexed access to mutable objects");
+ 
+  static_assert(std::is_same_v<
+                decltype(std::declval<ExampleClusterCollection>()[0]),
+                ExampleCluster>,
+                "collections should have indexed access to mutable objects");
+
+  static_assert(std::is_same_v<
+                decltype(std::declval<ExampleClusterCollection>().at(0)),
+                ExampleCluster>,
+                "collections should have indexed access to mutable objects");
+
+  REQUIRE(true);
+}
+
+TEST_CASE("const correct iterators on const collections", "[const-correctness]") {
+  const auto collection = ExampleHitCollection();
+  // this essentially checks the whole "chain" from begin() / end() through
+  // iterator operators
+  for (auto hit : collection) {
+    static_assert(std::is_same_v<decltype(hit), ConstExampleHit>, "const collection iterators should only return Const objects");
+  }
+
+  // but we can exercise it in a detailed fashion as well to make it easier to
+  // spot where things fail, should they fail
+  static_assert(std::is_same_v<
+                decltype(std::declval<const ExampleHitCollection>().begin()),
+                ExampleHitConstCollectionIterator>,
+                "const collection begin() should return a ConstCollectionIterator");
+
+  static_assert(std::is_same_v<
+                decltype(std::declval<const ExampleHitCollection>().end()),
+                ExampleHitConstCollectionIterator>,
+                "const collection end() should return a ConstCollectionIterator");
+
+  static_assert(std::is_same_v<
+                decltype(*std::declval<const ExampleHitCollection>().begin()),
+                ConstExampleHit>,
+                "ConstCollectionIterator should only give access to Const objects");
+
+  static_assert(std::is_same_v<
+                decltype(std::declval<ExampleHitConstCollectionIterator>().operator->()),
+                ConstExampleHit*>,
+                "ConstCollectionIterator should only give access to Const objects");
+
+  REQUIRE(true);
+}
+
+TEST_CASE("const correct iterators on collections", "[const-correctness]") {
+
+  auto collection = ExampleClusterCollection();
+  for (auto cluster : collection) {
+    static_assert(std::is_same_v<decltype(cluster), ExampleCluster>, "collection iterators should return mutable objects");
+    cluster.energy(42); // this will necessarily also compile
+  }
+
+  // check the individual steps again from above, to see where things fail if they fail
+  static_assert(std::is_same_v<
+                decltype(std::declval<ExampleClusterCollection>().end()),
+                ExampleClusterCollectionIterator>,
+                "non const collection end() should return a CollectionIterator");
+
+  static_assert(std::is_same_v<
+                decltype(std::declval<ExampleClusterCollection>().end()),
+                ExampleClusterCollectionIterator>,
+                "non const collection end() should return a CollectionIterator");
+
+  static_assert(std::is_same_v<
+                decltype(std::declval<ExampleClusterCollection>().end()),
+                ExampleClusterCollectionIterator>,
+                "collection end() should return a CollectionIterator");
+
+  static_assert(std::is_same_v<
+                decltype(*std::declval<ExampleClusterCollection>().begin()),
+                ExampleCluster>,
+                "CollectionIterator should give access to mutable objects");
+
+  static_assert(std::is_same_v<
+                decltype(std::declval<ExampleClusterCollectionIterator>().operator->()),
+                ExampleCluster*>,
+                "CollectionIterator should only give access to mutable objects");
+
+  REQUIRE(true);
+}

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -131,9 +131,10 @@ void write(podio::EventStore& store, WriterT& writer) {
     mcp.adddaughters( mcps[9] ) ;
 
     //--- now fix the parent relations
-    for( unsigned j=0,N=mcps.size();j<N;++j){
-      mcp = mcps[j] ;
-      for(auto p : mcp.daughters()) {
+    // use a range-based for loop here to see if we get mutable objects from the
+    // begin/end iterators
+    for (auto mc : mcps) {
+      for(auto p : mc.daughters()) {
         int dIndex = p.getObjectID().index ;
         auto d = mcps[ dIndex ] ;
         d.addparents( p ) ;


### PR DESCRIPTION
Cherry picked from #177
Fixes #176

BEGINRELEASENOTES
- Make collection element access const correct.

ENDRELEASENOTES

Introduce appropriate overloads for `operator[]` and `at` functions. Additionally introduce a new `ConstCollectionIterator` alongside the `CollectionIterator`. The former only gives access to `Const` classes, while the latter gives access to the normal classes.

As a test also make the `PythonEventStore` return a `const CollectionBase*` to see if that makes the python side also use the `Const` classes in this case.

- [ ] Check if the const-ness is correctly propagated to the python side of things
- [ ] Check if things can be made to work with root@6.20/04
