### PR TITLE
Add indexed access to the RelationRange

### DIFF
--- a/include/podio/RelationRange.h
+++ b/include/podio/RelationRange.h
@@ -16,19 +16,36 @@ namespace podio {
 
     RelationRange() = delete;
 
-    RelationRange(ConstIteratorType begin, ConstIteratorType end) : m_begin(begin), m_end(end) {}
+    RelationRange(ConstIteratorType begin, ConstIteratorType end) : m_begin(begin), m_end(end), m_size(std::distance(m_begin, m_end)) {}
 
     /// begin of the range (necessary for range-based for loop)
     ConstIteratorType begin() const { return m_begin; }
     /// end of the range (necessary for range-based for loop)
     ConstIteratorType end() const { return m_end; }
     /// convenience overload for size
-    size_t size() const { return std::distance(m_begin, m_end); }
+    size_t size() const { return m_size; }
     /// convenience overload to check if the range is empty
     bool empty() const { return m_begin == m_end; }
+    /// Indexed access
+    ReferenceType operator[](size_t i) const {
+      auto it = m_begin;
+      std::advance(it, i);
+      return *it;
+    }
+    /// Indexed access with range check
+    ReferenceType at(size_t i) const {
+      if (i < m_size) {
+        auto it = m_begin;
+        std::advance(it, i);
+        return *it;
+      }
+      throw std::out_of_range("index out of bounds for RelationRange");
+    }
+
   private:
     ConstIteratorType m_begin;
     ConstIteratorType m_end;
+    size_t m_size{0};
   };
 }
 

--- a/python/test_EventStore.py
+++ b/python/test_EventStore.py
@@ -59,6 +59,18 @@ class EventStoreTestCase(unittest.TestCase):
     for hit in ref_hits:
       self.assertTrue(hit in hits)
 
+  def test_relation_range(self):
+    """Test that the RelationRange functionality is also accessible in python"""
+    clusters = self.store.get("clusters")
+    hits = self.store.get("hits")
+
+    for cluster in clusters:
+      sume = 0
+      for hit in cluster.Hits():
+        self.assertTrue(hit in hits)
+        sume += hit.energy()
+      self.assertEqual(cluster.energy(), sume)
+
   def test_hash(self):
     clusters = self.store.get("clusters")
     ref_hits = []

--- a/tests/relation_range.cpp
+++ b/tests/relation_range.cpp
@@ -64,6 +64,10 @@ void doTestExampleMC(ExampleMCCollection const& collection)
   // Empty
   ASSERT_CONDITION(collection[7].daughters().size() == 0 && collection[7].parents().size() == 0,
                    "RelationRange of empty collection is not empty");
+  // Equivalent but potentially quicker way of checking an empty collection
+  ASSERT_CONDITION(collection[7].daughters().empty() && collection[7].parents().empty(),
+                   "RelationRange of empty collection is not empty");
+
   // alternatively check if a loop is entered
   for (const auto& p[[maybe_unused]]: collection[7].daughters()) {
     throw std::runtime_error("Range based for loop entered on a supposedly empty range");
@@ -77,6 +81,14 @@ void doTestExampleMC(ExampleMCCollection const& collection)
     ASSERT_EQUAL(p.PDG(), expectedPDG[index],
                  "ExampleMC daughters range points to wrong particle (by PDG)");
     index++;
+  }
+
+  // Check indexed access
+  const auto daughters = collection[0].daughters();
+  for (size_t i = 0; i < expectedPDG.size(); ++i) {
+    const auto daughter = daughters[i];
+    ASSERT_EQUAL(daughter.PDG(), expectedPDG[i],
+                 "ExampleMC daughter points to the wrong particle (by PDG)");
   }
 
   // mothers and daughters
@@ -96,6 +108,22 @@ void doTestExampleMC(ExampleMCCollection const& collection)
     ASSERT_EQUAL(p.PDG(), expectedPDG[index],
                  "ExampleMC parents range points to wrong particle (by PDG)");
     index++;
+  }
+
+  // Indexed access with range check
+  const auto parents = collection[2].parents();
+  for (size_t i = 0; i < expectedPDG.size(); ++i) {
+    const auto parent = parents.at(i);
+    ASSERT_EQUAL(parent.PDG(), expectedPDG[i],
+                 "ExampleMC parents points to the wrong particle (by PDG)");
+  }
+
+  try {
+    const auto parent = parents.at(3);
+    throw std::runtime_error("Trying to access out of bounds in a RelationRange::at should throw");
+  } catch (const std::out_of_range& err) {
+    ASSERT_EQUAL(err.what(), std::string("index out of bounds for RelationRange"),
+                 "Access out of bounds throws wrong exception");
   }
 
   // realistic case
@@ -120,7 +148,6 @@ void testExampleMC()
  fillExampleMCCollection(mcps);
  doTestExampleMC(mcps);
 }
-
 
 void testExampleWithVectorMember()
 {


### PR DESCRIPTION

BEGINRELEASENOTES
- Make it possible to do indexed access on a `RelationRange`, making the interface more akin to a `const std::vector`

ENDRELEASENOTES

Inspired by key4hep/EDM4hep#111

With these changes it becomes possible to do
```cpp
const auto& mcs = store.get<edm4hep::MCParticleCollection>("mcparticles");
auto particle = mcs[0];

auto parents = particle.getParents();
auto firstParent = parents[0]; // this was not possible before

for (auto par : parents) { /* do something with par. This was possible before already */ }
```