### PR TITLE
[WIP] Improve user facing API: make Object ctor from Obj* private

### DIFF
--- a/python/templates/ConstObject.h.jinja2
+++ b/python/templates/ConstObject.h.jinja2
@@ -35,6 +35,11 @@ public:
 {{ macros.common_object_funcs(class.bare_type, prefix='Const') }}
 
 private:
+
+  /// constructor from existing {{ class.bare_type }}Obj
+  Const{{  class.bare_type }}({{ class.bare_type }}Obj* obj);
+
+
   {{ class.bare_type }}Obj* m_obj;
 };
 

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -43,6 +43,9 @@ public:
 {{ macros.common_object_funcs(class.bare_type) }}
 
 private:
+  /// constructor from existing {{ class.bare_type }}Obj
+  {{  class.bare_type }}({{ class.bare_type }}Obj* obj);
+
   {{ class.bare_type }}Obj* m_obj;
 };
 

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -62,9 +62,6 @@
   {{  full_type }}({{ members | map(attribute='signature') | join(', ')  }});
 {% endif %}
 
-  /// constructor from existing {{ type }}Obj
-  {{  full_type }}({{ type }}Obj* obj);
-
   /// copy constructor
   {{  full_type }}(const {{  full_type }}& other);
 


### PR DESCRIPTION

This PR makes [this and similar constructors](https://edm4hep.web.cern.ch/classedm4hep_1_1_m_c_particle.html#a4cc4912e06c4ee5df29edaa97a18317d) 
```


edm4hep::MCParticle::MCParticle  (  MCParticleObj *  obj  ) 
```
private. As far as I can see there is no way for users to access a `MCParticleObj*` and they are not intended to do so, so this should not be part of the public API.

The downside implementationwise is that the constructors templating macro does not cover private, so I had to move it out of the macro.

BEGINRELEASENOTES
- Improve user facing API: make Object ctor from Obj* private

ENDRELEASENOTES