### PR TITLE
Disentangle storage concerns from collection and implement subset collections

### DIFF
--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -1,29 +1,24 @@
 #ifndef COLLECTIONBASE_H
 #define COLLECTIONBASE_H
 
+#include "podio/ObjectID.h"
+#include "podio/CollectionBuffers.h"
+
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "podio/ObjectID.h"
+
 
 namespace podio {
   // forward declarations
-  class ObjectID;
   class ICollectionProvider;
-  class CollectionBase;
-
-  using CollRefCollection = std::vector<std::vector<podio::ObjectID>*>;
-  using VectorMembersInfo = std::vector<std::pair<std::string, void*>>;
 
   class CollectionBase {
   public:
     /// prepare buffers for serialization
-    virtual void  prepareForWrite() = 0;
+    virtual void prepareForWrite() = 0;
 
-    //virtual void  write(CollectionBuffer& buffer) = 0;
-    //virtual void  read(CollectionBuffer& buffer) = 0;
-    
     /// re-create collection from buffers after read
     virtual void  prepareAfterRead() = 0;
 
@@ -36,11 +31,10 @@ namespace podio {
     /// get collection ID
     virtual unsigned getID() const = 0;
 
-    /// set I/O buffer
-    virtual void  setBuffer(void*) = 0;
+    /// Get the collection buffers for this collection
+    virtual podio::CollectionBuffers getBuffers() = 0;
 
-    /// get address of the pointer to the I/O buffer
-    virtual void* getBufferAddress() = 0;
+    // virtual void setBuffers(const podio::CollectionBuffers& buffers) = 0;
 
     /// check for validity of the container after read
     virtual bool isValid() const = 0;
@@ -56,12 +50,6 @@ namespace podio {
 
     /// clear the collection and all internal states
     virtual void clear() = 0 ;
-
-    /// return the buffers containing the object-relation information
-    virtual CollRefCollection* referenceCollections() = 0;
-
-    /// return pointers to vector members
-    virtual VectorMembersInfo* vectorMembers() = 0;
   };
 
 } // namespace

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -34,8 +34,6 @@ namespace podio {
     /// Get the collection buffers for this collection
     virtual podio::CollectionBuffers getBuffers() = 0;
 
-    // virtual void setBuffers(const podio::CollectionBuffers& buffers) = 0;
-
     /// check for validity of the container after read
     virtual bool isValid() const = 0;
 

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -50,6 +50,12 @@ namespace podio {
 
     /// clear the collection and all internal states
     virtual void clear() = 0 ;
+
+    /// check if this collection is a reference collection
+    virtual bool isReferenceCollection() const = 0;
+
+    /// declare this collection to be a reference collection
+    virtual void setReferenceCollection(bool setToRef=true) = 0;
   };
 
 } // namespace

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -51,11 +51,11 @@ namespace podio {
     /// clear the collection and all internal states
     virtual void clear() = 0 ;
 
-    /// check if this collection is a reference collection
-    virtual bool isReferenceCollection() const = 0;
+    /// check if this collection is a subset collection
+    virtual bool isSubsetCollection() const = 0;
 
-    /// declare this collection to be a reference collection
-    virtual void setReferenceCollection(bool setToRef=true) = 0;
+    /// declare this collection to be a subset collection
+    virtual void setSubsetCollection(bool setSubset=true) = 0;
   };
 
 } // namespace

--- a/include/podio/CollectionBuffers.h
+++ b/include/podio/CollectionBuffers.h
@@ -1,0 +1,34 @@
+#ifndef PODIO_COLLECTIONBUFFERS_H
+#define PODIO_COLLECTIONBUFFERS_H
+
+#include "podio/ObjectID.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+
+namespace podio {
+
+using CollRefCollection = std::vector<std::vector<podio::ObjectID>*>;
+using VectorMembersInfo = std::vector<std::pair<std::string, void*>>;
+
+/**
+ * Simple helper struct that bundles all the potentially necessary buffers that
+ * are necessary to represent a collection for I/O purposes.
+ */
+struct CollectionBuffers {
+  void* data{nullptr};
+  CollRefCollection* references{nullptr};
+  VectorMembersInfo* vectorMembers{nullptr};
+
+  template<typename DataT>
+  std::vector<DataT>* dataAsVector() {
+    // Are we at a beach? I can almost smell the C...
+    return *static_cast<std::vector<DataT>**>(data);
+  }
+};
+
+}
+
+#endif // PODIO_COLLECTIONBUFFERS_H

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -80,6 +80,8 @@ class ROOTReader : public IReader {
 
 
   private:
+    void createCollectionBranches(const std::vector<std::tuple<int, std::string, bool>>& collInfo);
+
     std::pair<TTree*, unsigned> getLocalTreeAndEntry(const std::string& treename);
     // Information about the data vector as wall as the collection class type
     // and the index in the collection branches cache vector

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -47,7 +47,7 @@ namespace podio {
     virtual SIOBlock* create(const std::string& name) const=0 ;
 
     // create a new collection for this block
-    virtual void createCollection() = 0;
+    virtual void createCollection(const bool referenceCollection=false) = 0;
 
   protected:
 
@@ -74,11 +74,13 @@ namespace podio {
 
     podio::CollectionIDTable* getTable() { return _table; }
     const std::vector<std::string>& getTypeNames() const { return _types; }
+    const std::vector<short>& getRefCollectionBits() const { return _isRefColl; }
 
   private:
     podio::EventStore* _store{nullptr};
     podio::CollectionIDTable* _table{nullptr};
     std::vector<std::string> _types{};
+    std::vector<short> _isRefColl{};
   };
 
 
@@ -130,7 +132,7 @@ namespace podio {
     std::shared_ptr<SIOBlock> createBlock( const podio::CollectionBase* col, const std::string& name) const;
 
     // return a block with a new collection (used for reading )
-    std::shared_ptr<SIOBlock> createBlock( const std::string& typeStr, const std::string& name) const;
+    std::shared_ptr<SIOBlock> createBlock( const std::string& typeStr, const std::string& name, const bool isRefColl=false) const;
 
     static SIOBlockFactory& instance() {
       static SIOBlockFactory me ;

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -47,7 +47,7 @@ namespace podio {
     virtual SIOBlock* create(const std::string& name) const=0 ;
 
     // create a new collection for this block
-    virtual void createCollection(const bool referenceCollection=false) = 0;
+    virtual void createCollection(const bool subsetCollection=false) = 0;
 
   protected:
 
@@ -74,13 +74,13 @@ namespace podio {
 
     podio::CollectionIDTable* getTable() { return _table; }
     const std::vector<std::string>& getTypeNames() const { return _types; }
-    const std::vector<short>& getRefCollectionBits() const { return _isRefColl; }
+    const std::vector<short>& getSubsetCollectionBits() const { return _isSubsetColl; }
 
   private:
     podio::EventStore* _store{nullptr};
     podio::CollectionIDTable* _table{nullptr};
     std::vector<std::string> _types{};
-    std::vector<short> _isRefColl{};
+    std::vector<short> _isSubsetColl{};
   };
 
 

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -85,7 +85,7 @@ namespace podio {
     int m_eventNumber{0};
     int m_lastEventRead{-1};
     std::vector<std::string> m_typeNames{};
-    std::vector<short> m_refCollectionBits{};
+    std::vector<short> m_subsetCollectionBits{};
 
     std::shared_ptr<SIOEventMetaDataBlock> m_eventMetaData{};
     std::shared_ptr<SIONumberedMetaDataBlock> m_runMetaData{};

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -85,6 +85,7 @@ namespace podio {
     int m_eventNumber{0};
     int m_lastEventRead{-1};
     std::vector<std::string> m_typeNames{};
+    std::vector<short> m_refCollectionBits{};
 
     std::shared_ptr<SIOEventMetaDataBlock> m_eventMetaData{};
     std::shared_ptr<SIONumberedMetaDataBlock> m_runMetaData{};

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -207,6 +207,7 @@ class ClassGenerator(object):
     self._fill_templates('ConstObject', datatype)
     self._fill_templates('Obj', datatype)
     self._fill_templates('Collection', datatype)
+    self._fill_templates('CollectionData', datatype)
 
     if 'SIO' in self.io_handlers:
       self._fill_templates('SIOBlock', datatype)

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -17,187 +17,90 @@
 
 {% with collection_type = class.bare_type + 'Collection' %}
 {{ collection_type }}::{{ collection_type }}() :
-  m_isValid(false), m_isReadFromFile(false), m_collectionID(0), m_entries()
-{%- for relation in OneToManyRelations + OneToOneRelations %},
-  m_rel_{{ relation.name }}(new std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>())
-{%- endfor %}
-{%- for member in VectorMembers %},
-  m_vec_{{ member.name }}(new std::vector<{{ member.full_type }}>())
-{%- endfor -%},
-  m_data(new {{ class.bare_type }}DataContainer()) {
-{% for relation in OneToManyRelations + OneToOneRelations %}
-  m_refCollections.push_back(new std::vector<podio::ObjectID>());
-{% endfor %}
-{% for member in VectorMembers %}
-  m_vecmem_info.emplace_back("{{ member.full_type }}", &m_vec_{{ member.name }});
-{% endfor %}
-}
+  m_isValid(false), m_isReadFromFile(false), m_collectionID(0), m_storage() {}
 
 {{ collection_type }}::~{{ collection_type }}() {
   clear();
-  if (m_data) delete m_data;
-{% if OneToManyRelations or OneToOneRelations %}
-  for (auto& pointer : m_refCollections) { if (pointer) delete pointer; }
-{% endif %}
-{% for relation in OneToManyRelations + OneToOneRelations %}
-  if (m_rel_{{ relation.name }}) delete m_rel_{{ relation.name }};
-{% endfor %}
-{% for member in VectorMembers %}
-  if (m_vec_{{ member.name }}) delete m_vec_{{ member.name }};
-{% endfor %}
 }
 
 Const{{ class.bare_type }} {{ collection_type }}::operator[](unsigned int index) const {
-  return Const{{ class.bare_type }}(m_entries[index]);
+  return Const{{ class.bare_type }}(m_storage.entries[index]);
 }
 
 Const{{ class.bare_type }} {{ collection_type }}::at(unsigned int index) const {
-  return Const{{ class.bare_type }}(m_entries.at(index));
+  return Const{{ class.bare_type }}(m_storage.entries.at(index));
 }
 
 {{ class.bare_type }} {{ collection_type }}::operator[](unsigned int index) {
-  return {{ class.bare_type }}(m_entries[index]);
+  return {{ class.bare_type }}(m_storage.entries[index]);
 }
 
 {{ class.bare_type }} {{ collection_type }}::at(unsigned int index) {
-  return {{ class.bare_type }}(m_entries.at(index));
+  return {{ class.bare_type }}(m_storage.entries.at(index));
 }
 
 size_t {{ collection_type }}::size() const {
-  return m_entries.size();
+  return m_storage.entries.size();
 }
 
 {{ class.bare_type }} {{ collection_type }}::create() {
-  auto obj = m_entries.emplace_back(new {{ class.bare_type }}Obj());
-{% for relation in OneToManyRelations %}
-  m_rel_{{ relation.name }}_tmp.push_back(obj->m_{{ relation.name }});
-{% endfor %}
-{% for member in VectorMembers %}
-  m_vecs_{{ member.name }}.push_back(obj->m_{{ member.name }});
-{% endfor %}
+  auto obj = m_storage.entries.emplace_back(new {{ class.bare_type }}Obj());
+{% if OneToManyRelations or VectorMembers %}
+  m_storage.createRelations(obj);
+{% endif %}
 
-  obj->id = {int(m_entries.size() - 1), m_collectionID};
+  obj->id = {int(m_storage.entries.size() - 1), m_collectionID};
   return {{ class.bare_type }}(obj);
 }
 
 void {{ collection_type }}::clear() {
-  m_data->clear();
-{% if OneToManyRelations or OneToOneRelations %}
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-{% endif %}
-{% for relation in OneToManyRelations %}
-  // clear relations to {{ relation.name }}. Make sure to unlink() the reference data as they may be gone already.
-  for (auto& pointer : m_rel_{{ relation.name }}_tmp) {
-    for (auto& item : *pointer) {
-      item.unlink();
-    }
-    delete pointer;
-  }
-  m_rel_{{ relation.name }}_tmp.clear();
-{{ macros.clear_relation(relation) }}
-{% endfor %}
-{% for relation in OneToOneRelations %}
-{{ macros.clear_relation(relation) }}
-{% endfor %}
-{% for member in VectorMembers %}
-  m_vec_{{ member.name }}->clear();
-  for (auto& vec : m_vecs_{{ member.name }}) { delete vec; }
-  m_vecs_{{ member.name }}.clear();
-
-{% endfor %}
-  for (auto& obj : m_entries) { delete obj; }
-  m_entries.clear();
+  m_storage.clear();
 }
 
 void {{ collection_type }}::prepareForWrite() {
-  m_data->reserve(m_entries.size());
-  for (auto& obj : m_entries) { m_data->push_back(obj->data); }
-
-  // if the collection has been read from a file the rest of the information is
-  // already in the correct format and we have to skip it, since the temporary
-  // buffers are invalid
+  // If the collection has been read from a file, there is nothing to do here
   if (m_isReadFromFile) return;
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
-
-{% for relation in OneToManyRelations %}
-  int {{ relation.name }}_index = 0;
-{% endfor %}
-{% for member in VectorMembers %}
-  const auto {{ member.name }}_size = std::accumulate(m_entries.begin(), m_entries.end(), 0, [](size_t sum, const {{ class.bare_type }}Obj* obj) { return sum + obj->m_{{ member.name }}->size(); });
-  m_vec_{{ member.name }}->reserve({{ member.name }}_size);
-  int {{ member.name }}_index = 0;
-{% endfor %}
-
-{%- if OneToManyRelations or VectorMembers %}
-  for (size_t i = 0, size = m_data->size(); i != size; ++i) {
-{% for relation in OneToManyRelations %}
-{{ macros.prepare_for_write_multi_relation(relation, loop.index0) }}
-{% endfor %}
-{% for member in VectorMembers %}
-{{ macros.prepare_for_write_vector_member(member) }}
-{% endfor %}
-  }
-{%- endif %}
-
-{% for relation in OneToOneRelations %}
-{{ macros.prepare_for_write_single_relation(relation, loop.index0, OneToManyRelations | length) }}
-{% endfor %}
+  m_storage.prepareForWrite();
 }
 
 void {{ collection_type }}::prepareAfterRead() {
-  int index = 0;
-  for (auto& data : *m_data) {
-    auto obj = new {{ class.bare_type }}Obj({index, m_collectionID}, data);
-
-{% for relation in OneToManyRelations %}
-    obj->m_{{ relation.name }} = m_rel_{{ relation.name }};
-{% endfor %}
-{% for member in VectorMembers %}
-    obj->m_{{ member.name }} = m_vec_{{ member.name }};
-{% endfor %}
-    m_entries.emplace_back(obj);
-    ++index;
-  }
-
-  // at this point we are done with the I/O buffer and can safely clear it to not
-  // have a redundant (but now useless) copy of the data
-  m_data->clear();
+  m_storage.prepareAfterRead(m_collectionID);
   m_isReadFromFile = true;
 }
 
 bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* {% if OneToManyRelations or OneToOneRelations -%}collectionProvider{%- endif -%}) {
-{% for relation in OneToManyRelations %}
-{{ macros.set_references_multi_relation(relation, loop.index0) }}
-{% endfor %}
-{% for relation in OneToOneRelations %}
-{{ macros.set_reference_single_relation(relation, loop.index0, OneToManyRelations | length) }}
-{% endfor %}
+{% if OneToManyRelations or OneToOneRelations %}
+  m_storage.setReferences(collectionProvider);
+{% endif %}
 
   return true; //TODO: check success
 }
 
 void {{ collection_type }}::push_back(Const{{ class.bare_type }} object) {
-  const auto size = m_entries.size();
+  const auto size = m_storage.entries.size();
   auto obj = object.m_obj;
   if (obj->id.index == podio::ObjectID::untracked) {
     obj->id = {(int)size, m_collectionID};
-    m_entries.push_back(obj);
-
-{% for relation in OneToManyRelations %}
-    m_rel_{{ relation.name }}_tmp.push_back(obj->m_{{ relation.name }});
-{% endfor %}
-{% for member in VectorMembers %}
-    m_vecs_{{ member.name }}.push_back(obj->m_{{ member.name }});
-{% endfor %}
+    m_storage.entries.push_back(obj);
+{% if OneToManyRelations or VectorMembers %}
+    m_storage.createRelations(obj);
+{% endif %}
   } else {
     throw std::invalid_argument("Object already in a collection. Cannot add it to a second collection");
   }
 }
 
-void {{ collection_type }}::setBuffer(void* address) {
-  if (m_data) delete m_data;
-  m_data = static_cast<{{ class.bare_type }}DataContainer*>(address);
+podio::CollectionBuffers {{ collection_type }}::getBuffers() {
+  return m_storage.getCollectionBuffers();
 }
+
+// void {{ collection_type }}::setBuffers(const podio::CollectionBuffers& buffers) {
+//   if (m_storage.data) delete m_storage.data;
+//   m_storage.data = static_cast<{{ class.bare_type }}DataContainer*>(buffers.data);
+
+//   m_storage.vecmem_info = std::move(*buffers.vectorMembers);
+//   m_storage.refCollections = std::move(*buffers.references);
+// }
 {% endwith %}
 
 {{ iterator_definitions(class) }}

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -17,7 +17,7 @@
 
 {% with collection_type = class.bare_type + 'Collection' %}
 {{ collection_type }}::{{ collection_type }}() :
-  m_isValid(false), m_isReadFromFile(false), m_isRefColl(false), m_collectionID(0), m_storage() {}
+  m_isValid(false), m_isReadFromFile(false), m_isSubsetColl(false), m_collectionID(0), m_storage() {}
 
 {{ collection_type }}::~{{ collection_type }}() {
   clear();
@@ -43,20 +43,20 @@ size_t {{ collection_type }}::size() const {
   return m_storage.entries.size();
 }
 
-void {{ collection_type }}::setReferenceCollection(bool setToRef) {
-  if (m_isRefColl != setToRef && !m_storage.entries.empty()) {
+void {{ collection_type }}::setSubsetCollection(bool setSubset) {
+  if (m_isSubsetColl != setSubset && !m_storage.entries.empty()) {
     throw std::logic_error("Cannot change the character of a collection that already contains elements");
   }
 
-  if (setToRef) {
-    m_storage.makeReferenceCollection();
+  if (setSubset) {
+    m_storage.makeSubsetCollection();
   }
-  m_isRefColl = setToRef;
+  m_isSubsetColl = setSubset;
 }
 
 {{ class.bare_type }} {{ collection_type }}::create() {
-  if (m_isRefColl) {
-    throw std::logic_error("Cannot create new elements on a reference collection");
+  if (m_isSubsetColl) {
+    throw std::logic_error("Cannot create new elements on a subset collection");
   }
 
   auto obj = m_storage.entries.emplace_back(new {{ class.bare_type }}Obj());
@@ -69,21 +69,21 @@ void {{ collection_type }}::setReferenceCollection(bool setToRef) {
 }
 
 void {{ collection_type }}::clear() {
-  m_storage.clear(m_isRefColl);
+  m_storage.clear(m_isSubsetColl);
 }
 
 void {{ collection_type }}::prepareForWrite() {
   // If the collection has been read from a file, there is nothing to do here
   if (m_isReadFromFile) return;
-  m_storage.prepareForWrite(m_isRefColl);
+  m_storage.prepareForWrite(m_isSubsetColl);
 }
 
 void {{ collection_type }}::prepareAfterRead() {
   // No need to go through this again if we have already done it
   if (m_isReadFromFile) return;
 
-  if (!m_isRefColl) {
-    // Reference collections do not store any data that would require post-processing
+  if (!m_isSubsetColl) {
+    // Subset collections do not store any data that would require post-processing
     m_storage.prepareAfterRead(m_collectionID);
   }
   m_isReadFromFile = true;
@@ -91,7 +91,7 @@ void {{ collection_type }}::prepareAfterRead() {
 
 bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* {% if OneToManyRelations or OneToOneRelations -%}collectionProvider{%- endif -%}) {
 {% if OneToManyRelations or OneToOneRelations %}
-  m_storage.setReferences(collectionProvider, m_isRefColl);
+  m_storage.setReferences(collectionProvider, m_isSubsetColl);
 {% endif %}
 
   return true; //TODO: check success
@@ -99,10 +99,10 @@ bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* {% i
 
 void {{ collection_type }}::push_back(Const{{ class.bare_type }} object) {
   // We have to do different things here depending on whether this is a
-  // reference collection or not. A normal collection cannot collect objects
-  // that are already part of another collection, while a reference collection
+  // subset collection or not. A normal collection cannot collect objects
+  // that are already part of another collection, while a subset collection
   // can only collect such objects
-  if (!m_isRefColl) {
+  if (!m_isSubsetColl) {
     auto obj = object.m_obj;
     if (obj->id.index == podio::ObjectID::untracked) {
       const auto size = m_storage.entries.size();
@@ -117,7 +117,7 @@ void {{ collection_type }}::push_back(Const{{ class.bare_type }} object) {
   } else {
     const auto obj = object.m_obj;
     if (obj->id.index < 0) {
-      throw std::invalid_argument("Object needs to be tracked by another collection in order for it to be storable in a reference collection");
+      throw std::invalid_argument("Object needs to be tracked by another collection in order for it to be storable in a subset collection");
     }
     m_storage.entries.push_back(obj);
     // No need to handle any relations here, since this is already done by the
@@ -126,7 +126,7 @@ void {{ collection_type }}::push_back(Const{{ class.bare_type }} object) {
 }
 
 podio::CollectionBuffers {{ collection_type }}::getBuffers() {
-  return m_storage.getCollectionBuffers(m_isRefColl);
+  return m_storage.getCollectionBuffers(m_isSubsetColl);
 }
 
 // void {{ collection_type }}::setBuffers(const podio::CollectionBuffers& buffers) {

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -17,7 +17,7 @@
 
 {% with collection_type = class.bare_type + 'Collection' %}
 {{ collection_type }}::{{ collection_type }}() :
-  m_isValid(false), m_isReadFromFile(false), m_collectionID(0), m_storage() {}
+  m_isValid(false), m_isReadFromFile(false), m_isRefColl(false), m_collectionID(0), m_storage() {}
 
 {{ collection_type }}::~{{ collection_type }}() {
   clear();
@@ -43,7 +43,22 @@ size_t {{ collection_type }}::size() const {
   return m_storage.entries.size();
 }
 
+void {{ collection_type }}::setReferenceCollection(bool setToRef) {
+  if (m_isRefColl != setToRef && !m_storage.entries.empty()) {
+    throw std::logic_error("Cannot change the character of a collection that already contains elements");
+  }
+
+  if (setToRef) {
+    m_storage.makeReferenceCollection();
+  }
+  m_isRefColl = setToRef;
+}
+
 {{ class.bare_type }} {{ collection_type }}::create() {
+  if (m_isRefColl) {
+    throw std::logic_error("Cannot create new elements on a reference collection");
+  }
+
   auto obj = m_storage.entries.emplace_back(new {{ class.bare_type }}Obj());
 {% if OneToManyRelations or VectorMembers %}
   m_storage.createRelations(obj);
@@ -54,44 +69,64 @@ size_t {{ collection_type }}::size() const {
 }
 
 void {{ collection_type }}::clear() {
-  m_storage.clear();
+  m_storage.clear(m_isRefColl);
 }
 
 void {{ collection_type }}::prepareForWrite() {
   // If the collection has been read from a file, there is nothing to do here
   if (m_isReadFromFile) return;
-  m_storage.prepareForWrite();
+  m_storage.prepareForWrite(m_isRefColl);
 }
 
 void {{ collection_type }}::prepareAfterRead() {
-  m_storage.prepareAfterRead(m_collectionID);
+  // No need to go through this again if we have already done it
+  if (m_isReadFromFile) return;
+
+  if (!m_isRefColl) {
+    // Reference collections do not store any data that would require post-processing
+    m_storage.prepareAfterRead(m_collectionID);
+  }
   m_isReadFromFile = true;
 }
 
 bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* {% if OneToManyRelations or OneToOneRelations -%}collectionProvider{%- endif -%}) {
 {% if OneToManyRelations or OneToOneRelations %}
-  m_storage.setReferences(collectionProvider);
+  m_storage.setReferences(collectionProvider, m_isRefColl);
 {% endif %}
 
   return true; //TODO: check success
 }
 
 void {{ collection_type }}::push_back(Const{{ class.bare_type }} object) {
-  const auto size = m_storage.entries.size();
-  auto obj = object.m_obj;
-  if (obj->id.index == podio::ObjectID::untracked) {
-    obj->id = {(int)size, m_collectionID};
-    m_storage.entries.push_back(obj);
+  // We have to do different things here depending on whether this is a
+  // reference collection or not. A normal collection cannot collect objects
+  // that are already part of another collection, while a reference collection
+  // can only collect such objects
+  if (!m_isRefColl) {
+    auto obj = object.m_obj;
+    if (obj->id.index == podio::ObjectID::untracked) {
+      const auto size = m_storage.entries.size();
+      obj->id = {(int)size, m_collectionID};
+      m_storage.entries.push_back(obj);
 {% if OneToManyRelations or VectorMembers %}
-    m_storage.createRelations(obj);
+      m_storage.createRelations(obj);
 {% endif %}
+    } else {
+      throw std::invalid_argument("Object already in a collection. Cannot add it to a second collection");
+    }
   } else {
-    throw std::invalid_argument("Object already in a collection. Cannot add it to a second collection");
+    const auto obj = object.m_obj;
+    if (obj->id.index < 0) {
+      throw std::invalid_argument("Object needs to be tracked by another collection in order for it to be storable in a reference collection");
+    }
+    m_storage.entries.push_back(obj);
+    // No need to handle any relations here, since this is already done by the
+    // "owning" collection
   }
 }
 
 podio::CollectionBuffers {{ collection_type }}::getBuffers() {
-  return m_storage.getCollectionBuffers();
+  return m_storage.getCollectionBuffers(m_isRefColl);
 }
 
 // void {{ collection_type }}::setBuffers(const podio::CollectionBuffers& buffers) {

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -129,13 +129,6 @@ podio::CollectionBuffers {{ collection_type }}::getBuffers() {
   return m_storage.getCollectionBuffers(m_isSubsetColl);
 }
 
-// void {{ collection_type }}::setBuffers(const podio::CollectionBuffers& buffers) {
-//   if (m_storage.data) delete m_storage.data;
-//   m_storage.data = static_cast<{{ class.bare_type }}DataContainer*>(buffers.data);
-
-//   m_storage.vecmem_info = std::move(*buffers.vectorMembers);
-//   m_storage.refCollections = std::move(*buffers.references);
-// }
 {% endwith %}
 
 {{ iterator_definitions(class) }}

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -64,11 +64,11 @@ public:
   /// fully qualified type name of elements - with namespace
   std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
 
-  bool isReferenceCollection() const final {
-    return m_isRefColl;
+  bool isSubsetCollection() const final {
+    return m_isSubsetColl;
   }
 
-  void setReferenceCollection(bool setToRef=true) final;
+  void setSubsetCollection(bool setSubset=true) final;
 
   /// Returns the object of given index
   Const{{ class.bare_type }} operator[](unsigned int index) const;
@@ -132,7 +132,7 @@ private:
 
   bool m_isValid{false};
   bool m_isReadFromFile{false};
-  bool m_isRefColl{false};
+  bool m_isSubsetColl{false};
   int m_collectionID{0};
   {{ class.bare_type }}CollectionData m_storage{};
 };
@@ -141,8 +141,8 @@ std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}Collection&
 
 template<typename... Args>
 {{ class.bare_type }} {{ class.bare_type }}Collection::create(Args&&... args) {
-  if (m_isRefColl) {
-    throw std::logic_error("Cannot create new elements on a reference collection");
+  if (m_isSubsetColl) {
+    throw std::logic_error("Cannot create new elements on a subset collection");
   }
   const int size = m_storage.entries.size();
   auto obj = new {{ class.bare_type }}Obj({size, m_collectionID}, {std::forward<Args>(args)...});

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -64,6 +64,12 @@ public:
   /// fully qualified type name of elements - with namespace
   std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
 
+  bool isReferenceCollection() const final {
+    return m_isRefColl;
+  }
+
+  void setReferenceCollection(bool setToRef=true) final;
+
   /// Returns the object of given index
   Const{{ class.bare_type }} operator[](unsigned int index) const;
   /// Returns the object of a given index
@@ -122,8 +128,11 @@ public:
 {% endfor %}
 
 private:
+  friend class {{ class.bare_type }}CollectionData;
+
   bool m_isValid{false};
   bool m_isReadFromFile{false};
+  bool m_isRefColl{false};
   int m_collectionID{0};
   {{ class.bare_type }}CollectionData m_storage{};
 };

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -141,9 +141,20 @@ std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}Collection&
 
 template<typename... Args>
 {{ class.bare_type }} {{ class.bare_type }}Collection::create(Args&&... args) {
+  if (m_isRefColl) {
+    throw std::logic_error("Cannot create new elements on a reference collection");
+  }
   const int size = m_storage.entries.size();
-  auto obj = new {{ class.bare_type }}Obj({size, m_collectionID}, {args...});
+  auto obj = new {{ class.bare_type }}Obj({size, m_collectionID}, {std::forward<Args>(args)...});
   m_storage.entries.push_back(obj);
+
+{% if OneToManyRelations or VectorMembers %}
+  // Need to initialize the relation vectors manually for the {ObjectID, {{class.bare_type}}Data} constructor
+{% for relation in OneToManyRelations + VectorMembers %}
+  obj->m_{{ relation.name }} = new std::vector<{{ relation.relation_type }}>();
+{% endfor %}
+  m_storage.createRelations(obj);
+{% endif %}
   return {{ class.bare_type }}(obj);
 }
 

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -10,6 +10,7 @@
 #include "{{ incfolder }}{{ class.bare_type }}Data.h"
 #include "{{ incfolder }}{{ class.bare_type }}.h"
 #include "{{ incfolder }}{{ class.bare_type }}Obj.h"
+#include "{{ incfolder }}{{ class.bare_type }}CollectionData.h"
 
 // podio specific includes
 #include "podio/ICollectionProvider.h"
@@ -25,8 +26,6 @@
 
 {{ utils.namespace_open(class.namespace) }}
 
-using {{ class.bare_type }}DataContainer = std::vector<{{ class.bare_type }}Data>;
-using {{ class.bare_type }}ObjPointerContainer = std::deque<{{ class.bare_type }}Obj*>;
 
 {{ iterator_declaration(class) }}
 
@@ -36,7 +35,6 @@ using {{ class.bare_type }}ObjPointerContainer = std::deque<{{ class.bare_type }
 A Collection is identified by an ID.
 */
 class {{ class.bare_type }}Collection : public podio::CollectionBase {
-
 public:
   using const_iterator = {{ class.bare_type }}ConstCollectionIterator;
   using iterator = {{ class.bare_type }}CollectionIterator;
@@ -66,7 +64,7 @@ public:
   /// fully qualified type name of elements - with namespace
   std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
 
-  /// Returns the const object of given index
+  /// Returns the object of given index
   Const{{ class.bare_type }} operator[](unsigned int index) const;
   /// Returns the object of a given index
   {{ class.bare_type }} operator[](unsigned int index);
@@ -81,16 +79,16 @@ public:
 
   void prepareForWrite() override final;
   void prepareAfterRead() override final;
-  void setBuffer(void* address) override final;
   bool setReferences(const podio::ICollectionProvider* collectionProvider) override final;
 
-  podio::CollRefCollection* referenceCollections() override final { return &m_refCollections; }
+  /// Get the collection buffers for this collection
+  podio::CollectionBuffers getBuffers() final;
 
-  podio::VectorMembersInfo* vectorMembers() override { return &m_vecmem_info; }
+  // void setBuffers(const podio::CollectionBuffers& buffers) final;
 
   void setID(unsigned ID) override final {
     m_collectionID = ID;
-    std::for_each(m_entries.begin(),m_entries.end(),
+    std::for_each(m_storage.entries.begin(), m_storage.entries.end(),
                   [ID] ({{ class.bare_type }}Obj* obj) { obj->id = {obj->id.index, static_cast<int>(ID)}; }
     );
     m_isValid = true;
@@ -106,23 +104,17 @@ public:
 
   // support for the iterator protocol
   iterator begin() {
-    return iterator(0, &m_entries);
+    return iterator(0, &m_storage.entries);
   }
   const_iterator begin() const {
-    return const_iterator(0, &m_entries);
+    return const_iterator(0, &m_storage.entries);
   }
   iterator end() {
-    return iterator(m_entries.size(), &m_entries);
+    return iterator(m_storage.entries.size(), &m_storage.entries);
   }
   const_iterator end() const {
-    return const_iterator(m_entries.size(), &m_entries);
+    return const_iterator(m_storage.entries.size(), &m_storage.entries);
   }
-
-  /// returns the address of the pointer to the data buffer
-  void* getBufferAddress() override final { return (void*)&m_data; }
-
-  /// Returns the pointer to the data buffer
-  std::vector<{{ class.bare_type }}Data>* _getBuffer() { return m_data; }
 
 {% for member in Members %}
   template<size_t arraysize>
@@ -133,35 +125,16 @@ private:
   bool m_isValid{false};
   bool m_isReadFromFile{false};
   int m_collectionID{0};
-  {{ class.bare_type }}ObjPointerContainer m_entries;
-
-  // members to handle 1-to-N-relations
-{% for relation in OneToManyRelations %}
-  std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>* m_rel_{{ relation.name }}; ///< Relation buffer for read / write
-  std::vector<std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>*> m_rel_{{ relation.name }}_tmp{}; ///< Relation buffer for internal book-keeping
-{% endfor %}
-{% for relation in OneToOneRelations %}
-  std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>* m_rel_{{ relation.name }}; ///< Relation buffer for read / write
-{% endfor %}
-
-  // members to handle vector members
-{% for member in VectorMembers %}
-  std::vector<{{ member.full_type }}>* m_vec_{{ member.name }}; /// combined vector of all objects in collection
-  std::vector<std::vector<{{ member.full_type }}>*> m_vecs_{{ member.name }}{}; /// pointers to individual member vectors
-{% endfor %}
-  // members to handle streaming
-  podio::CollRefCollection m_refCollections{};
-  podio::VectorMembersInfo m_vecmem_info{};
-  {{ class.bare_type }}DataContainer* m_data;
+  {{ class.bare_type }}CollectionData m_storage{};
 };
 
 std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}Collection& v);
 
 template<typename... Args>
 {{ class.bare_type }} {{ class.bare_type }}Collection::create(Args&&... args) {
-  const int size = m_entries.size();
+  const int size = m_storage.entries.size();
   auto obj = new {{ class.bare_type }}Obj({size, m_collectionID}, {args...});
-  m_entries.push_back(obj);
+  m_storage.entries.push_back(obj);
   return {{ class.bare_type }}(obj);
 }
 

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -90,8 +90,6 @@ public:
   /// Get the collection buffers for this collection
   podio::CollectionBuffers getBuffers() final;
 
-  // void setBuffers(const podio::CollectionBuffers& buffers) final;
-
   void setID(unsigned ID) override final {
     m_collectionID = ID;
     std::for_each(m_storage.entries.begin(), m_storage.entries.end(),
@@ -128,6 +126,9 @@ public:
 {% endfor %}
 
 private:
+  // For setReferences, we need to give our own CollectionData access to our
+  // private entries. Otherwise we would need to expose a public member function
+  // that gives access to the Obj* which is definitely not what we want
   friend class {{ class.bare_type }}CollectionData;
 
   bool m_isValid{false};

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -1,0 +1,157 @@
+{% import "macros/utils.jinja2" as utils %}
+{% import "macros/collections.jinja2" as macros %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#include "{{ incfolder }}{{ class.bare_type }}CollectionData.h"
+
+{% for include in includes_coll_cc %}
+{{ include }}
+{% endfor %}
+
+{{ utils.namespace_open(class.namespace) }}
+{% with class_type = class.bare_type + 'CollectionData' %}
+
+{{ class_type }}::{{ class_type }}() :
+{%- for relation in OneToManyRelations + OneToOneRelations %}
+  m_rel_{{ relation.name }}(new std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>()),
+{%- endfor %}
+{%- for member in VectorMembers %}
+  m_vec_{{ member.name }}(new std::vector<{{ member.full_type }}>()),
+{%- endfor -%}
+  m_data(new {{ class.bare_type }}DataContainer()) {
+{% for relation in OneToManyRelations + OneToOneRelations %}
+  m_refCollections.push_back(new std::vector<podio::ObjectID>());
+{% endfor %}
+{% for member in VectorMembers %}
+  m_vecmem_info.emplace_back("{{ member.full_type }}", &m_vec_{{ member.name }});
+{% endfor %}
+}
+
+{{ class_type }}::~{{ class_type }}() {
+  delete m_data;
+{% if OneToManyRelations or OneToOneRelations %}
+  for (auto& pointer : m_refCollections) delete pointer;
+{% endif %}
+{% for relation in OneToManyRelations + OneToOneRelations %}
+  delete m_rel_{{ relation.name }};
+{% endfor %}
+{% for member in VectorMembers %}
+  delete m_vec_{{ member.name }};
+{% endfor %}
+}
+
+void {{ class_type }}::clear() {
+  m_data->clear();
+{% if OneToManyRelations or OneToOneRelations %}
+  for (auto& pointer : m_refCollections) { pointer->clear(); }
+{% endif %}
+{% for relation in OneToManyRelations %}
+  // clear relations to {{ relation.name }}. Make sure to unlink() the reference data as they may be gone already.
+  for (auto& pointer : m_rel_{{ relation.name }}_tmp) {
+    for (auto& item : *pointer) {
+      item.unlink();
+    }
+    delete pointer;
+  }
+  m_rel_{{ relation.name }}_tmp.clear();
+{{ macros.clear_relation(relation) }}
+{% endfor %}
+{% for relation in OneToOneRelations %}
+{{ macros.clear_relation(relation) }}
+{% endfor %}
+{% for member in VectorMembers %}
+  m_vec_{{ member.name }}->clear();
+  for (auto& vec : m_vecs_{{ member.name }}) { delete vec; }
+  m_vecs_{{ member.name }}.clear();
+
+{% endfor %}
+  for (auto& obj : entries) { delete obj; }
+  entries.clear();
+}
+
+podio::CollectionBuffers {{ class_type }}::getCollectionBuffers() {
+  return {
+    (void*)&m_data,
+    &m_refCollections,
+    &m_vecmem_info
+  };
+}
+
+void {{ class_type }}::prepareForWrite() {
+  m_data->reserve(entries.size());
+  for (auto& obj : entries) { m_data->push_back(obj->data); }
+
+  for (auto& pointer : m_refCollections) { pointer->clear(); }
+
+{% for relation in OneToManyRelations %}
+  int {{ relation.name }}_index = 0;
+{% endfor %}
+{% for member in VectorMembers %}
+const auto {{ member.name }}_size = std::accumulate(entries.begin(), entries.end(), 0,
+  [](size_t sum, const {{ class.bare_type }}Obj* obj) { return sum + obj->m_{{ member.name }}->size(); });
+  m_vec_{{ member.name }}->reserve({{ member.name }}_size);
+  int {{ member.name }}_index = 0;
+{% endfor %}
+
+{%- if OneToManyRelations or VectorMembers %}
+  for (size_t i = 0, size = m_data->size(); i != size; ++i) {
+{% for relation in OneToManyRelations %}
+{{ macros.prepare_for_write_multi_relation(relation, loop.index0) }}
+{% endfor %}
+{% for member in VectorMembers %}
+{{ macros.prepare_for_write_vector_member(member) }}
+{% endfor %}
+  }
+{%- endif %}
+
+{% for relation in OneToOneRelations %}
+{{ macros.prepare_for_write_single_relation(relation, loop.index0, OneToManyRelations | length) }}
+{% endfor %}
+}
+
+void {{ class_type }}::prepareAfterRead(int collectionID) {
+  int index = 0;
+  for (auto& data : *m_data) {
+    auto obj = new {{ class.bare_type }}Obj({index, collectionID}, data);
+
+{% for relation in OneToManyRelations %}
+    obj->m_{{ relation.name }} = m_rel_{{ relation.name }};
+{% endfor %}
+{% for member in VectorMembers %}
+    obj->m_{{ member.name }} = m_vec_{{ member.name }};
+{% endfor %}
+    entries.emplace_back(obj);
+    ++index;
+  }
+
+  // at this point we could clear the I/O data buffer, but we keep them intact
+  // because then we can save a call to prepareForWrite
+}
+
+
+{% if OneToManyRelations or VectorMembers %}
+void {{ class_type }}::createRelations({{ class.bare_type }}Obj* obj) {
+ {% for relation in OneToManyRelations %}
+  m_rel_{{ relation.name }}_tmp.push_back(obj->m_{{ relation.name }});
+{% endfor %}
+{% for member in VectorMembers %}
+  m_vecs_{{ member.name }}.push_back(obj->m_{{ member.name }});
+{% endfor %}
+}
+{% endif %}
+
+{% if OneToManyRelations or OneToOneRelations %}
+void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectionProvider) {
+{% for relation in OneToManyRelations %}
+{{ macros.set_references_multi_relation(relation, loop.index0) }}
+{% endfor %}
+{% for relation in OneToOneRelations %}
+{{ macros.set_reference_single_relation(relation, loop.index0, OneToManyRelations | length) }}
+{% endfor %}
+
+}
+{% endif %}
+
+{% endwith %}
+
+{{ utils.namespace_close(class.namespace) }}

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -41,8 +41,8 @@
 {% endfor %}
 }
 
-void {{ class_type }}::clear(bool isRefColl) {
-  if (isRefColl) {
+void {{ class_type }}::clear(bool isSubsetColl) {
+  if (isSubsetColl) {
     // We don't own the objects so no cleanup to do here
     entries.clear();
     // Clear the ObjectID I/O buffer
@@ -79,20 +79,20 @@ void {{ class_type }}::clear(bool isRefColl) {
   entries.clear();
 }
 
-podio::CollectionBuffers {{ class_type }}::getCollectionBuffers(bool isRefColl) {
+podio::CollectionBuffers {{ class_type }}::getCollectionBuffers(bool isSubsetColl) {
   return {
-    isRefColl ? nullptr : (void*)&m_data,
+    isSubsetColl ? nullptr : (void*)&m_data,
     &m_refCollections, // only need to store the ObjectIDs of the referenced objects
     &m_vecmem_info
   };
 }
 
-void {{ class_type }}::prepareForWrite(bool isRefColl) {
+void {{ class_type }}::prepareForWrite(bool isSubsetColl) {
   for (auto& pointer : m_refCollections) { pointer->clear(); }
 
-  // If this is a reference collection use the relation storing mechanism to
+  // If this is a subset collection use the relation storing mechanism to
   // store the ObjectIDs of all referenced objects and nothing else
-  if (isRefColl) {
+  if (isSubsetColl) {
     for (const auto* obj : entries) {
       m_refCollections[0]->emplace_back(obj->id);
     }
@@ -161,8 +161,8 @@ void {{ class_type }}::createRelations({{ class.bare_type }}Obj* obj) {
 {% endif %}
 
 {% if OneToManyRelations or OneToOneRelations %}
-void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectionProvider, bool isRefColl) {
-  if (isRefColl) {
+void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectionProvider, bool isSubsetColl) {
+  if (isSubsetColl) {
     for (const auto& id : *m_refCollections[0]) {
 {{ macros.get_collection(class.full_type) }}
       entries.push_back(tmp_coll->m_storage.entries[id.index]);
@@ -181,8 +181,8 @@ void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectio
 }
 {% endif %}
 
-void {{ class_type }}::makeReferenceCollection() {
-  // Reference collections do not need all the data buffers that normal
+void {{ class_type }}::makeSubsetCollection() {
+  // Subset collections do not need all the data buffers that normal
   // collections need, so we can free them here
   m_vecmem_info.clear();
 
@@ -198,7 +198,7 @@ void {{ class_type }}::makeReferenceCollection() {
   m_vec_{{ member.name }} = nullptr;
 {% endfor %}
 
-  // Reference collections need one vector of ObjectIDs for I/O purposes.
+  // Subset collections need one vector of ObjectIDs for I/O purposes.
   for (auto& pointer : m_refCollections) {
     delete pointer;
   }

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -3,6 +3,7 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
 #include "{{ incfolder }}{{ class.bare_type }}CollectionData.h"
+#include "{{ incfolder }}{{ class.bare_type }}Collection.h"
 
 {% for include in includes_coll_cc %}
 {{ include }}
@@ -40,7 +41,16 @@
 {% endfor %}
 }
 
-void {{ class_type }}::clear() {
+void {{ class_type }}::clear(bool isRefColl) {
+  if (isRefColl) {
+    // We don't own the objects so no cleanup to do here
+    entries.clear();
+    // Clear the ObjectID I/O buffer
+    for (auto& pointer : m_refCollections) { pointer->clear(); }
+    return;
+  }
+
+  // Normal collections manage a bit more and have to clean up a bit more
   m_data->clear();
 {% if OneToManyRelations or OneToOneRelations %}
   for (auto& pointer : m_refCollections) { pointer->clear(); }
@@ -69,19 +79,29 @@ void {{ class_type }}::clear() {
   entries.clear();
 }
 
-podio::CollectionBuffers {{ class_type }}::getCollectionBuffers() {
+podio::CollectionBuffers {{ class_type }}::getCollectionBuffers(bool isRefColl) {
   return {
-    (void*)&m_data,
-    &m_refCollections,
+    isRefColl ? nullptr : (void*)&m_data,
+    &m_refCollections, // only need to store the ObjectIDs of the referenced objects
     &m_vecmem_info
   };
 }
 
-void {{ class_type }}::prepareForWrite() {
+void {{ class_type }}::prepareForWrite(bool isRefColl) {
+  for (auto& pointer : m_refCollections) { pointer->clear(); }
+
+  // If this is a reference collection use the relation storing mechanism to
+  // store the ObjectIDs of all referenced objects and nothing else
+  if (isRefColl) {
+    for (const auto* obj : entries) {
+      m_refCollections[0]->emplace_back(obj->id);
+    }
+    return;
+  }
+
+  // Normal collections have to store the data and all the relations
   m_data->reserve(entries.size());
   for (auto& obj : entries) { m_data->push_back(obj->data); }
-
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
 
 {% for relation in OneToManyRelations %}
   int {{ relation.name }}_index = 0;
@@ -141,7 +161,16 @@ void {{ class_type }}::createRelations({{ class.bare_type }}Obj* obj) {
 {% endif %}
 
 {% if OneToManyRelations or OneToOneRelations %}
-void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectionProvider) {
+void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectionProvider, bool isRefColl) {
+  if (isRefColl) {
+    for (const auto& id : *m_refCollections[0]) {
+{{ macros.get_collection(class.full_type) }}
+      entries.push_back(tmp_coll->m_storage.entries[id.index]);
+    }
+    return;
+  }
+
+  // Normal collections have to resolve all relations
 {% for relation in OneToManyRelations %}
 {{ macros.set_references_multi_relation(relation, loop.index0) }}
 {% endfor %}
@@ -151,6 +180,31 @@ void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectio
 
 }
 {% endif %}
+
+void {{ class_type }}::makeReferenceCollection() {
+  // Reference collections do not need all the data buffers that normal
+  // collections need, so we can free them here
+  m_vecmem_info.clear();
+
+  delete m_data;
+  m_data = nullptr;
+
+{% for relation in OneToManyRelations + OneToOneRelations %}
+  delete m_rel_{{ relation.name }};
+  m_rel_{{ relation.name }} = nullptr;
+{% endfor %}
+{% for member in VectorMembers %}
+  delete m_vec_{{ member.name }};
+  m_vec_{{ member.name }} = nullptr;
+{% endfor %}
+
+  // Reference collections need one vector of ObjectIDs for I/O purposes.
+  for (auto& pointer : m_refCollections) {
+    delete pointer;
+  }
+  m_refCollections.resize(1);
+  m_refCollections[0] = new std::vector<podio::ObjectID>();
+}
 
 {% endwith %}
 

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -1,0 +1,94 @@
+{% import "macros/utils.jinja2" as utils %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#ifndef {{ package_name.upper() }}_{{ class.bare_type }}_CollectionData_H
+#define {{ package_name.upper() }}_{{ class.bare_type }}_CollectionData_H
+
+// datamodel specific includes
+#include "{{ incfolder }}{{ class.bare_type }}Data.h"
+#include "{{ incfolder }}{{ class.bare_type }}Obj.h"
+
+// podio specific includes
+#include "podio/CollectionBuffers.h"
+#include "podio/ICollectionProvider.h"
+
+#include <deque>
+
+
+{{ utils.namespace_open(class.namespace) }}
+
+using {{ class.bare_type }}ObjPointerContainer = std::deque<{{ class.bare_type }}Obj*>;
+using {{ class.bare_type }}DataContainer = std::vector<{{ class.bare_type }}Data>;
+
+
+/**
+ * Class encapsulating everything related to storage of data that is needed by a
+ * collection.
+ */
+{% with class_type = class.bare_type + 'CollectionData' %}
+class {{ class.bare_type }}CollectionData {
+public:
+  /**
+   * The Objs of this collection
+   */
+  {{ class.bare_type }}ObjPointerContainer entries{};
+
+  /**
+   * Default constructor setting up the necessary buffers
+   */
+  {{ class_type }}();
+
+  /**
+   * Non copy-able class
+   */
+  {{ class_type }}(const {{ class_type }}&) = delete;
+  {{ class_type }}& operator=(const {{ class_type }}&) = delete;
+
+  /**
+   * Deconstructor
+   */
+  ~{{ class_type }}();
+
+  void clear();
+
+  podio::CollectionBuffers getCollectionBuffers();
+
+  void prepareForWrite();
+
+  void prepareAfterRead(int collectionID);
+
+{% if OneToManyRelations or VectorMembers %}
+  void createRelations({{ class.bare_type }}Obj* obj);
+{% endif %}
+
+{% if OneToManyRelations or OneToOneRelations %}
+  void setReferences(const podio::ICollectionProvider* collectionProvider);
+{% endif %}
+
+private:
+  // members to handle 1-to-N-relations
+{% for relation in OneToManyRelations %}
+  std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>* m_rel_{{ relation.name }}; ///< Relation buffer for read / write
+  std::vector<std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>*> m_rel_{{ relation.name }}_tmp{}; ///< Relation buffer for internal book-keeping
+{% endfor %}
+{% for relation in OneToOneRelations %}
+  std::vector<{{ relation.namespace }}::Const{{ relation.bare_type }}>* m_rel_{{ relation.name }}; ///< Relation buffer for read / write
+{% endfor %}
+
+  // members to handle vector members
+{% for member in VectorMembers %}
+  std::vector<{{ member.full_type }}>* m_vec_{{ member.name }}; /// combined vector of all objects in collection
+  std::vector<std::vector<{{ member.full_type }}>*> m_vecs_{{ member.name }}{}; /// pointers to individual member vectors
+{% endfor %}
+
+  // I/O related buffers
+  podio::CollRefCollection m_refCollections{};
+  podio::VectorMembersInfo m_vecmem_info{};
+  {{ class.bare_type }}DataContainer* m_data{nullptr};
+};
+{% endwith %}
+
+
+{{ utils.namespace_close(class.namespace) }}
+
+#endif

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -49,20 +49,22 @@ public:
    */
   ~{{ class_type }}();
 
-  void clear();
+  void clear(bool isRefColl);
 
-  podio::CollectionBuffers getCollectionBuffers();
+  podio::CollectionBuffers getCollectionBuffers(bool isRefColl);
 
-  void prepareForWrite();
+  void prepareForWrite(bool isRefColl);
 
   void prepareAfterRead(int collectionID);
+
+  void makeReferenceCollection();
 
 {% if OneToManyRelations or VectorMembers %}
   void createRelations({{ class.bare_type }}Obj* obj);
 {% endif %}
 
 {% if OneToManyRelations or OneToOneRelations %}
-  void setReferences(const podio::ICollectionProvider* collectionProvider);
+  void setReferences(const podio::ICollectionProvider* collectionProvider, bool isRefColl);
 {% endif %}
 
 private:

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -57,7 +57,7 @@ public:
 
   void prepareAfterRead(int collectionID);
 
-  void makeReferenceCollection();
+  void makeSubsetCollection();
 
 {% if OneToManyRelations or VectorMembers %}
   void createRelations({{ class.bare_type }}Obj* obj);

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -31,8 +31,8 @@ void handlePODDataSIO(devT& device, {{ class.namespace }}::{{ class.bare_type }}
 {% with block_class = class.bare_type + 'SIOBlock' %}
 
 void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
-
-  auto* dataVec = static_cast<{{ class.namespace }}::{{ class.bare_type }}Collection*>(_col)->_getBuffer();
+  auto collBuffers = _col->getBuffers();
+  auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
 
   unsigned size(0);
   device.data( size );
@@ -41,7 +41,7 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
   podio::handlePODDataSIO(device, &(*dataVec)[0], size);
 
   //---- read ref collections -----
-  podio::CollRefCollection* refCols = _col->referenceCollections() ;
+  auto* refCols = collBuffers.references;
   for( auto* refC : *refCols ){
     device.data( size ) ;
     refC->resize(size) ;
@@ -50,7 +50,7 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
 
 {% if VectorMembers %}
   //---- read vector members
-  podio::VectorMembersInfo * vecMemInfo = _col->vectorMembers() ;
+  auto* vecMemInfo = collBuffers.vectorMembers;
 
 {% for member in VectorMembers %}
 {{ macros.vector_member_read(member, loop.index0) }}
@@ -60,8 +60,8 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
 
 void {{ block_class }}::write(sio::write_device& device) {
   _col->prepareForWrite() ;
-
-  auto * dataVec = static_cast<{{ class.namespace }}::{{ class.bare_type}}Collection*>(_col)->_getBuffer() ;
+  auto collBuffers = _col->getBuffers();
+  auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
 
   unsigned size = dataVec->size() ;
   device.data( size ) ;
@@ -69,7 +69,7 @@ void {{ block_class }}::write(sio::write_device& device) {
   podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
 
   //---- write ref collections -----
-  podio::CollRefCollection* refCols = _col->referenceCollections() ;
+  auto* refCols = collBuffers.references;
   for( auto* refC : *refCols ){
     size = refC->size() ;
     device.data( size ) ;
@@ -78,7 +78,7 @@ void {{ block_class }}::write(sio::write_device& device) {
 
 {% if VectorMembers %}
   //---- write vector members
-  podio::VectorMembersInfo * vecMemInfo = _col->vectorMembers() ;
+  auto* vecMemInfo = collBuffers.vectorMembers;
 
 {% for member in VectorMembers %}
 {{ macros.vector_member_write(member, loop.index0) }}

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -33,7 +33,7 @@ void handlePODDataSIO(devT& device, {{ class.namespace }}::{{ class.bare_type }}
 
 void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
   auto collBuffers = _col->getBuffers();
-  if (not _col->isReferenceCollection()) {
+  if (not _col->isSubsetCollection()) {
     auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
     unsigned size(0);
     device.data( size );
@@ -64,7 +64,7 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
 void {{ block_class }}::write(sio::write_device& device) {
   _col->prepareForWrite() ;
   auto collBuffers = _col->getBuffers();
-  if (not _col->isReferenceCollection()) {
+  if (not _col->isSubsetCollection()) {
     auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
     unsigned size = dataVec->size() ;
     device.data( size ) ;
@@ -90,9 +90,9 @@ void {{ block_class }}::write(sio::write_device& device) {
 {% endif %}
 }
 
-void {{ block_class }}::createCollection(const bool referenceCollection) {
+void {{ block_class }}::createCollection(const bool subsetCollection) {
   setCollection(new {{ class.bare_type }}Collection);
-  _col->setReferenceCollection(referenceCollection);
+  _col->setSubsetCollection(subsetCollection);
 }
 
 {% endwith %}

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -3,6 +3,7 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
 #include "{{ incfolder }}{{ class.bare_type }}SIOBlock.h"
+#include "{{ incfolder }}{{ class.bare_type }}Collection.h"
 
 #include <sio/block.h>
 #include <sio/io_device.h>
@@ -32,17 +33,18 @@ void handlePODDataSIO(devT& device, {{ class.namespace }}::{{ class.bare_type }}
 
 void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
   auto collBuffers = _col->getBuffers();
-  auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
-
-  unsigned size(0);
-  device.data( size );
-  dataVec->resize(size);
-
-  podio::handlePODDataSIO(device, &(*dataVec)[0], size);
+  if (not _col->isReferenceCollection()) {
+    auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
+    unsigned size(0);
+    device.data( size );
+    dataVec->resize(size);
+    podio::handlePODDataSIO(device, &(*dataVec)[0], size);
+  }
 
   //---- read ref collections -----
   auto* refCols = collBuffers.references;
   for( auto* refC : *refCols ){
+    unsigned size{0};
     device.data( size ) ;
     refC->resize(size) ;
     podio::handlePODDataSIO( device ,  &((*refC)[0]), size ) ;
@@ -51,6 +53,7 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
 {% if VectorMembers %}
   //---- read vector members
   auto* vecMemInfo = collBuffers.vectorMembers;
+  unsigned size{0};
 
 {% for member in VectorMembers %}
 {{ macros.vector_member_read(member, loop.index0) }}
@@ -61,17 +64,17 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
 void {{ block_class }}::write(sio::write_device& device) {
   _col->prepareForWrite() ;
   auto collBuffers = _col->getBuffers();
-  auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
-
-  unsigned size = dataVec->size() ;
-  device.data( size ) ;
-
-  podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
+  if (not _col->isReferenceCollection()) {
+    auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
+    unsigned size = dataVec->size() ;
+    device.data( size ) ;
+    podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
+  }
 
   //---- write ref collections -----
   auto* refCols = collBuffers.references;
   for( auto* refC : *refCols ){
-    size = refC->size() ;
+    unsigned size = refC->size() ;
     device.data( size ) ;
     podio::handlePODDataSIO( device ,  &((*refC)[0]), size ) ;
   }
@@ -79,11 +82,17 @@ void {{ block_class }}::write(sio::write_device& device) {
 {% if VectorMembers %}
   //---- write vector members
   auto* vecMemInfo = collBuffers.vectorMembers;
+  unsigned size{0};
 
 {% for member in VectorMembers %}
 {{ macros.vector_member_write(member, loop.index0) }}
 {% endfor %}
 {% endif %}
+}
+
+void {{ block_class }}::createCollection(const bool referenceCollection) {
+  setCollection(new {{ class.bare_type }}Collection);
+  _col->setReferenceCollection(referenceCollection);
 }
 
 {% endwith %}

--- a/python/templates/SIOBlock.h.jinja2
+++ b/python/templates/SIOBlock.h.jinja2
@@ -33,7 +33,7 @@ public:
   // Write the particle data to the device
   virtual void write(sio::write_device& device) override;
 
-  virtual void createCollection(const bool referenceCollection=false) override;
+  virtual void createCollection(const bool subsetCollection=false) override;
 
   SIOBlock* create(const std::string& name) const override { return new {{ block_class }}(name); }
 };

--- a/python/templates/SIOBlock.h.jinja2
+++ b/python/templates/SIOBlock.h.jinja2
@@ -4,8 +4,6 @@
 #ifndef {{ package_name.upper() }}_{{ class.bare_type }}SIOBlock_H
 #define {{ package_name.upper() }}_{{ class.bare_type }}SIOBlock_H
 
-#include "{{ incfolder}}{{ class.bare_type }}Collection.h"
-
 #include "podio/SIOBlock.h"
 
 #include <sio/api.h>
@@ -35,9 +33,7 @@ public:
   // Write the particle data to the device
   virtual void write(sio::write_device& device) override;
 
-  virtual void createCollection() override {
-    setCollection(new {{ class.bare_type }}Collection);
-  }
+  virtual void createCollection(const bool referenceCollection=false) override;
 
   SIOBlock* create(const std::string& name) const override { return new {{ block_class }}(name); }
 };

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -51,7 +51,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   }
 {% endmacro %}
 
-{% macro _get_collection(type) %}
+{% macro get_collection(type) %}
       podio::CollectionBase* coll = nullptr;
       collectionProvider->get(id.collectionID, coll);
       {{ type }}Collection* tmp_coll = static_cast<{{ type }}Collection*>(coll);
@@ -61,7 +61,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   for (unsigned int i = 0, size = m_refCollections[{{ index }}]->size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
-{{ _get_collection(relation.full_type) }}
+{{ get_collection(relation.full_type) }}
       const auto tmp = (*tmp_coll)[id.index];
       m_rel_{{ relation.name }}->emplace_back(tmp);
     } else {
@@ -76,7 +76,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   for (unsigned int i = 0, size = entries.size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ real_index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
-  {{ _get_collection(relation.full_type) }}
+  {{ get_collection(relation.full_type) }}
       entries[i]->m_{{ relation.name }} = new Const{{ relation.bare_type }}((*tmp_coll)[id.index]);
     } else {
       entries[i]->m_{{ relation.name }} = nullptr;

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -2,9 +2,9 @@
 template<size_t arraysize>
 const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collection::{{ member.name }}() const {
   std::array<{{ member.full_type }}, arraysize> tmp;
-  const auto valid_size = std::min(arraysize, m_entries.size());
+  const auto valid_size = std::min(arraysize, m_storage.entries.size());
   for (unsigned i = 0; i < valid_size; ++i) {
-    tmp[i] = m_entries[i]->data.{{ member.name }};
+    tmp[i] = m_storage.entries[i]->data.{{ member.name }};
   }
   return tmp;
 }
@@ -42,7 +42,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
 
 {% macro prepare_for_write_single_relation(relation, index, start_index) %}
 {% set real_index = start_index + index %}
-  for (auto& obj : m_entries) {
+  for (auto& obj : entries) {
     if (obj->m_{{ relation.name }}) {
       m_refCollections[{{ real_index }}]->emplace_back(obj->m_{{ relation.name }}->getObjectID());
     } else {
@@ -52,7 +52,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
 {% endmacro %}
 
 {% macro _get_collection(type) %}
-      CollectionBase* coll = nullptr;
+      podio::CollectionBase* coll = nullptr;
       collectionProvider->get(id.collectionID, coll);
       {{ type }}Collection* tmp_coll = static_cast<{{ type }}Collection*>(coll);
 {%- endmacro %}
@@ -73,13 +73,13 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
 
 {% macro set_reference_single_relation(relation, index, start_index) %}
 {% set real_index = index + start_index %}
-  for (unsigned int i = 0, size = m_entries.size(); i != size; ++i) {
+  for (unsigned int i = 0, size = entries.size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ real_index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
   {{ _get_collection(relation.full_type) }}
-      m_entries[i]->m_{{ relation.name }} = new Const{{ relation.bare_type }}((*tmp_coll)[id.index]);
+      entries[i]->m_{{ relation.name }} = new Const{{ relation.bare_type }}((*tmp_coll)[id.index]);
     } else {
-      m_entries[i]->m_{{ relation.name }} = nullptr;
+      entries[i]->m_{{ relation.name }} = nullptr;
     }
   }
 {% endmacro %}

--- a/python/templates/macros/sioblocks.jinja2
+++ b/python/templates/macros/sioblocks.jinja2
@@ -1,15 +1,16 @@
 {% macro vector_member_write(member, index) %}
-    auto* vec{{ index }} = *reinterpret_cast<std::vector<{{ member.full_type }}>**>(vecMemInfo->at({{ index }}).second);
-    size = vec{{ index }}->size();
-    device.data(size);
-    podio::handlePODDataSIO(device, &(*vec{{ index }})[0], size);
+  auto* vec{{ index }} = *reinterpret_cast<std::vector<{{ member.full_type }}>**>(vecMemInfo->at({{ index }}).second);
+  size = vec{{ index }}->size();
+  device.data(size);
+  podio::handlePODDataSIO(device, &(*vec{{ index }})[0], size);
 
 {% endmacro %}
 
 
 {% macro vector_member_read(member, index) %}
-    auto* vec{{ index }} = *reinterpret_cast<std::vector<{{ member.full_type }}>**>(vecMemInfo->at({{ index }}).second);
-    device.data(size);
-    vec{{ index }}->resize(size);
-    podio::handlePODDataSIO(device, &(*vec{{ index }})[0], size);
+  auto* vec{{ index }} = *reinterpret_cast<std::vector<{{ member.full_type }}>**>(vecMemInfo->at({{ index }}).second);
+  size = 0u;
+  device.data(size);
+  vec{{ index }}->resize(size);
+  podio::handlePODDataSIO(device, &(*vec{{ index }})[0], size);
 {% endmacro %}

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -74,11 +74,11 @@ namespace podio {
     auto* collection = static_cast<CollectionBase*>(collectionClass->New());
     auto collBuffers = collection->getBuffers();
     // If we have a valid data buffer class we know that have to read data,
-    // otherwise we are handling a reference collection
+    // otherwise we are handling a subset collection
     if (theClass) {
       collBuffers.data = theClass->New();
     } else {
-      collection->setReferenceCollection();
+      collection->setSubsetCollection();
     }
 
     const auto localEntry = m_chain->LoadTree(m_eventNumber);
@@ -199,7 +199,7 @@ namespace podio {
  void ROOTReader::createCollectionBranches(const std::vector<std::tuple<int, std::string, bool>>& collInfo) {
     size_t collectionIndex{0};
 
-    for (const auto& [collID, collType, isRefColl] : collInfo) {
+    for (const auto& [collID, collType, isSubsetColl] : collInfo) {
       // We only write collections that are in the collectionIDTable, so no need
       // to check here
       const auto name = m_table->name(collID);
@@ -211,9 +211,9 @@ namespace podio {
       // temporary collection ourselves
       auto collection = std::unique_ptr<podio::CollectionBase>(
         static_cast<podio::CollectionBase*>(collectionClass->New()));
-      collection->setReferenceCollection(isRefColl);
+      collection->setSubsetCollection(isSubsetColl);
 
-      if (!isRefColl) {
+      if (!isSubsetColl) {
         // This branch is guaranteed to exist since only collections that are
         // also written to file are in the info metadata that we work with here
         branches.data = root_utils::getBranch(m_chain, name.c_str());
@@ -231,7 +231,7 @@ namespace podio {
       }
 
       const std::string bufferClassName = "std::vector<" + collection->getValueTypeName() + "Data>";
-      const auto bufferClass = isRefColl ? nullptr : TClass::GetClass(bufferClassName.c_str());
+      const auto bufferClass = isSubsetColl ? nullptr : TClass::GetClass(bufferClassName.c_str());
 
       m_storedClasses.emplace(
         name, std::make_tuple(bufferClass, collectionClass, collectionIndex++)

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -82,15 +82,17 @@ namespace podio {
       root_utils::CollectionBranches branches;
       branches.data = branch;
 
-      auto* collection = root_utils::prepareCollection(theClass, collectionClass);
+      auto* collection = static_cast<CollectionBase*>(collectionClass->New());
+      auto collBuffers = collection->getBuffers();
+      collBuffers.data = theClass->New();
 
-      if (auto refCollections = collection->referenceCollections()) {
+      if (auto refCollections = collBuffers.references) {
         for (size_t i = 0; i < refCollections->size(); ++i) {
           const auto brName = root_utils::refBranch(name, i);
           branches.refs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
         }
       }
-      if (auto vecMembers = collection->vectorMembers()) {
+      if (auto vecMembers = collBuffers.vectorMembers) {
         for (size_t i = 0; i < vecMembers->size(); ++i) {
           const auto brName = root_utils::vecBranch(name, i);
           branches.vecs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
@@ -116,7 +118,9 @@ namespace podio {
     const auto [theClass, collectionClass, index] = collInfo.second;
     auto& branches = m_collectionBranches[index];
 
-    auto* collection = root_utils::prepareCollection(theClass, collectionClass);
+    auto* collection = static_cast<CollectionBase*>(collectionClass->New());
+    auto collBuffers = collection->getBuffers();
+    collBuffers.data = theClass->New();
 
     const auto localEntry = m_chain->LoadTree(m_eventNumber);
     // After switching trees in the chain, branch pointers get invalidated so
@@ -127,7 +131,7 @@ namespace podio {
       branches.data = root_utils::getBranch(m_chain, name.c_str());
 
       // reference collections
-      if (auto* refCollections = collection->referenceCollections()) {
+      if (auto* refCollections = collBuffers.references) {
         for (size_t i = 0; i < refCollections->size(); ++i) {
           const auto brName = root_utils::refBranch(name, i);
           branches.refs[i] = root_utils::getBranch(m_chain, brName.c_str());
@@ -135,7 +139,7 @@ namespace podio {
       }
 
       // vector members
-      if (auto* vecMembers = collection->vectorMembers()) {
+      if (auto* vecMembers = collBuffers.vectorMembers) {
         for (size_t i = 0; i < vecMembers->size(); ++i) {
           const auto brName = root_utils::vecBranch(name, i);
           branches.vecs[i] = root_utils::getBranch(m_chain, brName.c_str());

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -68,7 +68,7 @@ namespace podio {
 
   CollectionBase* ROOTReader::getCollection(const std::pair<std::string, CollectionInfo>& collInfo) {
     const auto& name = collInfo.first;
-    const auto [theClass, collectionClass, index] = collInfo.second;
+    const auto& [theClass, collectionClass, index] = collInfo.second;
     auto& branches = m_collectionBranches[index];
 
     auto* collection = static_cast<CollectionBase*>(collectionClass->New());
@@ -137,7 +137,7 @@ namespace podio {
       m_chain->Add(filename.c_str());
     }
 
-   // read the meta data and build the collectionBranches cache
+    // read the meta data and build the collectionBranches cache
     // NOTE: This is a small pessimization, if we do not read all collections
     // afterwards, but it makes the handling much easier in general
     auto metadatatree = static_cast<TTree*>(m_chain->GetFile()->Get("metadata"));

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -10,7 +10,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include "TChain.h"
-#include "TROOT.h"
+#include "TClass.h"
 #include "TTreeCache.h"
 
 
@@ -56,60 +56,13 @@ namespace podio {
       return p->first;
     }
 
-    // Have we read this collection before? If so: use the cached information to
-    // speed up reading
+    // Do we know about this collection? If so, read it
     if (const auto& info = m_storedClasses.find(name); info != m_storedClasses.end()) {
       return getCollection(*info);
     }
 
-    // Otherwise do some setup first and then directly read the collection
-    if (auto branch = root_utils::getBranch(m_chain, name.c_str())) {
-      const std::string dataClassName = branch->GetClassName();
-      const auto* theClass = gROOT->GetClass(dataClassName.c_str());
-      if (theClass == nullptr) return nullptr;
-      // now create the transient collections
-      // some workaround until gcc supports regex properly:
-      auto dataClassString = std::string(dataClassName);
-      auto start = dataClassString.find("<");
-      auto end   = dataClassString.find(">");
-      //getting "TypeCollection" out of "vector<TypeData>"
-      auto classname = dataClassString.substr(start+1, end-start-5);
-      auto collectionClassName = classname+"Collection";
-      const auto* collectionClass = gROOT->GetClass(collectionClassName.c_str());
-      if (collectionClass == nullptr) return nullptr;
-
-      // create the branches and cache them
-      root_utils::CollectionBranches branches;
-      branches.data = branch;
-
-      auto* collection = static_cast<CollectionBase*>(collectionClass->New());
-      auto collBuffers = collection->getBuffers();
-      collBuffers.data = theClass->New();
-
-      if (auto refCollections = collBuffers.references) {
-        for (size_t i = 0; i < refCollections->size(); ++i) {
-          const auto brName = root_utils::refBranch(name, i);
-          branches.refs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
-        }
-      }
-      if (auto vecMembers = collBuffers.vectorMembers) {
-        for (size_t i = 0; i < vecMembers->size(); ++i) {
-          const auto brName = root_utils::vecBranch(name, i);
-          branches.vecs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
-        }
-      }
-
-      // cache the information
-      const auto collInfo = std::make_tuple(theClass, collectionClass, m_collectionIndex++);
-      m_storedClasses[name] = collInfo;
-      m_collectionBranches.push_back(branches);
-
-      // connect the branches and the buffers
-      root_utils::setCollectionAddresses(collection, branches);
-
-      return readCollectionData(branches, collection, 0, name);
-    }
-
+    // At this point this collection is definitely not in this file, because we
+    // have no information on how to construct it in the first place
     return nullptr;
   }
 
@@ -120,7 +73,13 @@ namespace podio {
 
     auto* collection = static_cast<CollectionBase*>(collectionClass->New());
     auto collBuffers = collection->getBuffers();
-    collBuffers.data = theClass->New();
+    // If we have a valid data buffer class we know that have to read data,
+    // otherwise we are handling a reference collection
+    if (theClass) {
+      collBuffers.data = theClass->New();
+    } else {
+      collection->setReferenceCollection();
+    }
 
     const auto localEntry = m_chain->LoadTree(m_eventNumber);
     // After switching trees in the chain, branch pointers get invalidated so
@@ -155,7 +114,7 @@ namespace podio {
 
   CollectionBase* ROOTReader::readCollectionData(const root_utils::CollectionBranches& branches, CollectionBase* collection, Long64_t entry, const std::string& name) {
     // Read all data
-    branches.data->GetEntry(entry);
+    if (branches.data) branches.data->GetEntry(entry);
     for (auto* br : branches.refs) br->GetEntry(entry);
     for (auto* br : branches.vecs) br->GetEntry(entry);
 
@@ -177,10 +136,20 @@ namespace podio {
     for (const auto& filename:  filenames) {
       m_chain->Add(filename.c_str());
     }
-    m_table = new CollectionIDTable();
+
+   // read the meta data and build the collectionBranches cache
+    // NOTE: This is a small pessimization, if we do not read all collections
+    // afterwards, but it makes the handling much easier in general
     auto metadatatree = static_cast<TTree*>(m_chain->GetFile()->Get("metadata"));
+    m_table = new CollectionIDTable();
     metadatatree->SetBranchAddress("CollectionIDs", &m_table);
+
+    auto collectionInfo = new std::vector<std::tuple<int, std::string, bool>>;
+    metadatatree->SetBranchAddress("CollectionTypeInfo", &collectionInfo);
     metadatatree->GetEntry(0);
+
+    createCollectionBranches(*collectionInfo);
+    delete collectionInfo;
   }
 
   void ROOTReader::closeFile(){
@@ -227,5 +196,48 @@ namespace podio {
     m_inputs.clear();
   }
 
+ void ROOTReader::createCollectionBranches(const std::vector<std::tuple<int, std::string, bool>>& collInfo) {
+    size_t collectionIndex{0};
+
+    for (const auto& [collID, collType, isRefColl] : collInfo) {
+      // We only write collections that are in the collectionIDTable, so no need
+      // to check here
+      const auto name = m_table->name(collID);
+
+      root_utils::CollectionBranches branches{};
+      const auto collectionClass = TClass::GetClass(collType.c_str());
+
+      // Need the collection here to setup all the branches. Have to manage the
+      // temporary collection ourselves
+      auto collection = std::unique_ptr<podio::CollectionBase>(
+        static_cast<podio::CollectionBase*>(collectionClass->New()));
+      collection->setReferenceCollection(isRefColl);
+
+      if (!isRefColl) {
+        // This branch is guaranteed to exist since only collections that are
+        // also written to file are in the info metadata that we work with here
+        branches.data = root_utils::getBranch(m_chain, name.c_str());
+      }
+
+      const auto buffers = collection->getBuffers();
+      for (size_t i = 0; i < buffers.references->size(); ++i) {
+        const auto brName = root_utils::refBranch(name, i);
+        branches.refs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
+      }
+
+      for (size_t i = 0; i < buffers.vectorMembers->size(); ++i) {
+        const auto brName = root_utils::vecBranch(name, i);
+        branches.vecs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
+      }
+
+      const std::string bufferClassName = "std::vector<" + collection->getValueTypeName() + "Data>";
+      const auto bufferClass = isRefColl ? nullptr : TClass::GetClass(bufferClassName.c_str());
+
+      m_storedClasses.emplace(
+        name, std::make_tuple(bufferClass, collectionClass, collectionIndex++)
+      );
+      m_collectionBranches.push_back(branches);
+    }
+  }
 
 } //namespace

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -101,7 +101,7 @@ void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
     const auto collIDTable = m_store->getCollectionIDTable();
     m_metadatatree->Branch("CollectionIDs", collIDTable);
 
-    // collectionID, collection type, reference collection
+    // collectionID, collection type, subset collection
     std::vector<std::tuple<int, std::string, bool>> collectionInfo;
     collectionInfo.reserve(m_collectionsToWrite.size());
     for (const auto& name : m_collectionsToWrite) {
@@ -110,7 +110,7 @@ void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
       // No check necessary, only registered collections possible
       m_store->get(name, coll);
       const auto collType = coll->getValueTypeName() + "Collection";
-      collectionInfo.emplace_back(collID, std::move(collType), coll->isReferenceCollection());
+      collectionInfo.emplace_back(collID, std::move(collType), coll->isSubsetCollection());
     }
 
     m_metadatatree->Branch("CollectionTypeInfo", &collectionInfo);

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -52,11 +52,12 @@ void ROOTWriter::writeEvent(){
 void ROOTWriter::createBranches(const std::vector<StoreCollection>& collections) {
   for (auto& [name, coll] : collections) {
     root_utils::CollectionBranches branches;
+    const auto collBuffers = coll->getBuffers();
     const auto collClassName = "vector<" + coll->getValueTypeName() + "Data>";
-    branches.data = m_datatree->Branch(name.c_str(), collClassName.c_str(), coll->getBufferAddress());
+    branches.data = m_datatree->Branch(name.c_str(), collClassName.c_str(), collBuffers.data);
 
     // reference collections
-    if (auto refColls = coll->referenceCollections()) {
+    if (auto refColls = collBuffers.references) {
       int i = 0;
       for (auto& c : (*refColls)) {
         const auto brName = root_utils::refBranch(name, i);
@@ -66,7 +67,7 @@ void ROOTWriter::createBranches(const std::vector<StoreCollection>& collections)
     }
 
     // vector members
-    if (auto vminfo = coll->vectorMembers()) {
+    if (auto vminfo = collBuffers.vectorMembers) {
       int i = 0;
       for (auto& [type, vec] : (*vminfo)) {
         const auto typeName = "vector<" + type + ">";

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -18,7 +18,7 @@ namespace podio {
     device.data(names);
     device.data(ids);
     device.data(_types);
-    device.data(_isRefColl);
+    device.data(_isSubsetColl);
 
     _table = new CollectionIDTable(std::move(ids), std::move(names));
   }
@@ -28,7 +28,7 @@ namespace podio {
     device.data(_table->ids());
 
     std::vector<std::string> typeNames;
-    std::vector<short> isRefColl;
+    std::vector<short> isSubsetColl;
     typeNames.reserve(_table->ids().size());
     for (const int id : _table->ids()) {
       CollectionBase* tmp;
@@ -36,10 +36,10 @@ namespace podio {
         std::cerr << "ERROR during writing of CollectionID table" << std::endl;
       }
       typeNames.push_back(tmp->getValueTypeName());
-      isRefColl.push_back(tmp->isReferenceCollection());
+      isSubsetColl.push_back(tmp->isSubsetCollection());
     }
     device.data(typeNames);
-    device.data(isRefColl);
+    device.data(isSubsetColl);
   }
 
   template<typename MappedT>

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -18,6 +18,7 @@ namespace podio {
     device.data(names);
     device.data(ids);
     device.data(_types);
+    device.data(_isRefColl);
 
     _table = new CollectionIDTable(std::move(ids), std::move(names));
   }
@@ -27,6 +28,7 @@ namespace podio {
     device.data(_table->ids());
 
     std::vector<std::string> typeNames;
+    std::vector<short> isRefColl;
     typeNames.reserve(_table->ids().size());
     for (const int id : _table->ids()) {
       CollectionBase* tmp;
@@ -34,8 +36,10 @@ namespace podio {
         std::cerr << "ERROR during writing of CollectionID table" << std::endl;
       }
       typeNames.push_back(tmp->getValueTypeName());
+      isRefColl.push_back(tmp->isReferenceCollection());
     }
     device.data(typeNames);
+    device.data(isRefColl);
   }
 
   template<typename MappedT>
@@ -105,12 +109,12 @@ namespace podio {
   }
 
 
-  std::shared_ptr<SIOBlock> SIOBlockFactory::createBlock(const std::string& typeStr, const std::string& name) const {
+  std::shared_ptr<SIOBlock> SIOBlockFactory::createBlock(const std::string& typeStr, const std::string& name, const bool isRefColl) const {
     const auto it = _map.find(typeStr) ;
 
     if( it != _map.end() ){
       auto blk = std::shared_ptr<SIOBlock>(it->second->create( name ));
-      blk->createCollection() ;
+      blk->createCollection(isRefColl) ;
       return blk;
     } else {
       return nullptr;

--- a/src/SIOReader.cc
+++ b/src/SIOReader.cc
@@ -125,7 +125,7 @@ namespace podio {
     m_blocks.push_back(m_eventMetaData);
 
     for (size_t i = 0; i < m_typeNames.size(); ++i) {
-      auto blk = podio::SIOBlockFactory::instance().createBlock(m_typeNames[i], m_table->names()[i]);
+      auto blk = podio::SIOBlockFactory::instance().createBlock(m_typeNames[i], m_table->names()[i], m_refCollectionBits[i]);
       m_blocks.push_back(blk);
       m_inputs.emplace_back(blk->getCollection(), m_table->names()[i]);
     }
@@ -147,6 +147,7 @@ namespace podio {
     auto* idTableBlock = static_cast<SIOCollectionIDTableBlock*>(blocks[0].get());
     m_table = idTableBlock->getTable();
     m_typeNames = idTableBlock->getTypeNames();
+    m_refCollectionBits = idTableBlock->getRefCollectionBits();
   }
 
   void SIOReader::readMetaDataRecord(std::shared_ptr<SIONumberedMetaDataBlock> mdBlock) {

--- a/src/SIOReader.cc
+++ b/src/SIOReader.cc
@@ -125,7 +125,7 @@ namespace podio {
     m_blocks.push_back(m_eventMetaData);
 
     for (size_t i = 0; i < m_typeNames.size(); ++i) {
-      auto blk = podio::SIOBlockFactory::instance().createBlock(m_typeNames[i], m_table->names()[i], m_refCollectionBits[i]);
+      auto blk = podio::SIOBlockFactory::instance().createBlock(m_typeNames[i], m_table->names()[i], m_subsetCollectionBits[i]);
       m_blocks.push_back(blk);
       m_inputs.emplace_back(blk->getCollection(), m_table->names()[i]);
     }
@@ -147,7 +147,7 @@ namespace podio {
     auto* idTableBlock = static_cast<SIOCollectionIDTableBlock*>(blocks[0].get());
     m_table = idTableBlock->getTable();
     m_typeNames = idTableBlock->getTypeNames();
-    m_refCollectionBits = idTableBlock->getRefCollectionBits();
+    m_subsetCollectionBits = idTableBlock->getSubsetCollectionBits();
   }
 
   void SIOReader::readMetaDataRecord(std::shared_ptr<SIONumberedMetaDataBlock> mdBlock) {

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -28,30 +28,24 @@ inline std::string vecBranch(const std::string& name, size_t index) {
 
 
 inline void setCollectionAddresses(podio::CollectionBase* collection, const CollectionBranches& branches) {
-  if (auto buffer = collection->getBufferAddress()) {
+  const auto collBuffers = collection->getBuffers();
+
+  if (auto buffer = collBuffers.data) {
     branches.data->SetAddress(buffer);
   }
 
-  if (auto refCollections = collection->referenceCollections()) {
+  if (auto refCollections = collBuffers.references) {
     for (size_t i = 0; i < refCollections->size(); ++i) {
       branches.refs[i]->SetAddress(&(*refCollections)[i]);
     }
   }
 
-  if (auto vecMembers = collection->vectorMembers()) {
+  if (auto vecMembers = collBuffers.vectorMembers) {
     for (size_t i = 0; i < vecMembers->size(); ++i) {
       branches.vecs[i]->SetAddress((*vecMembers)[i].second);
     }
   }
 }
-
-inline CollectionBase* prepareCollection(const TClass* dataClass, const TClass* collectionClass) {
-  auto* buffer = dataClass->New();
-  auto* collection = static_cast<CollectionBase*>(collectionClass->New());
-  collection->setBuffer(buffer);
-  return collection;
-}
-
 
 }
 

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -8,6 +8,7 @@
     <class name="podio::GenericParameters::MapType<float>"/>
     <class name="podio::GenericParameters::MapType<std::string>"/>
     <class name="std::map<int,podio::GenericParameters>"/>
+    <class name="std::vector<std::tuple<int, std::string, bool>>"/>
     <class name="podio::CollectionBase"/>
     <class name="podio::CollectionIDTable">
         <field name="m_mutex" transient="true"/>

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -94,13 +94,37 @@ void processEvent(podio::EventStore& store, int eventNum) {
     throw std::runtime_error("Collection 'clusters' should be present");
   }
 
+  // ----------------- MCParticleRefCollection ----------------------
+  // Test this before the MCParticle collection to make sure it actually loads
+  // the referenced collection(s) if they are not already present
+  auto& mcpRefs = store.get<ExampleMCCollection>("mcParticleRefs");
+  if (!mcpRefs.isValid()) throw std::runtime_error("Collection 'mcParticleRefs' should be present");
 
+  for (auto p : mcpRefs) {
+    if ((p.id() % 2) == 0) {
+      throw std::runtime_error("MCParticleRefCollection should only contain elements with odd ids");
+    }
+    if ((unsigned)p.getObjectID().collectionID == mcpRefs.getID()) {
+      throw std::runtime_error("objects of a reference collection should have a different collectionID than the reference collection");
+    }
+  }
+
+  // Now we can do some more tests actually comparing the references to the MC Particles
   auto& mcps =  store.get<ExampleMCCollection>("mcparticles");
   if( mcps.isValid() ){
+    if (mcpRefs.size() != mcps.size() / 2) {
+      throw std::runtime_error("'mcParticleRefs' collection has wrong size");
+    }
+    for (size_t i = 0; i < mcpRefs.size(); ++i) {
+      std::cout << mcpRefs[i] << std::endl;
+      std::cout << mcps[i] << std::endl;
+      if (!(mcpRefs[i] == mcps[2 * i + 1])) {
+        throw std::runtime_error("MCParticle reference does not point to the correct MCParticle");
+      }
+    }
+
     // check that we can retrieve the correct parent daughter relation
-    // set in write.cpp :
-
-
+    // set in write_test.h :
     //-------- print relations for debugging:
     for( auto p : mcps ){
       std::cout << " particle " << p.getObjectID().index << " has daughters: " ;

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -212,6 +212,19 @@ TEST_CASE("Referencing") {
   REQUIRE(success);
 }
 
+TEST_CASE("VariadicCreate", "Test that objects created via the variadic create template function handle relations correctly") {
+  auto store = podio::EventStore();
+  auto& clusters = store.create<ExampleClusterCollection>("clusters");
+
+  auto variadic_cluster = clusters.create(3.14f);
+  auto normal_cluster = clusters.create();
+  normal_cluster.energy(42);
+
+  variadic_cluster.addClusters(normal_cluster);
+  REQUIRE(variadic_cluster.Clusters_size() == 1);
+  REQUIRE(variadic_cluster.Clusters(0) == normal_cluster);
+}
+
 TEST_CASE("write_buffer") {
   bool success = true;
   auto store = podio::EventStore();

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -419,33 +419,33 @@ TEST_CASE("const correct iterators on collections", "[const-correctness]") {
   REQUIRE(true);
 }
 
-TEST_CASE("Reference collection basics", "[reference-colls]") {
+TEST_CASE("Subset collection basics", "[subset-colls]") {
   auto clusterRefs = ExampleClusterCollection();
-  clusterRefs.setReferenceCollection();
+  clusterRefs.setSubsetCollection();
 
   // The following will always be true
-  REQUIRE(clusterRefs.isReferenceCollection());
+  REQUIRE(clusterRefs.isSubsetCollection());
   const auto refCollBuffers = clusterRefs.getBuffers();
   REQUIRE(refCollBuffers.data == nullptr);
-  REQUIRE(refCollBuffers.vectorMembers->size() == 0u);
+  REQUIRE(refCollBuffers.vectorMembers->empty());
   REQUIRE(refCollBuffers.references->size() == 1u);
 }
 
-TEST_CASE("Reference collection can handle references", "[reference-colls]") {
+TEST_CASE("Subset collection can handle subsets", "[subset-colls]") {
    // Can only collect things that already live in a different colection
   auto clusters = ExampleClusterCollection();
   auto cluster = clusters.create();
 
   auto clusterRefs = ExampleClusterCollection();
-  clusterRefs.setReferenceCollection();
+  clusterRefs.setSubsetCollection();
   clusterRefs.push_back(cluster);
 
   auto clusterRef = clusterRefs[0];
-  static_assert(std::is_same_v<decltype(clusterRef), decltype(cluster)>, "Elements that can be obtained from a collection and a reference collection should have the same type");
+  static_assert(std::is_same_v<decltype(clusterRef), decltype(cluster)>, "Elements that can be obtained from a collection and a subset collection should have the same type");
 
   REQUIRE(clusterRef == cluster);
 
-  // These are "true" references, so changes should propagate
+  // These are "true" subsets, so changes should propagate
   cluster.energy(42);
   REQUIRE(clusterRef.energy() == 42);
   // Also in the other directon
@@ -453,13 +453,13 @@ TEST_CASE("Reference collection can handle references", "[reference-colls]") {
   REQUIRE(cluster.energy() == -42);
 }
 
-TEST_CASE("Collection iterators work with reference collections", "[reference-colls]") {
+TEST_CASE("Collection iterators work with subset collections", "[subset-colls]") {
   auto hits = ExampleHitCollection();
   auto hit1 = hits.create(0x42ULL,0.,0.,0.,0.);
   auto hit2 = hits.create(0x42ULL,1.,1.,1.,1.);
 
   auto hitRefs = ExampleHitCollection();
-  hitRefs.setReferenceCollection();
+  hitRefs.setSubsetCollection();
   for (const auto h : hits) hitRefs.push_back(h);
 
   // index-based looping / access
@@ -474,27 +474,27 @@ TEST_CASE("Collection iterators work with reference collections", "[reference-co
   }
 }
 
-TEST_CASE("Canont convert a normal collection into a reference collection", "[reference-colls]") {
+TEST_CASE("Canont convert a normal collection into a subset collection", "[subset-colls]") {
   auto clusterRefs = ExampleClusterCollection();
   auto cluster = clusterRefs.create();
 
-  REQUIRE_THROWS_AS(clusterRefs.setReferenceCollection(), std::logic_error);
+  REQUIRE_THROWS_AS(clusterRefs.setSubsetCollection(), std::logic_error);
 }
 
-TEST_CASE("Cannot convert a reference collection into a normal collection", "[reference-colls]") {
+TEST_CASE("Cannot convert a subset collection into a normal collection", "[subset-colls]") {
   auto clusterRefs = ExampleClusterCollection();
-  clusterRefs.setReferenceCollection();
+  clusterRefs.setSubsetCollection();
 
   auto clusters = ExampleClusterCollection();
   auto cluster = clusters.create();
   clusterRefs.push_back(cluster);
 
-  REQUIRE_THROWS_AS(clusterRefs.setReferenceCollection(false), std::logic_error);
+  REQUIRE_THROWS_AS(clusterRefs.setSubsetCollection(false), std::logic_error);
 }
 
-TEST_CASE("Reference collection only handles tracked objects", "[reference-colls]") {
+TEST_CASE("Subset collection only handles tracked objects", "[subset-colls]") {
   auto clusterRefs = ExampleClusterCollection();
-  clusterRefs.setReferenceCollection();
+  clusterRefs.setSubsetCollection();
   auto cluster = ExampleCluster();
 
   REQUIRE_THROWS_AS(clusterRefs.push_back(cluster), std::invalid_argument);

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -30,6 +30,7 @@ void write(podio::EventStore& store, WriterT& writer) {
 
   auto& info       = store.create<EventInfoCollection>("info");
   auto& mcps       = store.create<ExampleMCCollection>("mcparticles");
+  auto& moreMCs    = store.create<ExampleMCCollection>("moreMCs");
   auto& mcpsRefs   = store.create<ExampleMCCollection>("mcParticleRefs");
   mcpsRefs.setSubsetCollection();
   auto& hits       = store.create<ExampleHitCollection>("hits");
@@ -48,6 +49,7 @@ void write(podio::EventStore& store, WriterT& writer) {
 
   writer.registerForWrite("info");
   writer.registerForWrite("mcparticles");
+  writer.registerForWrite("moreMCs");
   writer.registerForWrite("mcParticleRefs");
   writer.registerForWrite("hits");
   writer.registerForWrite("clusters");
@@ -169,15 +171,28 @@ void write(podio::EventStore& store, WriterT& writer) {
     }
     //-------------------------------
 
-    // ----------------- add all "odd" mc particles into a reference collection
+    // ----------------- create a second MC collection -----------------
+    // Can use it to test subset collections that store elements from multiple
+    // collections
+    for (const auto&& mc : mcps) {
+      moreMCs.push_back(mc.clone());
+    }
+
+    // ----------------- add all "odd" mc particles into a subset collection
     for (auto p : mcps) {
       if (p.id() % 2) {
         mcpsRefs.push_back(p);
       }
     }
+    // ----------------- add the "even" counterparts from a different collection
+    for (auto p : moreMCs) {
+      if (p.id() % 2 == 0) {
+        mcpsRefs.push_back(p);
+      }
+    }
 
-    if (mcpsRefs.size() != mcps.size() / 2) {
-      throw std::runtime_error("The mcParticleRefs collection should now contain half as many elements as the mcparticles collection");
+    if (mcpsRefs.size() != mcps.size()) {
+      throw std::runtime_error("The mcParticleRefs collection should now contain as many elements as the mcparticles collection");
     }
     //-------------------------------
 

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -30,6 +30,8 @@ void write(podio::EventStore& store, WriterT& writer) {
 
   auto& info       = store.create<EventInfoCollection>("info");
   auto& mcps       = store.create<ExampleMCCollection>("mcparticles");
+  auto& mcpsRefs   = store.create<ExampleMCCollection>("mcParticleRefs");
+  mcpsRefs.setReferenceCollection();
   auto& hits       = store.create<ExampleHitCollection>("hits");
   auto& clusters   = store.create<ExampleClusterCollection>("clusters");
   auto& refs       = store.create<ExampleReferencingTypeCollection>("refs");
@@ -46,6 +48,7 @@ void write(podio::EventStore& store, WriterT& writer) {
 
   writer.registerForWrite("info");
   writer.registerForWrite("mcparticles");
+  writer.registerForWrite("mcParticleRefs");
   writer.registerForWrite("hits");
   writer.registerForWrite("clusters");
   writer.registerForWrite("refs");
@@ -163,6 +166,18 @@ void write(podio::EventStore& store, WriterT& writer) {
         std::cout << " " << it->getObjectID().index;
       }
 
+    }
+    //-------------------------------
+
+    // ----------------- add all "odd" mc particles into a reference collection
+    for (auto p : mcps) {
+      if (p.id() % 2) {
+        mcpsRefs.push_back(p);
+      }
+    }
+
+    if (mcpsRefs.size() != mcps.size() / 2) {
+      throw std::runtime_error("The mcParticleRefs collection should now contain half as many elements as the mcparticles collection");
     }
     //-------------------------------
 

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -31,7 +31,7 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& info       = store.create<EventInfoCollection>("info");
   auto& mcps       = store.create<ExampleMCCollection>("mcparticles");
   auto& mcpsRefs   = store.create<ExampleMCCollection>("mcParticleRefs");
-  mcpsRefs.setReferenceCollection();
+  mcpsRefs.setSubsetCollection();
   auto& hits       = store.create<ExampleHitCollection>("hits");
   auto& clusters   = store.create<ExampleClusterCollection>("clusters");
   auto& refs       = store.create<ExampleReferencingTypeCollection>("refs");


### PR DESCRIPTION
BEGINRELEASENOTES
- Introduce a `podio::CollectionBuffers` class that contains everything that is necessary for I/O of a given collection. **This is a breaking change in the collection interface** 
- Introduce  and generate a `CollectionData` class for each datatype that only manages the storage of a given collection.
  - Exposes only the `Obj` entries of each collection as well as the necessary functionality to add a new object (and its relations) to the collection.
- Implement "subset" collections that behave exactly the same as normal collections apart from an additional function call when creating them.

ENDRELEASENOTES

The `CollectionBuffers` helpers class makes the interaction between the readers/writers and the collections a bit clearer as it now happens in one function call instead of the three it took previously to connect all the buffers to the I/O system. This is a breaking change in the collection interface, but it is quite easy to fix on the calling side, where we now have
```cpp
const auto collBuffers = coll->getBuffers();

// the data buffer (address)
void* rawbuffer = collBuffers.data; // previously was coll->getBufferAddress();
const auto* buffer = collBuffers.dataAsVector<Data>(); // get a vector<Data>* if we know the datatype
// relations and vector members
const auto* refCollections = collBuffers.references; // previously was coll->referenceCollections();
const auto* vecMembers = collBuffers.vectorMembers; // previously was coll->vectorMembers();
```

The `CollectionData` classes manage everything that concerns the storage of a collection. They only expose the `entries` member to give a collection access to the entries of a collection. The `prepareAfterRead`, `prepareBeforeWrite`, `setReferences`  and `getBuffers` functions of the `Collection` are now essentially only passing through to the `CollectionData` which does all the heavy lifting. This now make the storage concerns separated enough from the collection interface that subset (aka "true reference") collections can be implemented without having to introduce a separate `RefCollection` class. The interface is the following:

```cpp
// FILLING
auto& recos = store.create<edm4hep::ReconstructedParticleCollection>("recos");
// fill

auto& muons = store.create<edm4hep::ReconstructedParticleCollection>("muons");
muons.setSubsetCollection(); // declare this as a subset collection
// Here I can only store objects already tracked by another collection
muons.push_back(recos[0]);

// READING
auto& muons = store.get<edm4hep::ReconstructedParticleCollection>("muons");
for (auto muon : muons) { /* use as ConstReconstructedParticle */ }
```

So when creating a subset collection one has to declare it as such with a separate function call, but when reading they behave as if they were a normal collection. The function call to declare a collection to be a subset collection could potentially be put into the `EventStore::create` call somehow if it is deemed too cumbersome.

Supersedes #177
Fixes #146, Fixes #166


- [x] Subset collections
- [x] Test with edm4hep
- [x] Clean up templates (and generated code)
- [x] Clean up commits