### PR TITLE
Test and fix for persisting a collection without its associated collections

### DIFF
--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -119,7 +119,7 @@ void {{ collection_type }}::push_back({{ class.bare_type }} object) {
   } else {
     const auto obj = object.m_obj;
     if (obj->id.index < 0) {
-      throw std::invalid_argument("Object needs to be tracked by another collection in order for it to be storable in a subset collection");
+      throw std::invalid_argument("Objects can only be stored in a subset collection if they are already elements of a collection");
     }
     m_storage.entries.push_back(obj);
     // No need to handle any relations here, since this is already done by the

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -94,9 +94,7 @@ void {{ collection_type }}::prepareAfterRead() {
 }
 
 bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* collectionProvider) {
-  m_storage.setReferences(collectionProvider, m_isSubsetColl);
-
-  return true; //TODO: check success
+  return m_storage.setReferences(collectionProvider, m_isSubsetColl);
 }
 
 void {{ collection_type }}::push_back({{ class.bare_type }} object) {

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -158,13 +158,13 @@ void {{ class_type }}::createRelations({{ class.bare_type }}Obj* obj) {
 }
 {% endif %}
 
-void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectionProvider, bool isSubsetColl) {
+bool {{ class_type }}::setReferences(const podio::ICollectionProvider* collectionProvider, bool isSubsetColl) {
   if (isSubsetColl) {
     for (const auto& id : *m_refCollections[0]) {
-{{ macros.get_collection(class.full_type) }}
-      entries.push_back(tmp_coll->m_storage.entries[id.index]);
+{{ macros.get_obj_ptr(class.full_type) }}
+      entries.push_back(obj);
     }
-    return;
+    return true; // TODO: check success, how?
   }
 
   // Normal collections have to resolve all relations
@@ -175,6 +175,7 @@ void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectio
 {{ macros.set_reference_single_relation(relation, loop.index0, OneToManyRelations | length) }}
 {% endfor %}
 
+  return true; // TODO: check success, how?
 }
 
 void {{ class_type }}::makeSubsetCollection() {

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -63,7 +63,7 @@ public:
   void createRelations({{ class.bare_type }}Obj* obj);
 {% endif %}
 
-  void setReferences(const podio::ICollectionProvider* collectionProvider, bool isSubsetColl);
+  bool setReferences(const podio::ICollectionProvider* collectionProvider, bool isSubsetColl);
 
 private:
   // members to handle 1-to-N-relations

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -53,8 +53,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
 
 {% macro get_collection(type) %}
       podio::CollectionBase* coll = nullptr;
-      auto collGetResult = collectionProvider->get(id.collectionID, coll);
-      if (collGetResult == false) { continue; }
+      if (!collectionProvider->get(id.collectionID, coll)) { continue; }
       {{ type }}Collection* tmp_coll = static_cast<{{ type }}Collection*>(coll);
 {%- endmacro %}
 

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -53,8 +53,9 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
 
 {% macro get_collection(type) %}
       podio::CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID, coll);
-      auto* tmp_coll = static_cast<{{ type }}Collection*>(coll);
+      auto collGetResult = collectionProvider->get(id.collectionID, coll);
+      if (collGetResult == false) { continue; }
+      {{ type }}Collection* tmp_coll = static_cast<{{ type }}Collection*>(coll);
 {%- endmacro %}
 
 {% macro set_references_multi_relation(relation, index) %}

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -51,10 +51,13 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   }
 {% endmacro %}
 
-{% macro get_collection(type) %}
+{% macro get_obj_ptr(type) %}
       podio::CollectionBase* coll = nullptr;
-      collectionProvider->get(id.collectionID, coll);
-      {{ type }}Collection* tmp_coll = static_cast<{{ type }}Collection*>(coll);
+      {{ type }}Obj* obj = nullptr;
+      if (collectionProvider->get(id.collectionID, coll)) {
+        auto* tmp_coll = static_cast<{{ type }}Collection*>(coll);
+        obj = tmp_coll->m_storage.entries[id.index];
+      }
 {%- endmacro %}
 
 {% macro set_references_multi_relation(relation, index) %}

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -53,7 +53,7 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
 
 {% macro get_collection(type) %}
       podio::CollectionBase* coll = nullptr;
-      if (!collectionProvider->get(id.collectionID, coll)) { continue; }
+      collectionProvider->get(id.collectionID, coll);
       {{ type }}Collection* tmp_coll = static_cast<{{ type }}Collection*>(coll);
 {%- endmacro %}
 
@@ -61,7 +61,12 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   for (unsigned int i = 0, size = m_refCollections[{{ index }}]->size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
-{{ get_collection(relation.full_type) }}
+      podio::CollectionBase* coll = nullptr;
+      if (!collectionProvider->get(id.collectionID, coll)) {
+        m_rel_{{ relation.name }}->emplace_back(nullptr);
+        continue;
+      }
+      {{ relation.full_type }}Collection* tmp_coll = static_cast<{{ relation.full_type }}Collection*>(coll);
       const auto tmp = (*tmp_coll)[id.index];
       m_rel_{{ relation.name }}->emplace_back(tmp);
     } else {
@@ -76,7 +81,12 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
   for (unsigned int i = 0, size = entries.size(); i != size; ++i) {
     const auto id = (*m_refCollections[{{ real_index }}])[i];
     if (id.index != podio::ObjectID::invalid) {
-  {{ get_collection(relation.full_type) }}
+      podio::CollectionBase* coll = nullptr;
+      if (!collectionProvider->get(id.collectionID, coll)) {
+        entries[i]->m_{{ relation.name }} = nullptr;
+        continue;
+      }
+      {{ relation.full_type }}Collection* tmp_coll = static_cast<{{ relation.full_type }}Collection*>(coll);
       entries[i]->m_{{ relation.name }} = new {{ relation.full_type }}((*tmp_coll)[id.index]);
     } else {
       entries[i]->m_{{ relation.name }} = nullptr;

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -1,7 +1,7 @@
 {% macro constructors_destructors(type, members, prefix='') %}
 {% set full_type = prefix + type %}
 {{ full_type }}::{{ full_type }}() : m_obj(new {{ type }}Obj()) {
-  m_obj->acquire();
+  if (m_obj) m_obj->acquire();
 }
 
 {% if members %}
@@ -14,7 +14,7 @@
 {% endif %}
 
 {{ full_type}}::{{ full_type }}(const {{ full_type }}& other) : m_obj(other.m_obj) {
-  m_obj->acquire();
+  if (m_obj) m_obj->acquire();
 }
 
 {{  full_type }}& {{ full_type }}::operator=({{ full_type }} other) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ function(CREATE_PODIO_TEST sourcefile additional_libs)
     )
 endfunction()
 
-set(root_dependent_tests write.cpp read.cpp read-multiple.cpp relation_range.cpp read_and_write.cpp write_timed.cpp read_timed.cpp)
+set(root_dependent_tests write.cpp read.cpp read-multiple.cpp relation_range.cpp read_and_write.cpp read_and_write_associated.cpp write_timed.cpp read_timed.cpp)
 set(root_libs TestDataModelDict podio::podioRootIO)
 foreach( sourcefile ${root_dependent_tests} )
   CREATE_PODIO_TEST(${sourcefile} "${root_libs}")

--- a/tests/read_and_write_associated.cpp
+++ b/tests/read_and_write_associated.cpp
@@ -81,10 +81,15 @@ void readCollection() {
 
     auto& clusters = store.get<ExampleClusterCollection>("clusters");
     if(clusters.isValid()){
-      // // auto cluster = clusters[0];
-      // // for (auto j = cluster.Hits_begin(), end = cluster.Hits_end(); j!=end; ++i){
-        // // std::cout << "  Referenced hit has an energy of " << j->energy() << std::endl;
-      // // }
+      for (const auto& cluster : clusters) {
+        if (cluster.isAvailable()) {
+          for (const auto& hit : cluster.Hits()) {
+            if (hit.isAvailable()) {
+              throw std::runtime_error("Hit is available, although it has not been written");
+            }
+          }
+        }
+      }
     } else {
       throw std::runtime_error("Collection 'clusters' should be present");
     }

--- a/tests/read_and_write_associated.cpp
+++ b/tests/read_and_write_associated.cpp
@@ -1,0 +1,104 @@
+#include "podio/ROOTWriter.h"
+#include "podio/ROOTReader.h"
+#include "podio/EventStore.h"
+
+#include "datamodel/EventInfoCollection.h"
+#include "datamodel/ExampleHitCollection.h"
+#include "datamodel/ExampleClusterCollection.h"
+
+#include <string>
+#include <iostream>
+
+void writeCollection() {
+
+  auto store = podio::EventStore();
+  podio::ROOTWriter writer("example1.root", &store);
+
+  std::cout << "start writting collections...\n";
+  auto& info       = store.create<EventInfoCollection>("info");
+  auto& hits       = store.create<ExampleHitCollection>("hits");
+  auto& clusters   = store.create<ExampleClusterCollection>("clusters");
+
+  writer.registerForWrite("clusters");
+  // writer.registerForWrite("hits");
+
+  unsigned nevents = 2;
+
+  for(unsigned i=0; i<nevents; ++i) {
+
+    auto item1 = MutableEventInfo();
+    item1.Number(i);
+    info.push_back(item1);
+
+    auto& evtMD = store.getEventMetaData() ;
+    evtMD.setValue( "UserEventWeight" , (float) 100.*i ) ;
+    std::cout << " event number: " << i << std::endl;
+    evtMD.setValue( "UserEventName" , std::to_string(i)) ;
+
+    auto hit1 = ExampleHit( 0xbad, 0.,0.,0.,23.+i);
+    auto hit2 = ExampleHit( 0xcaffee,1.,0.,0.,12.+i);
+
+    hits.push_back(hit1);
+    hits.push_back(hit2);
+
+    // Clusters
+    auto cluster  = MutableExampleCluster();
+    auto clu0  = MutableExampleCluster();
+    auto clu1  = MutableExampleCluster();
+
+    clu0.addHits(hit1);
+    clu0.energy(hit1.energy());
+    clu1.addHits(hit2);
+    clu1.energy(hit2.energy());
+    cluster.addHits(hit1);
+    cluster.addHits(hit2);
+    cluster.energy(hit1.energy()+hit2.energy());
+    cluster.addClusters( clu0 ) ;
+    cluster.addClusters( clu1 ) ;
+
+    clusters.push_back(clu0);
+    clusters.push_back(clu1);
+    clusters.push_back(cluster);
+
+    writer.writeEvent();
+    store.clearCollections();    
+  }
+  writer.finish();
+}
+
+void readCollection() {
+
+  // Start reading the input
+  auto reader = podio::ROOTReader();
+  reader.openFile("example1.root");
+
+  auto store = podio::EventStore();
+  store.setReader(&reader);
+
+  const auto nEvents = reader.getEntries();
+
+  for(unsigned i=0; i<nEvents; ++i) {
+
+    auto& clusters = store.get<ExampleClusterCollection>("clusters");
+    if(clusters.isValid()){
+      // // auto cluster = clusters[0];
+      // // for (auto j = cluster.Hits_begin(), end = cluster.Hits_end(); j!=end; ++i){
+        // // std::cout << "  Referenced hit has an energy of " << j->energy() << std::endl;
+      // // }
+    } else {
+      throw std::runtime_error("Collection 'clusters' should be present");
+    }
+  
+    store.clear();
+    reader.endOfEvent();
+  }
+
+}
+
+int main() {
+
+  writeCollection();
+  readCollection();
+
+  return 0;
+}

--- a/tests/read_and_write_associated.cpp
+++ b/tests/read_and_write_associated.cpp
@@ -22,7 +22,7 @@ void writeCollection() {
 
   writer.registerForWrite("clusters");
   // writer.registerForWrite("hits");
-  // writer.registerForWrite("hits_subset");
+  writer.registerForWrite("hits_subset");
 
   unsigned nevents = 2;
 
@@ -100,6 +100,16 @@ void readCollection() {
       }
     } else {
       throw std::runtime_error("Collection 'clusters' should be present");
+    }
+
+    // Test for subset collections
+    auto& hits_subset = store.get<ExampleHitCollection>("hits_subset");
+    if(hits_subset.isValid()) {
+      for (const auto& hit : hits_subset) {
+        if (hit.isAvailable()) {
+          throw std::runtime_error("Hit is available, although it has not been written");
+        }
+      }
     }
   
     store.clear();

--- a/tests/read_and_write_associated.cpp
+++ b/tests/read_and_write_associated.cpp
@@ -18,9 +18,11 @@ void writeCollection() {
   auto& info       = store.create<EventInfoCollection>("info");
   auto& hits       = store.create<ExampleHitCollection>("hits");
   auto& clusters   = store.create<ExampleClusterCollection>("clusters");
+  auto& hits_subset   = store.create<ExampleHitCollection>("hits_subset");
 
   writer.registerForWrite("clusters");
   // writer.registerForWrite("hits");
+  // writer.registerForWrite("hits_subset");
 
   unsigned nevents = 2;
 
@@ -31,9 +33,9 @@ void writeCollection() {
     info.push_back(item1);
 
     auto& evtMD = store.getEventMetaData() ;
-    evtMD.setValue( "UserEventWeight" , (float) 100.*i ) ;
+    evtMD.setValue( "UserEventWeight" , (float) 100.*i );
     std::cout << " event number: " << i << std::endl;
-    evtMD.setValue( "UserEventName" , std::to_string(i)) ;
+    evtMD.setValue( "UserEventName" , std::to_string(i));
 
     auto hit1 = ExampleHit( 0xbad, 0.,0.,0.,23.+i);
     auto hit2 = ExampleHit( 0xcaffee,1.,0.,0.,12.+i);
@@ -53,15 +55,21 @@ void writeCollection() {
     cluster.addHits(hit1);
     cluster.addHits(hit2);
     cluster.energy(hit1.energy()+hit2.energy());
-    cluster.addClusters( clu0 ) ;
-    cluster.addClusters( clu1 ) ;
+    cluster.addClusters( clu0 );
+    cluster.addClusters( clu1 );
 
+    // Add tracked hits to subset hits collection
+    hits_subset.setSubsetCollection(true);
+    hits_subset.push_back(hit1);
+    hits_subset.push_back(hit2);
+
+    // Push all clusters
     clusters.push_back(clu0);
     clusters.push_back(clu1);
     clusters.push_back(cluster);
 
     writer.writeEvent();
-    store.clearCollections();    
+    store.clearCollections();
   }
   writer.finish();
 }
@@ -80,7 +88,7 @@ void readCollection() {
   for(unsigned i=0; i<nEvents; ++i) {
 
     auto& clusters = store.get<ExampleClusterCollection>("clusters");
-    if(clusters.isValid()){
+    if(clusters.isValid()) {
       for (const auto& cluster : clusters) {
         if (cluster.isAvailable()) {
           for (const auto& hit : cluster.Hits()) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix crashes that happen when reading collections that have related objects in collections that have not been persisted.
- Fix similar crashes for subset collections where the original collection has not been persisted.
  - The expected behavior in both cases is that podio does not crash when reading such collections, but only once the user tries to actually access such a missing object. Each object has an `isAvailable` function to guard against such crashes if need be.
- Add a test that makes sure that the expected behavior is the one that is observed.
- Fix a somewhat related bug in `setReferences` which was mistakenly a no-op for collections of a type without relations. Since this is the mechanism we use for restoring subset collections it obviously has to be present for all types.

ENDRELEASENOTES

Original problem:
- Create some collection (cluster), then add an associated collection to it (addHit). Finally persist only the original collection but not its associated collections.
- When reading these collections this will fail (segfault)
- Expected behaviour: to be able to read the clusters without a crash, marking the associated collections as invalid.

I created a test that writes and reads some cluster collection, which will fails with a segfault.
Only the clusters are registered for write: the hits are not written. If hits are registered for write the test works without issue.
I pushed a fix which checks the result of `collectionProvider->get()`, and if this fails will just continue to the next referenced collection. 

As an example, this would generated something like this:

```cpp
void ExampleClusterCollectionData::setReferences(const podio::ICollectionProvider* collectionProvider, bool isSubsetColl) {
// ...
  // Normal collections have to resolve all relations
  for (unsigned int i = 0, size = m_refCollections[0]->size(); i != size; ++i) {
    const auto id = (*m_refCollections[0])[i];
    if (id.index != podio::ObjectID::invalid) {
      podio::CollectionBase* coll = nullptr;
      auto collProvResult = collectionProvider->get(id.collectionID, coll);
      if (collProvResult == false) { continue; }
      ExampleHitCollection* tmp_coll = static_cast<ExampleHitCollection*>(coll);
      const auto tmp = (*tmp_coll)[id.index];
      m_rel_Hits->emplace_back(tmp);
    } else {
      m_rel_Hits->emplace_back(nullptr);
    }
  }
// ...
}
```