### PR TITLE
Make assignment operator increase ref count

### DIFF
--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -20,6 +20,7 @@
 {{  full_type }}& {{ full_type }}::operator=(const {{ full_type }}& other) {
   if (m_obj) m_obj->release();
   m_obj = other.m_obj;
+  m_obj->acquire();
   return *this;
 }
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1,5 +1,6 @@
 // STL
 #include <iostream>
+#include <map>
 #include <stdexcept>
 #include <vector>
 #include <type_traits>
@@ -44,6 +45,23 @@ TEST_CASE("Basics") {
   const ExampleHitCollection* coll3(nullptr);
   if (store.get("wrongName",coll3) != false) success = false;
   REQUIRE(success);
+}
+
+TEST_CASE("Assignment-operator ref count") {
+  // Make sure that the assignment operator handles the reference count
+  // correctly. (Will trigger in an ASan build if it is not the case)
+  // See https://github.com/AIDASoft/podio/issues/200
+  std::map<int, ExampleHit> hitMap;
+  for (int i = 0; i < 10; ++i) {
+    auto hit = ExampleHit(0x42ULL, i, i, i, i);
+    hitMap[i] = hit;
+  }
+
+  // hits should still be valid here
+  for (int i = 0; i < 10; ++i) {
+    const auto hit = hitMap[i];
+    REQUIRE(hit.energy() == i);
+  }
 }
 
 TEST_CASE("Clearing"){


### PR DESCRIPTION

BEGINRELEASENOTES
- Make assignment operator increase the reference count to avoid possible heap-after-free usage. (Fixes #200)

ENDRELEASENOTES