### PR TITLE
Add preprocessor macros to retrieve versions

### DIFF
--- a/podioVersion.h
+++ b/podioVersion.h
@@ -1,4 +1,9 @@
 #ifndef podioVersion_h
 #define podioVersion_h
 #define podio_VERSION @podio_VERSION@
+#define podio_VERSION_MAJOR @podio_VERSION_MAJOR@
+#define podio_VERSION_MINOR @podio_VERSION_MINOR@
+#define podio_VERSION_PATCH @podio_VERSION_PATCH@
+#define podio_VERSION_ENCODE(a,b,c) (((a) << 16) + ((b) << 8) + (c))
+#define podio_VERSION_CODE podio_VERSION_ENCODE(podio_VERSION_MAJOR,podio_VERSION_MINOR,podio_VERSION_PATCH)
 #endif


### PR DESCRIPTION
BEGINRELEASENOTES
- Add preprocessor macros to retrieve versions

ENDRELEASENOTES

I've realized that retrieving versions for preprocessing is somehow quite tricky in Podio. Adding a preprocessor macro would make it more helpful to developers (support backward compatibility for lcg releases, .etc). I believe that the macro will be okay as long as we maintain `major.minor.patch` convention for the version (mimicked how ROOT does for versioning [[link](https://root.cern.ch/doc/master/RVersion_8h_source.html)]), but please let me know if there is any kind of issue you concern. Thanks.