### PR TITLE
Fix a few smaller issues in the datafile validation

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -268,10 +268,6 @@ class ClassGenerator(object):
     for relation in datatype['OneToManyRelations']:
       if self._needs_include(relation):
         includes.add(self._build_include(relation.bare_type))
-      elif relation.is_array:
-        includes.add('#include <array>')
-        if not relation.is_builtin_array:
-          includes.add(self._build_include(relation.array_bare_type))
 
     for vectormember in datatype['VectorMembers']:
       if vectormember.full_type in self.reader.components:

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, absolute_import, print_function
 
 import os
 import errno
+import sys
 import subprocess
 from io import open
 import pickle
@@ -23,7 +24,7 @@ except ImportError:
 import jinja2
 
 from podio_config_reader import PodioConfigReader, ClassDefinitionValidator
-from generator_utils import DataType
+from generator_utils import DataType, DefinitionError
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_DIR = os.path.join(THIS_DIR, 'templates')
@@ -65,7 +66,12 @@ class ClassGenerator(object):
     self.yamlfile = yamlfile
 
     self.reader = PodioConfigReader(yamlfile)
-    self.reader.read()
+    try:
+      self.reader.read()
+    except DefinitionError as err:
+      print(f'Error while generating the datamodel: {err}')
+      sys.exit(1)
+
     self.include_subfolder = self.reader.options["includeSubfolder"]
 
     self.env = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATE_DIR),

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -194,7 +194,7 @@ class ClassDefinitionValidator(object):
 
   def _check_members(self, classname, members):
     """Check the members of a class for name clashes or undefined classes"""
-    all_types = [n for n in self.datatypes] + [n for n in self.components]
+    all_types = self.components
 
     all_members = {}
     for member in members:

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -232,6 +232,12 @@ class ClassDefinitionValidator(object):
         raise DefinitionError("'{}' declares a non-allowed many-relation to '{}'"
                               .format(classname, relation.full_type))
 
+    one_relations = definition.get("OneToOneRelations", [])
+    for relation in one_relations:
+      if relation.full_type not in self.datatypes:
+        raise DefinitionError("'{}' declares a non-allowed single-relation to '{}'"
+                              .format(classname, relation.full_type))
+
     vector_members = definition.get("VectorMembers", [])
     for vecmem in vector_members:
       if not vecmem.is_builtin and vecmem.full_type not in self.components:

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -144,10 +144,10 @@ class ClassDefinitionValidator(object):
     validations"""
     self.warnings = set()
 
-  def validate(self, components, datatypes, expose_pod_members):
+  def validate(self, datamodel, expose_pod_members):
     """Validate the datamodel"""
-    self.components = components
-    self.datatypes = datatypes
+    self.components = datamodel['components']
+    self.datatypes = datamodel['datatypes']
     self.expose_pod_members = expose_pod_members
     self._clear()
 
@@ -435,5 +435,9 @@ class PodioConfigReader(object):
 
     # If this doesn't raise an exception everything should in principle work out
     validator = ClassDefinitionValidator()
-    validator.validate(self.components, self.datatypes, self.options.get("exposePODMembers", False))
+    datamodel = {
+        'components': self.components,
+        'datatypes': self.datatypes,
+        }
+    validator.validate(datamodel, False)
     self.warnings = validator.warnings

--- a/python/test_ClassDefinitionValidator.py
+++ b/python/test_ClassDefinitionValidator.py
@@ -180,8 +180,9 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
     with self.assertRaises(DefinitionError):
       self.validate(make_dm(self.valid_component, datatype), True)
 
-  def test_datatype_valid_many_relations(self):
-    self.valid_datatype['DataType']['OneToManyRelations'] = [
+
+  def _test_datatype_valid_relations(self, rel_type):
+    self.valid_datatype['DataType'][rel_type] = [
         MemberVariable(type='DataType', name='selfRelation')
         ]
     self._assert_no_exception(DefinitionError,
@@ -192,31 +193,43 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
         'Author': 'John Cleese',
         'Description': 'Tis but a scratch',
         'Members': [MemberVariable(type='int', name='counter', description='number of arms')],
-        'OneToManyRelations': [MemberVariable(type='DataType', name='relation', description='soo many relations')]
+        rel_type: [MemberVariable(type='DataType', name='relation', description='soo many relations')]
         }
 
     self._assert_no_exception(DefinitionError, '{} should validate a valid relation',
                               self.validate, make_dm(self.valid_component, self.valid_datatype), False)
 
-  def test_datatype_invalid_many_relations(self):
+  def test_datatype_valid_many_relations(self):
+    self._test_datatype_valid_relations('OneToManyRelations')
+
+  def test_datatype_valid_single_relations(self):
+    self._test_datatype_valid_relations('OneToOneRelations')
+
+  def _test_datatype_invalid_relations(self, rel_type):
     datatype = deepcopy(self.valid_datatype)
-    datatype['DataType']['OneToManyRelations'] = [MemberVariable(type='NonExistentDataType',
-                                                                 name='aName')]
+    datatype['DataType'][rel_type] = [MemberVariable(type='NonExistentDataType',
+                                                     name='aName')]
     with self.assertRaises(DefinitionError):
       self.validate(make_dm({}, datatype), False)
 
     datatype = deepcopy(self.valid_datatype)
-    datatype['DataType']['OneToManyRelations'] = [MemberVariable(type='Component',
-                                                                 name='componentRelation')]
+    datatype['DataType'][rel_type] = [MemberVariable(type='Component',
+                                                     name='componentRelation')]
     with self.assertRaises(DefinitionError):
       self.validate(make_dm(self.valid_component, datatype), False)
 
     datatype = deepcopy(self.valid_datatype)
-    datatype['DataType']['OneToManyRelations'] = [
+    datatype['DataType'][rel_type] = [
         MemberVariable(array_type='int', array_size='42', name='arrayRelation')
         ]
     with self.assertRaises(DefinitionError):
       self.validate(make_dm({}, datatype), False)
+
+  def test_datatype_invalid_many_relations(self):
+    self._test_datatype_invalid_relations('OneToManyRelations')
+
+  def test_datatype_invalid_single_relations(self):
+    self._test_datatype_invalid_relations('OneToOneRelations')
 
   def test_datatype_valid_vector_members(self):
     self.valid_datatype['DataType']['VectorMembers'] = [MemberVariable(type='int', name='someInt')]

--- a/python/test_ClassDefinitionValidator.py
+++ b/python/test_ClassDefinitionValidator.py
@@ -180,6 +180,16 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
     with self.assertRaises(DefinitionError):
       self.validate(make_dm(self.valid_component, datatype), True)
 
+    datatype = deepcopy(self.valid_datatype)
+    datatype['AnotherType'] = {
+        'Author': 'Avril L.',
+        'Description': 'I\'m just a datatype',
+        }
+    datatype['DataType']['Members'].append(
+        MemberVariable(type='AnotherType', name='impossibleType',
+                       description='Another datatype cannot be a member'))
+    with self.assertRaises(DefinitionError):
+      self.validate(make_dm(self.valid_component, datatype), False)
 
   def _test_datatype_valid_relations(self, rel_type):
     self.valid_datatype['DataType'][rel_type] = [


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a few small issues in the datamodel yaml file validation. **These do not change the behavior of code generation, they just try to catch problems earlier**
  - Make sure that `OneToManyRelations` and `OneToOneRelations` have the same restrictions
  - Only allow `components`, builtins and arrays of those as `Members`
- Make the API of `validate` slightly more generic by taking a dict instead of multiple arguments.
- Make the generator exit with an easier to read error message in case of a validation problem instead of printing a full backtrace.

ENDRELEASENOTES