### PR TITLE
Add templated get/set functionality for GenericParameters and deprecate non-templated versions

### DIFF
--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -201,10 +201,10 @@ public:
 private:
   /// Get a reference to the internal map for a given type (necessary for SIO)
   template <typename T>
-  const MapType<T>& getMap() const {
-    if constexpr (std::is_same_v<T, int>) {
+  const MapType<detail::GetVectorType<T>>& getMap() const {
+    if constexpr (std::is_same_v<detail::GetVectorType<T>, int>) {
       return _intMap;
-    } else if constexpr (std::is_same_v<T, float>) {
+    } else if constexpr (std::is_same_v<detail::GetVectorType<T>, float>) {
       return _floatMap;
     } else {
       return _stringMap;
@@ -213,10 +213,10 @@ private:
 
   /// Get a reference to the internal map for a given type (necessary for SIO)
   template <typename T>
-  MapType<T>& getMap() {
-    if constexpr (std::is_same_v<T, int>) {
+  MapType<detail::GetVectorType<T>>& getMap() {
+    if constexpr (std::is_same_v<detail::GetVectorType<T>, int>) {
       return _intMap;
-    } else if constexpr (std::is_same_v<T, float>) {
+    } else if constexpr (std::is_same_v<detail::GetVectorType<T>, float>) {
       return _floatMap;
     } else {
       return _stringMap;
@@ -232,7 +232,7 @@ private:
 
 template <typename T, typename>
 const T& GenericParameters::getValue(const std::string& key) const {
-  const auto& map = getMap<detail::GetVectorType<T>>();
+  const auto& map = getMap<T>();
   const auto it = map.find(key);
   // If there is no entry to the key, we just return an empty default
   // TODO: make this case detectable from the outside
@@ -264,18 +264,19 @@ T GenericParameters::getValue(const std::string& key) const {
 
 template <typename T, typename>
 void GenericParameters::setValue(const std::string& key, T value) {
-  auto& map = getMap<detail::GetVectorType<T>>();
+  auto& map = getMap<T>();
   if constexpr (detail::isVector<T>) {
     map.insert_or_assign(key, std::move(value));
   } else {
-    std::vector<detail::GetVectorType<T>> v = {value};
+    // Wrap the value into a vector with exactly one entry and store that
+    std::vector<T> v = {value};
     map.insert_or_assign(key, std::move(v));
   }
 }
 
 template <typename T, typename>
 size_t GenericParameters::getN(const std::string& key) const {
-  const auto& map = getMap<detail::GetVectorType<T>>();
+  const auto& map = getMap<T>();
   if (const auto it = map.find(key); it != map.end()) {
     return it->second.size();
   }
@@ -285,7 +286,7 @@ size_t GenericParameters::getN(const std::string& key) const {
 template <typename T, typename>
 std::vector<std::string> GenericParameters::getKeys() const {
   std::vector<std::string> keys;
-  const auto& map = getMap<detail::GetVectorType<T>>();
+  const auto& map = getMap<T>();
   std::transform(map.begin(), map.end(), std::back_inserter(keys), [](const auto& pair) { return pair.first; });
 
   return keys;

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -11,36 +11,27 @@
 
 namespace podio {
 
-/**
- * The types which are supported in the GenericParameters
- */
+/// The types which are supported in the GenericParameters
 using SupportedGenericDataTypes = std::tuple<int, float, std::string>;
 
+/// Static bool for determining if a type T is a supported GenericParamter type
 template <typename T>
 static constexpr bool isSupportedGenericDataType = detail::isAnyOrVectorOf<T, SupportedGenericDataTypes>;
 
-/**
- * Alias template to be used for enabling / disabling template overloads that
- * should only be present for actually supported data types
- */
+/// Alias template to be used for enabling / disabling template overloads that
+/// should only be present for actually supported data types
 template <typename T>
 using EnableIfValidGenericDataType = typename std::enable_if_t<isSupportedGenericDataType<T>>;
 
-/**
- * The data types for which a return by value should be preferred over a return
- * by const-ref
- */
+/// The data types for which a return by value should be preferred over a return
+/// by const-ref
 using ValueReturnGenericDataTypes = std::tuple<int, float>;
 
-/**
- * Alias template for enabling return by value overloads
- */
+/// Alias template for enabling return by value overloads
 template <typename T>
 using EnableIfValueReturnGenericDataType = std::enable_if_t<detail::isInTuple<T, ValueReturnGenericDataTypes>>;
 
-/**
- * Alias template for return by const ref overloads
- */
+/// Alias template for return by const ref overloads
 template <typename T>
 using EnableIfConstRefReturnGenericDataType =
     std::enable_if_t<std::is_same_v<T, std::string> ||
@@ -71,18 +62,15 @@ private:
   using StringMap = MapType<std::string>;
 
 public:
-  /**
-   * Get the value that is stored under the given key
-   */
+  /// Get the value that is stored under the given key (by const reference)
   template <typename T, typename = EnableIfConstRefReturnGenericDataType<T>>
   const T& getValue(const std::string& key) const;
 
-  /**
-   * Get the value that is stored under the given key
-   */
+  /// Get the value that is stored under the given key (by value)
   template <typename T, typename = EnableIfValueReturnGenericDataType<T>>
   T getValue(const std::string& key) const;
 
+  /// Store (a copy of) the passed value under the given key
   template <typename T, typename = std::enable_if_t<isSupportedGenericDataType<T>>>
   void setValue(const std::string& key, T value);
 
@@ -97,9 +85,11 @@ public:
     setValue<std::vector<T>>(key, std::move(values));
   }
 
+  /// Get the number of elements stored under the given key for a type
   template <typename T, typename = EnableIfValidGenericDataType<T>>
   size_t getN(const std::string& key) const;
 
+  /// Get all available keys for a given type
   template <typename T, typename = EnableIfValidGenericDataType<T>>
   std::vector<std::string> getKeys() const;
 
@@ -209,6 +199,7 @@ public:
   }
 
 private:
+  /// Get a reference to the internal map for a given type (necessary for SIO)
   template <typename T>
   const MapType<T>& getMap() const {
     if constexpr (std::is_same_v<T, int>) {
@@ -220,6 +211,7 @@ private:
     }
   }
 
+  /// Get a reference to the internal map for a given type (necessary for SIO)
   template <typename T>
   MapType<T>& getMap() {
     if constexpr (std::is_same_v<T, int>) {

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -288,6 +288,7 @@ template <typename T, typename>
 std::vector<std::string> GenericParameters::getKeys() const {
   std::vector<std::string> keys;
   const auto& map = getMap<T>();
+  keys.reserve(map.size());
   std::transform(map.begin(), map.end(), std::back_inserter(keys), [](const auto& pair) { return pair.first; });
 
   return keys;

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -241,8 +241,7 @@ private:
   IntMap _intMap{};
   FloatMap _floatMap{};
   StringMap _stringMap{};
-
-}; // class
+};
 
 template <typename T, typename>
 GenericDataReturnType<T> GenericParameters::getValue(const std::string& key) const {
@@ -263,38 +262,6 @@ GenericDataReturnType<T> GenericParameters::getValue(const std::string& key) con
     return iv[0];
   }
 }
-
-// template <typename T, typename>
-// const T& GenericParameters::getValue(const std::string& key) const {
-//   const auto& map = getMap<T>();
-//   const auto it = map.find(key);
-//   // If there is no entry to the key, we just return an empty default
-//   // TODO: make this case detectable from the outside
-//   if (it == map.end()) {
-//     static const auto empty = T{};
-//     return empty;
-//   }
-
-//   // Here we have to check whether the return type is a vector or a single value
-//   if constexpr (detail::isVector<T>) {
-//     return it->second;
-//   } else {
-//     const auto& iv = it->second;
-//     return iv[0];
-//   }
-// }
-
-// template <typename T, typename>
-// T GenericParameters::getValue(const std::string& key) const {
-//   // Function not enabled for vector return types
-//   const auto& map = getMap<T>();
-//   const auto it = map.find(key);
-//   if (it == map.end()) {
-//     return T{};
-//   }
-//   // No need to differentiate between vector and single value return case here
-//   return (it->second)[0];
-// }
 
 template <typename T, typename>
 void GenericParameters::setValue(const std::string& key, T value) {

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <vector>
 
+#define DEPRECATED_ACCESS [[deprecated("Use templated access functionality")]]
+
 namespace podio {
 
 /// The types which are supported in the GenericParameters
@@ -37,6 +39,8 @@ using EnableIfConstRefReturnGenericDataType =
     std::enable_if_t<std::is_same_v<T, std::string> ||
                      (detail::isInTuple<T, detail::TupleOfVector<SupportedGenericDataTypes>>)>;
 
+// These should be trivial to remove once the deprecated non-templated access
+// functionality is actually removed
 typedef std::vector<int> IntVec;
 typedef std::vector<float> FloatVec;
 typedef std::vector<std::string> StringVec;
@@ -95,66 +99,66 @@ public:
 
   /** Returns the first integer value for the given key.
    */
-  int getIntVal(const std::string& key) const;
+  DEPRECATED_ACCESS int getIntVal(const std::string& key) const;
 
   /** Returns the first float value for the given key.
    */
-  float getFloatVal(const std::string& key) const;
+  DEPRECATED_ACCESS float getFloatVal(const std::string& key) const;
 
   /** Returns the first string value for the given key.
    */
-  const std::string& getStringVal(const std::string& key) const;
+  DEPRECATED_ACCESS const std::string& getStringVal(const std::string& key) const;
 
   /** Adds all integer values for the given key to values.
    *  Returns a reference to values for convenience.
    */
-  IntVec& getIntVals(const std::string& key, IntVec& values) const;
+  DEPRECATED_ACCESS IntVec& getIntVals(const std::string& key, IntVec& values) const;
 
   /** Adds all float values for the given key to values.
    *  Returns a reference to values for convenience.
    */
-  FloatVec& getFloatVals(const std::string& key, FloatVec& values) const;
+  DEPRECATED_ACCESS FloatVec& getFloatVals(const std::string& key, FloatVec& values) const;
 
   /** Adds all float values for the given key to values.
    *  Returns a reference to values for convenience.
    */
-  StringVec& getStringVals(const std::string& key, StringVec& values) const;
+  DEPRECATED_ACCESS StringVec& getStringVals(const std::string& key, StringVec& values) const;
 
   /** Returns a list of all keys of integer parameters.
    */
-  const StringVec& getIntKeys(StringVec& keys) const;
+  DEPRECATED_ACCESS const StringVec& getIntKeys(StringVec& keys) const;
 
   /** Returns a list of all keys of float parameters.
    */
-  const StringVec& getFloatKeys(StringVec& keys) const;
+  DEPRECATED_ACCESS const StringVec& getFloatKeys(StringVec& keys) const;
 
   /** Returns a list of all keys of string parameters.
    */
-  const StringVec& getStringKeys(StringVec& keys) const;
+  DEPRECATED_ACCESS const StringVec& getStringKeys(StringVec& keys) const;
 
   /** The number of integer values stored for this key.
    */
-  int getNInt(const std::string& key) const;
+  DEPRECATED_ACCESS int getNInt(const std::string& key) const;
 
   /** The number of float values stored for this key.
    */
-  int getNFloat(const std::string& key) const;
+  DEPRECATED_ACCESS int getNFloat(const std::string& key) const;
 
   /** The number of string values stored for this key.
    */
-  int getNString(const std::string& key) const;
+  DEPRECATED_ACCESS int getNString(const std::string& key) const;
 
   /** Set integer values for the given key.
    */
-  void setValues(const std::string& key, const IntVec& values);
+  DEPRECATED_ACCESS void setValues(const std::string& key, const IntVec& values);
 
   /** Set float values for the given key.
    */
-  void setValues(const std::string& key, const FloatVec& values);
+  DEPRECATED_ACCESS void setValues(const std::string& key, const FloatVec& values);
 
   /** Set string values for the given key.
    */
-  void setValues(const std::string& key, const StringVec& values);
+  DEPRECATED_ACCESS void setValues(const std::string& key, const StringVec& values);
 
   /// erase all elements
   void clear() {

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -2,6 +2,7 @@
 #define PODIO_USERDATACOLLECTION_H
 
 #include "podio/CollectionBase.h"
+#include "podio/utilities/TypeHelpers.h"
 
 #include <map>
 #include <string>
@@ -17,40 +18,17 @@
 
 namespace podio {
 
-namespace detail {
-
-  // some templates to ensure valid and supported user types
-  // as suggested by T.Madlener, DESY
-
-  /** tuple of basic types supported in user vector
-   */
-  using SupportedUserDataTypes =
-      std::tuple<float, double, int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t>;
-
-  /**
-   * Helper function to check whether a type T is in an std::tuple<Ts...>
-   */
-  template <typename T, typename... Ts>
-  constexpr bool inTuple(std::tuple<Ts...>) {
-    return (std::is_same_v<T, Ts> || ...);
-  }
-
-  /**
-   * Compile time helper function to check whether the given type is in the list
-   * of supported types
-   */
-  template <typename T>
-  constexpr bool isSupported() {
-    return inTuple<T>(SupportedUserDataTypes{});
-  }
-} // namespace detail
+/** tuple of basic types supported in user vector
+ */
+using SupportedUserDataTypes =
+    std::tuple<float, double, int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t>;
 
 /**
  * Alias template to be used to enable template specializations only for the types listed in the
  * SupportedUserDataTypes list
  */
 template <typename T>
-using EnableIfSupportedUserType = std::enable_if_t<detail::isSupported<T>()>;
+using EnableIfSupportedUserType = std::enable_if_t<detail::isInTuple<T, SupportedUserDataTypes>>;
 
 /** helper template to provide readable type names for basic types with macro PODIO_ADD_USER_TYPE(type)
  */

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -1,0 +1,106 @@
+#ifndef PODIO_UTILITIES_TYPEHELPERS_H
+#define PODIO_UTILITIES_TYPEHELPERS_H
+
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+namespace podio {
+namespace detail {
+
+  /**
+   * Helper struct to determine whether a given type T is in a tuple of types
+   * that act as a type list in this case
+   */
+  template <typename T, typename>
+  struct TypeInTupleHelper : std::false_type {};
+
+  template <typename T, typename... Ts>
+  struct TypeInTupleHelper<T, std::tuple<Ts...>> : std::bool_constant<(std::is_same_v<T, Ts> || ...)> {};
+
+  /**
+   * variable template for determining whether type T is in a tuple with types
+   * Ts
+   */
+  template <typename T, typename Tuple>
+  static constexpr bool isInTuple = TypeInTupleHelper<T, Tuple>::value;
+
+  /**
+   * Helper struct to turn a tuple of types into a tuple of a template of types, e.g.
+   *
+   * std::tuple<int, float> -> std::tuple<std::vector<int>, std::vector<float>>
+   * if the passed template is std::vector
+   *
+   * NOTE: making the template template parameter to Template variadic because
+   * clang will not be satisfied otherwise if we use it with, e.g. std::vector.
+   * This will also make root dictionary generation fail. GCC works without this
+   * small workaround and is standard compliant in this case, whereas clang is
+   * not.
+   */
+  template <template <typename...> typename Template, typename T>
+  struct ToTupleOfTemplateHelper;
+
+  template <template <typename...> typename Template, typename... Ts>
+  struct ToTupleOfTemplateHelper<Template, std::tuple<Ts...>> {
+    using type = std::tuple<Template<Ts>...>;
+  };
+
+  /**
+   * Type alias to turn a tuple of types into a tuple of vector of types
+   */
+  template <typename Tuple>
+  using TupleOfVector = typename ToTupleOfTemplateHelper<std::vector, Tuple>::type;
+
+  /**
+   * Alias template to get the type of a tuple resulting from a concatenation of
+   * tuples
+   * See: https://devblogs.microsoft.com/oldnewthing/20200622-00/?p=103900
+   */
+  template <typename... Tuples>
+  using TupleCatType = decltype(std::tuple_cat(std::declval<Tuples>()...));
+
+  /**
+   * variable template for determining whether the type T is in the tuple of all
+   * types or in the tuple of all vector of the passed types
+   */
+  template <typename T, typename Tuple>
+  static constexpr bool isAnyOrVectorOf = isInTuple<T, TupleCatType<Tuple, TupleOfVector<Tuple>>>;
+
+  /**
+   * Helper struct to extract the type from a std::vector or return the
+   * original type if it is not a vector. Works only for "simple" types and does
+   * not strip const-ness
+   */
+  template <typename T>
+  struct GetVectorTypeHelper {
+    using type = T;
+  };
+
+  template <typename T>
+  struct GetVectorTypeHelper<std::vector<T>> {
+    using type = T;
+  };
+
+  template <typename T>
+  using GetVectorType = typename GetVectorTypeHelper<T>::type;
+
+  /**
+   * Helper struct to detect whether a type is a std::vector
+   */
+  template <typename T>
+  struct IsVectorHelper : std::false_type {};
+
+  template <typename T>
+  struct IsVectorHelper<std::vector<T>> : std::true_type {};
+
+  /**
+   * Alias template for deciding whether the passed type T is a vector or not
+   */
+  template <typename T>
+  static constexpr bool isVector = IsVectorHelper<T>::value;
+
+} // namespace detail
+} // namespace podio
+
+#endif // PODIO_UTILITIES_TYPEHELPERS_H

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -31,7 +31,7 @@ FloatVec& GenericParameters::getFloatVals(const std::string& key, FloatVec& valu
 }
 
 StringVec& GenericParameters::getStringVals(const std::string& key, StringVec& values) const {
-  for (const auto v : getValue<std::vector<std::string>>(key)) {
+  for (const auto& v : getValue<std::vector<std::string>>(key)) {
     values.push_back(v);
   }
   return values;

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -4,131 +4,82 @@
 
 namespace podio {
 
-template <typename T>
-T getValFromMap(const GenericParameters::MapType<T>& map, const std::string& key) {
-  const auto it = map.find(key);
-  if (it == map.end()) {
-    return T{};
-  }
-  const auto& iv = it->second;
-  return iv[0];
-}
-
-// overload for string such that return by const ref is preferred
-const std::string& getValFromMap(const GenericParameters::MapType<std::string>& map, const std::string& key) {
-  static const std::string empty("");
-  auto it = map.find(key);
-  if (it == map.end()) {
-    return empty;
-  }
-  const auto& iv = it->second;
-  return iv[0];
-}
-
 int GenericParameters::getIntVal(const std::string& key) const {
-  return getValFromMap(_intMap, key);
+  return getValue<int>(key);
 }
 
 float GenericParameters::getFloatVal(const std::string& key) const {
-  return getValFromMap(_floatMap, key);
+  return getValue<float>(key);
 }
 
 const std::string& GenericParameters::getStringVal(const std::string& key) const {
-  return getValFromMap(_stringMap, key);
+  return getValue<std::string>(key);
 }
 
-template <typename T>
-std::vector<T>& fillValsFromMap(const GenericParameters::MapType<T>& map, const std::string& key,
-                                std::vector<T>& values) {
-  auto it = map.find(key);
-  if (it != map.end()) {
-    values.insert(values.end(), it->second.begin(), it->second.end());
+IntVec& GenericParameters::getIntVals(const std::string& key, IntVec& values) const {
+  for (const auto v : getValue<std::vector<int>>(key)) {
+    values.push_back(v);
   }
   return values;
 }
 
-IntVec& GenericParameters::getIntVals(const std::string& key, IntVec& values) const {
-  return fillValsFromMap(_intMap, key, values);
-}
-
 FloatVec& GenericParameters::getFloatVals(const std::string& key, FloatVec& values) const {
-  return fillValsFromMap(_floatMap, key, values);
+  for (const auto v : getValue<std::vector<float>>(key)) {
+    values.push_back(v);
+  }
+  return values;
 }
 
 StringVec& GenericParameters::getStringVals(const std::string& key, StringVec& values) const {
-  return fillValsFromMap(_stringMap, key, values);
-}
-
-template <typename T>
-const StringVec& getKeys(const GenericParameters::MapType<T>& map, StringVec& keys) {
-  std::transform(map.begin(), map.end(), std::back_inserter(keys), [](auto const& pair) { return pair.first; });
-  return keys;
+  for (const auto v : getValue<std::vector<std::string>>(key)) {
+    values.push_back(v);
+  }
+  return values;
 }
 
 const StringVec& GenericParameters::getIntKeys(StringVec& keys) const {
-  return getKeys(_intMap, keys);
+  for (const auto& k : getKeys<int>()) {
+    keys.push_back(k);
+  }
+  return keys;
 }
 
 const StringVec& GenericParameters::getFloatKeys(StringVec& keys) const {
-  return getKeys(_floatMap, keys);
+  for (const auto& k : getKeys<float>()) {
+    keys.push_back(k);
+  }
+  return keys;
 }
 
 const StringVec& GenericParameters::getStringKeys(StringVec& keys) const {
-  return getKeys(_stringMap, keys);
-}
-
-template <typename T>
-int getStoredElements(const GenericParameters::MapType<T>& map, const std::string& key) {
-  auto it = map.find(key);
-  if (it == map.end()) {
-    return 0;
+  for (const auto& k : getKeys<std::string>()) {
+    keys.push_back(k);
   }
-  return it->second.size();
+  return keys;
 }
 
 int GenericParameters::getNInt(const std::string& key) const {
-  return getStoredElements(_intMap, key);
+  return getN<int>(key);
 }
 
 int GenericParameters::getNFloat(const std::string& key) const {
-  return getStoredElements(_floatMap, key);
+  return getN<float>(key);
 }
 
 int GenericParameters::getNString(const std::string& key) const {
-  return getStoredElements(_stringMap, key);
-}
-
-void GenericParameters::setValue(const std::string& key, int value) {
-
-  _intMap[key].clear();
-  _intMap[key].push_back(value);
-}
-
-void GenericParameters::setValue(const std::string& key, float value) {
-
-  _floatMap[key].clear();
-  _floatMap[key].push_back(value);
-}
-
-void GenericParameters::setValue(const std::string& key, const std::string& value) {
-
-  _stringMap[key].clear();
-  _stringMap[key].push_back(value);
+  return getN<std::string>(key);
 }
 
 void GenericParameters::setValues(const std::string& key, const IntVec& values) {
-
-  _intMap[key].assign(values.begin(), values.end());
+  setValue(key, values);
 }
 
 void GenericParameters::setValues(const std::string& key, const FloatVec& values) {
-
-  _floatMap[key].assign(values.begin(), values.end());
+  setValue(key, values);
 }
 
 void GenericParameters::setValues(const std::string& key, const StringVec& values) {
-
-  _stringMap[key].assign(values.begin(), values.end());
+  setValue(key, values);
 }
 
 } // namespace podio

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -42,7 +42,7 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 void processEvent(podio::EventStore& store, int eventNum, podio::version::Version fileVersion) {
 
   const auto& evtMD = store.getEventMetaData();
-  float evtWeight = evtMD.getFloatVal("UserEventWeight");
+  float evtWeight = evtMD.getValue<float>("UserEventWeight");
   if (evtWeight != (float)100. * eventNum) {
     std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << (float)100. * eventNum << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
@@ -50,7 +50,7 @@ void processEvent(podio::EventStore& store, int eventNum, podio::version::Versio
   std::stringstream ss;
   ss << " event_number_" << eventNum;
   const auto& evtMD2 = store.getEventMetaData();
-  const auto& evtName = evtMD2.getStringVal("UserEventName");
+  const auto& evtName = evtMD2.getValue<std::string>("UserEventName");
   if (evtName != ss.str()) {
     std::cout << " read UserEventName: " << evtName << " - expected : " << ss.str() << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventName'");
@@ -91,7 +91,7 @@ void processEvent(podio::EventStore& store, int eventNum, podio::version::Versio
   // read collection meta data
   auto& hits = store.get<ExampleHitCollection>("hits");
   auto colMD = store.getCollectionMetaData(hits.getID());
-  const auto& es = colMD.getStringVal("CellIDEncodingString");
+  const auto& es = colMD.getValue<std::string>("CellIDEncodingString");
   if (es != std::string("system:8,barrel:3,layer:6,slice:5,x:-16,y:-16")) {
     std::cout << " meta data from collection 'hits' with id = " << hits.getID() << " read CellIDEncodingString: " << es
               << " - expected : system:8,barrel:3,layer:6,slice:5,x:-16,y:-16" << std::endl;

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -42,7 +42,7 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 void processEvent(podio::EventStore& store, int eventNum, podio::version::Version fileVersion) {
 
   const auto& evtMD = store.getEventMetaData();
-  float evtWeight = evtMD.getValue<float>("UserEventWeight");
+  auto evtWeight = evtMD.getValue<float>("UserEventWeight");
   if (evtWeight != (float)100. * eventNum) {
     std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << (float)100. * eventNum << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -56,6 +56,18 @@ void processEvent(podio::EventStore& store, int eventNum, podio::version::Versio
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventName'");
   }
 
+  if (fileVersion > podio::version::Version{0, 14, 1}) {
+    const auto& someVectorData = evtMD.getValue<std::vector<int>>("SomeVectorData");
+    if (someVectorData.size() != 4) {
+      throw std::runtime_error("Couldn't read event meta data parameters: 'SomeVectorData'");
+    }
+    for (int i = 0; i < 4; ++i) {
+      if (someVectorData[i] != i + 1) {
+        throw std::runtime_error("Couldn't read event meta data parameters: 'SomeVectorData'");
+      }
+    }
+  }
+
   try {
     // not assigning to a variable, because it will remain unused, we just want
     // the exception here

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -746,6 +746,9 @@ TEST_CASE("GenericParameters", "[generic-parameters]") {
 
   gp.setValue("anInt", 42);
   REQUIRE(gp.getValue<int>("anInt") == 42);
+  // Make sure that resetting a value with the same key works
+  gp.setValue("anInt", -42);
+  REQUIRE(gp.getValue<int>("anInt") == -42);
 
   // Make sure that passing a string literal is converted to a string on the fly
   gp.setValue("aString", "const char initialized");
@@ -770,6 +773,11 @@ TEST_CASE("GenericParameters", "[generic-parameters]") {
   REQUIRE(storedFloats.size() == 2);
   REQUIRE(storedFloats[0] == 3.14f);
   REQUIRE(storedFloats[1] == 2.718f);
+
+  // We can at this point reset this to a single value with the same key even if
+  // it has been a vector before
+  gp.setValue("someFloats", 12.34f);
+  REQUIRE(gp.getValue<float>("someFloats") == 12.34f);
 
   // Missing values return the default initialized ones
   REQUIRE(gp.getValue<int>("MissingValue") == int{});

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -774,7 +774,9 @@ TEST_CASE("GenericParameters", "[generic-parameters]") {
   // Missing values return the default initialized ones
   REQUIRE(gp.getValue<int>("MissingValue") == int{});
   REQUIRE(gp.getValue<float>("MissingValue") == float{});
-  REQUIRE(gp.getValue<std::string>("MissingValue") == std::string{});
+  REQUIRE(gp.getValue<std::string>("MissingValue") == std::string{}); // NOLINT(readability-container-size-empty): We
+                                                                      // want the explicit comparison here
+
   // Same for vectors
   REQUIRE(gp.getValue<std::vector<int>>("MissingValue").empty());
   REQUIRE(gp.getValue<std::vector<float>>("MissingValue").empty());

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -89,6 +89,7 @@ void write(podio::EventStore& store, WriterT& writer) {
     std::stringstream ss;
     ss << " event_number_" << i;
     evtMD.setValue("UserEventName", ss.str());
+    evtMD.setValue("SomeVectorData", {1, 2, 3, 4});
 
     auto& colMD = store.getCollectionMetaData(hits.getID());
     colMD.setValue("CellIDEncodingString", "system:8,barrel:3,layer:6,slice:5,x:-16,y:-16");


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the getters and setters for the `GenericParameters` templated functions and add a deprecation warning for the untemplated ones.
- Define a `SupportedGenericDataTypes` tuple defining the types (and vectors of those) that can be stored in `GenericParameters`
- Add a `podio/utilities/TypeHelpers.h` header with some type handling helpers.

ENDRELEASENOTES

Removing the non-templated functions will result in some minor differences in the setting interface, mainly that the `vector` and single value functions now both use the `setValue` function instead of separate `setValue` and `setValues`. On the getter side there are a few more differences, most importantly that the functions that return `vector`s now have exactly the same interface as the single value getters. Previously the `vector` ones used a pre-allocated `vector` to fill the values into. Additionally, they returned a const-ref to the passed in vector, which leads to having two references with different mutability to the same vector. Overall the interface becomes more uniform and adding additional types, essentially requires to change some compile time configuration instead of implementing additional named overloads.

Previously:
```cpp
auto& md = store.getEventMetaData();
// set values
md.setValue("someInt", 42);
std::vector<std::string> strings = {"abc", "def", "ghi"};
md.setValues("someStrings", strings);

// get values from the meta data
const auto& strVal = md.getStringVal("key");  // return by const-ref
const auto intVal = md.getIntVal("someInt");  // return by value
std::vector<float> floatValues;
const auto& floatVals = md.getFloatVals("anotherKey", floatValues);  // need to pass in a pre-allocated vector
// Now floatValues and floatVals are references to the same vector with different mutability
```

Now:
```cpp
auto& md = store.getEventMetaData();
// set values
md.setValue("someInt", 42);
std::vector<std::string> strings = {"abc", "def", "ghi"};
md.setValue("someStrings", strings);

// get values
const auto& strVal = md.getValue<std::string>("key");  // return by const-ref
const auto intVal = md.getValue<int>("someInt");       // return by value
const auto& floatValues = md.getValue<std::vector<float>>("anotherKey");
// Only one const ref to the contents
```

This is a somewhat preparatory step for future developments that can however "stand on its own". To keep things working downstream the non-templated ones are now simply slated for deprecation.

@fdplacido Does something like this make conversions easier to handle or would you like to keep the non-templated functions?

~Needs other PRs first:~
- [x] targets `develop` for the moment for a cleaner diff.