### PR TITLE
Fix typo in cmake config template for downstream usage

### DIFF
--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -25,7 +25,7 @@ set(PODIO_IO_HANDLERS "@PODIO_IO_HANDLERS@")
 
 include(CMakeFindDependencyMacro)
 find_dependency(ROOT @ROOT_VERSION@)
-if(@REQUIRE_PYTHON_VERSION)
+if(@REQUIRE_PYTHON_VERSION@)
   find_dependency(Python @REQUIRE_PYTHON_VERSION@ COMPONENTS Interpreter)
 else()
   find_dependency(Python COMPONENTS Interpreter)


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a typo in the cmake config for finding the correct python version when cmake is used in downstream packages.

ENDRELEASENOTES

This wasn't really a problem, since the same `find_dependency` is present in any case, just without a specified version. Originally this was introduced in #214 