### PR TITLE
Ignore new test in sanitizer builds

### DIFF
--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -14,6 +14,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     write
     read
     read_and_write
+    read_and_write_associated
     write_timed
     read_timed
     check_benchmark_outputs


### PR DESCRIPTION
BEGINRELEASENOTES
- Ignore the test introduced in #235 in sanitizer builds as it currently breaks.

ENDRELEASENOTES

Is there a way to make github actions pick up the latest master and apply the PR on top of that before running? That would have caught this earlier.