### PR TITLE
CI: update compilers for dev builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         LCG: ["LCG_99/x86_64-centos7-gcc8-opt",
               "LCG_99/x86_64-centos7-clang10-opt",
               "LCG_99/x86_64-centos8-gcc10-opt",
-              "dev3/x86_64-centos7-clang10-opt",
-              "dev4/x86_64-centos7-gcc10-opt",
-              "dev4/x86_64-centos7-clang10-opt"]
+              "dev3/x86_64-centos7-clang12-opt",
+              "dev4/x86_64-centos7-gcc11-opt",
+              "dev4/x86_64-centos7-clang12-opt"]
     steps:
     - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@v2


### PR DESCRIPTION
The clang10 builds are suppressed and no longer updated.

Other question is whether to replace LCG_99 with 101 (or wait until 102 comes out)

BEGINRELEASENOTES
-  CI: use clang12 and gcc11 for tests based on dev stacks

ENDRELEASENOTES