### PR TITLE
Fix incorrect handling of subset collections of types without relations

### DIFF
--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -93,10 +93,8 @@ void {{ collection_type }}::prepareAfterRead() {
   m_isPrepared = true;
 }
 
-bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* {% if OneToManyRelations or OneToOneRelations -%}collectionProvider{%- endif -%}) {
-{% if OneToManyRelations or OneToOneRelations %}
+bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* collectionProvider) {
   m_storage.setReferences(collectionProvider, m_isSubsetColl);
-{% endif %}
 
   return true; //TODO: check success
 }

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -30,9 +30,7 @@
 
 {{ class_type }}::~{{ class_type }}() {
   delete m_data;
-{% if OneToManyRelations or OneToOneRelations %}
   for (auto& pointer : m_refCollections) delete pointer;
-{% endif %}
 {% for relation in OneToManyRelations + OneToOneRelations %}
   delete m_rel_{{ relation.name }};
 {% endfor %}

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -158,7 +158,6 @@ void {{ class_type }}::createRelations({{ class.bare_type }}Obj* obj) {
 }
 {% endif %}
 
-{% if OneToManyRelations or OneToOneRelations %}
 void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectionProvider, bool isSubsetColl) {
   if (isSubsetColl) {
     for (const auto& id : *m_refCollections[0]) {
@@ -177,7 +176,6 @@ void {{ class_type }}::setReferences(const podio::ICollectionProvider* collectio
 {% endfor %}
 
 }
-{% endif %}
 
 void {{ class_type }}::makeSubsetCollection() {
   // Subset collections do not need all the data buffers that normal

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -63,9 +63,7 @@ public:
   void createRelations({{ class.bare_type }}Obj* obj);
 {% endif %}
 
-{% if OneToManyRelations or OneToOneRelations %}
   void setReferences(const podio::ICollectionProvider* collectionProvider, bool isSubsetColl);
-{% endif %}
 
 private:
   // members to handle 1-to-N-relations

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -22,6 +22,7 @@
 
 // STL
 #include <limits>
+#include <stdexcept>
 #include <vector>
 #include <iostream>
 #include <exception>
@@ -86,6 +87,13 @@ void processEvent(podio::EventStore& store, int eventNum) {
     throw std::runtime_error("Couldn't read event meta data parameters 'CellIDEncodingString'");
   }
 
+  auto& hitRefs = store.get<ExampleHitCollection>("hitRefs");
+  if (hitRefs.size() != hits.size()) {
+    throw std::runtime_error("hit and subset hit collection do not have the same size");
+  }
+  if (!(hits[1] == hitRefs[0] && hits[0] == hitRefs[1])) {
+    throw std::runtime_error("hit subset collections do not have the expected contents");
+  }
 
   auto& clusters = store.get<ExampleClusterCollection>("clusters");
   if(clusters.isValid()){

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -35,6 +35,8 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& mcpsRefs   = store.create<ExampleMCCollection>("mcParticleRefs");
   mcpsRefs.setSubsetCollection();
   auto& hits       = store.create<ExampleHitCollection>("hits");
+  auto& hitRefs    = store.create<ExampleHitCollection>("hitRefs");
+  hitRefs.setSubsetCollection();
   auto& clusters   = store.create<ExampleClusterCollection>("clusters");
   auto& refs       = store.create<ExampleReferencingTypeCollection>("refs");
   auto& refs2      = store.create<ExampleReferencingTypeCollection>("refs2");
@@ -55,6 +57,7 @@ void write(podio::EventStore& store, WriterT& writer) {
   writer.registerForWrite("moreMCs");
   writer.registerForWrite("mcParticleRefs");
   writer.registerForWrite("hits");
+  writer.registerForWrite("hitRefs");
   writer.registerForWrite("clusters");
   writer.registerForWrite("refs");
   writer.registerForWrite("refs2");
@@ -95,6 +98,9 @@ void write(podio::EventStore& store, WriterT& writer) {
 
     hits.push_back(hit1);
     hits.push_back(hit2);
+
+    hitRefs.push_back(hit2);
+    hitRefs.push_back(hit1);
 
     // ---- add some MC particles ----
     auto mcp0 = ExampleMC();


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that collections of types without relations can still be used properly as subset collections. Previous to these changes, the necessary functionality was not generated if a datatype had no relations (i.e. not a single `OneToOneRelation` or `OneToManyRelation`).
- Add a check of this functionality to the write/read tests.

ENDRELEASENOTES