### PR TITLE
Add build version and utilities to work with it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ spack*
 
 # Generated files
 *podio_generated_files.cmake
+
+# Populated by cmake before build
+/include/podio/podioVersion.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 # ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
 
-if(NOT CMAKE_CXX_STANDARD MATCHES "17")
+if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
@@ -139,9 +139,9 @@ if(CREATE_DOC)
 	include(cmake/podioDoxygen.cmake)
 endif()
 #--- add version files ---------------------------------------------------------
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/podioVersion.h
-               ${CMAKE_CURRENT_BINARY_DIR}/podioVersion.h )
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/podioVersion.h
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/podioVersion.in.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/include/podio/podioVersion.h )
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/podio/podioVersion.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/podio )
 
 #--- add license files ---------------------------------------------------------

--- a/include/podio/IReader.h
+++ b/include/podio/IReader.h
@@ -1,12 +1,13 @@
 #ifndef IREADER_H
 #define IREADER_H
 
+#include "podio/podioVersion.h"
+
 #include <algorithm>
 #include <string>
 #include <vector>
 #include <map>
 
-#include <iostream>
 
 /*
 
@@ -43,6 +44,9 @@ class IReader {
 
     virtual void openFile(const std::string& filename) = 0;
     virtual void closeFile() = 0;
+
+    /// Get the podio version with which the current file has been written
+    virtual podio::version::Version currentFileVersion() const = 0;
 };
 
 } // namespace

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -64,6 +64,8 @@ class ROOTReader : public IReader {
     /// Check if TFile is valid
     virtual bool isValid() const override final;
 
+    podio::version::Version currentFileVersion() const override { return m_fileVersion; }
+
   private:
 
     /// Implementation for collection reading
@@ -109,6 +111,8 @@ class ROOTReader : public IReader {
     // read and we start caching the branches.
     size_t m_collectionIndex = 0;
     std::vector<root_utils::CollectionBranches> m_collectionBranches{};
+
+    podio::version::Version m_fileVersion{0, 0, 0};
 };
 
 } // namespace

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -5,6 +5,7 @@
 #include <podio/CollectionIDTable.h>
 #include <podio/GenericParameters.h>
 #include <podio/EventStore.h>
+#include <podio/podioVersion.h>
 
 #include <sio/block.h>
 #include <sio/version.h>
@@ -60,10 +61,10 @@ namespace podio {
   class SIOCollectionIDTableBlock : public sio::block {
   public:
     SIOCollectionIDTableBlock() :
-      sio::block("CollectionIDs", sio::version::encode_version(0, 2)) {}
+      sio::block("CollectionIDs", sio::version::encode_version(0, 3)) {}
 
     SIOCollectionIDTableBlock(podio::EventStore* store) :
-      sio::block("CollectionIDs", sio::version::encode_version(0, 2)),
+      sio::block("CollectionIDs", sio::version::encode_version(0, 3)),
       _store(store), _table(store->getCollectionIDTable()) {}
 
     SIOCollectionIDTableBlock(const SIOCollectionIDTableBlock&) = delete;
@@ -81,6 +82,7 @@ namespace podio {
     podio::CollectionIDTable* _table{nullptr};
     std::vector<std::string> _types{};
     std::vector<short> _isSubsetColl{};
+    podio::version::Version podioVersion{podio::version::build_version};
   };
 
 

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -76,6 +76,7 @@ namespace podio {
     podio::CollectionIDTable* getTable() { return _table; }
     const std::vector<std::string>& getTypeNames() const { return _types; }
     const std::vector<short>& getSubsetCollectionBits() const { return _isSubsetColl; }
+    podio::version::Version getPodioVersion() const { return podioVersion; }
 
   private:
     podio::EventStore* _store{nullptr};

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -55,6 +55,8 @@ namespace podio {
 
     void endOfEvent() override;
 
+    podio::version::Version currentFileVersion() const override { return m_fileVersion; }
+
   private:
     /// Implementation for collection reading
     CollectionBase* readCollection(const std::string& name) override final;
@@ -99,6 +101,8 @@ namespace podio {
     sio::block_list  m_blocks {} ;
 
     SIOFileTOCRecord m_tocRecord{};
+
+    podio::version::Version m_fileVersion{0};
   };
 
 

--- a/include/podio/TimedReader.h
+++ b/include/podio/TimedReader.h
@@ -94,6 +94,11 @@ public:
     runVoidTimed(false, "close_file", &IReader::closeFile);
   }
 
+  podio::version::Version currentFileVersion() const override {
+    // no need to time this as it is really just a very simple get
+    return m_reader.currentFileVersion();
+  }
+
 private:
   void recordTime (bool perEvent, const std::string& step, ClockT::duration duration) const {
     if (perEvent) {

--- a/podioVersion.h
+++ b/podioVersion.h
@@ -1,4 +1,0 @@
-#ifndef podioVersion_h
-#define podioVersion_h
-#define podio_VERSION @podio_VERSION@
-#endif

--- a/podioVersion.in.h
+++ b/podioVersion.in.h
@@ -8,10 +8,26 @@
 #include <compare>
 #endif
 
+// Some preprocessor constants and macros for the use cases where they might be
+// necessary
+
+/// Define a version to be used in podio.
+#define PODIO_VERSION(major, minor, patch) (((unsigned long)(major) << 32) | ((unsigned long)(minor) << 16) | ((unsigned long)(patch)))
+/// Get the major version from a preprocessor defined version
+#define PODIO_MAJOR_VERSION(v) (((v) & (-1UL >> 16)) >> 32)
+/// Get the minor version from a preprocessor defined version
+#define PODIO_MINOR_VERSION(v) (((v) & (-1UL >> 32)) >> 16)
+/// Get the patch version from a preprocessor defined version
+#define PODIO_PATCH_VERSION(v) ((v) & (-1UL >> 48))
+
+// Some helper constants that are populated by the cmake configure step
 #define podio_VERSION @podio_VERSION@
 #define podio_VERSION_MAJOR @podio_VERSION_MAJOR@
 #define podio_VERSION_MINOR @podio_VERSION_MINOR@
 #define podio_VERSION_PATCH @podio_VERSION_PATCH@
+
+/// The encoded version with which podio has been built
+#define PODIO_BUILD_VERSION PODIO_VERSION(podio_VERSION_MAJOR, podio_VERSION_MINOR, podio_VERSION_PATCH)
 
 namespace podio::version {
 
@@ -49,7 +65,19 @@ namespace podio::version {
   /**
    * The current build version
    */
-  static constexpr Version build_version{@podio_VERSION_MAJOR@, @podio_VERSION_MINOR@, @podio_VERSION_PATCH@};
+  static constexpr Version build_version{podio_VERSION_MAJOR, podio_VERSION_MINOR, podio_VERSION_PATCH};
+
+  /**
+   * Decode a version from a 64 bit unsigned
+   */
+  static constexpr Version decode_version(unsigned long version) noexcept {
+    return Version{
+      (uint16_t) PODIO_MAJOR_VERSION(version),
+      (uint16_t) PODIO_MINOR_VERSION(version),
+      (uint16_t) PODIO_PATCH_VERSION(version)
+    };
+  }
+
 
   enum class Compatibility {
     AnyNewer,  ///< A version is equal or higher than another version
@@ -57,6 +85,7 @@ namespace podio::version {
     SameMinor, ///< Two versions have the same major and minor version
     Exact      ///< Two versions are exactly the same
   };
+
 
   /**
    * Check if Version va is compatible with Version vb under a given
@@ -78,7 +107,7 @@ namespace podio::version {
   /**
    * Check if the version is compatible with the current build_version
    */
-  inline constexpr bool compatible(Version v, Compatibility compat=Compatibility::AnyNewer) {
+  inline constexpr bool compatible(Version v, Compatibility compat=Compatibility::AnyNewer) noexcept {
     return compatible(v, build_version, compat);
   }
    

--- a/podioVersion.in.h
+++ b/podioVersion.in.h
@@ -31,6 +31,11 @@
 
 namespace podio::version {
 
+  /**
+   * Version class consisting of 3 16 bit unsigned integers to hold the major,
+   * minor and patch version. Provides constexpr comparison operators that allow
+   * to use this class in constexpr-if clauses.
+   */
   struct Version {
     uint16_t major{0};
     uint16_t minor{0};

--- a/podioVersion.in.h
+++ b/podioVersion.in.h
@@ -1,0 +1,88 @@
+#ifndef podioVersion_h
+#define podioVersion_h
+
+#include <cstdint>
+#include <tuple>
+#include <ostream>
+#if __cplusplus >= 202002L
+#include <compare>
+#endif
+
+#define podio_VERSION @podio_VERSION@
+#define podio_VERSION_MAJOR @podio_VERSION_MAJOR@
+#define podio_VERSION_MINOR @podio_VERSION_MINOR@
+#define podio_VERSION_PATCH @podio_VERSION_PATCH@
+
+namespace podio::version {
+
+  struct Version {
+    uint16_t major{0};
+    uint16_t minor{0};
+    uint16_t patch{0};
+
+#if __cplusplus >= 202002L
+    auto operator<=>(const Version&) const = default;
+#else
+// No spaceship yet in c++17
+#define DEFINE_COMP_OPERATOR(OP)                                                   \
+    constexpr bool operator OP(const Version& o) const noexcept {                  \
+      return std::tie(major, minor, patch) OP std::tie(o.major, o.minor, o.patch); \
+    }
+
+    DEFINE_COMP_OPERATOR(<)
+    DEFINE_COMP_OPERATOR(<=)
+    DEFINE_COMP_OPERATOR(>)
+    DEFINE_COMP_OPERATOR(>=)
+    DEFINE_COMP_OPERATOR(==)
+    DEFINE_COMP_OPERATOR(!=)
+
+#undef DEFINE_COMP_OPERATOR
+#endif
+
+    friend std::ostream& operator<<(std::ostream&, const Version& v);
+  };
+
+  inline std::ostream& operator<<(std::ostream& os, const Version& v) {
+    return os << v.major << "." << v.minor << "." << v.patch;
+  }
+
+  /**
+   * The current build version
+   */
+  static constexpr Version build_version{@podio_VERSION_MAJOR@, @podio_VERSION_MINOR@, @podio_VERSION_PATCH@};
+
+  enum class Compatibility {
+    AnyNewer,  ///< A version is equal or higher than another version
+    SameMajor, ///< Two versions have the same major version
+    SameMinor, ///< Two versions have the same major and minor version
+    Exact      ///< Two versions are exactly the same
+  };
+
+  /**
+   * Check if Version va is compatible with Version vb under a given
+   * compatibility strategy (defaults AnyNewer).
+   */
+  inline constexpr bool compatible(Version va, Version vb, Compatibility compat=Compatibility::AnyNewer) noexcept {
+    switch (compat) {
+      case Compatibility::Exact:
+        return va == vb;
+      case Compatibility::AnyNewer:
+        return va >= vb;
+      case Compatibility::SameMajor:
+        return va.major == vb.major;
+      case Compatibility::SameMinor:
+        return va.major == vb.major && va.minor == vb.minor;
+    }
+  }
+
+  /**
+   * Check if the version is compatible with the current build_version
+   */
+  inline constexpr bool compatible(Version v, Compatibility compat=Compatibility::AnyNewer) {
+    return compatible(v, build_version, compat);
+  }
+   
+}
+
+
+#endif

--- a/podioVersion.in.h
+++ b/podioVersion.in.h
@@ -1,5 +1,5 @@
-#ifndef podioVersion_h
-#define podioVersion_h
+#ifndef PODIO_VERSION_H
+#define PODIO_VERSION_H
 
 #include <cstdint>
 #include <tuple>
@@ -82,40 +82,6 @@ namespace podio::version {
       (uint16_t) PODIO_PATCH_VERSION(version)
     };
   }
-
-
-  enum class Compatibility {
-    AnyNewer,  ///< A version is equal or higher than another version
-    SameMajor, ///< Two versions have the same major version
-    SameMinor, ///< Two versions have the same major and minor version
-    Exact      ///< Two versions are exactly the same
-  };
-
-
-  /**
-   * Check if Version va is compatible with Version vb under a given
-   * compatibility strategy (defaults AnyNewer).
-   */
-  inline constexpr bool compatible(Version va, Version vb, Compatibility compat=Compatibility::AnyNewer) noexcept {
-    switch (compat) {
-      case Compatibility::Exact:
-        return va == vb;
-      case Compatibility::AnyNewer:
-        return va >= vb;
-      case Compatibility::SameMajor:
-        return va.major == vb.major;
-      case Compatibility::SameMinor:
-        return va.major == vb.major && va.minor == vb.minor;
-    }
-  }
-
-  /**
-   * Check if the version is compatible with the current build_version
-   */
-  inline constexpr bool compatible(Version v, Compatibility compat=Compatibility::AnyNewer) noexcept {
-    return compatible(v, build_version, compat);
-  }
-   
 }
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ SET(headers
   ${CMAKE_SOURCE_DIR}/include/podio/ObjectID.h
   ${CMAKE_SOURCE_DIR}/include/podio/PythonEventStore.h
   ${CMAKE_SOURCE_DIR}/include/podio/UserDataCollection.h
+  ${CMAKE_SOURCE_DIR}/include/podio/podioVersion.h
   )
 PODIO_GENERATE_DICTIONARY(podioDict ${headers} SELECTION selection.xml
   OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}podioDict${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -12,6 +12,7 @@
 #include "TChain.h"
 #include "TClass.h"
 #include "TTreeCache.h"
+#include <memory>
 
 
 namespace podio {
@@ -144,6 +145,11 @@ namespace podio {
     m_table = new CollectionIDTable();
     metadatatree->SetBranchAddress("CollectionIDs", &m_table);
 
+    podio::version::Version* versionPtr{nullptr};
+    if (auto* versionBranch = root_utils::getBranch(metadatatree, "PodioVersion")) {
+      versionBranch->SetAddress(&versionPtr);
+    }
+
     // Check if the CollectionTypeInfo branch is there and assume that the file
     // has been written with with podio pre #197 (<0.13.1) if that is not the case
     if (auto* collInfoBranch = root_utils::getBranch(metadatatree, "CollectionTypeInfo")) {
@@ -159,6 +165,9 @@ namespace podio {
       const auto collectionInfo = root_utils::reconstructCollectionInfo(m_chain, *m_table);
       createCollectionBranches(collectionInfo);
     }
+
+    m_fileVersion = versionPtr ? *versionPtr : podio::version::Version{0, 0, 0};
+    delete versionPtr;
   }
 
   void ROOTReader::closeFile(){

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -4,6 +4,7 @@
 #include "podio/CollectionBase.h"
 #include "podio/EventStore.h"
 #include "podio/ROOTWriter.h"
+#include "podio/podioVersion.h"
 
 // ROOT specifc includes
 #include "TFile.h"
@@ -116,6 +117,10 @@ void ROOTWriter::setBranches(const std::vector<StoreCollection>& collections) {
     }
 
     m_metadatatree->Branch("CollectionTypeInfo", &collectionInfo);
+
+    podio::version::Version podioVersion = podio::version::build_version;
+    m_metadatatree->Branch("PodioVersion", &podioVersion);
+
     m_metadatatree->Fill();
 
     m_colMDtree->Branch("colMD", "std::map<int,podio::GenericParameters>", m_store->getColMetaDataMap() ) ;

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -23,6 +23,12 @@ namespace podio {
     }
 
     _table = new CollectionIDTable(std::move(ids), std::move(names));
+
+    if (version >= sio::version::encode_version(0, 3)) {
+      device.data(podioVersion.major);
+      device.data(podioVersion.minor);
+      device.data(podioVersion.patch);
+    }
   }
 
   void SIOCollectionIDTableBlock::write(sio::write_device& device) {
@@ -42,6 +48,10 @@ namespace podio {
     }
     device.data(typeNames);
     device.data(isSubsetColl);
+
+    device.data(podioVersion.major);
+    device.data(podioVersion.minor);
+    device.data(podioVersion.patch);
   }
 
   template<typename MappedT>

--- a/src/SIOReader.cc
+++ b/src/SIOReader.cc
@@ -149,6 +149,7 @@ namespace podio {
     m_table = idTableBlock->getTable();
     m_typeNames = idTableBlock->getTypeNames();
     m_subsetCollectionBits = idTableBlock->getSubsetCollectionBits();
+    m_fileVersion = idTableBlock->getPodioVersion();
   }
 
   void SIOReader::readMetaDataRecord(std::shared_ptr<SIONumberedMetaDataBlock> mdBlock) {

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -15,6 +15,7 @@
     </class>
     <class name="podio::PythonEventStore">
     </class>
+    <class name="podio::version::Version"/>
     <class name="podio::ObjectID"/>
     <class name="vector<podio::ObjectID>"/>
     <class name="podio::UserDataCollection<float>"/>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,11 +25,31 @@ function(CREATE_PODIO_TEST sourcefile additional_libs)
     )
 endfunction()
 
-set(root_dependent_tests write.cpp read.cpp read-multiple.cpp relation_range.cpp read_and_write.cpp read_and_write_associated.cpp write_timed.cpp read_timed.cpp read-legacy-files.cpp)
+set(root_dependent_tests write.cpp read.cpp read-multiple.cpp relation_range.cpp read_and_write.cpp read_and_write_associated.cpp write_timed.cpp read_timed.cpp)
 set(root_libs TestDataModelDict podio::podioRootIO)
 foreach( sourcefile ${root_dependent_tests} )
   CREATE_PODIO_TEST(${sourcefile} "${root_libs}")
 endforeach()
+
+message(STATUS "Getting test input files")
+execute_process(
+  COMMAND bash ${CMAKE_CURRENT_LIST_DIR}/get_test_inputs.sh
+  OUTPUT_VARIABLE PODIO_TEST_INPUT_DATA_DIR
+  RESULT_VARIABLE TEST_INPUTS_AVAILABLE
+  )
+if (NOT "${TEST_INPUTS_AVAILABLE}" STREQUAL "0")
+  message(WARNING "Could not get test input files. Will skip some tests that depend on these")
+else()
+  message(STATUS "Test inputs stored in " ${PODIO_TEST_INPUT_DATA_DIR})
+
+  add_executable(read-legacy-files read-legacy-files.cpp)
+  target_link_libraries(read-legacy-files TestDataModel TestDataModelDict podio::podioRootIO)
+  add_test(NAME read-legacy-files COMMAND read-legacy-files ${PODIO_TEST_INPUT_DATA_DIR}/example.root)
+
+  set_property(TEST read-legacy-files PROPERTY ENVIRONMENT
+    LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH}
+  )
+endif()
 
 CREATE_PODIO_TEST(ostream_operator.cpp "")
 CREATE_PODIO_TEST(write_ascii.cpp "")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ function(CREATE_PODIO_TEST sourcefile additional_libs)
     )
 endfunction()
 
-set(root_dependent_tests write.cpp read.cpp read-multiple.cpp relation_range.cpp read_and_write.cpp read_and_write_associated.cpp write_timed.cpp read_timed.cpp)
+set(root_dependent_tests write.cpp read.cpp read-multiple.cpp relation_range.cpp read_and_write.cpp read_and_write_associated.cpp write_timed.cpp read_timed.cpp read-legacy-files.cpp)
 set(root_libs TestDataModelDict podio::podioRootIO)
 foreach( sourcefile ${root_dependent_tests} )
   CREATE_PODIO_TEST(${sourcefile} "${root_libs}")

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -19,6 +19,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     read_timed
     check_benchmark_outputs
     read-multiple
+    read-legacy-files
 
     write_sio
     read_sio

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -14,6 +14,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     write
     read
     read_and_write
+    read_and_write_associated
     write_timed
     read_timed
     check_benchmark_outputs

--- a/tests/get_test_inputs.sh
+++ b/tests/get_test_inputs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Create a temporay folder to get the data to
+PODIO_TEST_INPUT_DATA_DIR=$(mktemp -d -p $(pwd) test_input_data_XXXXXXXX)
+export PODIO_TEST_INPUT_DATA_DIR
+
+# Get a legacy file with the oldest version that we still support
+cd ${PODIO_TEST_INPUT_DATA_DIR}
+wget https://key4hep.web.cern.ch:443/testFiles/podio/v00-13/example.root > /dev/null 2>&1
+
+# Announce where we store variables to the outside
+echo -n ${PODIO_TEST_INPUT_DATA_DIR}

--- a/tests/read-legacy-files.cpp
+++ b/tests/read-legacy-files.cpp
@@ -1,0 +1,12 @@
+#include "read_test.h"
+#include "podio/ROOTReader.h"
+
+int main(){
+  auto reader = podio::ROOTReader();
+  reader.openFile("https://key4hep.web.cern.ch/testFiles/podio/v00-13/example.root");
+
+  run_read_test(reader);
+
+  reader.closeFile();
+  return 0;
+}

--- a/tests/read-legacy-files.cpp
+++ b/tests/read-legacy-files.cpp
@@ -1,9 +1,16 @@
-#include "read_test.h"
 #include "podio/ROOTReader.h"
+#include "read_test.h"
 
-int main(){
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    std::cerr << "Usage: read-legacy-files inputfile" << std::endl;
+    return 1;
+  }
+
   auto reader = podio::ROOTReader();
-  reader.openFile("https://key4hep.web.cern.ch/testFiles/podio/v00-13/example.root");
+  reader.openFile(argv[1]);
 
   run_read_test(reader);
 

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -4,6 +4,9 @@
 int main(){
   auto reader = podio::ROOTReader();
   reader.openFile("example.root");
+  if (reader.currentFileVersion() != podio::version::build_version) {
+    return 1;
+  }
 
   run_read_test(reader);
 

--- a/tests/read_and_write.cpp
+++ b/tests/read_and_write.cpp
@@ -21,7 +21,7 @@ int main(){
   for(unsigned i=0; i<nEvents; ++i) {
     if(i%1000==0)
       std::cout<<"reading event "<<i<<std::endl;
-    processEvent(store, i);
+    processEvent(store, i, reader.currentFileVersion());
 
     writer.writeEvent() ;
     

--- a/tests/read_and_write_sio.cpp
+++ b/tests/read_and_write_sio.cpp
@@ -21,7 +21,7 @@ int main() {
   for(unsigned i=0; i<nEvents; ++i) {
     if(i%1000==0)
       std::cout<<"reading event "<<i<<std::endl;
-    processEvent(store, i);
+    processEvent(store, i, reader.currentFileVersion());
 
     writer.writeEvent();
 

--- a/tests/read_sio.cpp
+++ b/tests/read_sio.cpp
@@ -5,6 +5,9 @@ int main(){
 //  auto reader = podio::SIOReader();
   podio::SIOReader reader; // SIOReader has no copy c'tor ...
   reader.openFile("example.sio");
+  if (reader.currentFileVersion() != podio::version::build_version) {
+    return 1;
+  }
 
   run_read_test(reader);
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -688,42 +688,6 @@ TEST_CASE("Version tests", "[versioning]") {
     STATIC_REQUIRE(ver_1_1_1 > ver_1_1);
     STATIC_REQUIRE(ver_2_0_2 < ver_2_1);
   }
-
-  SECTION("Compatibility: default") {
-    // Assume Compatibility == AnyNewer (default)
-    STATIC_REQUIRE(compatible(ver_2, ver_1));
-    STATIC_REQUIRE(compatible(ver_1_1, ver_1));
-    STATIC_REQUIRE(compatible(ver_1_1_1, ver_1_1));
-    STATIC_REQUIRE(compatible(ver_2_0_2, ver_2));
-
-    // opposite direction
-    STATIC_REQUIRE_FALSE(compatible(ver_2, ver_2_0_2));
-    STATIC_REQUIRE_FALSE(compatible(ver_1, ver_2));
-  }
-
-  SECTION("Compatibility: SameMajor") {
-    STATIC_REQUIRE(compatible(ver_1, ver_1_1, Compatibility::SameMajor));
-    STATIC_REQUIRE(compatible(ver_1_1, ver_1, Compatibility::SameMajor));
-    STATIC_REQUIRE(compatible(ver_1, ver_1_1_1, Compatibility::SameMajor));
-    STATIC_REQUIRE(compatible(ver_1_1_1, ver_1, Compatibility::SameMajor));
-    STATIC_REQUIRE(compatible(ver_1_1, ver_1_1_1, Compatibility::SameMajor));
-    STATIC_REQUIRE(compatible(ver_2_0_2, ver_2, Compatibility::SameMajor));
-    STATIC_REQUIRE(compatible(ver_2, ver_2_0_2, Compatibility::SameMajor));
-  }
-
-  SECTION("Compatibility: SameMinor") {
-    STATIC_REQUIRE(compatible(ver_1, ver_1_0_2, Compatibility::SameMinor));
-    STATIC_REQUIRE_FALSE(compatible(ver_1_1, ver_1, Compatibility::SameMinor));
-    STATIC_REQUIRE(compatible(ver_1_1, ver_1_1_1, Compatibility::SameMinor));
-    STATIC_REQUIRE(compatible(ver_1_1_1, ver_1_1, Compatibility::SameMinor));
-  }
-
-  SECTION("Compatibility: Exact") {
-    STATIC_REQUIRE(compatible(ver_1, Version{1}, Compatibility::Exact));
-    STATIC_REQUIRE_FALSE(compatible(ver_1, ver_1_1, Compatibility::Exact));
-    STATIC_REQUIRE_FALSE(compatible(ver_1, ver_1_1_1, Compatibility::Exact));
-    STATIC_REQUIRE_FALSE(compatible(ver_1, ver_2, Compatibility::Exact));
-  }
 }
 
 TEST_CASE("Preprocessor version tests", "[versioning]") {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -725,3 +725,40 @@ TEST_CASE("Version tests", "[versioning]") {
     STATIC_REQUIRE_FALSE(compatible(ver_1, ver_2, Compatibility::Exact));
   }
 }
+
+TEST_CASE("Preprocessor version tests", "[versioning]") {
+  SECTION("Basic functionality") {
+    using namespace podio::version;
+    // Check that preprocessor comparisons work
+    STATIC_REQUIRE(PODIO_BUILD_VERSION == PODIO_VERSION(build_version.major, build_version.minor, build_version.patch));
+
+    // Make sure that we can actually decode 64 bit versions
+    STATIC_REQUIRE(decode_version(PODIO_BUILD_VERSION) == build_version);
+
+    STATIC_REQUIRE(PODIO_MAJOR_VERSION(PODIO_BUILD_VERSION) == build_version.major);
+    STATIC_REQUIRE(PODIO_MINOR_VERSION(PODIO_BUILD_VERSION) == build_version.minor);
+    STATIC_REQUIRE(PODIO_PATCH_VERSION(PODIO_BUILD_VERSION) == build_version.patch);
+
+    // Make a few checks where other versions are "maxed out"
+    STATIC_REQUIRE(PODIO_MAJOR_VERSION(PODIO_VERSION(10000, 65535, 65535)) == 10000);
+    STATIC_REQUIRE(PODIO_MINOR_VERSION(PODIO_VERSION(65535, 20000, 65535)) == 20000);
+    STATIC_REQUIRE(PODIO_PATCH_VERSION(PODIO_VERSION(65535, 65535, 30000)) == 30000);
+  }
+
+  SECTION("Comparing") {
+    // Using some large numbers here to check what happens if we start to
+    // actually use the 16 available bits
+    // patch version
+    STATIC_REQUIRE(PODIO_VERSION(10000, 20000, 39999) < PODIO_VERSION(10000, 20000, 40000));
+
+    // minor version
+    STATIC_REQUIRE(PODIO_VERSION(10000, 30000, 33333) > PODIO_VERSION(10000, 29999, 33333));
+    STATIC_REQUIRE(PODIO_VERSION(10000, 30000, 33333) < PODIO_VERSION(10000, 30001, 44444));
+
+    // major version
+    STATIC_REQUIRE(PODIO_VERSION(20000, 40000, 0) < PODIO_VERSION(20001, 40000, 0));
+    STATIC_REQUIRE(PODIO_VERSION(20000, 40000, 10000) < PODIO_VERSION(20001, 30000, 0));
+    STATIC_REQUIRE(PODIO_VERSION(20001, 40000, 10000) > PODIO_VERSION(20000, 40000, 20000));
+    STATIC_REQUIRE(PODIO_VERSION(20000, 40000, 10000) > PODIO_VERSION(19999, 50000, 30000));
+  }
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Extend the `podioVersion.h` header that is configured by cmake to hold some version utilities.
  - `podio::version::Version` class holding three `uint16_t`s for major, minor and patch version, plus `constexpr` comparison operators.
  - static const(expr) `podio::version::build_version` that holds the current (i.e. last tag) version of podio
  - Add preprocessor macros with similar functionality
    - `PODIO_VERSION` takes a major, minor and a patch version number and encodes it into a 64 bit version constant. 
    - `PODIO_[MAJOR|MINOR|PATCH]_VERSION` macros can extracts these values again from a 64 bit encoded version. 
    - `PODIO_BUILD_VERSION` holds the 64 bit encoded current (i.e. last tag) version of podio
- Reorder the read tests slightly and make some sections version dependent
- Add legacy file read test from #230 

ENDRELEASENOTES

This is a first shot at this. Some of the open questions that might warrant discussion:
- [x] Do we need 3 16 bit unsigned ints or should we try to have all three parts in one 32 bit integer?
- [x] ~Double overload of the `compatible` function: Should we consider a different name for the one that checks if a version is compatible with the current `build_version`?~ Removed for now as meaning is not well defined (yet).
- [x] Do we need pre-processor capabilities for versions as well, or are we content with compile time functionality?
- [x] Is configuring the `podioVersion.h` header into the `include/podio` source directory what we should be doing?