### PR TITLE
Make the generation macro use the python found by CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,9 @@ IF((TARGET ROOT::PyROOT OR TARGET ROOT::ROOTTPython) AND ${ROOT_VERSION} VERSION
   ENDIF()
   message( STATUS "Python version used for building ROOT ${ROOT_PYTHON_VERSION}" )
   message( STATUS "Required python version ${REQUIRE_PYTHON_VERSION}")
-  FIND_PACKAGE(Python ${REQUIRE_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Development)
+  FIND_PACKAGE(Python ${REQUIRE_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Development Interpreter)
 ELSE()
-  FIND_PACKAGE(Python COMPONENTS Development)
+  FIND_PACKAGE(Python COMPONENTS Development Interpreter)
 ENDIF()
 
 # ROOT only sets usage requirements from 6.14, so for

--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -25,6 +25,11 @@ set(PODIO_IO_HANDLERS "@PODIO_IO_HANDLERS@")
 
 include(CMakeFindDependencyMacro)
 find_dependency(ROOT @ROOT_VERSION@)
+if(@REQUIRE_PYTHON_VERSION)
+  find_dependency(Python @REQUIRE_PYTHON_VERSION@ COMPONENTS Interpreter)
+else()
+  find_dependency(Python COMPONENTS Interpreter)
+endif()
 
 if(@ENABLE_SIO@)
   find_dependency(SIO)

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -150,7 +150,7 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
   message(STATUS "Creating '${datamodel}' datamodel")
   # we need to boostrap the data model, so this has to be executed in the cmake run
   execute_process(
-    COMMAND python ${podio_PYTHON_DIR}/podio_class_generator.py ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
+    COMMAND ${Python_EXECUTABLE} ${podio_PYTHON_DIR}/podio_class_generator.py ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE podio_generate_command_retval
     )


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the CMake datamodel generation macro use the python interpreter that is also found by CMake to avoid accidentally picking up an unsuitable system provided version that might be on `PATH`.

ENDRELEASENOTES