### PR TITLE
Add specificity to cmake filter pattern for ROOT sources in src/

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,8 +13,8 @@ endif()
 
 # Remove SIO and ROOT related things from the core library
 LIST(FILTER sources EXCLUDE REGEX SIO.*)
-LIST(FILTER sources EXCLUDE REGEX ROOT.*|PythonEventStore.*|root.* )
-LIST(FILTER root_sources INCLUDE REGEX ROOT.*|PythonEventStore.*|root.* )
+LIST(FILTER sources EXCLUDE REGEX ROOT.*|PythonEventStore.*|root[a-z|A-z|0-9].* )
+LIST(FILTER root_sources INCLUDE REGEX ROOT.*|PythonEventStore.*|root[a-z|A-z|0-9].* )
 
 # Main Library, no external dependencies
 add_library(podio SHARED ${sources})


### PR DESCRIPTION
We are building podio with automated processes inside a docker container. For various reasons, this means the build directory is in `/tmp/root/spack-build/` etc. With the full source tree checked out in that path, the EXCLUDE and INCLUDE patterns are too greedy and just remove everything on account of the `root` in the path itself.

We think the PR is warranted even for a problem that has an origin in the local build directories since we are using a standard `spack containerize` workflow that others may encounter as well. The only negative effects we can identify is that future files in `src/` that do not follow `root` with a letter or number may not be matched, but that would be immediately clear to the developer when that happens.