### PR TITLE
Fix a few smaller generation issues (once more)

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -250,6 +250,8 @@ class ClassGenerator(object):
     datatype['forward_declarations_obj'] = fwd_declarations
     datatype['includes_obj'] = self._sort_includes(includes)
     datatype['includes_cc_obj'] = self._sort_includes(includes_cc)
+    needs_destructor = datatype['VectorMembers'] or datatype['OneToManyRelations'] or datatype['OneToOneRelations']
+    datatype['obj_needs_destructor'] = needs_destructor
 
   def _preprocess_for_class(self, datatype):
     """Do the preprocessing that is necessary for the classes and Const classes"""

--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -43,6 +43,7 @@
 {% endfor %}
 }
 
+{% if obj_needs_destructor -%}
 {{ obj_type }}::~{{ obj_type }}() {
 {% with multi_relations = OneToManyRelations + VectorMembers %}
 {%- if multi_relations %}
@@ -58,5 +59,7 @@
   if (m_{{ relation.name }}) delete m_{{ relation.name }};
 {% endfor %}
 }
+{%- endif %}
+
 {% endwith %}
 {{ utils.namespace_close(class.namespace) }}

--- a/python/templates/Obj.h.jinja2
+++ b/python/templates/Obj.h.jinja2
@@ -33,7 +33,11 @@ public:
   {{ obj_type }}(const podio::ObjectID id, {{ class.bare_type }}Data data);
   /// No assignment operator
   {{ obj_type }}& operator=(const {{ obj_type }}&) = delete;
+{% if obj_needs_destructor %}
   virtual ~{{ obj_type }}();
+{% else %}
+  virtual ~{{ obj_type }}() = default;
+{% endif %}
 
 public:
   {{ class.bare_type }}Data data;

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -77,7 +77,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
     const auto id = (*m_refCollections[{{ real_index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
   {{ get_collection(relation.full_type) }}
-      entries[i]->m_{{ relation.name }} = new Const{{ relation.bare_type }}((*tmp_coll)[id.index]);
+      entries[i]->m_{{ relation.name }} = new {{ relation.as_qualified_const() }}((*tmp_coll)[id.index]);
     } else {
       entries[i]->m_{{ relation.name }} = nullptr;
     }

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -69,7 +69,7 @@
   {{  full_type }}(const {{  full_type }}& other);
 
   /// copy-assignment operator
-  {{  full_type }}& operator=(const {{  full_type }}& other);
+  {{  full_type }}& operator=({{ full_type }} other);
 
   /// support cloning (deep-copy)
   {{  full_type }} clone() const;
@@ -96,6 +96,11 @@
   unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index; }
 
   const podio::ObjectID getObjectID() const;
+
+  friend void swap({{ full_type }}& a, {{ full_type }}& b) {
+    using std::swap;
+    swap(a.m_obj, b.m_obj); // swap out the internal pointers
+  }
 {%- endmacro %}
 
 

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -17,10 +17,8 @@
   m_obj->acquire();
 }
 
-{{  full_type }}& {{ full_type }}::operator=(const {{ full_type }}& other) {
-  if (m_obj) m_obj->release();
-  m_obj = other.m_obj;
-  m_obj->acquire();
+{{  full_type }}& {{ full_type }}::operator=({{ full_type }} other) {
+  swap(*this, other);
   return *this;
 }
 

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -147,6 +147,14 @@ datatypes :
     OneToManyRelations :
      - ex42::ExampleWithNamespace refs // multiple refs in a namespace
 
+  ExampleWithDifferentNamespaceRelations:
+    Description: "Datatype using a namespaced relation without being in the same namespace"
+    Author: "Thomas Madlener"
+    OneToOneRelations:
+      - ex42::ExampleWithNamespace rel // a relation in a different namespace
+    OneToManyRelations:
+      - ex42::ExampleWithNamespace rels // relations in a different namespace
+
   ExampleWithArray:
     Description: "Datatype with an array member"
     Author: "Joschka Lingemann"


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the `Obj` destructors `= default` where possible, i.e. if a datatype has no relations to handle
- Make the assignment operators of the user facing classes use the "copy-and-swap" idiom
- Fix the problem where `OneToOneRelations` needed to be from the same namespace as the datatype they are used in (#216)

ENDRELEASENOTES

Fixes #216, fixes #203