### PR TITLE
Add test to read a legacy (v00-13) root file

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ function(CREATE_PODIO_TEST sourcefile additional_libs)
     )
 endfunction()
 
-set(root_dependent_tests write.cpp read.cpp read-multiple.cpp relation_range.cpp read_and_write.cpp write_timed.cpp read_timed.cpp)
+set(root_dependent_tests write.cpp read.cpp read-multiple.cpp relation_range.cpp read_and_write.cpp write_timed.cpp read_timed.cpp read-legacy-files.cpp)
 set(root_libs TestDataModelDict podio::podioRootIO)
 foreach( sourcefile ${root_dependent_tests} )
   CREATE_PODIO_TEST(${sourcefile} "${root_libs}")

--- a/tests/read-legacy-files.cpp
+++ b/tests/read-legacy-files.cpp
@@ -1,0 +1,12 @@
+#include "read_test.h"
+#include "podio/ROOTReader.h"
+
+int main(){
+  auto reader = podio::ROOTReader();
+  reader.openFile("https://key4hep.web.cern.ch/testFiles/podio/v00-13/example.root");
+
+  run_read_test(reader);
+
+  reader.closeFile();
+  return 0;
+}


### PR DESCRIPTION
I created a root file using the `write` test exe of podio v00-13 and am reading this from a server. This means that the testsuite now needs network access, but nevertheless an important test to have.

BEGINRELEASENOTES
- Add test to read a legacy (v00-13) root file
ENDRELEASENOTES