### PR TITLE
[WIP] Add a generic variant based type that can be used for interface-like functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ spack*
 # Tooling
 /.clangd/
 /compile_commands.json
+
+# Generated files
+*podio_generated_files.cmake

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -147,12 +147,17 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     ${podio_PYTHON_DIR}/podio_config_reader.py
   )
 
+  message(STATUS "Creating '${datamodel}' datamodel")
   # we need to boostrap the data model, so this has to be executed in the cmake run
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E echo "Creating \"${datamodel}\" data model"
     COMMAND python ${podio_PYTHON_DIR}/podio_class_generator.py ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE podio_generate_command_retval
     )
+
+  IF(NOT ${podio_generate_command_retval} EQUAL 0)
+    message(FATAL_ERROR "Could not generate datamodel '${datamodel}'. Check your definition in '${YAML_FILE}'")
+  ENDIF()
 
   # Get the generated headers and source files
   include(${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake)

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -142,6 +142,9 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
     ${YAML_FILE}
     ${PODIO_TEMPLATES}
+    ${podio_PYTHON_DIR}/podio_class_generator.py
+    ${podio_PYTHON_DIR}/generator_utils.py
+    ${podio_PYTHON_DIR}/podio_config_reader.py
   )
 
   # we need to boostrap the data model, so this has to be executed in the cmake run

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -134,6 +134,7 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     # At least build the ROOT selection.xml by default for now
     SET(ARG_IO_BACKEND_HANDLERS "ROOT")
   ENDIF()
+
   # we need to boostrap the data model, so this has to be executed in the cmake run
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E echo "Creating \"${datamodel}\" data model"
@@ -141,19 +142,18 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
-  file(GLOB headers ${ARG_OUTPUT_FOLDER}/${datamodel}/*.h)
-  file(GLOB sources ${ARG_OUTPUT_FOLDER}/src/*.cc)
-
-  set (${RETURN_HEADERS} ${headers} PARENT_SCOPE)
-  set (${RETURN_SOURCES} ${sources} PARENT_SCOPE)
-
   add_custom_target(create_${datamodel}
     COMMENT "Re-Creating \"${datamodel}\" data model"
     DEPENDS ${YAML_FILE}
-    BYPRODUCTS ${sources} ${headers}
+    BYPRODUCTS ${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake
     COMMAND python ${podio_PYTHON_DIR}/podio_class_generator.py --quiet ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
+
+  include(${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake)
+
+  set (${RETURN_HEADERS} ${headers} PARENT_SCOPE)
+  set (${RETURN_SOURCES} ${sources} PARENT_SCOPE)
 
 endfunction()
 

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -135,6 +135,15 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     SET(ARG_IO_BACKEND_HANDLERS "ROOT")
   ENDIF()
 
+  # Make sure that we re run the generation process everytime either the
+  # templates or the yaml file changes.
+  include(${podio_PYTHON_DIR}/templates/CMakeLists.txt)
+  set_property(
+    DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+    ${YAML_FILE}
+    ${PODIO_TEMPLATES}
+  )
+
   # we need to boostrap the data model, so this has to be executed in the cmake run
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E echo "Creating \"${datamodel}\" data model"
@@ -142,14 +151,7 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
-  add_custom_target(create_${datamodel}
-    COMMENT "Re-Creating \"${datamodel}\" data model"
-    DEPENDS ${YAML_FILE}
-    BYPRODUCTS ${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake
-    COMMAND python ${podio_PYTHON_DIR}/podio_class_generator.py --quiet ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
+  # Get the generated headers and source files
   include(${ARG_OUTPUT_FOLDER}/podio_generated_files.cmake)
 
   set (${RETURN_HEADERS} ${headers} PARENT_SCOPE)

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -4,10 +4,9 @@
 #include "podio/ObjectID.h"
 #include "podio/CollectionBuffers.h"
 
-#include <string>
 #include <utility>
 #include <vector>
-
+#include <string_view>
 
 
 namespace podio {
@@ -41,7 +40,7 @@ namespace podio {
     virtual size_t size() const = 0;
 
     /// fully qualified type name of elements - with namespace
-    virtual std::string getValueTypeName() const = 0;
+    virtual std::string_view getValueTypeName() const = 0;
 
     /// destructor
     virtual ~CollectionBase() = default;

--- a/include/podio/GenericWrapper.h
+++ b/include/podio/GenericWrapper.h
@@ -26,10 +26,10 @@ using remove_cvref_t = typename remove_cvref<T>::type;
 
 // Helper bool to check if the first type is any of the passed other types after
 // stripping all const, volatile and references from the first type
-// I.e. the following will compile:
-// static_assert(isAnyOf<const int&, int>);
 template<typename T, typename ...Ts>
 constexpr bool isAnyOf = (std::is_same_v<remove_cvref_t<T>, Ts> || ...);
+// I.e. the following works
+static_assert(isAnyOf<const int&, int>);
 
 // Helper struct to select functions/overloads depending on whether the first
 // type is actually one of the other passed types (after removing any const and

--- a/include/podio/GenericWrapper.h
+++ b/include/podio/GenericWrapper.h
@@ -113,7 +113,7 @@ class GenericWrapper {
   template<typename T>
   using EnableForObjPtrTypes = detail::EnableIfAnyOf<T,
                                                      detail::GetObjPtrT<WrappedTypes>...>;
- 
+
 
 public:
   /// Public helper type for enabling one "default" constructor in the using

--- a/include/podio/GenericWrapper.h
+++ b/include/podio/GenericWrapper.h
@@ -119,6 +119,9 @@ public:
     return std::visit([](auto&& obj) { return obj->id; }, m_obj);
   }
 
+protected:
+  VariantT m_obj;
+
 private:
   void acquireObj() {
     std::visit([](auto&& obj) { obj->acquire(); }, m_obj);
@@ -128,8 +131,6 @@ private:
       if(obj) obj->release();
     }, m_obj);
   }
-
-  VariantT m_obj;
 };
 
 

--- a/include/podio/GenericWrapper.h
+++ b/include/podio/GenericWrapper.h
@@ -1,0 +1,138 @@
+#ifndef PODIO_GENERICWRAPPER_H
+#define PODIO_GENERICWRAPPER_H
+
+#include "podio/ObjectID.h"
+
+#include <type_traits>
+#include <variant>
+#include <iostream>
+
+namespace podio {
+namespace detail {
+
+#if __cplusplus > 201704L
+// Only available in c++20
+using std::remove_cvref_t;
+#else
+// Simple enough to roll our own quickly
+template<class T>
+struct remove_cvref {
+  using type = std::remove_cv_t<std::remove_reference_t<T>>;
+};
+
+template<class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+#endif
+
+// Helper bool to check if the first type is any of the passed other types after
+// stripping all const, volatile and references from the first type
+// I.e. the following will compile:
+// static_assert(isAnyOf<const int&, int>);
+template<typename T, typename ...Ts>
+constexpr bool isAnyOf = (std::is_same_v<remove_cvref_t<T>, Ts> || ...);
+
+// Helper struct to select functions/overloads depending on whether the first
+// type is actually one of the other passed types (after removing any const and
+// volatile qualifiers). See also isAnyOf
+template<typename T, typename ...Ts>
+struct EnableIfAnyOf : std::enable_if<isAnyOf<T, Ts...>, bool> {};
+
+// Helper struct to determine whether a type as an ObjPtrT subtype
+// Mainly used for slightly nicer error messages
+template<typename T, typename=std::void_t<>>
+struct HasObjPtr : std::false_type {};
+
+template<typename T>
+struct HasObjPtr<T, std::void_t<typename T::ObjPtrT>> : std::true_type {};
+
+template<typename T>
+constexpr bool hasObjPtr = HasObjPtr<T>::value;
+
+template<typename ...Ts>
+constexpr bool allHaveObjPtrT = (hasObjPtr<Ts> && ...);
+
+// Helper type for getting the type of the Obj pointer that is stored in the
+// class.
+// NOTE: Not SFINAE friendly by design!
+template<typename T>
+struct GetObjPtr {
+  using type = typename T::ObjPtrT;
+};
+
+template<typename T>
+using GetObjPtrT = typename GetObjPtr<T>::type;
+
+} // namespace detail
+
+
+/**
+ * GenericWrapper class that can wrap any number of DataTypes as long as they
+ * have a public ObjPtrT typedef/subtype. The wrapper internally stores the Obj*
+ * of the passed value type into a std::variant of all the passed types. It also
+ * defines the some commonly used functions that all data types provide. The
+ * intended use case is to inherit form this GenericWrapper and then implement
+ * necessary additional functionality in the inheriting class that can then be
+ * used just as any other podio generated class.
+ */
+template<typename ...WrappedTypes>
+class GenericWrapper {
+  static_assert(detail::allHaveObjPtrT<WrappedTypes...>, "All WrappedTypes must have a public ObjPtrT subtype");
+  using VariantT = typename std::variant<detail::GetObjPtrT<WrappedTypes>...>;
+
+public:
+  template<typename T,
+           typename detail::EnableIfAnyOf<T, WrappedTypes...>::type = false>
+  GenericWrapper(T value) : m_obj(value.m_obj) {
+    value.m_obj->acquire(); // TODO: go through std::visit as well here?
+  }
+
+  template<typename ObjT,
+           typename detail::EnableIfAnyOf<ObjT, detail::GetObjPtrT<WrappedTypes>...>::type = false>
+  GenericWrapper(ObjT* obj) : m_obj(obj) {
+    obj->acquire(); // TODO: go through std::visit as well here?
+  }
+
+  ~GenericWrapper() {
+    releaseObj();
+  }
+
+  // No default constructor as the "empty" wrapper is really not something that
+  // makes sense in this case
+  GenericWrapper() = delete;
+
+  GenericWrapper(GenericWrapper const& other) : m_obj(other.m_obj) {
+    acquireObj();
+  }
+
+  GenericWrapper& operator=(GenericWrapper const& other) {
+    releaseObj();
+    m_obj = other.m_obj;
+    acquireObj();
+    return *this;
+  }
+
+  void unlink() {
+    std::visit([](auto&& obj) { obj = nullptr; }, m_obj);
+  }
+
+  const podio::ObjectID getObjectID() const {
+    return std::visit([](auto&& obj) { return obj->id; }, m_obj);
+  }
+
+private:
+  void acquireObj() {
+    std::visit([](auto&& obj) { obj->acquire(); }, m_obj);
+  }
+  void releaseObj() {
+    std::visit([](auto&& obj) {
+      if(obj) obj->release();
+    }, m_obj);
+  }
+
+  VariantT m_obj;
+};
+
+
+}
+
+#endif

--- a/include/podio/GenericWrapper.h
+++ b/include/podio/GenericWrapper.h
@@ -104,15 +104,15 @@ class GenericWrapper {
   /// Private helper type for enabling functions that should work with "Const"
   /// and the default classes
   template<typename T>
-  using EnableForValueTypes =  detail::EnableIfAnyOf<T,
-                                                     WrappedTypes...,
-                                                     detail::GetConstT<WrappedTypes>...>;
+  using EnableIfValueType =  detail::EnableIfAnyOf<T,
+                                                   WrappedTypes...,
+                                                   detail::GetConstT<WrappedTypes>...>;
 
   /// Private helper type for enabling functions that whould work for ObjPtrT
   /// template arguments
   template<typename T>
-  using EnableForObjPtrTypes = detail::EnableIfAnyOf<T,
-                                                     detail::GetObjPtrT<WrappedTypes>...>;
+  using EnableIfObjPtrType = detail::EnableIfAnyOf<T,
+                                                   detail::GetObjPtrT<WrappedTypes>...>;
 
 
 public:
@@ -126,13 +126,13 @@ public:
                                               >;
 
   template<typename T,
-           typename = EnableForValueTypes<T>>
+           typename = EnableIfValueType<T>>
   GenericWrapper(T value) : m_obj(value.m_obj) {
     value.m_obj->acquire(); // TODO: go through std::visit as well here?
   }
 
   template<typename ObjT,
-           typename = EnableForObjPtrTypes<ObjT>>
+           typename = EnableIfObjPtrType<ObjT>>
   GenericWrapper(ObjT* obj) : m_obj(obj) {
     obj->acquire(); // TODO: go through std::visit as well here?
   }
@@ -176,7 +176,7 @@ public:
   }
 
   template<typename U,
-           typename = EnableForValueTypes<U>>
+           typename = EnableIfValueType<U>>
   bool isCurrentType() const {
     return std::holds_alternative<detail::GetObjPtrT<U>>(m_obj);
   }

--- a/include/podio/ObjBase.h
+++ b/include/podio/ObjBase.h
@@ -36,7 +36,7 @@ namespace podio {
     /// ID of the object
     podio::ObjectID id;
 
-  private:
+  public:
     /// reference counter
     std::atomic<unsigned> ref_counter;
 

--- a/include/podio/ObjBase.h
+++ b/include/podio/ObjBase.h
@@ -36,7 +36,7 @@ namespace podio {
     /// ID of the object
     podio::ObjectID id;
 
-  public:
+  private:
     /// reference counter
     std::atomic<unsigned> ref_counter;
 

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -95,6 +95,7 @@ class MemberVariable(object):
     self.is_builtin = False
     self.is_builtin_array = False
     self.is_array = False
+    self.interface_types = []
     # ensure that this will break somewhere if requested but not set
     self.namespace, self.bare_type = None, None
     self.array_namespace, self.array_bare_type = None, None

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -250,6 +250,8 @@ class ClassGenerator(object):
     datatype['forward_declarations_obj'] = fwd_declarations
     datatype['includes_obj'] = self._sort_includes(includes)
     datatype['includes_cc_obj'] = self._sort_includes(includes_cc)
+    needs_destructor = datatype['VectorMembers'] or datatype['OneToManyRelations'] or datatype['OneToOneRelations']
+    datatype['obj_needs_destructor'] = needs_destructor
 
   def _preprocess_for_class(self, datatype):
     """Do the preprocessing that is necessary for the classes and Const classes"""

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -84,6 +84,7 @@ class ClassGenerator(object):
     self.expose_pod_members = self.reader.options["exposePODMembers"]
 
     self.clang_format = []
+    self.generated_files = []
 
   def process(self):
     for name, component in self.reader.components.items():
@@ -95,6 +96,8 @@ class ClassGenerator(object):
     if 'ROOT' in self.io_handlers:
       self._create_selection_xml()
     self.print_report()
+
+    self._write_cmake_lists_file()
 
   def print_report(self):
     if not self.verbose:
@@ -126,6 +129,7 @@ class ClassGenerator(object):
     else:
       fullname = os.path.join(self.install_dir, "src", name)
     if not self.dryrun:
+      self.generated_files.append(fullname)
       if self.clang_format:
         cfproc = subprocess.Popen(self.clang_format, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         content = cfproc.communicate(input=content.encode())[0].decode()
@@ -376,6 +380,36 @@ class ClassGenerator(object):
         includes.add(self._build_include(member.bare_type))
 
     return self._sort_includes(includes)
+
+  def _write_cmake_lists_file(self):
+    """Write the names of all generated header and src files into cmake lists"""
+    header_files = (f for f in self.generated_files if f.endswith('.h'))
+    src_files = (f for f in self.generated_files if f.endswith('.cc'))
+    xml_files = (f for f in self.generated_files if f.endswith('.xml'))
+
+    def _write_list(list_file, name, target_folder, files, comment):
+      """Write all files into a cmake variable using the target_folder as path to the
+      file"""
+      list_file.write(f'# {comment}\n')
+      list_file.write(f'SET({name}\n')
+      for full_file in files:
+        fname = os.path.basename(full_file)
+        list_file.write(f'  {os.path.join(target_folder, fname)}\n')
+
+      list_file.write(')\n')
+
+    with open(f'{self.install_dir}/podio_generated_files.cmake', 'w') as list_file:
+      list_file.write('# AUTOMATICALLY GENERATED FILE - DO NOT EDIT\n\n')
+
+      _write_list(list_file, 'headers', r'${ARG_OUTPUT_FOLDER}/${datamodel}',
+                  header_files, 'Generated header files')
+
+      _write_list(list_file, 'sources', r'${ARG_OUTPUT_FOLDER}/src',
+                  src_files, 'Generated source files')
+
+      _write_list(list_file, 'selection_xml', r'${ARG_OUTPUT_FOLDER}/src',
+                  xml_files, 'Generated xml files')
+
 
   @staticmethod
   def _is_pod_type(members):

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -398,9 +398,6 @@ class ClassGenerator(object):
         self._build_include(typ.bare_type) for typ in interface['Types']
         ]
 
-    import pprint
-    pprint.pprint(interface)
-
     return interface
 
   def _get_member_includes(self, members):

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -470,14 +470,14 @@ class PodioConfigReader(object):
 
   def _read_interface(self, value):
     """Read the interface and put it into an easily digestible format"""
-    interface = value
+    interface = {}
     for category, definition in value.items():
       if category == 'Members':
         members = []
         for member in definition:
           members.append(self.member_parser.parse(member, False))
         interface['Members'] = members
-      if category == 'Types':
+      elif category == 'Types':
         types = []
         for typ in definition:
           types.append(DataType(typ))

--- a/python/templates/CMakeLists.txt
+++ b/python/templates/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(PODIO_TEMPLATES
+  ${CMAKE_CURRENT_LIST_DIR}/Collection.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Collection.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/CollectionData.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/CollectionData.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Component.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/ConstObject.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/ConstObject.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Data.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Obj.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Object.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Object.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Obj.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/selection.xml.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/SIOBlock.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/SIOBlock.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/collections.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/declarations.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/implementations.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/iterator.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/sioblocks.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/utils.jinja2
+)

--- a/python/templates/CMakeLists.txt
+++ b/python/templates/CMakeLists.txt
@@ -14,10 +14,15 @@ set(PODIO_TEMPLATES
   ${CMAKE_CURRENT_LIST_DIR}/selection.xml.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/SIOBlock.cc.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/SIOBlock.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Wrapped.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Wrapped.cc.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/ConstWrapped.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/ConstWrapped.cc.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/macros/collections.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/macros/declarations.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/macros/implementations.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/macros/iterator.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/macros/sioblocks.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/macros/utils.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/wrappers.jinja2
 )

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -62,7 +62,7 @@ public:
   size_t size() const override final;
 
   /// fully qualified type name of elements - with namespace
-  std::string getValueTypeName() const override { return std::string("{{ (class | string ).strip(':') }}"); }
+  std::string_view getValueTypeName() const override { return m_valueTypeName; }
 
   bool isSubsetCollection() const final {
     return m_isSubsetColl;
@@ -130,6 +130,8 @@ private:
   // private entries. Otherwise we would need to expose a public member function
   // that gives access to the Obj* which is definitely not what we want
   friend class {{ class.bare_type }}CollectionData;
+
+  static constexpr std::string_view m_valueTypeName = "{{ (class | string).strip(':') }}";
 
   bool m_isValid{false};
   bool m_isReadFromFile{false};

--- a/python/templates/ConstObject.h.jinja2
+++ b/python/templates/ConstObject.h.jinja2
@@ -11,6 +11,7 @@
 {{ include }}
 {% endfor %}
 #include "podio/ObjectID.h"
+#include "podio/GenericWrapper.h"
 
 {{ utils.forward_decls(forward_declarations) }}
 
@@ -21,6 +22,10 @@ class Const{{ class.bare_type }} {
   friend class {{ class.bare_type }};
   friend class {{ class.bare_type }}Collection;
   friend class {{ class.bare_type }}ConstCollectionIterator;
+
+  // Allow the wrapper to access the private Obj*
+  template<bool, typename...>
+  friend class podio::GenericWrapper;
 
 public:
   using ObjPtrT = {{ class.bare_type }}Obj*;
@@ -35,7 +40,7 @@ public:
 {{ utils.if_present(ConstExtraCode, "declaration") }}
 {{ macros.common_object_funcs(class.bare_type, prefix='Const') }}
 
-public: // TODO: make private again
+private:
   {{ class.bare_type }}Obj* m_obj;
 };
 

--- a/python/templates/ConstObject.h.jinja2
+++ b/python/templates/ConstObject.h.jinja2
@@ -18,13 +18,13 @@
 
 {{ macros.class_description(class.bare_type, Description, Author, prefix='Const') }}
 class Const{{ class.bare_type }} {
-  using ObjPtrT = {{ class.bare_type }}Obj*;
-
   friend class {{ class.bare_type }};
   friend class {{ class.bare_type }}Collection;
   friend class {{ class.bare_type }}ConstCollectionIterator;
 
 public:
+  using ObjPtrT = {{ class.bare_type }}Obj*;
+
 {{ macros.constructors_destructors(class.bare_type, Members, prefix='Const') }}
 
 public:

--- a/python/templates/ConstObject.h.jinja2
+++ b/python/templates/ConstObject.h.jinja2
@@ -18,6 +18,7 @@
 
 {{ macros.class_description(class.bare_type, Description, Author, prefix='Const') }}
 class Const{{ class.bare_type }} {
+  using ObjPtrT = {{ class.bare_type }}Obj*;
 
   friend class {{ class.bare_type }};
   friend class {{ class.bare_type }}Collection;
@@ -34,7 +35,7 @@ public:
 {{ utils.if_present(ConstExtraCode, "declaration") }}
 {{ macros.common_object_funcs(class.bare_type, prefix='Const') }}
 
-private:
+public: // TODO: make private again
   {{ class.bare_type }}Obj* m_obj;
 };
 

--- a/python/templates/ConstWrapped.cc.jinja2
+++ b/python/templates/ConstWrapped.cc.jinja2
@@ -1,0 +1,17 @@
+{% import "macros/utils.jinja2" as utils %}
+{% import "macros/wrappers.jinja2" as macros %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#include "{{ incfolder }}{{ class.bare_type }}Const.h"
+
+{{ utils.namespace_open(class.namespace) }}
+
+{{ macros.member_getters(class, Members, use_get_syntax, prefix='Const') }}
+
+std::ostream& operator<<(std::ostream& os, const Const{{ class.bare_type }}& value) {
+  return std::visit([&os](auto&& obj) -> std::ostream& {
+    return os << obj;
+  }, value.m_obj);
+}
+
+{{ utils.namespace_close(class.namespace) }}

--- a/python/templates/ConstWrapped.h.jinja2
+++ b/python/templates/ConstWrapped.h.jinja2
@@ -18,9 +18,10 @@
 {{ macros.class_description(class.bare_type, Description, Author, prefix='Const' )}}
 
 {% with class_type = 'Const' + class.bare_type %}
-class {{ class_type }} : public podio::GenericWrapper<{{ Types | join(', ') }}> {
+class {{ class_type }} : public podio::GenericWrapper<false, {{ Types | join(', ') }}> {
 private:
-  using WrapperT = podio::GenericWrapper<{{ Types | join(', ')}}>;
+  // The underlying wrapper is immutable
+  using WrapperT = podio::GenericWrapper<false, {{ Types | join(', ')}}>;
 public:
   /// A {{ class.bare_type }} can only be constructed from a concrete value
   {{ class_type }}() = delete;

--- a/python/templates/ConstWrapped.h.jinja2
+++ b/python/templates/ConstWrapped.h.jinja2
@@ -1,0 +1,46 @@
+{% import "macros/utils.jinja2" as utils %}
+{% import "macros/declarations.jinja2" as macros %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+{% for include in include_types %}
+{{ include }}
+{% endfor %}
+
+#include "podio/GenericWrapper.h"
+
+#include <ostream>
+
+#ifndef {{ package_name.upper() }}_Const{{ class.bare_type }}_H
+#define {{ package_name.upper() }}_Const{{ class.bare_type }}_H
+
+{{ utils.namespace_open(class.namespace) }}
+
+{{ macros.class_description(class.bare_type, Description, Author, prefix='Const' )}}
+
+{% with class_type = 'Const' + class.bare_type %}
+class {{ class_type }} : public podio::GenericWrapper<{{ Types | join(', ') }}> {
+private:
+  using WrapperT = podio::GenericWrapper<{{ Types | join(', ')}}>;
+public:
+  /// A {{ class.bare_type }} can only be constructed from a concrete value
+  {{ class_type }}() = delete;
+
+  /// The default constructor takes anything that can be converted into this type
+  template<typename T,
+           WrapperT::EnableWrapper<T> = false>
+  {{ class_type }}(T&& val) : WrapperT(std::forward<T>(val)) {}
+
+  /// Constructor from another {{ class.bare_type }}
+  {{ class_type }}({{ class_type }} const& other) : WrapperT(other.m_obj) {}
+
+  /// The class can also get initialized from another wrapper of the same type
+  {{ class_type }}(WrapperT const& other) : WrapperT(other) {}
+
+{{ macros.member_getters(Members, use_get_syntax) }}
+friend std::ostream& operator<<(std::ostream& os, const {{ class_type }}& value);
+};
+
+{% endwith %}
+
+{{ utils.namespace_close(class.namespace )}}
+#endif

--- a/python/templates/ConstWrapped.h.jinja2
+++ b/python/templates/ConstWrapped.h.jinja2
@@ -43,5 +43,5 @@ friend std::ostream& operator<<(std::ostream& os, const {{ class_type }}& value)
 
 {% endwith %}
 
-{{ utils.namespace_close(class.namespace )}}
+{{ utils.namespace_close(class.namespace) }}
 #endif

--- a/python/templates/ConstWrapped.h.jinja2
+++ b/python/templates/ConstWrapped.h.jinja2
@@ -27,7 +27,7 @@ public:
 
   /// The default constructor takes anything that can be converted into this type
   template<typename T,
-           WrapperT::EnableWrapper<T> = false>
+           typename = WrapperT::EnableWrapper<T>>
   {{ class_type }}(T&& val) : WrapperT(std::forward<T>(val)) {}
 
   /// Constructor from another {{ class.bare_type }}

--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -43,6 +43,7 @@
 {% endfor %}
 }
 
+{% if obj_needs_destructor -%}
 {{ obj_type }}::~{{ obj_type }}() {
 {% with multi_relations = OneToManyRelations + VectorMembers %}
 {%- if multi_relations %}
@@ -58,5 +59,7 @@
   if (m_{{ relation.name }}) delete m_{{ relation.name }};
 {% endfor %}
 }
+{%- endif %}
+
 {% endwith %}
 {{ utils.namespace_close(class.namespace) }}

--- a/python/templates/Obj.h.jinja2
+++ b/python/templates/Obj.h.jinja2
@@ -33,7 +33,11 @@ public:
   {{ obj_type }}(const podio::ObjectID id, {{ class.bare_type }}Data data);
   /// No assignment operator
   {{ obj_type }}& operator=(const {{ obj_type }}&) = delete;
+{% if obj_needs_destructor %}
   virtual ~{{ obj_type }}();
+{% else %}
+  virtual ~{{ obj_type }}() = default;
+{% endif %}
 
 public:
   {{ class.bare_type }}Data data;

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -12,6 +12,7 @@
 {{ include }}
 {% endfor %}
 #include "podio/ObjectID.h"
+#include "podio/GenericWrapper.h"
 #include <ostream>
 
 {{ utils.forward_decls(forward_declarations) }}
@@ -24,6 +25,10 @@ class {{ class.bare_type }} {
   friend class {{ class.bare_type }}Collection;
   friend class {{ class.bare_type }}CollectionIterator;
   friend class Const{{ class.bare_type }};
+
+  // Allow the wrapper to access the private Obj*
+  template<bool, typename...>
+  friend class podio::GenericWrapper;
 
 public:
   using ObjPtrT = {{ class.bare_type }}Obj*;
@@ -44,7 +49,7 @@ public:
 {{ utils.if_present(ConstExtraCode, "declaration") }}
 {{ macros.common_object_funcs(class.bare_type) }}
 
-public: // TODO: make private again
+private:
   {{ class.bare_type }}Obj* m_obj;
 };
 

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -26,6 +26,7 @@ class {{ class.bare_type }} {
   friend class Const{{ class.bare_type }};
 
 public:
+  using ObjPtrT = {{ class.bare_type }}Obj*;
 
 {{ macros.constructors_destructors(class.bare_type, Members) }}
   /// conversion to const object
@@ -42,7 +43,7 @@ public:
 {{ utils.if_present(ConstExtraCode, "declaration") }}
 {{ macros.common_object_funcs(class.bare_type) }}
 
-private:
+public: // TODO: make private again
   {{ class.bare_type }}Obj* m_obj;
 };
 

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -27,6 +27,7 @@ class {{ class.bare_type }} {
 
 public:
   using ObjPtrT = {{ class.bare_type }}Obj*;
+  using ConstT = Const{{ class.bare_type }};
 
 {{ macros.constructors_destructors(class.bare_type, Members) }}
   /// conversion to const object

--- a/python/templates/Wrapped.cc.jinja2
+++ b/python/templates/Wrapped.cc.jinja2
@@ -7,5 +7,6 @@
 {{ utils.namespace_open(class.namespace) }}
 
 {{ macros.member_getters(class, Members, use_get_syntax) }}
+{{ macros.member_setters(class, Members, use_get_syntax) }}
 
 {{ utils.namespace_close(class.namespace) }}

--- a/python/templates/Wrapped.cc.jinja2
+++ b/python/templates/Wrapped.cc.jinja2
@@ -1,0 +1,11 @@
+{% import "macros/utils.jinja2" as utils %}
+{% import "macros/wrappers.jinja2" as macros %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#include "{{ incfolder }}{{ class.bare_type }}.h"
+
+{{ utils.namespace_open(class.namespace) }}
+
+{{ macros.member_getters(class, Members, use_get_syntax) }}
+
+{{ utils.namespace_close(class.namespace) }}

--- a/python/templates/Wrapped.h.jinja2
+++ b/python/templates/Wrapped.h.jinja2
@@ -26,7 +26,7 @@ public:
 
   /// The default constructor takes anything that can be converted into this type
   template<typename T,
-           WrapperT::EnableWrapper<T> = false>
+           typename = WrapperT::EnableWrapper<T>>
   {{ class.bare_type }}(T&& val) : WrapperT(std::forward<T>(val)) {}
 
   /// Constructor from another {{ class.bare_type }}

--- a/python/templates/Wrapped.h.jinja2
+++ b/python/templates/Wrapped.h.jinja2
@@ -15,8 +15,6 @@
 {{ utils.namespace_open(class.namespace) }}
 
 {{ macros.class_description(class.bare_type, Description, Author )}}
-
-{{ utils.namespace_close(class.namespace )}}
 class {{ class.bare_type }} : public podio::GenericWrapper<true, {{ Types | join(', ') }}> {
 private:
   // The underlying Wrapper type is Mutable
@@ -39,5 +37,7 @@ public:
 {{ macros.member_getters(Members, use_get_syntax) }}
 {{ macros.member_setters(Members, use_get_syntax) }}
 };
+
+{{ utils.namespace_close(class.namespace )}}
 
 #endif

--- a/python/templates/Wrapped.h.jinja2
+++ b/python/templates/Wrapped.h.jinja2
@@ -1,0 +1,42 @@
+{% import "macros/utils.jinja2" as utils %}
+{% import "macros/declarations.jinja2" as macros %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#include "{{ incfolder }}{{ class.bare_type }}Const.h"
+{% for include in include_types %}
+{{ include }}
+{% endfor %}
+
+#include "podio/GenericWrapper.h"
+
+#ifndef {{ package_name.upper() }}_{{ class.bare_type }}_H
+#define {{ package_name.upper() }}_{{ class.bare_type }}_H
+
+{{ utils.namespace_open(class.namespace) }}
+
+{{ macros.class_description(class.bare_type, Description, Author )}}
+
+{{ utils.namespace_close(class.namespace )}}
+class {{ class.bare_type }} : public podio::GenericWrapper<{{ Types | join(', ') }}> {
+private:
+  using WrapperT = podio::GenericWrapper<{{ Types | join(', ')}}>;
+public:
+  /// A {{ class.bare_type }} can only be constructed from a concrete value
+  {{ class.bare_type }}() = delete;
+
+  /// The default constructor takes anything that can be converted into this type
+  template<typename T,
+           WrapperT::EnableWrapper<T> = false>
+  {{ class.bare_type }}(T&& val) : WrapperT(std::forward<T>(val)) {}
+
+  /// Constructor from another {{ class.bare_type }}
+  {{ class.bare_type }}({{ class.bare_type }} const& other) : WrapperT(other.m_obj) {}
+
+  /// The class can also get initialized from another wrapper of the same type
+  {{ class.bare_type }}(WrapperT const& other) : WrapperT(other) {}
+
+{{ macros.member_getters(Members, use_get_syntax) }}
+{{ macros.member_setters(Members, use_get_syntax) }}
+};
+
+#endif

--- a/python/templates/Wrapped.h.jinja2
+++ b/python/templates/Wrapped.h.jinja2
@@ -17,9 +17,10 @@
 {{ macros.class_description(class.bare_type, Description, Author )}}
 
 {{ utils.namespace_close(class.namespace )}}
-class {{ class.bare_type }} : public podio::GenericWrapper<{{ Types | join(', ') }}> {
+class {{ class.bare_type }} : public podio::GenericWrapper<true, {{ Types | join(', ') }}> {
 private:
-  using WrapperT = podio::GenericWrapper<{{ Types | join(', ')}}>;
+  // The underlying Wrapper type is Mutable
+  using WrapperT = podio::GenericWrapper<true, {{ Types | join(', ')}}>;
 public:
   /// A {{ class.bare_type }} can only be constructed from a concrete value
   {{ class.bare_type }}() = delete;

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -57,27 +57,64 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
       {{ type }}Collection* tmp_coll = static_cast<{{ type }}Collection*>(coll);
 {%- endmacro %}
 
+{% macro _add_multi_relation(relation) %}
+{% if relation.interface_types %}
+      podio::CollectionBase* coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      const auto typeName = coll->getValueTypeName(); // TODO something more elegant
+{% for int_type in relation.interface_types %}
+      if (typeName == "{{ int_type.full_type }}") {
+        auto* tmp_coll = static_cast<{{ int_type.full_type }}Collection*>(coll);
+        const auto tmp = (*tmp_coll)[id.index];
+        m_rel_{{ relation.name }}->emplace_back(tmp);
+      }
+{% endfor %}
+{% else %}
+{{ get_collection(relation.full_type) }}
+      const auto tmp = (*tmp_coll)[id.index];
+      m_rel_{{ relation.name }}->emplace_back(tmp);
+{% endif %}
+{%- endmacro %}
+
 {% macro set_references_multi_relation(relation, index) %}
   for (unsigned int i = 0, size = m_refCollections[{{ index }}]->size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
-{{ get_collection(relation.full_type) }}
-      const auto tmp = (*tmp_coll)[id.index];
-      m_rel_{{ relation.name }}->emplace_back(tmp);
+{{ _add_multi_relation(relation) }}
     } else {
+{% if relation.interface_types %}
+      // Need to cast to a dedicated type here. Just use one of the variants
+      m_rel_{{ relation.name }}->emplace_back(static_cast<{{ relation.interface_types[0] }}Obj*>(nullptr));
+{% else %}
       m_rel_{{ relation.name }}->emplace_back(nullptr);
+{% endif %}
     }
   }
 {% endmacro %}
 
+{% macro _add_single_relation(relation) %}
+{% if relation.interface_types %}
+      podio::CollectionBase* coll = nullptr;
+      collectionProvider->get(id.collectionID, coll);
+      const auto typeName = coll->getValueTypeName(); // TODO: something more elegant
+{% for int_type in relation.interface_types %}
+      if (typeName == "{{ int_type.full_type }}") {
+        auto* tmp_coll = static_cast<{{ int_type.full_type }}Collection*>(coll);
+        entries[i]->m_{{ relation.name }} = new {{ relation.as_qualified_const() }}((*tmp_coll)[id.index]);
+      }
+{% endfor %}
+{% else %}
+{{ get_collection(relation.full_type) }}
+      entries[i]->m_{{ relation.name }} = new {{ relation.as_qualified_const() }}((*tmp_coll)[id.index]);
+{% endif %}
+{%- endmacro %}
 
 {% macro set_reference_single_relation(relation, index, start_index) %}
 {% set real_index = index + start_index %}
   for (unsigned int i = 0, size = entries.size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ real_index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
-  {{ get_collection(relation.full_type) }}
-      entries[i]->m_{{ relation.name }} = new {{ relation.as_qualified_const() }}((*tmp_coll)[id.index]);
+{{ _add_single_relation(relation) }}
     } else {
       entries[i]->m_{{ relation.name }} = nullptr;
     }

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -77,7 +77,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
     const auto id = (*m_refCollections[{{ real_index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
   {{ get_collection(relation.full_type) }}
-      entries[i]->m_{{ relation.name }} = new Const{{ relation.bare_type }}((*tmp_coll)[id.index]);
+      entries[i]->m_{{ relation.name }} = new {{ relation.as_qualified_const() }}((*tmp_coll)[id.index]);
     } else {
       entries[i]->m_{{ relation.name }} = nullptr;
     }

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -69,7 +69,7 @@
   {{  full_type }}(const {{  full_type }}& other);
 
   /// copy-assignment operator
-  {{  full_type }}& operator=(const {{  full_type }}& other);
+  {{  full_type }}& operator=({{ full_type }} other);
 
   /// support cloning (deep-copy)
   {{  full_type }} clone() const;
@@ -96,6 +96,11 @@
   unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index; }
 
   const podio::ObjectID getObjectID() const;
+
+  friend void swap({{ full_type }}& a, {{ full_type }}& b) {
+    using std::swap;
+    swap(a.m_obj, b.m_obj); // swap out the internal pointers
+  }
 {%- endmacro %}
 
 

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -17,10 +17,8 @@
   m_obj->acquire();
 }
 
-{{  full_type }}& {{ full_type }}::operator=(const {{ full_type }}& other) {
-  if (m_obj) m_obj->release();
-  m_obj = other.m_obj;
-  m_obj->acquire();
+{{  full_type }}& {{ full_type }}::operator=({{ full_type }} other) {
+  swap(*this, other);
   return *this;
 }
 

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -78,7 +78,12 @@ void {{ class.bare_type }}::{{ sub_member.setter_name(get_syntax) }}({{ sub_memb
 {% for relation in relations %}
 const {{ relation.relation_type }} {{ class_type }}::{{ relation.getter_name(get_syntax) }}() const {
   if (!m_obj->m_{{ relation.name }}) {
+{% if relation.interface_types %}
+    // We need to give the nullptr an arbitrary type to make an interface class work
+    return {{ relation.relation_type }}(static_cast<{{ relation.interface_types[0] }}::ObjPtrT>(nullptr));
+{% else %}
     return {{ relation.relation_type }}(nullptr);
+{% endif %}
   }
   return {{ relation.relation_type }}(*(m_obj->m_{{ relation.name }}));
 }

--- a/python/templates/macros/wrappers.jinja2
+++ b/python/templates/macros/wrappers.jinja2
@@ -1,0 +1,26 @@
+{% macro member_getters(class, members, get_syntax, prefix='') %}
+{% set class_type = prefix + class.bare_type %}
+{% for member in members %}
+const {{ member.full_type }}& {{ class_type }}::{{ member.getter_name(use_get_syntax) }}() const {
+  return std::visit([](auto&& obj) -> const {{ member.full_type}}& {
+    return obj->data.{{ member.name }};
+  }, m_obj);
+}
+{% if member.is_array %}
+const {{ member.array_type }}& {{ class_type }}::{{ member.getter_name(get_syntax) }}(size_t i) const {
+  return std::visit([](auto& obj) -> const {{ member.array_type }}& {
+    return obj->data.{{ member.name }}[i];
+  }, m_obj);
+}
+{% endif %}
+{% if member.sub_members %}
+{% for sub_member in member.sub_members %}
+const {{ sub_member.full_type }}& {{ class_type }}::{{ sub_member.getter_name(get_syntax) }}() const {
+  return std::visit([](auto&& obj) -> const {{ sub_member.full_type }}& {
+    return m_obj->data.{{ member.name }}.{{ sub_member.name }};
+  }, m_obj);
+}
+{% endfor %}
+{%- endif %}
+{% endfor %}
+{% endmacro %}

--- a/python/templates/macros/wrappers.jinja2
+++ b/python/templates/macros/wrappers.jinja2
@@ -24,3 +24,38 @@ const {{ sub_member.full_type }}& {{ class_type }}::{{ sub_member.getter_name(ge
 {%- endif %}
 {% endfor %}
 {% endmacro %}
+
+
+{% macro member_setters(class, members, get_syntax) %}
+{% for member in members %}
+void {{ class.bare_type }}::{{ member.setter_name(get_syntax) }}({{ member.full_type }} value) {
+  std::visit([value](auto&& obj) { obj->data.{{ member.name }} = value;}, m_obj);
+}
+{% if member.is_array %}
+void {{ class.bare_type }}::{{ member.setter_name(get_syntax) }}(size_t i, {{ member.array_type }} value) {
+  std::visit([i, value](auto&& obj) { obj->data.{{ member.name }}[i] = value;}, m_obj);
+}
+{% endif %}
+{% if not member.is_builtin %}
+{{ member.full_type }}& {{ class.bare_type }}::{{ member.name }}() {
+  return std::visit([](auto&& obj) -> {{ member.full_type }}& {
+    return obj->data.{{ member.name }};
+  }, m_obj);
+}
+{% endif %}
+{% if members.sub_members %}
+{% for sub_member in members.sub_members %}
+void {{ class.bare_type }}::{{ sub_member.member_setter(get_syntax) }}({{ sub_member.full_type }} value) {
+  std::visit([value](auto&& obj) { obj->data.{{ member.name }}.{{ sub_member.name }} = value; }, m_obj);
+}
+{% if not sub_member.is_builtin %}
+{{ sub_member.full_type }}& {{ class.bare_type }}::{{ sub_member.name }}() {
+  return std::visit([](auto&& obj) -> {{ sub_member.full_type }}& {
+    return obj->data.{{ member.name }}.{{ sub_member.name }};
+  }, m_obj);
+}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endmacro %}

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -230,7 +230,8 @@ namespace podio {
         branches.vecs.push_back(root_utils::getBranch(m_chain, brName.c_str()));
       }
 
-      const std::string bufferClassName = "std::vector<" + collection->getValueTypeName() + "Data>";
+      using namespace std::string_literals;
+      const auto bufferClassName = "std::vector<"s + collection->getValueTypeName().data() + "Data>";
       const auto bufferClass = isSubsetColl ? nullptr : TClass::GetClass(bufferClassName.c_str());
 
       m_storedClasses.emplace(

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -50,12 +50,13 @@ void ROOTWriter::writeEvent(){
 }
 
 void ROOTWriter::createBranches(const std::vector<StoreCollection>& collections) {
+  using namespace std::string_literals;
   for (auto& [name, coll] : collections) {
     root_utils::CollectionBranches branches;
     const auto collBuffers = coll->getBuffers();
     if (collBuffers.data) {
       // only create the data buffer branch if necessary
-      const auto collClassName = "vector<" + coll->getValueTypeName() + "Data>";
+      const auto collClassName = "vector<"s + coll->getValueTypeName().data() + "Data>";
       branches.data = m_datatree->Branch(name.c_str(), collClassName.c_str(), collBuffers.data);
     }
 
@@ -96,6 +97,7 @@ void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
 
 
   void ROOTWriter::finish(){
+    using namespace std::string_literals;
     // now we want to safe the metadata. This includes info about the
     // collections
     const auto collIDTable = m_store->getCollectionIDTable();
@@ -109,7 +111,7 @@ void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
       const podio::CollectionBase* coll{nullptr};
       // No check necessary, only registered collections possible
       m_store->get(name, coll);
-      const auto collType = coll->getValueTypeName() + "Collection";
+      const auto collType = coll->getValueTypeName().data() + "Collection"s;
       collectionInfo.emplace_back(collID, std::move(collType), coll->isSubsetCollection());
     }
 

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -35,7 +35,7 @@ namespace podio {
       if (!_store->get(id, tmp)) {
         std::cerr << "ERROR during writing of CollectionID table" << std::endl;
       }
-      typeNames.push_back(tmp->getValueTypeName());
+      typeNames.emplace_back(tmp->getValueTypeName().data());
       isSubsetColl.push_back(tmp->isSubsetCollection());
     }
     device.data(typeNames);
@@ -122,7 +122,7 @@ namespace podio {
   }
 
   std::shared_ptr<SIOBlock> SIOBlockFactory::createBlock(const podio::CollectionBase* col, const std::string& name) const {
-    const std::string typeStr = col->getValueTypeName() ;
+    const std::string typeStr{col->getValueTypeName()};
     const auto it = _map.find(typeStr) ;
 
     if( it!= _map.end() ) {

--- a/src/SIOWriter.cc
+++ b/src/SIOWriter.cc
@@ -139,7 +139,7 @@ namespace podio {
     // Check if we can instantiate the blocks here so that we can skip the checks later
     if (auto blk = podio::SIOBlockFactory::instance().createBlock( colB, name ); !blk) {
       const auto typName = colB->getValueTypeName();
-      throw std::runtime_error( std::string("could not create SIOBlock for type: ")+typName ) ;
+      throw std::runtime_error( std::string("could not create SIOBlock for type: ")+typName.data() ) ;
     }
 
     m_collectionsToWrite.push_back(name);

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -174,3 +174,22 @@ datatypes :
       - uint64_t fixedU64 // unsigned int with exactly 64 bits
       - uint32_t fixedU32 // unsigned int with exactly 32 bits
       - StructWithFixedWithTypes fixedWidthStruct // struct with more fixed width types
+
+  ExampleWithInterfaceRelation:
+    Description: "Datatype that uses an interface type as one of its relations"
+    Author: "Thomas Madlener"
+    OneToOneRelations:
+      - TypeWithEnergy aSingleEnergyType // single relation
+    OneToManyRelations:
+      - TypeWithEnergy manyEnergies // multiple relations
+
+interfaces:
+  TypeWithEnergy:
+    Description: "Generic interface for all types with an energy member"
+    Author: "Thomas Madlener"
+    Types:
+      - ExampleMC
+      - ExampleCluster
+      - ExampleHit
+    Members:
+      - double energy // the energy

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -147,6 +147,14 @@ datatypes :
     OneToManyRelations :
      - ex42::ExampleWithNamespace refs // multiple refs in a namespace
 
+  ExampleWithDifferentNamespaceRelations:
+    Description: "Datatype using a namespaced relation without being in the same namespace"
+    Author: "Thomas Madlener"
+    OneToOneRelations:
+      - ex42::ExampleWithNamespace rel // a relation in a different namespace
+    OneToManyRelations:
+      - ex42::ExampleWithNamespace rels // relations in a different namespace
+
   ExampleWithArray:
     Description: "Datatype with an array member"
     Author: "Joschka Lingemann"

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -180,8 +180,16 @@ datatypes :
     Author: "Thomas Madlener"
     OneToOneRelations:
       - TypeWithEnergy aSingleEnergyType // single relation
+      - ex42::AnotherTypeWithEnergy energyRelation // another single relation
     OneToManyRelations:
       - TypeWithEnergy manyEnergies // multiple relations
+      - ex42::AnotherTypeWithEnergy moreEnergies // multiple namespace relations
+
+  nsp::EnergyInNamespace:
+    Description: "A type with energy in a namespace"
+    Author: "Thomas Madlener"
+    Members:
+      - double energy // energy
 
 interfaces:
   TypeWithEnergy:
@@ -191,5 +199,14 @@ interfaces:
       - ExampleMC
       - ExampleCluster
       - ExampleHit
+    Members:
+      - double energy // the energy
+
+  ex42::AnotherTypeWithEnergy:
+    Description: "Another interface type for making sure they also work in namespaces"
+    Author: "Thomas Madlener"
+    Types:
+      - ExampleHit
+      - nsp::EnergyInNamespace
     Members:
       - double energy // the energy

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <map>
 #include <stdexcept>
+#include <variant>
 #include <vector>
 #include <type_traits>
 
@@ -530,4 +531,23 @@ TEST_CASE("GenericWrapper basics") {
 
   wrapper = ExampleCluster{};
   std::cout << "+++++++++++++++++++++++++++++++++++++\n";
+}
+
+TEST_CASE("GenericWrapper getting values") {
+  using WrapperT = podio::GenericWrapper<ExampleHit, ExampleCluster>;
+
+  ExampleHitCollection hits{};
+  auto inputHit = hits.create();
+
+  WrapperT wrapper{inputHit};
+
+  REQUIRE(wrapper.isCurrentType<ExampleHit>());
+  REQUIRE(!wrapper.isCurrentType<ExampleCluster>());
+  // Cannot yet work with Const types
+  //REQUIRE(wrapper.isCurrentType<ConstExampleHit>());
+
+  REQUIRE_THROWS_AS(wrapper.getValue<ExampleCluster>(), std::bad_variant_access);
+
+  auto hit = wrapper.getValue<ExampleHit>();
+  REQUIRE(hit == inputHit);
 }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -519,7 +519,7 @@ TEST_CASE("Subset collection only handles tracked objects", "[subset-colls]") {
 }
 
 TEST_CASE("GenericWrapper basics") {
-  using WrapperT = podio::GenericWrapper<ExampleHit, ExampleCluster>;
+  using WrapperT = podio::GenericWrapper<true, ExampleHit, ExampleCluster>;
 
   const podio::ObjectID untracked = {podio::ObjectID::untracked, podio::ObjectID::untracked};
 
@@ -536,7 +536,7 @@ TEST_CASE("GenericWrapper basics") {
 
 
 TEST_CASE("GenericWrapper getting values") {
-  using WrapperT = podio::GenericWrapper<ExampleHit, ExampleCluster>;
+  using WrapperT = podio::GenericWrapper<true, ExampleHit, ExampleCluster>;
 
   ExampleHitCollection hits{};
   auto inputHit = hits.create();
@@ -554,6 +554,7 @@ TEST_CASE("GenericWrapper getting values") {
   auto hit = wrapper.getValue<ExampleHit>();
   REQUIRE(hit == inputHit);
 
+  // Can also get a Const user class from a mutable wrapper
   auto constHit = wrapper.getValue<ConstExampleHit>();
   REQUIRE(constHit == hit);
 }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -9,6 +9,7 @@
 
 // podio specific includes
 #include "podio/EventStore.h"
+#include "podio/GenericWrapper.h"
 
 // Test data types
 #include "datamodel/EventInfoCollection.h"
@@ -514,4 +515,19 @@ TEST_CASE("Subset collection only handles tracked objects", "[subset-colls]") {
 
   REQUIRE_THROWS_AS(clusterRefs.push_back(cluster), std::invalid_argument);
   REQUIRE_THROWS_AS(clusterRefs.create(), std::logic_error);
+}
+
+TEST_CASE("GenericWrapper basics") {
+  std::cout << "+++++++++++++++++++++++++++++++++++++\n";
+  using WrapperT = podio::GenericWrapper<ExampleHit, ExampleCluster>;
+
+  const podio::ObjectID untracked = {podio::ObjectID::untracked, podio::ObjectID::untracked};
+
+  WrapperT wrapper{ExampleHit{}};
+  std::cout << "----------------------------------------\n";
+
+  REQUIRE(wrapper.getObjectID() == untracked);
+
+  wrapper = ExampleCluster{};
+  std::cout << "+++++++++++++++++++++++++++++++++++++\n";
 }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -519,19 +519,21 @@ TEST_CASE("Subset collection only handles tracked objects", "[subset-colls]") {
 }
 
 TEST_CASE("GenericWrapper basics") {
-  std::cout << "+++++++++++++++++++++++++++++++++++++\n";
   using WrapperT = podio::GenericWrapper<ExampleHit, ExampleCluster>;
 
   const podio::ObjectID untracked = {podio::ObjectID::untracked, podio::ObjectID::untracked};
 
   WrapperT wrapper{ExampleHit{}};
-  std::cout << "----------------------------------------\n";
-
   REQUIRE(wrapper.getObjectID() == untracked);
 
   wrapper = ExampleCluster{};
-  std::cout << "+++++++++++++++++++++++++++++++++++++\n";
+  REQUIRE(wrapper.getObjectID() == untracked);
+
+  auto coll = ExampleHitCollection{};
+  wrapper = coll.create();
+  REQUIRE(wrapper.getObjectID() == podio::ObjectID{(int)coll.getID(), 0});
 }
+
 
 TEST_CASE("GenericWrapper getting values") {
   using WrapperT = podio::GenericWrapper<ExampleHit, ExampleCluster>;
@@ -542,12 +544,16 @@ TEST_CASE("GenericWrapper getting values") {
   WrapperT wrapper{inputHit};
 
   REQUIRE(wrapper.isCurrentType<ExampleHit>());
+  // We currently do not really differentitate between holding a Const or a
+  // mutable value
+  REQUIRE(wrapper.isCurrentType<ConstExampleHit>());
   REQUIRE(!wrapper.isCurrentType<ExampleCluster>());
-  // Cannot yet work with Const types
-  //REQUIRE(wrapper.isCurrentType<ConstExampleHit>());
 
   REQUIRE_THROWS_AS(wrapper.getValue<ExampleCluster>(), std::bad_variant_access);
 
   auto hit = wrapper.getValue<ExampleHit>();
   REQUIRE(hit == inputHit);
+
+  auto constHit = wrapper.getValue<ConstExampleHit>();
+  REQUIRE(constHit == hit);
 }

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -15,6 +15,7 @@
 #include "datamodel/ExampleWithStringCollection.h"
 #include "datamodel/ExampleWithArrayCollection.h"
 #include "datamodel/ExampleWithFixedWidthIntegersCollection.h"
+#include "datamodel/ExampleWithInterfaceRelationCollection.h"
 
 #include "podio/EventStore.h"
 
@@ -46,6 +47,7 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& strings    = store.create<ExampleWithStringCollection>("strings");
   auto& arrays     = store.create<ExampleWithArrayCollection>("arrays");
   auto& fixedWidthInts = store.create<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
+  auto& interfaceTypes = store.create<ExampleWithInterfaceRelationCollection>("interfaceTypes");
 
   writer.registerForWrite("info");
   writer.registerForWrite("mcparticles");
@@ -64,6 +66,7 @@ void write(podio::EventStore& store, WriterT& writer) {
   writer.registerForWrite("strings");
   writer.registerForWrite("arrays");
   writer.registerForWrite("fixedWidthInts");
+  writer.registerForWrite("interfaceTypes");
 
   unsigned nevents = 2000;
 
@@ -314,6 +317,22 @@ void write(podio::EventStore& store, WriterT& writer) {
     arbComp.fixedUnsigned16 = 12345;
     arbComp.fixedInteger32 = -1234567890;
     arbComp.fixedInteger64 = -1234567890123456789ll;
+
+    // interface relation types
+    auto energyType1 = interfaceTypes.create();
+    energyType1.aSingleEnergyType(hits[0]);
+    energyType1.addmanyEnergies(hits[1]);
+    energyType1.addmanyEnergies(clusters[1]);
+    energyType1.addmanyEnergies(mcps[1]);
+
+    auto energyType2 = interfaceTypes.create();
+    energyType2.aSingleEnergyType(clusters[0]);
+
+    auto energyType3 = interfaceTypes.create();
+    energyType3.aSingleEnergyType(mcps[0]);
+    energyType3.addmanyEnergies(hits[0]);
+    energyType3.addmanyEnergies(hits[1]);
+    energyType3.addmanyEnergies(clusters[1]);
 
     writer.writeEvent();
     store.clearCollections();


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `podio::GenericWrapper` class that can wrap multiple user data types via an underlying `std::variant`.
- Make it possible to add an optional `interface` section to the datamodel definition where "interface" classes can be defined. These datatypes use the `podio::GenericWrapper` and can store multiple different user datatypes that all offer similar functionality and serve as a sort of "base type" that can then be used as any other datatype.

ENDRELEASENOTES

Contains all changes from #143 and #217

# Rationale
It is possible that there are specialized datatypes that all offer very similar functionality, e.g. in LCIO there is a whole [hierarchy of `TrackerHit` classes](https://ilcsoft.desy.de/LCIO/current/doc/doxygen_api/html/classEVENT_1_1TrackerHit.html), which means that e.g. EDM4hep will also potentially need more than one `TrackerHit` class (see key4hep/EDM4hep#121). Adding more datatypes is quite trivial (e.g. key4hep/EDM4hep#122). However, it is currently not possible to have a heterogeneous collection of different datatypes in podio generated datamodels. Hence, e.g. a "simple" `Track` class, which can store different types of `TrackerHit`s within a single `OneToManyRelation` is not possible and a definition would have to look like this:
```yaml
edm4hep::Track:
  # all the other things
  OneToManyRelations:
    - edm4hep::TrackerHitPlane planeHits // planar tracker hits
    - edm4hep::TrackerHit                // tracker hits
    # potentially more different types
```
This makes for a rather awkward usage as all the possible relations have to be checked and it is not easily possible to simply loop over all tracker hits, regardless of their type. Additionally, every time a new tracker hit type is added all user code that does such a loop would have to be changed, to now also include the new type (arguably such additions would hopefully be few, but even once might be enough already)

# Proposed solution
## `podio::GenericWrappers`
The proposed implementation solves this problem by introducing a `podio::GenericWrapper` class, that on a very basic level looks like this (not strictly valid c++, just for illustrating the point, see the code for details)
```cpp
template<bool Mutable, typename ...WrappedTypes>
class GenericWrappers {
  // some functionality
  // The internal variant that stores the Obj* of all wrapped types
  std::variant<WrappedTypesObjPtr...> m_obj;
};
```
Using the internal `std::variant` the `GenericWrappers` class offers some basic functionality that is expected from all user-facing objects (e.g. `getObjectID`), via `std::visit`. Additionally, it offers functionality to probe what the currently held type is, as well as functionality to try and get the "actual" type from the generic wrapper (if it is currently held). These are the two functions:
```cpp
template<typename U, /*enable_if trickery*/>
bool isCurrentType() const;

template<typename U, /*enable_if trickery*/>
U getValue() const;
// + a non-const overload for cases where Mutable == true
```

With this class users can already do something like
```cpp
using TrackHit = podio::GenericWrapper<true, edm4hep::TrackerHit, edm4hep::TrackerHitPlane>;
auto trackHit = TrackHit{edm4hep::TrackerHit()};
assert(trackHit.isCurrentType<edm4hep::TrackerHit>());

trackHit = edm4hep::TrackerHitPlane();
auto planeHit = trackHit.getValue<edm4hep::TrackerHitPlane>();
```

## Interface types
The `GenericWrapper` class allows to store different tracker hit classes in one type. However, its functionality is (deliberately) limited and to do something useful it is still necessary to cast back to the original tracker hit type. To solve this, additional wrapper classes are introduced to the generated code, which inherit from `podio::GenericWrapper`. They are generated from datatype definitions in a new section of the datamodel yaml (taking edm4hep and LCIO here, but there is also another example in the PR for the podio example datamodel)
```yaml
datatypes:
  edm4hep::TrackerHitPlane:
    # definition
  edm4hep::TrackerHitZCylinder:
    # definition

  edm4hep::Track:
    # all the rest
    OneToManyRelations:
      - edm4hep::TrackerHit trackHit // track hits. NOTE not to be confused with the current TrackerHit!
  
interfaces:
  edm4hep::TrackerHit:
    # description + author omitted
    Types:
      - edm4hep::TrackerHitPlane
      - edm4hep::TrackerHitZCylinder
     Members:
      - edm4hep::Vector3d position // the 3D position 
```

For all datatypes in the `interfaces` section user facing classes are generated that behave exactly the same as other datamodel classes, with the only difference, that they have to be initialized with another value (they cannot be default constructed). The `Members` section of each type defines the publicly available setter and getter functions on these "interface" types. In this case only the `getPosition` (and `setPosition` on the mutable classes) would be available from the `TrackerHit` class (while `TrackerHitPlane` would have more getters/setters). Note that in the current implementation these have to be actual data member of the wrapped types.

## Some implementation details
- All generated user facing classes have gained a public `ObjPtrT` typedef for the corresponding `Obj*`
- The mutable user facing classes additionally have gained a public `ConstT` typedef for the corresponding `Const` class
- The first boolean template parameter in `podio::GenericWrapper` steers whether a non-const `getValue` template function is available, that also gives access to mutable user facing classes. If it is false, only the const version will be available, that will also give access to the `Const` classes. This is necessary to not introduce a way to do an accidental `const_cast`, by initializing the wrapper with a `Const` value but then getting a mutable value out of it.

----------------------
- [ ] Clean up commit history
- [ ] Document GenericWrapper
- [ ] Naming and syntax
  - [ ] In the datamodel yaml files (do we want to call the new section `interfaces`?)
  - [ ] For the `GenericWrapper` class (I really think the current name doesn't really capture the intent, but I haven't found a better one yet)
- [ ] Find out why two of the CI workflows are failing (and why is it only two that are failing)
- [x] Fix access rights again (partially released during development)