### PR TITLE
Add user data collections w/ basic types

### DIFF
--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -40,8 +40,12 @@ namespace podio {
     /// number of elements in the collection
     virtual size_t size() const = 0;
 
+    /// fully qualified type name
+    virtual std::string getTypeName() const = 0;
     /// fully qualified type name of elements - with namespace
     virtual std::string getValueTypeName() const = 0;
+    /// fully qualified type name of stored POD elements - with namespace
+    virtual std::string getDataTypeName() const = 0;
 
     /// destructor
     virtual ~CollectionBase() = default;

--- a/include/podio/SIOBlockUserData.h
+++ b/include/podio/SIOBlockUserData.h
@@ -10,6 +10,7 @@
 
 #include <typeindex>
 #include <string>
+#include <algorithm>
 
 
 namespace{

--- a/include/podio/SIOBlockUserData.h
+++ b/include/podio/SIOBlockUserData.h
@@ -1,5 +1,5 @@
-#ifndef UserDataSIOBlock_H
-#define UserDataSIOBlock_H
+#ifndef SIOBlockUserData_H
+#define SIOBlockUserData_H
 
 #include "podio/SIOBlock.h"
 #include "podio/UserDataCollection.h"
@@ -12,18 +12,30 @@
 #include <string>
 
 
+namespace{
+
+  /// helper function to get valid sio block names
+  std::string sio_name(const std::string str){
+    std::string s = str ;
+    std::replace( s.begin(), s.end(), ' ', '_');
+    return s ;
+  }
+}
+
+namespace podio{
+
 template <typename BasicType>
-class UserDataSIOBlock: public podio::SIOBlock {
+class SIOBlockUserData: public podio::SIOBlock {
 public:
-  UserDataSIOBlock() :
-    SIOBlock( podio::userDataTypeName<BasicType>() ,
+  SIOBlockUserData() :
+    SIOBlock( ::sio_name( podio::userDataTypeName<BasicType>() ) ,
 	      sio::version::encode_version(0, 1)) {
 
     podio::SIOBlockFactory::instance().registerBlockForCollection(
       podio::userDataTypeName<BasicType>()  , this);
   }
 
-  UserDataSIOBlock(const std::string& name) :
+  SIOBlockUserData(const std::string& name) :
     SIOBlock(name, sio::version::encode_version(0, 1)) {}
 
 
@@ -50,9 +62,9 @@ public:
   }
 
   SIOBlock* create(const std::string& name) const override {
-    return new UserDataSIOBlock(name);
+    return new SIOBlockUserData(name);
   }
 };
 
-
+}
 #endif

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -23,10 +23,10 @@ namespace podio {
 
     const std::map< const std::type_index, const std::string >_typeMap =
     {
-      { std::type_index( typeid(int) ),   "podio::int"   },
-      { std::type_index( typeid(long) ),  "podio::long"  },
-      { std::type_index( typeid(float) ), "podio::float" },
-      { std::type_index( typeid(double) ),"podio::double"}
+      { std::type_index( typeid(int) ),   "podio::User_int"   },
+      { std::type_index( typeid(long) ),  "podio::User_long"  },
+      { std::type_index( typeid(float) ), "podio::User_float" },
+      { std::type_index( typeid(double) ),"podio::User_double"}
     } ;
 
   public:
@@ -154,16 +154,10 @@ namespace podio {
 
   /// some typedefs to make ROOT and the ROOTWriter happy
 
-  typedef UserDataCollection<int>    intCollection ;
-  typedef UserDataCollection<long>   longCollection ;
-  typedef UserDataCollection<float>  floatCollection ;
-  typedef UserDataCollection<double> doubleCollection ;
-
-  // are these needed or not ? the ROOT branch is created w/ "vector<xxxData>" where xxx is int, float, ...
-   // typedef int    intData ;
-   // typedef long   longData ;
-   // typedef float  floatData ;
-   // typedef double doubleData ;
+  typedef UserDataCollection<int>    User_intCollection ;
+  typedef UserDataCollection<long>   User_longCollection ;
+  typedef UserDataCollection<float>  User_floatCollection ;
+  typedef UserDataCollection<double> User_doubleCollection ;
 
 } // namespace
 

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -49,6 +49,17 @@ namespace podio {
     constexpr bool isSupported() {
       return inTuple<T>(SupportedUserDataTypes{});
     }
+
+
+    /// some static type checks to ensure our assumptions on the fundamental types are correct
+    // note: eventually we might need some more generic tests and checks on type equivalence and
+    //       size_of supported types in PODIO as this also can affect the generated POD types...
+    static_assert( std::is_same_v<int16_t,short>);
+    static_assert( std::is_same_v<int32_t,int>);
+    static_assert( std::is_same_v<int64_t,long long>);
+    static_assert( std::is_same_v<uint16_t,unsigned short>);
+    static_assert( std::is_same_v<uint32_t,unsigned>);
+    static_assert( std::is_same_v<uint64_t,unsigned long long>);
   }
 
   /**
@@ -64,26 +75,26 @@ namespace podio {
   template <typename BasicType, typename = EnableIfSupportedUserType<BasicType> >
   constexpr const char*  userDataTypeName() ;
 
-  PODIO_ADD_USER_TYPE(int)
+  // PODIO_ADD_USER_TYPE(int)
   PODIO_ADD_USER_TYPE(long)
   PODIO_ADD_USER_TYPE(float)
   PODIO_ADD_USER_TYPE(double)
-  PODIO_ADD_USER_TYPE(unsigned)
-//  PODIO_ADD_USER_TYPE(unsigned int)
+  // PODIO_ADD_USER_TYPE(unsigned)
+  // PODIO_ADD_USER_TYPE(unsigned int)
   PODIO_ADD_USER_TYPE(unsigned long)
   PODIO_ADD_USER_TYPE(char)
-  PODIO_ADD_USER_TYPE(short)
-  PODIO_ADD_USER_TYPE(long long)
-  PODIO_ADD_USER_TYPE(unsigned long long)
-//  PODIO_ADD_USER_TYPE(int16_t)
-//  PODIO_ADD_USER_TYPE(int32_t)
-//  PODIO_ADD_USER_TYPE(int64_t)
+  // PODIO_ADD_USER_TYPE(short)
+  // PODIO_ADD_USER_TYPE(long long)
+  // PODIO_ADD_USER_TYPE(unsigned long long)
+  PODIO_ADD_USER_TYPE(int16_t)
+  PODIO_ADD_USER_TYPE(int32_t)
+  PODIO_ADD_USER_TYPE(int64_t)
   PODIO_ADD_USER_TYPE(uint16_t)
-//  PODIO_ADD_USER_TYPE(uint32_t)
-//  PODIO_ADD_USER_TYPE(uint64_t)
+  PODIO_ADD_USER_TYPE(uint32_t)
+  PODIO_ADD_USER_TYPE(uint64_t)
 
 // note: duplicate types on 'standard' hardware are commented out here
-
+//       but left in for a potential updata in the future...
 
   /** Collection of basic types for additional user data not defined in the EDM.
    *  The data is stored in an std::vector<basic_type>. Supported are all basic types supported in
@@ -197,6 +208,10 @@ namespace podio {
 
 
   };
+
+
+// don't make this macro public as it should only be used internally here...
+#undef PODIO_ADD_USER_TYPE
 
 } // namespace
 

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -17,6 +17,9 @@ namespace podio {
   class  UserDataTypes{
   private:
     UserDataTypes() = default ;
+    UserDataTypes(const UserDataTypes& ) = delete;
+    UserDataTypes& operator=(const UserDataTypes& ) = delete;
+    ~UserDataTypes() = default;
 
     const std::map< const std::type_index, const std::string >_typeMap =
     {
@@ -31,6 +34,11 @@ namespace podio {
     std::string name( std::type_index idx ){
       auto it = _typeMap.find( idx ) ;
       return it != _typeMap.end() ? it->second  :  "UNKNOWN"  ;
+    }
+
+    // typename w/ 'podio::' replaced by 'podio_'
+    std::string sio_name( std::type_index idx ){
+      return std::string("podio_") + name( idx ).substr( 7 , 1024)  ;
     }
 
     static UserDataTypes& instance(){
@@ -132,11 +140,15 @@ namespace podio {
 
   /// some typedefs to make ROOT happy
 
-  typedef UserDataCollection<int>   intCollection ;
-  typedef UserDataCollection<float> floatCollection ;
+  typedef UserDataCollection<int>    intCollection ;
+  typedef UserDataCollection<long>   longCollection ;
+  typedef UserDataCollection<float>  floatCollection ;
+  typedef UserDataCollection<double> doubleCollection ;
 
-  typedef int   intData ;
-  typedef float floatData ;
+  typedef int    intData ;
+  typedef long   longData ;
+  typedef float  floatData ;
+  typedef double doubleData ;
 
 } // namespace
 

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -54,12 +54,20 @@ namespace podio {
     /// some static type checks to ensure our assumptions on the fundamental types are correct
     // note: eventually we might need some more generic tests and checks on type equivalence and
     //       size_of supported types in PODIO as this also can affect the generated POD types...
+
     static_assert( std::is_same_v<int16_t,short>);
     static_assert( std::is_same_v<int32_t,int>);
-    static_assert( std::is_same_v<int64_t,long long>);
     static_assert( std::is_same_v<uint16_t,unsigned short>);
     static_assert( std::is_same_v<uint32_t,unsigned>);
+    // temporary workaround for differences on APPLE and Linux
+#if defined(__APPLE__)
+    static_assert( std::is_same_v<int64_t,long long>);
     static_assert( std::is_same_v<uint64_t,unsigned long long>);
+#else
+    static_assert( std::is_same_v<int64_t,long>);
+    static_assert( std::is_same_v<uint64_t,unsigned long>);
+#endif
+
   }
 
   /**

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -159,10 +159,11 @@ namespace podio {
   typedef UserDataCollection<float>  floatCollection ;
   typedef UserDataCollection<double> doubleCollection ;
 
-  typedef int    intData ;
-  typedef long   longData ;
-  typedef float  floatData ;
-  typedef double doubleData ;
+  // are these needed or not ? the ROOT branch is created w/ "vector<xxxData>" where xxx is int, float, ...
+   // typedef int    intData ;
+   // typedef long   longData ;
+   // typedef float  floatData ;
+   // typedef double doubleData ;
 
 } // namespace
 

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -125,6 +125,20 @@ namespace podio {
     /// declare this collection to be a subset collectionv - no effect
     void setSubsetCollection(bool) override final {}
 
+
+    // ----- some wrapers for std::vector and access to the complete std::vector (if really needed)
+
+    typename std::vector<BasicType>::iterator begin() { return _vec.begin() ; }
+    typename std::vector<BasicType>::iterator end()   { return _vec.end() ; }
+    typename std::vector<BasicType>::const_iterator begin() const { return _vec.begin() ; }
+    typename std::vector<BasicType>::const_iterator end()   const { return _vec.end() ; }
+
+    typename std::vector<BasicType>::reference operator[](size_t idx) { return _vec[idx] ; }
+    typename std::vector<BasicType>::const_reference operator[](size_t idx) const { return _vec[idx] ; }
+
+    void resize( size_t count ) { _vec.resize( count ) ; }
+    void push_back( const BasicType& value ) { _vec.push_back( value ) ; }
+
     /// access to the actual data vector
     typename std::vector<BasicType>& vec() {
       return _vec;
@@ -138,7 +152,7 @@ namespace podio {
 
   };
 
-  /// some typedefs to make ROOT happy
+  /// some typedefs to make ROOT and the ROOTWriter happy
 
   typedef UserDataCollection<int>    intCollection ;
   typedef UserDataCollection<long>   longCollection ;

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -84,16 +84,19 @@ namespace podio {
   constexpr const char*  userDataTypeName() ;
 
   // PODIO_ADD_USER_TYPE(int)
-  PODIO_ADD_USER_TYPE(long)
   PODIO_ADD_USER_TYPE(float)
   PODIO_ADD_USER_TYPE(double)
   // PODIO_ADD_USER_TYPE(unsigned)
   // PODIO_ADD_USER_TYPE(unsigned int)
+#if defined(__APPLE__)
+  PODIO_ADD_USER_TYPE(long)
   PODIO_ADD_USER_TYPE(unsigned long)
+#else
+  PODIO_ADD_USER_TYPE(long long)
+  PODIO_ADD_USER_TYPE(unsigned long long)
+#endif
   PODIO_ADD_USER_TYPE(char)
   // PODIO_ADD_USER_TYPE(short)
-  // PODIO_ADD_USER_TYPE(long long)
-  // PODIO_ADD_USER_TYPE(unsigned long long)
   PODIO_ADD_USER_TYPE(int16_t)
   PODIO_ADD_USER_TYPE(int32_t)
   PODIO_ADD_USER_TYPE(int64_t)

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -12,40 +12,14 @@
 
 namespace podio {
 
+  template <typename BasicType>
+  std::string userDataTypeName() { throw std::runtime_error( std::string(" unsupported type for UserDataCollection: ")
+							     + typeid(BasicType).name() ) ; }
 
-  ///helper class providing names for basic types used in UserDataCollection<T>
-  class  UserDataTypes{
-  private:
-    UserDataTypes() = default ;
-    UserDataTypes(const UserDataTypes& ) = delete;
-    UserDataTypes& operator=(const UserDataTypes& ) = delete;
-    ~UserDataTypes() = default;
-
-    const std::map< const std::type_index, const std::string >_typeMap =
-    {
-      { std::type_index( typeid(int) ),   "podio::User_int"   },
-      { std::type_index( typeid(long) ),  "podio::User_long"  },
-      { std::type_index( typeid(float) ), "podio::User_float" },
-      { std::type_index( typeid(double) ),"podio::User_double"}
-    } ;
-
-  public:
-
-    std::string name( std::type_index idx ){
-      auto it = _typeMap.find( idx ) ;
-      return it != _typeMap.end() ? it->second  :  "UNKNOWN"  ;
-    }
-
-    // typename w/ 'podio::' replaced by 'podio_'
-    std::string sio_name( std::type_index idx ){
-      return std::string("podio_") + name( idx ).substr( 7 , 1024)  ;
-    }
-
-    static UserDataTypes& instance(){
-      static UserDataTypes me ;
-      return me ;
-    }
-  } ;
+  template <>  std::string userDataTypeName<int>()   {return "int" ; }
+  template <>  std::string userDataTypeName<float>() {return "float" ; }
+  template <>  std::string userDataTypeName<long>()  {return "long" ; }
+  template <>  std::string userDataTypeName<double>(){return "double" ; }
 
 
   /// Templated base class for storing std::vectors of basic types as user data in PODIO
@@ -105,11 +79,15 @@ namespace podio {
       return _vec.size() ;
     }
 
-    /// fully qualified type name of elements - with namespace
-    std::string getValueTypeName() const override final {
+    /// fully qualified type name
+    std::string getTypeName() const override { return std::string("podio::UserDataCollection<")
+	+ userDataTypeName< BasicType >() + ">" ; }
 
-      return UserDataTypes::instance().name( typeid(BasicType) ) ;
-    }
+    /// fully qualified type name of elements - with namespace
+    std::string getValueTypeName() const override { return userDataTypeName< BasicType >() ; }
+
+    /// fully qualified type name of stored POD elements - with namespace
+    std::string getDataTypeName() const override { return  userDataTypeName< BasicType >() ; }
 
     /// clear the collection and all internal states
     void clear() override final {

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -130,13 +130,6 @@ namespace podio {
 
   };
 
-  /// some typedefs to make ROOT and the ROOTWriter happy
-
-  typedef UserDataCollection<int>    User_intCollection ;
-  typedef UserDataCollection<long>   User_longCollection ;
-  typedef UserDataCollection<float>  User_floatCollection ;
-  typedef UserDataCollection<double> User_doubleCollection ;
-
 } // namespace
 
 #endif

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -12,15 +12,11 @@
 
 namespace podio {
 
-  template <typename BasicType>
-  class UserDataCollection : public CollectionBase {
 
+  ///helper class providing names for basic types used in UserDataCollection<T>
+  class  UserDataTypes{
   private:
-    std::vector<BasicType> _vec ;
-    std::vector<BasicType>* _vecPtr = &_vec ;
-    int m_collectionID{0};
-    CollRefCollection m_refCollections{};
-    VectorMembersInfo m_vecmem_info{};
+    UserDataTypes() = default ;
 
     const std::map< const std::type_index, const std::string >_typeMap =
     {
@@ -29,6 +25,31 @@ namespace podio {
       { std::type_index( typeid(float) ), "podio::float" },
       { std::type_index( typeid(double) ),"podio::double"}
     } ;
+
+  public:
+
+    std::string name( std::type_index idx ){
+      auto it = _typeMap.find( idx ) ;
+      return it != _typeMap.end() ? it->second  :  "UNKNOWN"  ;
+    }
+
+    static UserDataTypes& instance(){
+      static UserDataTypes me ;
+      return me ;
+    }
+  } ;
+
+
+  /// Templated base class for storing std::vectors of basic types as user data in PODIO
+  template <typename BasicType>
+  class UserDataCollection : public CollectionBase {
+
+  private:
+    std::vector<BasicType> _vec{} ;
+    std::vector<BasicType>* _vecPtr = &_vec ;
+    int m_collectionID{0};
+    CollRefCollection m_refCollections{};
+    VectorMembersInfo m_vecmem_info{};
 
   public:
 
@@ -78,8 +99,8 @@ namespace podio {
 
     /// fully qualified type name of elements - with namespace
     std::string getValueTypeName() const override final {
-      auto it = _typeMap.find( std::type_index( typeid(BasicType) ) ) ;
-      return it != _typeMap.end() ? it->second  :  "UNKNOWN"  ;
+
+      return UserDataTypes::instance().name( typeid(BasicType) ) ;
     }
 
     /// clear the collection and all internal states
@@ -101,7 +122,7 @@ namespace podio {
       return _vec;
     }
 
-    /// access to the actual data vector
+    /// const access to the actual data vector
     const typename std::vector<BasicType>& vec() const {
       return _vec;
     }

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -64,21 +64,21 @@ namespace podio {
   template <typename BasicType, typename = EnableIfSupportedUserType<BasicType> >
   constexpr const char*  userDataTypeName() ;
 
-  PODIO_ADD_USER_TYPE(int);
-  PODIO_ADD_USER_TYPE(long);
-  PODIO_ADD_USER_TYPE(float);
-  PODIO_ADD_USER_TYPE(double);
-  PODIO_ADD_USER_TYPE(unsigned);
-//  PODIO_ADD_USER_TYPE(unsigned int);
-  PODIO_ADD_USER_TYPE(unsigned long);
-  PODIO_ADD_USER_TYPE(char);
-  PODIO_ADD_USER_TYPE(short);
-  PODIO_ADD_USER_TYPE(long long);
-  PODIO_ADD_USER_TYPE(unsigned long long);
-//  PODIO_ADD_USER_TYPE(int16_t);
-//  PODIO_ADD_USER_TYPE(int32_t);
-//  PODIO_ADD_USER_TYPE(int64_t);
-  PODIO_ADD_USER_TYPE(uint16_t);
+  PODIO_ADD_USER_TYPE(int)
+  PODIO_ADD_USER_TYPE(long)
+  PODIO_ADD_USER_TYPE(float)
+  PODIO_ADD_USER_TYPE(double)
+  PODIO_ADD_USER_TYPE(unsigned)
+//  PODIO_ADD_USER_TYPE(unsigned int)
+  PODIO_ADD_USER_TYPE(unsigned long)
+  PODIO_ADD_USER_TYPE(char)
+  PODIO_ADD_USER_TYPE(short)
+  PODIO_ADD_USER_TYPE(long long)
+  PODIO_ADD_USER_TYPE(unsigned long long)
+//  PODIO_ADD_USER_TYPE(int16_t)
+//  PODIO_ADD_USER_TYPE(int32_t)
+//  PODIO_ADD_USER_TYPE(int64_t)
+  PODIO_ADD_USER_TYPE(uint16_t)
 //  PODIO_ADD_USER_TYPE(uint32_t)
 //  PODIO_ADD_USER_TYPE(uint64_t)
 

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -22,12 +22,12 @@ namespace podio {
     CollRefCollection m_refCollections{};
     VectorMembersInfo m_vecmem_info{};
 
-    const std::map< std::type_index, const std::string >_typeMap =
-    { 
-      { std::type_index( typeid(int) ) , "podio::int" } ,
-      { std::type_index( typeid(long) ) , "podio::long" } ,
-      { std::type_index( typeid(float) ) , "podio::float" } ,
-      { std::type_index( typeid(double) ) , "podio::double" } 
+    const std::map< const std::type_index, const std::string >_typeMap =
+    {
+      { std::type_index( typeid(int) ),   "podio::int"   },
+      { std::type_index( typeid(long) ),  "podio::long"  },
+      { std::type_index( typeid(float) ), "podio::float" },
+      { std::type_index( typeid(double) ),"podio::double"}
     } ;
 
   public:
@@ -35,7 +35,7 @@ namespace podio {
     UserDataCollection() = default ;
     UserDataCollection(const UserDataCollection& ) = delete;
     UserDataCollection& operator=(const UserDataCollection& ) = delete;
-
+    ~UserDataCollection() = default;
 
 
     /// prepare buffers for serialization
@@ -45,7 +45,9 @@ namespace podio {
     void  prepareAfterRead() override final {}
 
     /// initialize references after read
-    bool setReferences(const ICollectionProvider* collectionProvider) override final {  return true ;}
+    bool setReferences(const ICollectionProvider* ) override final {
+      return true ;
+    }
 
     /// set collection ID
     void setID(unsigned id) override final {
@@ -66,7 +68,6 @@ namespace podio {
 
     /// check for validity of the container after read
     bool isValid() const override final {
-      // nothing to chek here - or ?
       return true ;
     }
 
@@ -79,12 +80,7 @@ namespace podio {
     std::string getValueTypeName() const override final {
       auto it = _typeMap.find( std::type_index( typeid(BasicType) ) ) ;
       return it != _typeMap.end() ? it->second  :  "UNKNOWN"  ;
-
-	//return typeid(BasicType).name() ;
     }
-
-    /// destructor
-    ~UserDataCollection() = default;
 
     /// clear the collection and all internal states
     void clear() override final {
@@ -93,27 +89,32 @@ namespace podio {
 
 
     /// check if this collection is a subset collection - no subset possible
-    bool isSubsetCollection() const override final {return false ;}
+    bool isSubsetCollection() const override final {
+      return false ;
+    }
 
     /// declare this collection to be a subset collectionv - no effect
-    void setSubsetCollection(bool setSubset=true) override final {}
-
+    void setSubsetCollection(bool) override final {}
 
     /// access to the actual data vector
-    typename std::vector<BasicType>& vec() { return _vec; }
-    
+    typename std::vector<BasicType>& vec() {
+      return _vec;
+    }
+
     /// access to the actual data vector
-    const typename std::vector<BasicType>& vec() const { return _vec; }
+    const typename std::vector<BasicType>& vec() const {
+      return _vec;
+    }
 
 
   };
 
   /// some typedefs to make ROOT happy
 
-  typedef UserDataCollection<int> intCollection ;
+  typedef UserDataCollection<int>   intCollection ;
   typedef UserDataCollection<float> floatCollection ;
 
-  typedef int intData ;
+  typedef int   intData ;
   typedef float floatData ;
 
 } // namespace

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -1,0 +1,121 @@
+#ifndef USERDATACOLLECTION_H
+#define USERDATACOLLECTION_H
+
+#include "podio/CollectionBase.h"
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+#include <typeindex>
+
+
+namespace podio {
+
+  template <typename BasicType>
+  class UserDataCollection : public CollectionBase {
+
+  private:
+    std::vector<BasicType> _vec ;
+    std::vector<BasicType>* _vecPtr = &_vec ;
+    int m_collectionID{0};
+    CollRefCollection m_refCollections{};
+    VectorMembersInfo m_vecmem_info{};
+
+    const std::map< std::type_index, const std::string >_typeMap =
+    { 
+      { std::type_index( typeid(int) ) , "podio::int" } ,
+      { std::type_index( typeid(long) ) , "podio::long" } ,
+      { std::type_index( typeid(float) ) , "podio::float" } ,
+      { std::type_index( typeid(double) ) , "podio::double" } 
+    } ;
+
+  public:
+
+    UserDataCollection() = default ;
+    UserDataCollection(const UserDataCollection& ) = delete;
+    UserDataCollection& operator=(const UserDataCollection& ) = delete;
+
+
+
+    /// prepare buffers for serialization
+    void prepareForWrite() override final {}
+
+    /// re-create collection from buffers after read
+    void  prepareAfterRead() override final {}
+
+    /// initialize references after read
+    bool setReferences(const ICollectionProvider* collectionProvider) override final {  return true ;}
+
+    /// set collection ID
+    void setID(unsigned id) override final {
+      m_collectionID = id;
+    }
+
+    /// get collection ID
+    unsigned getID() const override final {
+      return m_collectionID ;
+    }
+
+    /// Get the collection buffers for this collection
+    podio::CollectionBuffers getBuffers() override final {
+      return { &_vecPtr,
+	&m_refCollections, // only need to store the ObjectIDs of the referenced objects
+	&m_vecmem_info } ;
+    }
+
+    /// check for validity of the container after read
+    bool isValid() const override final {
+      // nothing to chek here - or ?
+      return true ;
+    }
+
+    /// number of elements in the collection
+    size_t size() const override final {
+      return _vec.size() ;
+    }
+
+    /// fully qualified type name of elements - with namespace
+    std::string getValueTypeName() const override final {
+      auto it = _typeMap.find( std::type_index( typeid(BasicType) ) ) ;
+      return it != _typeMap.end() ? it->second  :  "UNKNOWN"  ;
+
+	//return typeid(BasicType).name() ;
+    }
+
+    /// destructor
+    ~UserDataCollection() = default;
+
+    /// clear the collection and all internal states
+    void clear() override final {
+      _vec.clear() ;
+    } ;
+
+
+    /// check if this collection is a subset collection - no subset possible
+    bool isSubsetCollection() const override final {return false ;}
+
+    /// declare this collection to be a subset collectionv - no effect
+    void setSubsetCollection(bool setSubset=true) override final {}
+
+
+    /// access to the actual data vector
+    typename std::vector<BasicType>& vec() { return _vec; }
+    
+    /// access to the actual data vector
+    const typename std::vector<BasicType>& vec() const { return _vec; }
+
+
+  };
+
+  /// some typedefs to make ROOT happy
+
+  typedef UserDataCollection<int> intCollection ;
+  typedef UserDataCollection<float> floatCollection ;
+
+  typedef int intData ;
+  typedef float floatData ;
+
+} // namespace
+
+#endif

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -9,7 +9,7 @@
 #include <vector>
 #include <typeindex>
 
-#define PODIO_ADD_USER_TYPE(type) template<> constexpr const char* userDataTypeName<type>( return #type; }
+#define PODIO_ADD_USER_TYPE(type) template<> constexpr const   char* userDataTypeName<type>(){ return #type ; }
 
 
 namespace podio {
@@ -25,10 +25,12 @@ namespace podio {
     /** tuple of basic types supported in user vector
      */
     using SupportedUserDataTypes = std::tuple<
-      int,
-      float,
-      long,
-      double
+      int, long, float, double,
+      unsigned int, unsigned, unsigned long,
+      char, short, long long,
+      unsigned long long,
+      int16_t, int32_t, int64_t,
+      uint16_t, uint32_t, uint64_t
       >;
 
     /**
@@ -57,15 +59,30 @@ namespace podio {
   using EnableIfSupportedUserType = std::enable_if_t<detail::isSupported<T>()>;
 
 
-  /** helper template to provide readable type names for basic types
+  /** helper template to provide readable type names for basic types with macro PODIO_ADD_USER_TYPE(type)
    */
   template <typename BasicType, typename = EnableIfSupportedUserType<BasicType> >
   constexpr const char*  userDataTypeName() ;
 
-  template <> constexpr const char* userDataTypeName<int>()   {return "int" ; }
-  template <> constexpr const char* userDataTypeName<float>() {return "float" ; }
-  template <> constexpr const char* userDataTypeName<long>()  {return "long" ; }
-  template <> constexpr const char* userDataTypeName<double>(){return "double" ; }
+  PODIO_ADD_USER_TYPE(int);
+  PODIO_ADD_USER_TYPE(long);
+  PODIO_ADD_USER_TYPE(float);
+  PODIO_ADD_USER_TYPE(double);
+  PODIO_ADD_USER_TYPE(unsigned);
+//  PODIO_ADD_USER_TYPE(unsigned int);
+  PODIO_ADD_USER_TYPE(unsigned long);
+  PODIO_ADD_USER_TYPE(char);
+  PODIO_ADD_USER_TYPE(short);
+  PODIO_ADD_USER_TYPE(long long);
+  PODIO_ADD_USER_TYPE(unsigned long long);
+//  PODIO_ADD_USER_TYPE(int16_t);
+//  PODIO_ADD_USER_TYPE(int32_t);
+//  PODIO_ADD_USER_TYPE(int64_t);
+  PODIO_ADD_USER_TYPE(uint16_t);
+//  PODIO_ADD_USER_TYPE(uint32_t)
+//  PODIO_ADD_USER_TYPE(uint64_t)
+
+// note: duplicate types on 'standard' hardware are commented out here
 
 
   /** Collection of basic types for additional user data not defined in the EDM.

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -25,12 +25,9 @@ namespace podio {
     /** tuple of basic types supported in user vector
      */
     using SupportedUserDataTypes = std::tuple<
-      int, long, float, double,
-      unsigned int, unsigned, unsigned long,
-      char, short, long long,
-      unsigned long long,
-      int16_t, int32_t, int64_t,
-      uint16_t, uint32_t, uint64_t
+      float, double,
+      int8_t, int16_t, int32_t, int64_t,
+      uint8_t, uint16_t, uint32_t, uint64_t
       >;
 
     /**
@@ -49,25 +46,6 @@ namespace podio {
     constexpr bool isSupported() {
       return inTuple<T>(SupportedUserDataTypes{});
     }
-
-
-    /// some static type checks to ensure our assumptions on the fundamental types are correct
-    // note: eventually we might need some more generic tests and checks on type equivalence and
-    //       size_of supported types in PODIO as this also can affect the generated POD types...
-
-    static_assert( std::is_same_v<int16_t,short>);
-    static_assert( std::is_same_v<int32_t,int>);
-    static_assert( std::is_same_v<uint16_t,unsigned short>);
-    static_assert( std::is_same_v<uint32_t,unsigned>);
-    // temporary workaround for differences on APPLE and Linux
-#if defined(__APPLE__)
-    static_assert( std::is_same_v<int64_t,long long>);
-    static_assert( std::is_same_v<uint64_t,unsigned long long>);
-#else
-    static_assert( std::is_same_v<int64_t,long>);
-    static_assert( std::is_same_v<uint64_t,unsigned long>);
-#endif
-
   }
 
   /**
@@ -83,33 +61,22 @@ namespace podio {
   template <typename BasicType, typename = EnableIfSupportedUserType<BasicType> >
   constexpr const char*  userDataTypeName() ;
 
-  // PODIO_ADD_USER_TYPE(int)
   PODIO_ADD_USER_TYPE(float)
   PODIO_ADD_USER_TYPE(double)
-  // PODIO_ADD_USER_TYPE(unsigned)
-  // PODIO_ADD_USER_TYPE(unsigned int)
-#if defined(__APPLE__)
-  PODIO_ADD_USER_TYPE(long)
-  PODIO_ADD_USER_TYPE(unsigned long)
-#else
-  PODIO_ADD_USER_TYPE(long long)
-  PODIO_ADD_USER_TYPE(unsigned long long)
-#endif
-  PODIO_ADD_USER_TYPE(char)
-  // PODIO_ADD_USER_TYPE(short)
+
+  PODIO_ADD_USER_TYPE(int8_t)
   PODIO_ADD_USER_TYPE(int16_t)
   PODIO_ADD_USER_TYPE(int32_t)
   PODIO_ADD_USER_TYPE(int64_t)
+  PODIO_ADD_USER_TYPE(uint8_t)
   PODIO_ADD_USER_TYPE(uint16_t)
   PODIO_ADD_USER_TYPE(uint32_t)
   PODIO_ADD_USER_TYPE(uint64_t)
 
-// note: duplicate types on 'standard' hardware are commented out here
-//       but left in for a potential updata in the future...
 
   /** Collection of basic types for additional user data not defined in the EDM.
    *  The data is stored in an std::vector<basic_type>. Supported are all basic types supported in
-   *  PODIO - @see SupportedUserDataTypes.
+   *  PODIO, i.e. float, double and 8-64 bit fixed size signed and unsigned integers - @see SupportedUserDataTypes.
    *  @author F.Gaede, DESY
    *  @date Sep 2021
    */

--- a/include/podio/UserDataSIOBlock.h
+++ b/include/podio/UserDataSIOBlock.h
@@ -1,0 +1,63 @@
+#ifndef UserDataSIOBlock_H
+#define UserDataSIOBlock_H
+
+#include "podio/SIOBlock.h"
+#include "podio/UserDataCollection.h"
+
+#include <sio/api.h>
+#include <sio/io_device.h>
+#include <sio/version.h>
+
+#include <typeindex>
+#include <string>
+
+
+template <typename BasicType>
+class UserDataSIOBlock: public podio::SIOBlock {
+public:
+  UserDataSIOBlock() :
+    SIOBlock( podio::UserDataTypes::instance().sio_name( typeid(BasicType) ),
+	      sio::version::encode_version(0, 1)) {
+
+    podio::SIOBlockFactory::instance().registerBlockForCollection(
+      podio::UserDataTypes::instance().name( typeid(BasicType) ) , this);
+  }
+
+  UserDataSIOBlock(const std::string& name) :
+    SIOBlock(name, sio::version::encode_version(0, 1)) {}
+
+
+  virtual void read(sio::read_device& device, sio::version_type /*version*/) override {
+    auto collBuffers = _col->getBuffers();
+    if (not _col->isSubsetCollection()) {
+      auto* dataVec = collBuffers.dataAsVector<BasicType>();
+      unsigned size(0);
+      device.data( size );
+      dataVec->resize(size);
+      podio::handlePODDataSIO(device, &(*dataVec)[0], size);
+    }
+  }
+
+  virtual void write(sio::write_device& device) override {
+    _col->prepareForWrite() ;
+    auto collBuffers = _col->getBuffers();
+    if (not _col->isSubsetCollection()) {
+      auto* dataVec = collBuffers.dataAsVector<BasicType>();
+      unsigned size = dataVec->size() ;
+      device.data( size ) ;
+      podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
+    }
+  }
+
+  virtual void createCollection(const bool subsetCollection=false) override{
+    setCollection(new podio::UserDataCollection<BasicType>);
+    _col->setSubsetCollection(subsetCollection);
+  }
+
+  SIOBlock* create(const std::string& name) const override {
+    return new UserDataSIOBlock(name);
+  }
+};
+
+
+#endif

--- a/include/podio/UserDataSIOBlock.h
+++ b/include/podio/UserDataSIOBlock.h
@@ -16,11 +16,11 @@ template <typename BasicType>
 class UserDataSIOBlock: public podio::SIOBlock {
 public:
   UserDataSIOBlock() :
-    SIOBlock( podio::UserDataTypes::instance().sio_name( typeid(BasicType) ),
+    SIOBlock( podio::userDataTypeName<BasicType>() ,
 	      sio::version::encode_version(0, 1)) {
 
     podio::SIOBlockFactory::instance().registerBlockForCollection(
-      podio::UserDataTypes::instance().name( typeid(BasicType) ) , this);
+      podio::userDataTypeName<BasicType>()  , this);
   }
 
   UserDataSIOBlock(const std::string& name) :

--- a/include/podio/UserDataSIOBlock.h
+++ b/include/podio/UserDataSIOBlock.h
@@ -29,29 +29,24 @@ public:
 
   virtual void read(sio::read_device& device, sio::version_type /*version*/) override {
     auto collBuffers = _col->getBuffers();
-    if (not _col->isSubsetCollection()) {
-      auto* dataVec = collBuffers.dataAsVector<BasicType>();
-      unsigned size(0);
-      device.data( size );
-      dataVec->resize(size);
-      podio::handlePODDataSIO(device, &(*dataVec)[0], size);
-    }
+    auto* dataVec = collBuffers.dataAsVector<BasicType>();
+    unsigned size(0);
+    device.data( size );
+    dataVec->resize(size);
+    podio::handlePODDataSIO(device, &(*dataVec)[0], size);
   }
 
   virtual void write(sio::write_device& device) override {
     _col->prepareForWrite() ;
     auto collBuffers = _col->getBuffers();
-    if (not _col->isSubsetCollection()) {
-      auto* dataVec = collBuffers.dataAsVector<BasicType>();
-      unsigned size = dataVec->size() ;
-      device.data( size ) ;
-      podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
-    }
+    auto* dataVec = collBuffers.dataAsVector<BasicType>();
+    unsigned size = dataVec->size() ;
+    device.data( size ) ;
+    podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
   }
 
-  virtual void createCollection(const bool subsetCollection=false) override{
+  virtual void createCollection(const bool) override{
     setCollection(new podio::UserDataCollection<BasicType>);
-    _col->setSubsetCollection(subsetCollection);
   }
 
   SIOBlock* create(const std::string& name) const override {

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -61,8 +61,12 @@ public:
   /// number of elements in the collection
   size_t size() const override final;
 
+  /// fully qualified type name
+  std::string getTypeName() const override { return std::string("{{ (class | string ).strip(':')+"Collection" }}"); }
   /// fully qualified type name of elements - with namespace
   std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
+  /// fully qualified type name of stored POD elements - with namespace
+  std::string getDataTypeName() const override { return std::string("{{ (class | string ).strip(':')+"Data" }}"); }
 
   bool isSubsetCollection() const final {
     return m_isSubsetColl;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ SET(headers
   ${CMAKE_SOURCE_DIR}/include/podio/IReader.h
   ${CMAKE_SOURCE_DIR}/include/podio/ObjectID.h
   ${CMAKE_SOURCE_DIR}/include/podio/PythonEventStore.h
+  ${CMAKE_SOURCE_DIR}/include/podio/UserDataCollection.h
   )
 PODIO_GENERATE_DICTIONARY(podioDict ${headers} SELECTION selection.xml
   OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}podioDict${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -230,7 +230,7 @@ namespace podio {
         branches.vecs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
       }
 
-      const std::string bufferClassName = "std::vector<" + collection->getValueTypeName() + "Data>";
+      const std::string bufferClassName = "std::vector<" + collection->getDataTypeName() + ">";
       const auto bufferClass = isSubsetColl ? nullptr : TClass::GetClass(bufferClassName.c_str());
 
       m_storedClasses.emplace(

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -56,17 +56,8 @@ void ROOTWriter::createBranches(const std::vector<StoreCollection>& collections)
     if (collBuffers.data) {
       // only create the data buffer branch if necessary
 
-      std::string valTypeName = coll->getValueTypeName() ;
+      auto collClassName = "vector<" + coll->getDataTypeName() +">";
 
-      auto collClassName = "vector<" + valTypeName + "Data>";
-
-      auto it = valTypeName.find("podio::User_") ;
-      if(it == 0 ){
-	valTypeName = valTypeName.substr( 12 , 1024 ) ; // rm 'podio_user_' prefix
-	 collClassName = "vector<" + valTypeName +">";
-      }
-
-      std::cout << " **** create branch " << collClassName << std::endl ;
       branches.data = m_datatree->Branch(name.c_str(), collClassName.c_str(), collBuffers.data);
     }
 
@@ -120,7 +111,7 @@ void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
       const podio::CollectionBase* coll{nullptr};
       // No check necessary, only registered collections possible
       m_store->get(name, coll);
-      const auto collType = coll->getValueTypeName() + "Collection";
+      const auto collType = coll->getTypeName() ;
       collectionInfo.emplace_back(collID, std::move(collType), coll->isSubsetCollection());
     }
 

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -55,7 +55,18 @@ void ROOTWriter::createBranches(const std::vector<StoreCollection>& collections)
     const auto collBuffers = coll->getBuffers();
     if (collBuffers.data) {
       // only create the data buffer branch if necessary
-      const auto collClassName = "vector<" + coll->getValueTypeName() + "Data>";
+
+      std::string valTypeName = coll->getValueTypeName() ;
+
+      auto collClassName = "vector<" + valTypeName + "Data>";
+
+      auto it = valTypeName.find("podio::User_") ;
+      if(it == 0 ){
+	valTypeName = valTypeName.substr( 12 , 1024 ) ; // rm 'podio_user_' prefix
+	 collClassName = "vector<" + valTypeName +">";
+      }
+
+      std::cout << " **** create branch " << collClassName << std::endl ;
       branches.data = m_datatree->Branch(name.c_str(), collClassName.c_str(), collBuffers.data);
     }
 

--- a/src/SIOBlockUserData.cc
+++ b/src/SIOBlockUserData.cc
@@ -1,9 +1,44 @@
+#include "podio/SIOBlockUserData.h"
 
-#include "podio/UserDataSIOBlock.h"
+#define PODIO_ADD_USER_TYPE_SIO(type) static UserDataSIOBlock<type>    _default##type##CollcetionSIOBlock ;
 
+namespace podio{
 
-// static variable needed for registering in SIOBlock factory
-static UserDataSIOBlock<int>    _dummyIntCollcetionSIOBlock ;
-static UserDataSIOBlock<long>   _dummyLongCollcetionSIOBlock ;
-static UserDataSIOBlock<float>  _dummyFloatCollcetionSIOBlock ;
-static UserDataSIOBlock<double> _dummyDoubleCollcetionSIOBlock ;
+  static SIOBlockUserData<int> _defaultintCollcetionSIOBlock ;
+  static SIOBlockUserData<long> _defaultlongCollcetionSIOBlock ;
+  static SIOBlockUserData<float> _defaultfloatCollcetionSIOBlock ;
+  static SIOBlockUserData<double> _defaultdoubleCollcetionSIOBlock ;
+  static SIOBlockUserData<unsigned> _defaultunsignedCollcetionSIOBlock ;
+  static SIOBlockUserData<unsigned int> _defaultunsignedintCollcetionSIOBlock ;
+  static SIOBlockUserData<unsigned long> _defaultunsignedlongCollcetionSIOBlock ;
+  static SIOBlockUserData<char> _defaultcharCollcetionSIOBlock ;
+  static SIOBlockUserData<short> _defaultshortCollcetionSIOBlock ;
+  static SIOBlockUserData<long long> _defaultlonglongCollcetionSIOBlock ;
+  static SIOBlockUserData<unsigned long long> _defaultunsignedlonglongCollcetionSIOBlock ;
+  static SIOBlockUserData<int16_t> _defaultint16_tCollcetionSIOBlock ;
+  static SIOBlockUserData<int32_t> _defaultint32_tCollcetionSIOBlock ;
+  static SIOBlockUserData<int64_t> _defaultint64_tCollcetionSIOBlock ;
+  static SIOBlockUserData<uint16_t> _defaultuint16_tCollcetionSIOBlock ;
+  static SIOBlockUserData<uint32_t> _defaultuint32_tCollcetionSIOBlock ;
+  static SIOBlockUserData<uint64_t> _defaultuint64_tCollcetionSIOBlock ;
+
+}
+
+// g++ -E ../src/SIOBlockUserData.cc
+// PODIO_ADD_USER_TYPE_SIO(int)
+// PODIO_ADD_USER_TYPE_SIO(long)
+// PODIO_ADD_USER_TYPE_SIO(float)
+// PODIO_ADD_USER_TYPE_SIO(double)
+// PODIO_ADD_USER_TYPE_SIO(unsigned)
+// PODIO_ADD_USER_TYPE_SIO(unsigned int)
+// PODIO_ADD_USER_TYPE_SIO(unsigned long)
+// PODIO_ADD_USER_TYPE_SIO(char)
+// PODIO_ADD_USER_TYPE_SIO(short)
+// PODIO_ADD_USER_TYPE_SIO(long long)
+// PODIO_ADD_USER_TYPE_SIO(unsigned long long)
+// PODIO_ADD_USER_TYPE_SIO(int16_t)
+// PODIO_ADD_USER_TYPE_SIO(int32_t)
+// PODIO_ADD_USER_TYPE_SIO(int64_t)
+// PODIO_ADD_USER_TYPE_SIO(uint16_t)
+// PODIO_ADD_USER_TYPE_SIO(uint32_t)
+// PODIO_ADD_USER_TYPE_SIO(uint64_t)

--- a/src/SIOBlockUserData.cc
+++ b/src/SIOBlockUserData.cc
@@ -2,5 +2,8 @@
 #include "podio/UserDataSIOBlock.h"
 
 
-static UserDataSIOBlock<int> _dummyIntCollcetionSIOBlock ;
-static UserDataSIOBlock<float> _dummyFloatCollcetionSIOBlock ;
+// static variable needed for registering in SIOBlock factory
+static UserDataSIOBlock<int>    _dummyIntCollcetionSIOBlock ;
+static UserDataSIOBlock<long>   _dummyLongCollcetionSIOBlock ;
+static UserDataSIOBlock<float>  _dummyFloatCollcetionSIOBlock ;
+static UserDataSIOBlock<double> _dummyDoubleCollcetionSIOBlock ;

--- a/src/SIOBlockUserData.cc
+++ b/src/SIOBlockUserData.cc
@@ -1,0 +1,6 @@
+
+#include "podio/UserDataSIOBlock.h"
+
+
+static UserDataSIOBlock<int> _dummyIntCollcetionSIOBlock ;
+static UserDataSIOBlock<float> _dummyFloatCollcetionSIOBlock ;

--- a/src/SIOBlockUserData.cc
+++ b/src/SIOBlockUserData.cc
@@ -1,20 +1,20 @@
 #include "podio/SIOBlockUserData.h"
 
-#define PODIO_ADD_USER_TYPE_SIO(type) static UserDataSIOBlock<type>    _default##type##CollcetionSIOBlock ;
+//#define PODIO_ADD_USER_TYPE_SIO(type) static UserDataSIOBlock<type>    _default##type##CollcetionSIOBlock ;
 
 namespace podio{
 
-  static SIOBlockUserData<int> _defaultintCollcetionSIOBlock ;
+  //  static SIOBlockUserData<int> _defaultintCollcetionSIOBlock ;
   static SIOBlockUserData<long> _defaultlongCollcetionSIOBlock ;
   static SIOBlockUserData<float> _defaultfloatCollcetionSIOBlock ;
   static SIOBlockUserData<double> _defaultdoubleCollcetionSIOBlock ;
-  static SIOBlockUserData<unsigned> _defaultunsignedCollcetionSIOBlock ;
-  static SIOBlockUserData<unsigned int> _defaultunsignedintCollcetionSIOBlock ;
+  //  static SIOBlockUserData<unsigned> _defaultunsignedCollcetionSIOBlock ;
+  //  static SIOBlockUserData<unsigned int> _defaultunsignedintCollcetionSIOBlock ;
   static SIOBlockUserData<unsigned long> _defaultunsignedlongCollcetionSIOBlock ;
   static SIOBlockUserData<char> _defaultcharCollcetionSIOBlock ;
-  static SIOBlockUserData<short> _defaultshortCollcetionSIOBlock ;
-  static SIOBlockUserData<long long> _defaultlonglongCollcetionSIOBlock ;
-  static SIOBlockUserData<unsigned long long> _defaultunsignedlonglongCollcetionSIOBlock ;
+  // static SIOBlockUserData<short> _defaultshortCollcetionSIOBlock ;
+  // static SIOBlockUserData<long long> _defaultlonglongCollcetionSIOBlock ;
+  // static SIOBlockUserData<unsigned long long> _defaultunsignedlonglongCollcetionSIOBlock ;
   static SIOBlockUserData<int16_t> _defaultint16_tCollcetionSIOBlock ;
   static SIOBlockUserData<int32_t> _defaultint32_tCollcetionSIOBlock ;
   static SIOBlockUserData<int64_t> _defaultint64_tCollcetionSIOBlock ;

--- a/src/SIOBlockUserData.cc
+++ b/src/SIOBlockUserData.cc
@@ -4,23 +4,15 @@
 
 namespace podio{
 
-  //  static SIOBlockUserData<int> _defaultintCollcetionSIOBlock ;
-  static SIOBlockUserData<float> _defaultfloatCollcetionSIOBlock ;
-  static SIOBlockUserData<double> _defaultdoubleCollcetionSIOBlock ;
-  //  static SIOBlockUserData<unsigned> _defaultunsignedCollcetionSIOBlock ;
-  //  static SIOBlockUserData<unsigned int> _defaultunsignedintCollcetionSIOBlock ;
-#if defined(__APPLE__)
-  static SIOBlockUserData<long> _defaultlongCollcetionSIOBlock ;
-  static SIOBlockUserData<unsigned long> _defaultunsignedlongCollcetionSIOBlock ;
-#else
-  static SIOBlockUserData<long long> _defaultlonglongCollcetionSIOBlock ;
-  static SIOBlockUserData<unsigned long long> _defaultunsignedlonglongCollcetionSIOBlock ;
-#endif
-  static SIOBlockUserData<char> _defaultcharCollcetionSIOBlock ;
-  // static SIOBlockUserData<short> _defaultshortCollcetionSIOBlock ;
-  static SIOBlockUserData<int16_t> _defaultint16_tCollcetionSIOBlock ;
-  static SIOBlockUserData<int32_t> _defaultint32_tCollcetionSIOBlock ;
-  static SIOBlockUserData<int64_t> _defaultint64_tCollcetionSIOBlock ;
+  static SIOBlockUserData<float>   _defaultfloatCollcetionSIOBlock ;
+  static SIOBlockUserData<double>  _defaultdoubleCollcetionSIOBlock ;
+
+  static SIOBlockUserData<int8_t>   _defaultint8_tCollcetionSIOBlock ;
+  static SIOBlockUserData<int16_t>  _defaultint16_tCollcetionSIOBlock ;
+  static SIOBlockUserData<int32_t>  _defaultint32_tCollcetionSIOBlock ;
+  static SIOBlockUserData<int64_t>  _defaultint64_tCollcetionSIOBlock ;
+
+  static SIOBlockUserData<uint8_t>  _defaultuint8_tCollcetionSIOBlock ;
   static SIOBlockUserData<uint16_t> _defaultuint16_tCollcetionSIOBlock ;
   static SIOBlockUserData<uint32_t> _defaultuint32_tCollcetionSIOBlock ;
   static SIOBlockUserData<uint64_t> _defaultuint64_tCollcetionSIOBlock ;

--- a/src/SIOBlockUserData.cc
+++ b/src/SIOBlockUserData.cc
@@ -5,16 +5,19 @@
 namespace podio{
 
   //  static SIOBlockUserData<int> _defaultintCollcetionSIOBlock ;
-  static SIOBlockUserData<long> _defaultlongCollcetionSIOBlock ;
   static SIOBlockUserData<float> _defaultfloatCollcetionSIOBlock ;
   static SIOBlockUserData<double> _defaultdoubleCollcetionSIOBlock ;
   //  static SIOBlockUserData<unsigned> _defaultunsignedCollcetionSIOBlock ;
   //  static SIOBlockUserData<unsigned int> _defaultunsignedintCollcetionSIOBlock ;
+#if defined(__APPLE__)
+  static SIOBlockUserData<long> _defaultlongCollcetionSIOBlock ;
   static SIOBlockUserData<unsigned long> _defaultunsignedlongCollcetionSIOBlock ;
+#else
+  static SIOBlockUserData<long long> _defaultlonglongCollcetionSIOBlock ;
+  static SIOBlockUserData<unsigned long long> _defaultunsignedlonglongCollcetionSIOBlock ;
+#endif
   static SIOBlockUserData<char> _defaultcharCollcetionSIOBlock ;
   // static SIOBlockUserData<short> _defaultshortCollcetionSIOBlock ;
-  // static SIOBlockUserData<long long> _defaultlonglongCollcetionSIOBlock ;
-  // static SIOBlockUserData<unsigned long long> _defaultunsignedlonglongCollcetionSIOBlock ;
   static SIOBlockUserData<int16_t> _defaultint16_tCollcetionSIOBlock ;
   static SIOBlockUserData<int32_t> _defaultint32_tCollcetionSIOBlock ;
   static SIOBlockUserData<int64_t> _defaultint64_tCollcetionSIOBlock ;

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -17,9 +17,9 @@
     </class>
     <class name="podio::ObjectID"/>
     <class name="vector<podio::ObjectID>"/>
-    <class name="podio::User_intCollection"/>
-    <class name="podio::User_longCollection"/>
-    <class name="podio::User_floatCollection"/>
-    <class name="podio::User_doubleCollection"/>
+    <class name="podio::UserDataCollection<int>"/>
+    <class name="podio::UserDataCollection<long>"/>
+    <class name="podio::UserDataCollection<float>"/>
+    <class name="podio::UserDataCollection<double>"/>
     </selection>
 </lcgdict>

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -4,6 +4,8 @@
     <class name="podio::IntVec"/>
     <class name="podio::FloatVec"/>
     <class name="podio::StringVec"/>
+    <class name="podio::intCollection"/>
+    <class name="podio::floatCollection"/>
     <class name="podio::GenericParameters::MapType<int>"/>
     <class name="podio::GenericParameters::MapType<float>"/>
     <class name="podio::GenericParameters::MapType<std::string>"/>

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -21,5 +21,19 @@
     <class name="podio::UserDataCollection<long>"/>
     <class name="podio::UserDataCollection<float>"/>
     <class name="podio::UserDataCollection<double>"/>
-    </selection>
+    <class name="podio::UserDataCollection<unsigned>"/>
+    <class name="podio::UserDataCollection<unsigned int>"/>
+    <class name="podio::UserDataCollection<unsigned long>"/>
+    <class name="podio::UserDataCollection<char>"/>
+    <class name="podio::UserDataCollection<short>"/>
+    <class name="podio::UserDataCollection<long long>"/>
+    <class name="podio::UserDataCollection<unsigned long long>"/>
+    <class name="podio::UserDataCollection<int16_t>"/>
+    <class name="podio::UserDataCollection<int32_t>"/>
+    <class name="podio::UserDataCollection<int64_t>"/>
+    <class name="podio::UserDataCollection<uint16_t>"/>
+    <class name="podio::UserDataCollection<uint32_t>"/>
+    <class name="podio::UserDataCollection<uint64_t>"/>
+
+  </selection>
 </lcgdict>

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -17,20 +17,13 @@
     </class>
     <class name="podio::ObjectID"/>
     <class name="vector<podio::ObjectID>"/>
-    <class name="podio::UserDataCollection<int>"/>
-    <class name="podio::UserDataCollection<long>"/>
     <class name="podio::UserDataCollection<float>"/>
     <class name="podio::UserDataCollection<double>"/>
-    <class name="podio::UserDataCollection<unsigned>"/>
-    <class name="podio::UserDataCollection<unsigned int>"/>
-    <class name="podio::UserDataCollection<unsigned long>"/>
-    <class name="podio::UserDataCollection<char>"/>
-    <class name="podio::UserDataCollection<short>"/>
-    <class name="podio::UserDataCollection<long long>"/>
-    <class name="podio::UserDataCollection<unsigned long long>"/>
+    <class name="podio::UserDataCollection<int8_t>"/>
     <class name="podio::UserDataCollection<int16_t>"/>
     <class name="podio::UserDataCollection<int32_t>"/>
     <class name="podio::UserDataCollection<int64_t>"/>
+    <class name="podio::UserDataCollection<uint8_t>"/>
     <class name="podio::UserDataCollection<uint16_t>"/>
     <class name="podio::UserDataCollection<uint32_t>"/>
     <class name="podio::UserDataCollection<uint64_t>"/>

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -17,9 +17,9 @@
     </class>
     <class name="podio::ObjectID"/>
     <class name="vector<podio::ObjectID>"/>
-    <class name="podio::intCollection"/>
-    <class name="podio::longCollection"/>
-    <class name="podio::floatCollection"/>
-    <class name="podio::doubleCollection"/>
+    <class name="podio::User_intCollection"/>
+    <class name="podio::User_longCollection"/>
+    <class name="podio::User_floatCollection"/>
+    <class name="podio::User_doubleCollection"/>
     </selection>
 </lcgdict>

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -4,8 +4,6 @@
     <class name="podio::IntVec"/>
     <class name="podio::FloatVec"/>
     <class name="podio::StringVec"/>
-    <class name="podio::intCollection"/>
-    <class name="podio::floatCollection"/>
     <class name="podio::GenericParameters::MapType<int>"/>
     <class name="podio::GenericParameters::MapType<float>"/>
     <class name="podio::GenericParameters::MapType<std::string>"/>
@@ -19,5 +17,9 @@
     </class>
     <class name="podio::ObjectID"/>
     <class name="vector<podio::ObjectID>"/>
+    <class name="podio::intCollection"/>
+    <class name="podio::longCollection"/>
+    <class name="podio::floatCollection"/>
+    <class name="podio::doubleCollection"/>
     </selection>
 </lcgdict>

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -329,7 +329,7 @@ void processEvent(podio::EventStore& store, int eventNum) {
 
 
 
-  auto& usrInts = store.get<podio::UserDataCollection<int> >("userInts");
+  auto& usrInts = store.get<podio::UserDataCollection<uint64_t> >("userInts");
 
 #if 0 //access via vector
   auto& uivec = usrInts.vec() ;

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -18,6 +18,8 @@
 #include "podio/EventStore.h"
 #include "podio/IReader.h"
 
+#include "podio/UserDataCollection.h"
+
 // STL
 #include <limits>
 #include <vector>
@@ -61,6 +63,17 @@ void processEvent(podio::EventStore& store, int eventNum) {
       throw std::runtime_error("Trying to get non present collection \'notthere' should throw an exception");
     }
   }
+
+
+  auto& usrInts = store.get<podio::UserDataCollection<int> >("userInts");
+  auto& uivec = usrInts.vec() ;
+
+  int myInt = 0 ;
+  for( int iu : uivec ){
+    if( iu != myInt++ )
+      throw std::runtime_error("Couldn't read userInts properly"); ;
+  }
+
 
   auto& strings = store.get<ExampleWithStringCollection>("strings");
   if(strings.isValid()){

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -65,16 +65,6 @@ void processEvent(podio::EventStore& store, int eventNum) {
   }
 
 
-  auto& usrInts = store.get<podio::UserDataCollection<int> >("userInts");
-  auto& uivec = usrInts.vec() ;
-
-  int myInt = 0 ;
-  for( int iu : uivec ){
-    if( iu != myInt++ )
-      throw std::runtime_error("Couldn't read userInts properly"); ;
-  }
-
-
   auto& strings = store.get<ExampleWithStringCollection>("strings");
   if(strings.isValid()){
     auto string = strings[0];
@@ -336,6 +326,32 @@ void processEvent(podio::EventStore& store, int eventNum) {
   check_fixed_width_value(arbComps.fixedInteger64, std::int64_t{-1234567890123456789}, "int64");
   check_fixed_width_value(arbComps.fixedInteger32, std::int32_t{-1234567890}, "int32");
   check_fixed_width_value(arbComps.fixedUnsigned16, std::uint16_t{12345}, "uint16");
+
+
+
+  auto& usrInts = store.get<podio::UserDataCollection<int> >("userInts");
+
+#if 0 //access via vector
+  auto& uivec = usrInts.vec() ;
+  int myInt = 0 ;
+  for( int iu : uivec ){
+    if( iu != myInt++ )
+      throw std::runtime_error("Couldn't read userInts properly"); ;
+  }
+#else // access in direct range based for loop
+  int myInt = 0 ;
+  for( int iu : usrInts ){
+    if( iu != myInt++ )
+      throw std::runtime_error("Couldn't read userInts properly"); ;
+  }
+#endif
+
+  auto& usrDbl = store.get<podio::UserDataCollection<double> >("userDoubles");
+  for( double d : usrDbl ){
+    if( d != 42. )
+      throw std::runtime_error("Couldn't read userDoubles properly"); ;
+  }
+
 }
 
 void run_read_test(podio::IReader& reader) {

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -49,7 +49,7 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& arrays     = store.create<ExampleWithArrayCollection>("arrays");
   auto& fixedWidthInts = store.create<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
   //  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
-  auto& usrInts = store.create<podio::intCollection>("userInts");
+  auto& usrInts = store.create<podio::User_intCollection>("userInts");
   auto& usrDoubles = store.create<podio::UserDataCollection<double> >("userDoubles");
 
   writer.registerForWrite("info");

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -48,8 +48,7 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& strings    = store.create<ExampleWithStringCollection>("strings");
   auto& arrays     = store.create<ExampleWithArrayCollection>("arrays");
   auto& fixedWidthInts = store.create<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
-  //  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
-  auto& usrInts = store.create<podio::User_intCollection>("userInts");
+  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
   auto& usrDoubles = store.create<podio::UserDataCollection<double> >("userDoubles");
 
   writer.registerForWrite("info");

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -47,7 +47,7 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& strings    = store.create<ExampleWithStringCollection>("strings");
   auto& arrays     = store.create<ExampleWithArrayCollection>("arrays");
   auto& fixedWidthInts = store.create<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
-  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
+  auto& usrInts = store.create<podio::UserDataCollection<uint64_t> >("userInts");
   auto& usrDoubles = store.create<podio::UserDataCollection<double> >("userDoubles");
 
   writer.registerForWrite("info");
@@ -325,7 +325,7 @@ void write(podio::EventStore& store, WriterT& writer) {
     auto& uivec = usrInts ;
     uivec.resize( i + 1 ) ;
     int myInt = 0 ;
-    for( int& iu : uivec ){
+    for( auto& iu : uivec ){
       iu = myInt++  ;
     }
     // and some user double values

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -48,8 +48,9 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& strings    = store.create<ExampleWithStringCollection>("strings");
   auto& arrays     = store.create<ExampleWithArrayCollection>("arrays");
   auto& fixedWidthInts = store.create<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
-//  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
+  //  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
   auto& usrInts = store.create<podio::intCollection>("userInts");
+  auto& usrDoubles = store.create<podio::UserDataCollection<double> >("userDoubles");
 
   writer.registerForWrite("info");
   writer.registerForWrite("mcparticles");
@@ -69,19 +70,13 @@ void write(podio::EventStore& store, WriterT& writer) {
   writer.registerForWrite("arrays");
   writer.registerForWrite("fixedWidthInts");
   writer.registerForWrite("userInts");
+  writer.registerForWrite("userDoubles");
 
   unsigned nevents = 2000;
 
   for(unsigned i=0; i<nevents; ++i) {
     if(i % 1000 == 0) {
       std::cout << "processing event " << i << std::endl;
-    }
-
-    auto& uivec = usrInts.vec() ;
-    uivec.resize( i + 1 ) ;
-    int myInt = 0 ;
-    for( int& iu : uivec ){
-      iu = myInt++  ;
     }
 
     auto item1 = EventInfo();
@@ -326,6 +321,22 @@ void write(podio::EventStore& store, WriterT& writer) {
     arbComp.fixedUnsigned16 = 12345;
     arbComp.fixedInteger32 = -1234567890;
     arbComp.fixedInteger64 = -1234567890123456789ll;
+
+
+    // add some plain ints as user data
+    auto& uivec = usrInts ;
+    uivec.resize( i + 1 ) ;
+    int myInt = 0 ;
+    for( int& iu : uivec ){
+      iu = myInt++  ;
+    }
+    // and some user double values
+    unsigned nd = 100 ;
+    usrDoubles.resize( nd ) ;
+    for(unsigned id=0 ; id<nd ; ++id){
+      usrDoubles[id] = 42. ;
+    }
+
 
     writer.writeEvent();
     store.clearCollections();

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -17,7 +17,6 @@
 #include "datamodel/ExampleWithFixedWidthIntegersCollection.h"
 
 #include "podio/UserDataCollection.h"
-
 #include "podio/EventStore.h"
 
 // STL

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -48,7 +48,8 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& strings    = store.create<ExampleWithStringCollection>("strings");
   auto& arrays     = store.create<ExampleWithArrayCollection>("arrays");
   auto& fixedWidthInts = store.create<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
-  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
+//  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
+  auto& usrInts = store.create<podio::intCollection>("userInts");
 
   writer.registerForWrite("info");
   writer.registerForWrite("mcparticles");

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -16,6 +16,8 @@
 #include "datamodel/ExampleWithArrayCollection.h"
 #include "datamodel/ExampleWithFixedWidthIntegersCollection.h"
 
+#include "podio/UserDataCollection.h"
+
 #include "podio/EventStore.h"
 
 // STL
@@ -46,6 +48,7 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& strings    = store.create<ExampleWithStringCollection>("strings");
   auto& arrays     = store.create<ExampleWithArrayCollection>("arrays");
   auto& fixedWidthInts = store.create<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
+  auto& usrInts = store.create<podio::UserDataCollection<int> >("userInts");
 
   writer.registerForWrite("info");
   writer.registerForWrite("mcparticles");
@@ -64,12 +67,20 @@ void write(podio::EventStore& store, WriterT& writer) {
   writer.registerForWrite("strings");
   writer.registerForWrite("arrays");
   writer.registerForWrite("fixedWidthInts");
+  writer.registerForWrite("userInts");
 
   unsigned nevents = 2000;
 
   for(unsigned i=0; i<nevents; ++i) {
     if(i % 1000 == 0) {
       std::cout << "processing event " << i << std::endl;
+    }
+
+    auto& uivec = usrInts.vec() ;
+    uivec.resize( i + 1 ) ;
+    int myInt = 0 ;
+    for( int& iu : uivec ){
+      iu = myInt++  ;
     }
 
     auto item1 = EventInfo();


### PR DESCRIPTION
BEGINRELEASENOTES
- add possibility to store additional user data as collections of fundamental types in PODIO files
     -  uses `std::vector<basic_type>`
     - stored in simple branch in root (and simple block in SIO)
     - all fundamental types supported in PODIO (except bool) can be written
- example code:
```c++
  auto& usrInts = store.create<podio::UserDataCollection<uint64_t> >("userInts");
  auto& usrDoubles = store.create<podio::UserDataCollection<double> >("userDoubles");
  // ...

  // add some unsigned ints
  usrInts.resize( i + 1 ) ;
  int myInt = 0 ;
  for( auto& iu : usrInts ){
    iu = myInt++  ;
  }
  // and some user double values
  unsigned nd = 100 ;
  usrDoubles.resize( nd ) ;
  for(unsigned id=0 ; id<nd ; ++id){
    usrDoubles[id] = 42. ;
  }
```

- should replace https://github.com/key4hep/EDM4hep/pull/114 in a more efficient way

ENDRELEASENOTES

This should address most needs for storing user defined data in PODIO in an efficient way without any overhead.  In ROOT every user data collection is stored directly in a branch of the given type and can be accessed directly.
No relations to or from the user defined collections are foreseen. Users need to keep track if indices, e.g. by running collections parallel to existing PODIO (EDM4hep) collections.

This PR should work now as an example for possible treatment of additional user data. Open questions:

- [x] should the set of basic_types be restricted ?
- [x] if so, to which types ?
- [x] some code cleanup/improvement needed (see suggestions below)
- [x] ...
