### PR TITLE
Make collections movable

### DIFF
--- a/include/podio/CollectionBuffers.h
+++ b/include/podio/CollectionBuffers.h
@@ -6,11 +6,15 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <memory>
 
 
 namespace podio {
 
-using CollRefCollection = std::vector<std::vector<podio::ObjectID>*>;
+template<typename T>
+using UVecPtr = std::unique_ptr<std::vector<T>>;
+
+using CollRefCollection = std::vector<UVecPtr<podio::ObjectID>>;
 using VectorMembersInfo = std::vector<std::pair<std::string, void*>>;
 
 /**

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -85,7 +85,10 @@ namespace podio {
 
   private:
     std::vector<BasicType> _vec{} ;
-    std::vector<BasicType>* _vecPtr = &_vec ;
+    // Pointer to the actual storage, necessary for I/O. In order to have
+    // simpler move-semantics this will be set and properly initialized on
+    // demand during the call to getBuffers
+    std::vector<BasicType>* _vecPtr{nullptr};
     int m_collectionID{0};
     CollRefCollection m_refCollections{};
     VectorMembersInfo m_vecmem_info{};
@@ -95,6 +98,8 @@ namespace podio {
     UserDataCollection() = default ;
     UserDataCollection(const UserDataCollection& ) = delete;
     UserDataCollection& operator=(const UserDataCollection& ) = delete;
+    UserDataCollection(UserDataCollection&&) = default;
+    UserDataCollection& operator=(UserDataCollection&&) = default;
     ~UserDataCollection() = default;
 
 
@@ -121,6 +126,7 @@ namespace podio {
 
     /// Get the collection buffers for this collection
     podio::CollectionBuffers getBuffers() override final {
+      _vecPtr = &_vec; // Set the pointer to the correct internal vector
       return { &_vecPtr,
 	&m_refCollections,
 	&m_vecmem_info } ;

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -302,15 +302,18 @@ class ClassGenerator(object):
 
   def _preprocess_for_collection(self, datatype):
     """Do the necessary preprocessing for the collection"""
-    includes_cc = set()
+    includes_cc, includes = set(), set()
+
     for relation in datatype['OneToManyRelations'] + datatype['OneToOneRelations']:
       if datatype['class'].bare_type != relation.bare_type:
         includes_cc.add(self._build_include(relation.bare_type + 'Collection'))
+        includes.add(self._build_include(relation.bare_type))
 
     if datatype['VectorMembers']:
       includes_cc.add('#include <numeric>')
 
     datatype['includes_coll_cc'] = self._sort_includes(includes_cc)
+    datatype['includes_coll_data'] = self._sort_includes(includes)
 
     # the ostream operator needs a bit of help from the python side in the form
     # of some pre processing but also in the form of formatting, both are done

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -41,8 +41,12 @@ public:
   using iterator = {{ class.bare_type }}MutableCollectionIterator;
 
   {{ class.bare_type }}Collection();
+  // This is a move-only type
   {{ class.bare_type }}Collection(const {{ class.bare_type}}Collection& ) = delete;
   {{ class.bare_type }}Collection& operator=(const {{ class.bare_type}}Collection& ) = delete;
+  {{ class.bare_type }}Collection({{ class.bare_type }}Collection&&) = default;
+  {{ class.bare_type }}Collection& operator=({{ class.bare_type }}Collection&&) = default;
+
 //  {{ class.bare_type }}Collection({{ class.bare_type }}Vector* data, int collectionID);
   ~{{ class.bare_type }}Collection();
 

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -13,82 +13,19 @@
 {% with class_type = class.bare_type + 'CollectionData' %}
 
 {{ class_type }}::{{ class_type }}() :
-{%- for relation in OneToManyRelations + OneToOneRelations %}
+{% for relation in OneToManyRelations + OneToOneRelations %}
   m_rel_{{ relation.name }}(new std::vector<{{ relation.namespace }}::{{ relation.bare_type }}>()),
-{%- endfor %}
+{% endfor %}
 {%- for member in VectorMembers %}
   m_vec_{{ member.name }}(new std::vector<{{ member.full_type }}>()),
-{%- endfor -%}
+{% endfor %}
   m_data(new {{ class.bare_type }}DataContainer()) {
 {% for relation in OneToManyRelations + OneToOneRelations %}
-  m_refCollections.push_back(new std::vector<podio::ObjectID>());
+  m_refCollections.emplace_back(std::make_unique<std::vector<podio::ObjectID>>());
 {% endfor %}
 {% for member in VectorMembers %}
   m_vecmem_info.emplace_back("{{ member.full_type }}", &m_vec_{{ member.name }});
 {% endfor %}
-}
-
-{{ class_type }}::~{{ class_type }}() {
-  delete m_data;
-  for (auto& pointer : m_refCollections) delete pointer;
-{% for relation in OneToManyRelations + OneToOneRelations %}
-  delete m_rel_{{ relation.name }};
-{% endfor %}
-{% for member in VectorMembers %}
-  delete m_vec_{{ member.name }};
-{% endfor %}
-}
-
-{{ class_type }}::{{ class_type }}({{ class_type }}&& other) :
-  entries(std::move(other.entries)),
-{%- for relation in OneToManyRelations %}
-  m_rel_{{ relation.name }}(std::move(other.m_rel_{{ relation.name }})),
-  m_rel_{{ relation.name }}_tmp(std::move(other.m_rel_{{ relation.name }}_tmp)),
-{%- endfor %}
-{%- for relation in OneToOneRelations %}
-  m_rel_{{ relation.name }}(std::move(other.m_rel_{{ relation.name }})),
-{%- endfor %}
-{%- for member in VectorMembers %}
-  m_vec_{{ member.name }}(std::move(other.m_vec_{{ member.name }})),
-  m_vecs_{{ member.name }}(std::move(other.m_vecs_{{ member.name }})),
-{%- endfor %}
-  m_refCollections(std::move(other.m_refCollections)),
-  m_vecmem_info(std::move(other.m_vecmem_info)),
-  m_data(std::move(other.m_data)) {
-  // Reset the pointers in the moved from object
-{% for relation in OneToManyRelations + OneToOneRelations %}
-  m_rel_{{ relation.name }} = nullptr;
-{% endfor %}
-{% for member in VectorMembers %}
-  m_vec_{{ member.name }} = nullptr;
-{% endfor %}
-  other.m_data = nullptr;
-}
-
-{{ class_type }}& {{ class_type }}::operator=({{ class_type }}&& other) {
-  entries = std::move(other.entries);
-{% for relation in OneToManyRelations %}
-  m_rel_{{ relation.name }} = std::move(other.m_rel_{{ relation.name }});
-  m_rel_{{ relation.name }} = nullptr;
-  m_rel_{{ relation.name }}_tmp = std::move(other.m_rel_{{ relation.name }}_tmp);
-{% endfor %}
-{% for relation in OneToOneRelations %}
-  m_rel_{{ relation.name }} = std::move(other.m_rel_{{ relation.name }});
-  m_rel_{{ relation.name }} = nullptr;
-{% endfor %}
-{% for member in VectorMembers %}
-  m_vec_{{ member.name }}= std::move(other.m_vec_{{ member.name }});
-  m_vec_{{ member.name }} = nullptr;
-  m_vecs_{{ member.name }} = std::move(other.m_vecs_{{ member.name }});
-{% endfor %}
-
-  m_refCollections = std::move(other.m_refCollections);
-  m_vecmem_info = std::move(other.m_vecmem_info);
-
-  m_data = std::move(other.m_data);
-  other.m_data = nullptr;
-
-  return *this;
 }
 
 void {{ class_type }}::clear(bool isSubsetColl) {
@@ -101,7 +38,7 @@ void {{ class_type }}::clear(bool isSubsetColl) {
   }
 
   // Normal collections manage a bit more and have to clean up a bit more
-  m_data->clear();
+  if (m_data) m_data->clear();
 {% if OneToManyRelations or OneToOneRelations %}
   for (auto& pointer : m_refCollections) { pointer->clear(); }
 {% endif %}
@@ -111,7 +48,6 @@ void {{ class_type }}::clear(bool isSubsetColl) {
     for (auto& item : *pointer) {
       item.unlink();
     }
-    delete pointer;
   }
   m_rel_{{ relation.name }}_tmp.clear();
 {{ macros.clear_relation(relation) }}
@@ -120,8 +56,7 @@ void {{ class_type }}::clear(bool isSubsetColl) {
 {{ macros.clear_relation(relation) }}
 {% endfor %}
 {% for member in VectorMembers %}
-  m_vec_{{ member.name }}->clear();
-  for (auto& vec : m_vecs_{{ member.name }}) { delete vec; }
+  if (m_vec_{{ member.name }}) m_vec_{{ member.name }}->clear();
   m_vecs_{{ member.name }}.clear();
 
 {% endfor %}
@@ -185,10 +120,10 @@ void {{ class_type }}::prepareAfterRead(int collectionID) {
     auto obj = new {{ class.bare_type }}Obj({index, collectionID}, data);
 
 {% for relation in OneToManyRelations %}
-    obj->m_{{ relation.name }} = m_rel_{{ relation.name }};
+    obj->m_{{ relation.name }} = m_rel_{{ relation.name }}.get();
 {% endfor %}
 {% for member in VectorMembers %}
-    obj->m_{{ member.name }} = m_vec_{{ member.name }};
+    obj->m_{{ member.name }} = m_vec_{{ member.name }}.get();
 {% endfor %}
     entries.emplace_back(obj);
     ++index;
@@ -202,10 +137,12 @@ void {{ class_type }}::prepareAfterRead(int collectionID) {
 {% if OneToManyRelations or VectorMembers %}
 void {{ class_type }}::createRelations({{ class.bare_type }}Obj* obj) {
  {% for relation in OneToManyRelations %}
-  m_rel_{{ relation.name }}_tmp.push_back(obj->m_{{ relation.name }});
+  // We take ownership of these here
+  m_rel_{{ relation.name }}_tmp.emplace_back(obj->m_{{ relation.name }});
 {% endfor %}
 {% for member in VectorMembers %}
-  m_vecs_{{ member.name }}.push_back(obj->m_{{ member.name }});
+  // We take ownership of these here
+  m_vecs_{{ member.name }}.emplace_back(obj->m_{{ member.name }});
 {% endfor %}
 }
 {% endif %}
@@ -234,24 +171,18 @@ void {{ class_type }}::makeSubsetCollection() {
   // collections need, so we can free them here
   m_vecmem_info.clear();
 
-  delete m_data;
-  m_data = nullptr;
+  m_data.reset(nullptr);
 
 {% for relation in OneToManyRelations + OneToOneRelations %}
-  delete m_rel_{{ relation.name }};
-  m_rel_{{ relation.name }} = nullptr;
+  m_rel_{{ relation.name }}.reset(nullptr);
 {% endfor %}
 {% for member in VectorMembers %}
-  delete m_vec_{{ member.name }};
-  m_vec_{{ member.name }} = nullptr;
+  m_vec_{{ member.name }}.reset(nullptr);
 {% endfor %}
 
   // Subset collections need one vector of ObjectIDs for I/O purposes.
-  for (auto& pointer : m_refCollections) {
-    delete pointer;
-  }
   m_refCollections.resize(1);
-  m_refCollections[0] = new std::vector<podio::ObjectID>();
+  m_refCollections[0] = std::make_unique<std::vector<podio::ObjectID>>();
 }
 
 {% endwith %}

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -39,6 +39,58 @@
 {% endfor %}
 }
 
+{{ class_type }}::{{ class_type }}({{ class_type }}&& other) :
+  entries(std::move(other.entries)),
+{%- for relation in OneToManyRelations %}
+  m_rel_{{ relation.name }}(std::move(other.m_rel_{{ relation.name }})),
+  m_rel_{{ relation.name }}_tmp(std::move(other.m_rel_{{ relation.name }}_tmp)),
+{%- endfor %}
+{%- for relation in OneToOneRelations %}
+  m_rel_{{ relation.name }}(std::move(other.m_rel_{{ relation.name }})),
+{%- endfor %}
+{%- for member in VectorMembers %}
+  m_vec_{{ member.name }}(std::move(other.m_vec_{{ member.name }})),
+  m_vecs_{{ member.name }}(std::move(other.m_vecs_{{ member.name }})),
+{%- endfor %}
+  m_refCollections(std::move(other.m_refCollections)),
+  m_vecmem_info(std::move(other.m_vecmem_info)),
+  m_data(std::move(other.m_data)) {
+  // Reset the pointers in the moved from object
+{% for relation in OneToManyRelations + OneToOneRelations %}
+  m_rel_{{ relation.name }} = nullptr;
+{% endfor %}
+{% for member in VectorMembers %}
+  m_vec_{{ member.name }} = nullptr;
+{% endfor %}
+  other.m_data = nullptr;
+}
+
+{{ class_type }}& {{ class_type }}::operator=({{ class_type }}&& other) {
+  entries = std::move(other.entries);
+{% for relation in OneToManyRelations %}
+  m_rel_{{ relation.name }} = std::move(other.m_rel_{{ relation.name }});
+  m_rel_{{ relation.name }} = nullptr;
+  m_rel_{{ relation.name }}_tmp = std::move(other.m_rel_{{ relation.name }}_tmp);
+{% endfor %}
+{% for relation in OneToOneRelations %}
+  m_rel_{{ relation.name }} = std::move(other.m_rel_{{ relation.name }});
+  m_rel_{{ relation.name }} = nullptr;
+{% endfor %}
+{% for member in VectorMembers %}
+  m_vec_{{ member.name }}= std::move(other.m_vec_{{ member.name }});
+  m_vec_{{ member.name }} = nullptr;
+  m_vecs_{{ member.name }} = std::move(other.m_vecs_{{ member.name }});
+{% endfor %}
+
+  m_refCollections = std::move(other.m_refCollections);
+  m_vecmem_info = std::move(other.m_vecmem_info);
+
+  m_data = std::move(other.m_data);
+  other.m_data = nullptr;
+
+  return *this;
+}
+
 void {{ class_type }}::clear(bool isSubsetColl) {
   if (isSubsetColl) {
     // We don't own the objects so no cleanup to do here

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -39,10 +39,12 @@ public:
   {{ class_type }}();
 
   /**
-   * Non copy-able class
+   * Non copy-able, move-only class
    */
   {{ class_type }}(const {{ class_type }}&) = delete;
   {{ class_type }}& operator=(const {{ class_type }}&) = delete;
+  {{ class_type }}({{ class_type }}&& other);
+  {{ class_type }}& operator=({{ class_type }}&& other);
 
   /**
    * Deconstructor

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -13,7 +13,7 @@
 #include "podio/ICollectionProvider.h"
 
 #include <deque>
-
+#include <memory>
 
 {{ utils.namespace_open(class.namespace) }}
 
@@ -43,13 +43,13 @@ public:
    */
   {{ class_type }}(const {{ class_type }}&) = delete;
   {{ class_type }}& operator=(const {{ class_type }}&) = delete;
-  {{ class_type }}({{ class_type }}&& other);
-  {{ class_type }}& operator=({{ class_type }}&& other);
+  {{ class_type }}({{ class_type }}&& other) = default;
+  {{ class_type }}& operator=({{ class_type }}&& other) = default;
 
   /**
    * Deconstructor
    */
-  ~{{ class_type }}();
+  ~{{ class_type }}() = default;
 
   void clear(bool isSubsetColl);
 
@@ -70,23 +70,23 @@ public:
 private:
   // members to handle 1-to-N-relations
 {% for relation in OneToManyRelations %}
-  std::vector<{{ relation.namespace }}::{{ relation.bare_type }}>* m_rel_{{ relation.name }}; ///< Relation buffer for read / write
-  std::vector<std::vector<{{ relation.namespace }}::{{ relation.bare_type }}>*> m_rel_{{ relation.name }}_tmp{}; ///< Relation buffer for internal book-keeping
+  podio::UVecPtr<{{ relation.namespace }}::{{ relation.bare_type }}> m_rel_{{ relation.name }};  ///< Relation buffer for read / write
+  std::vector<podio::UVecPtr<{{ relation.namespace }}::{{ relation.bare_type }}>> m_rel_{{ relation.name }}_tmp{}; ///< Relation buffer for internal book-keeping
 {% endfor %}
 {% for relation in OneToOneRelations %}
-  std::vector<{{ relation.namespace }}::{{ relation.bare_type }}>* m_rel_{{ relation.name }}; ///< Relation buffer for read / write
+  podio::UVecPtr<{{ relation.namespace }}::{{ relation.bare_type }}> m_rel_{{ relation.name }}; ///< Relation buffer for read / write
 {% endfor %}
 
   // members to handle vector members
 {% for member in VectorMembers %}
-  std::vector<{{ member.full_type }}>* m_vec_{{ member.name }}; /// combined vector of all objects in collection
-  std::vector<std::vector<{{ member.full_type }}>*> m_vecs_{{ member.name }}{}; /// pointers to individual member vectors
+  podio::UVecPtr<{{ member.full_type }}> m_vec_{{ member.name }}; /// combined vector of all objects in collection
+  std::vector<podio::UVecPtr<{{ member.full_type }}>> m_vecs_{{ member.name }}{}; /// pointers to individual member vectors
 {% endfor %}
 
   // I/O related buffers
   podio::CollRefCollection m_refCollections{};
   podio::VectorMembersInfo m_vecmem_info{};
-  {{ class.bare_type }}DataContainer* m_data{nullptr};
+  std::unique_ptr<{{ class.bare_type }}DataContainer> m_data{nullptr};
 };
 {% endwith %}
 

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -7,6 +7,9 @@
 // datamodel specific includes
 #include "{{ incfolder }}{{ class.bare_type }}Data.h"
 #include "{{ incfolder }}{{ class.bare_type }}Obj.h"
+{% for include in includes_coll_data %}
+{{ include }}
+{% endfor %}
 
 // podio specific includes
 #include "podio/CollectionBuffers.h"

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -38,16 +38,16 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
     unsigned size(0);
     device.data( size );
     dataVec->resize(size);
-    podio::handlePODDataSIO(device, &(*dataVec)[0], size);
+    podio::handlePODDataSIO(device, dataVec->data(), size);
   }
 
   //---- read ref collections -----
   auto* refCols = collBuffers.references;
-  for( auto* refC : *refCols ){
+  for( auto& refC : *refCols ){
     unsigned size{0};
     device.data( size ) ;
     refC->resize(size) ;
-    podio::handlePODDataSIO( device ,  &((*refC)[0]), size ) ;
+    podio::handlePODDataSIO( device ,  refC->data(), size ) ;
   }
 
 {% if VectorMembers %}
@@ -68,15 +68,15 @@ void {{ block_class }}::write(sio::write_device& device) {
     auto* dataVec = collBuffers.dataAsVector<{{ class.full_type }}Data>();
     unsigned size = dataVec->size() ;
     device.data( size ) ;
-    podio::handlePODDataSIO( device ,  &(*dataVec)[0], size ) ;
+    podio::handlePODDataSIO( device ,  dataVec->data(), size ) ;
   }
 
   //---- write ref collections -----
   auto* refCols = collBuffers.references;
-  for( auto* refC : *refCols ){
+  for( auto& refC : *refCols ){
     unsigned size = refC->size() ;
     device.data( size ) ;
-    podio::handlePODDataSIO( device ,  &((*refC)[0]), size ) ;
+    podio::handlePODDataSIO( device ,  refC->data(), size ) ;
   }
 
 {% if VectorMembers %}

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -12,8 +12,10 @@ const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collect
 
 
 {% macro clear_relation(relation) %}
-  for (auto& item : (*m_rel_{{ relation.name }})) { item.unlink(); }
-  m_rel_{{ relation.name }}->clear();
+  if (m_rel_{{ relation.name }}) {
+    for (auto& item : (*m_rel_{{ relation.name }})) { item.unlink(); }
+    m_rel_{{ relation.name }}->clear();
+  }
 {% endmacro %}
 
 {% macro _relation_index_handling(relation) %}

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -66,7 +66,7 @@ void ROOTWriter::createBranches(const std::vector<StoreCollection>& collections)
       int i = 0;
       for (auto& c : (*refColls)) {
         const auto brName = root_utils::refBranch(name, i);
-        branches.refs.push_back(m_datatree->Branch(brName.c_str(), c));
+        branches.refs.push_back(m_datatree->Branch(brName.c_str(), c.get()));
         ++i;
       }
     }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -623,5 +623,36 @@ TEST_CASE("Move-only collections", "[collections][move-semantics]") {
 
     checkCollections(newHits, newClusters, newVecMems);
   }
+
+
+  SECTION("Subset collections can be moved") {
+    auto subsetHits = ExampleHitCollection();
+    subsetHits.setSubsetCollection();
+    for (auto hit : hitColl) subsetHits.push_back(hit);
+    checkCollections(subsetHits, clusterColl, vecMemColl);
+
+    auto newSubsetHits = std::move(subsetHits);
+    REQUIRE(newSubsetHits.isSubsetCollection());
+    checkCollections(newSubsetHits, clusterColl, vecMemColl);
+
+    auto subsetClusters = ExampleClusterCollection();
+    subsetClusters.setSubsetCollection();
+    for (auto cluster : clusterColl) subsetClusters.push_back(cluster);
+    checkCollections(newSubsetHits, subsetClusters, vecMemColl);
+
+    // Test move-assignment here as well
+    auto newSubsetClusters = ExampleClusterCollection();
+    newSubsetClusters = std::move(subsetClusters);
+    REQUIRE(newSubsetClusters.isSubsetCollection());
+    checkCollections(newSubsetHits, newSubsetClusters, vecMemColl);
+
+    auto subsetVecs = ExampleWithVectorMemberCollection();
+    subsetVecs.setSubsetCollection();
+    for (auto vec : vecMemColl) subsetVecs.push_back(vec);
+    checkCollections(newSubsetHits, newSubsetClusters, subsetVecs);
+
+    auto newSubsetVecs = std::move(subsetVecs);
+    REQUIRE(newSubsetVecs.isSubsetCollection());
+    checkCollections(hitColl, clusterColl, newSubsetVecs);
   }
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the `CollectionData` classes use `unique_ptr` instead of raw pointers, wherever they actually own the pointer.
- Implement move constructors and move assignment operators for collections. Thanks to the usage of `unique_ptr` for ownership management in the `CollectionData`, these can be `default`ed in `Collection` and `CollectionData`.
- Add a few tests to check that moving collections actually works.

ENDRELEASENOTES

- [x] Builds on #251 