### PR TITLE
[WIP] Make it possible for users to define default values in the datamodel yaml file

### DIFF
--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Module holding some generator utility functions
 """
@@ -124,6 +124,10 @@ class MemberVariable:
       self.includes.add('#include <array>')
 
     self.is_builtin = self.full_type in BUILTIN_TYPES
+    # Check if this is a string and add the corresponding include
+    if self.full_type == 'std::string':
+      self.includes.add('#include <string>')
+
     # We still have to check if this type is a valid fixed width type that we
     # also consider to be builtin types
     if not self.is_builtin:

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -2,7 +2,6 @@
 """
 Module holding some generator utility functions
 """
-from __future__ import unicode_literals, absolute_import, print_function
 
 import re
 

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -12,7 +12,7 @@ def _get_namespace_class(full_type):
   DefinitionError if a nested namespace is found"""
   cnameparts = full_type.split('::')
   if len(cnameparts) > 2:
-    raise DefinitionError("'{}' is a type with a nested namespace. not supperted, yet.".format(full_type))
+    raise DefinitionError(f"'{full_type}' is a type with a nested namespace. not supperted, yet.")
   if len(cnameparts) == 2:
     # If in std namespace, consider that to be part of the type instead and only
     # split namespace if that is not the case
@@ -78,7 +78,7 @@ class DataType:
 
   def __str__(self):
     if self.namespace:
-      scoped_type = '::{}::{}'.format(self.namespace, self.bare_type)
+      scoped_type = f'::{self.namespace}::{self.bare_type}'
     else:
       scoped_type = self.full_type
 
@@ -104,7 +104,7 @@ class MemberVariable:
     self.includes = set()
 
     if kwargs:
-      raise ValueError("Unused kwargs in MemberVariable: {}".format(list(kwargs.keys())))
+      raise ValueError(f"Unused kwargs in MemberVariable: {list(kwargs.keys())}")
 
     if self.array_type is not None and self.array_size is not None:
       self.is_array = True
@@ -120,7 +120,7 @@ class MemberVariable:
             self.array_type = f'std::{self.array_type}'
           self.includes.add('#include <cstdint>')
 
-      self.full_type = r'std::array<{}, {}>'.format(self.array_type, self.array_size)
+      self.full_type = rf'std::array<{self.array_type}, {self.array_size}>'
       self.includes.add('#include <array>')
 
     self.is_builtin = self.full_type in BUILTIN_TYPES
@@ -153,13 +153,13 @@ class MemberVariable:
     """string representation"""
     # Make sure to include scope-operator if necessary
     if self.namespace:
-      scoped_type = '::{}::{}'.format(self.namespace, self.bare_type)
+      scoped_type = f'::{self.namespace}::{self.bare_type}'
     else:
       scoped_type = self.full_type
 
-    definition = r'{} {}{{}};'.format(scoped_type, self.name)
+    definition = rf'{scoped_type} {self.name}{{}};'
     if self.description:
-      definition += r' ///< {}'.format(self.description)
+      definition += rf' ///< {self.description}'
     return definition
 
   def getter_name(self, get_syntax):

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -90,6 +90,7 @@ class MemberVariable:
     self.name = name
     self.full_type = kwargs.pop('type', '')
     self.description = kwargs.pop('description', '')
+    self.default_val = kwargs.pop('default_val', None)
     self.is_builtin = False
     self.is_builtin_array = False
     self.is_array = False
@@ -156,7 +157,11 @@ class MemberVariable:
     else:
       scoped_type = self.full_type
 
-    definition = rf'{scoped_type} {self.name}{{}};'
+    if self.default_val:
+      definition = rf'{scoped_type} {self.name}{{{self.default_val}}};'
+    else:
+      definition = rf'{scoped_type} {self.name}{{}};'
+
     if self.description:
       definition += rf' ///< {self.description}'
     return definition

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -1,8 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Podio class generator script"""
-
-from __future__ import unicode_literals, absolute_import, print_function
 
 import os
 import sys
@@ -10,16 +8,9 @@ import subprocess
 import pickle
 from copy import deepcopy
 
-# collections.abc not available for python2, so again some special care here
-try:
-  from collections.abc import Mapping
-except ImportError:
-  from collections import Mapping
+from collections.abc import Mapping
 
-try:
-  from itertools import zip_longest
-except ImportError:
-  from itertools import izip_longest as zip_longest
+from itertools import zip_longest
 
 import jinja2
 

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -1,4 +1,4 @@
-"""Datamodel yaml configuration file reading and validation utilities"""
+"""Datamodel yaml configuration file reading and validation utilities."""
 
 from __future__ import absolute_import, unicode_literals, print_function
 
@@ -23,8 +23,8 @@ class MemberParser:
   # builtin types above. Currently this is done by simple brute-forcing.
   # To "ensure" that the builtin matching is greedy and picks up as much as
   # possible, sort the types by their length in descending order
-  builtin_str = r'|'.join(r'(?:{})'.format(t) for t in sorted(BUILTIN_TYPES, key=len, reverse=True))
-  type_str = r'({builtin_re}|(?:\:{{2}})?[a-zA-Z]+[a-zA-Z0-9:_]*)'.format(builtin_re=builtin_str)
+  builtin_str = r'|'.join(f'(?:{t})' for t in sorted(BUILTIN_TYPES, key=len, reverse=True))
+  type_str = rf'({builtin_str}|(?:\:{{2}})?[a-zA-Z]+[a-zA-Z0-9:_]*)'
   type_re = re.compile(type_str)
 
   # Names can be almost anything as long as it doesn't start with a digit and
@@ -36,17 +36,15 @@ class MemberParser:
   # stripping of trailing whitespaces is done later as it is hard to do with regex
   comment_str = r'\/\/ *(.*)'
   # std::array declaration with some whitespace distribution freedom
-  array_str = r' *std::array *< *{typ} *, *([0-9]+) *>'.format(typ=type_str)
+  array_str = rf' *std::array *< *{type_str} *, *([0-9]+) *>'
 
   array_re = re.compile(array_str)
-  full_array_re = re.compile(r'{array} *{name} *{comment}'.format(
-      array=array_str, name=name_str, comment=comment_str))
-  member_re = re.compile(r' *{typ} +{name} *{comment}'.format(
-      typ=type_str, name=name_str, comment=comment_str))
+  full_array_re = re.compile(rf'{array_str} *{name_str} *{comment_str}')
+  member_re = re.compile(rf' *{type_str} +{name_str} *{comment_str}')
 
   # For cases where we don't require a description
-  bare_member_re = re.compile(r' *{typ} +{name}'.format(typ=type_str, name=name_str))
-  bare_array_re = re.compile(r' *{array} +{name}'.format(array=array_str, name=name_str))
+  bare_member_re = re.compile(rf' *{type_str} +{name_str}')
+  bare_array_re = re.compile(rf' *{array_str} +{name_str}')
 
   @staticmethod
   def _parse_with_regexps(string, regexps_callbacks):

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -1,7 +1,5 @@
 """Datamodel yaml configuration file reading and validation utilities."""
 
-from __future__ import absolute_import, unicode_literals, print_function
-
 import copy
 import re
 import warnings

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -145,6 +145,10 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.default_val, '1, 2, 3')
     self.assertEqual(parsed.name, 'array')
 
+    parsed = parser.parse(r'std::array<int, 25> array{1, 2, 3} // we do not have to init the complete array')
+    self.assertEqual(parsed.full_type, r'std::array<int, 25>')
+    self.assertEqual(parsed.default_val, r'1, 2, 3')
+
     # These are cases where we cannot really decide whether the initialization
     # is valid just from the member declaration. We let them pass here
     parsed = parser.parse('nsp::SomeValue val {42} // default values can have space')

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -21,6 +21,7 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.full_type, r'float')
     self.assertEqual(parsed.name, r'someFloat')
     self.assertEqual(parsed.description, r'with an additional comment')
+    self.assertTrue(parsed.default_val is None)
 
     parsed = parser.parse(r'float float2 // with numbers')
     self.assertEqual(parsed.full_type, r'float')
@@ -88,6 +89,7 @@ class MemberParserTest(unittest.TestCase):
     self.assertTrue(parsed.is_builtin_array)
     self.assertEqual(int(parsed.array_size), 4)
     self.assertEqual(parsed.array_type, r'double')
+    self.assertTrue(parsed.default_val is None)
 
     # an array definition as terse as possible
     parsed = parser.parse(r'std::array<int,2>anArray//with a comment')
@@ -121,6 +123,36 @@ class MemberParserTest(unittest.TestCase):
     self.assertTrue(parsed.is_builtin_array)
     self.assertEqual(parsed.array_type, r'std::uint32_t')
 
+  def test_parse_valid_default_value(self):
+    """Test that member variables can be parsed correctly if they have a user
+    defined default value"""
+    parser = MemberParser()
+
+    parsed = parser.parse(r'int fortyTwo{43} // default values can lie')
+    self.assertEqual(parsed.full_type, r'int')
+    self.assertEqual(parsed.name, r'fortyTwo')
+    self.assertEqual(parsed.description, 'default values can lie')
+    self.assertEqual(parsed.default_val, r'43')
+    self.assertEqual(str(parsed), 'int fortyTwo{43}; ///< default values can lie')
+
+    parsed = parser.parse(r'float f{3.14f}', require_description=False)
+    self.assertEqual(parsed.full_type, 'float')
+    self.assertEqual(parsed.name, 'f')
+    self.assertEqual(parsed.default_val, '3.14f')
+
+    parsed = parser.parse('nsp::SomeValue val {42} // default values can have space')
+    self.assertEqual(parsed.full_type, 'nsp::SomeValue')
+    self.assertEqual(parsed.name, 'val')
+    self.assertEqual(parsed.default_val, '42')
+    self.assertEqual(parsed.namespace, 'nsp')
+    self.assertEqual(parsed.bare_type, 'SomeValue')
+
+    # NOTE: The default values do not have to make sense at the moment!
+    parsed = parser.parse(r'int weirdDefault{whatever, even space} // same')
+    self.assertEqual(parsed.full_type, r'int')
+    self.assertEqual(parsed.name, r'weirdDefault')
+    self.assertEqual(parsed.default_val, r'whatever, even space')
+
   def test_parse_invalid(self):
     """Test that invalid member variable definitions indeed fail during parsing"""
     # setup an empty parser
@@ -136,7 +168,8 @@ class MemberParserTest(unittest.TestCase):
         r'std::array<int, 2> anArrayWithoutDescription',
         r'std::array<__foo, 3> anArray // with invalid type',
         r'std::array<double, N> array // with invalid size',
-        r'int another ill formed name // some comment'
+        r'int another ill formed name // some comment',
+        r'float illFormedDefault {',
 
         # Some examples of valid c++ that are rejected by the validation
         r'unsigned long int uLongInt // technically valid c++, but not in our builtin list',
@@ -148,7 +181,13 @@ class MemberParserTest(unittest.TestCase):
         r'uint_fast64_t disallowed // only allow fixed width integers with exact widths',
         r'std::int_least16_t disallowed // also adding a std namespace here does not make these allowed',
         r'std::uint_fast16_t disallowed // also adding a std namespace here does not make these allowed',
-        r'std::array<uint_fast16_t, 42> disallowedArray // arrays should not accept disallowed fixed width types'
+        r'std::array<uint_fast16_t, 42> disallowedArray // arrays should not accept disallowed fixed width types',
+
+        # Default values cannot be empty
+        r'int emptyDefault{} // valid c++, but we want an explicit default value here',
+        # Arrays cannot be user initialized
+        r'std::array<int, 3> array{1, 2, 3} // We do not allow user initialization for arrays',
+        r'std::array<int, 1> array{1, 2, 3} // because validating this is really non-trivial',
         ]
 
     for inp in invalid_inputs:

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -181,3 +181,12 @@ datatypes :
       - uint32_t fixedU32 // unsigned int with exactly 32 bits
       - StructWithFixedWithTypes fixedWidthStruct // struct with more fixed width types
       - std::array<int16_t, 2> fixedWidthArray // 32 bits split into two times 16 bits
+
+  ExampleWithUserInit:
+    Description: "Datatype with user defined initialization values"
+    Author: "Thomas Madlener"
+    Members:
+      - std::int16_t i16Val{42} // some int16 value
+      - std::array<float, 2> floats {3.14f, 1.23f} // some float values
+      - ex2::NamespaceStruct s{10, 11} // one that we happen to know works
+      - double d{9.876e5} // double val

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -40,6 +40,11 @@ components :
       - std::int64_t fixedInteger64 // int with exactly 64 bits
       - int32_t fixedInteger32 // int with exactly 32 bits
 
+  CompWithInit:
+    Members:
+      - int i{42} // is there even another value to initialize ints to?
+      - std::array<double, 10> arr {1.2, 3.4} // half initialized double array
+
 datatypes :
 
   EventInfo:
@@ -190,3 +195,4 @@ datatypes :
       - std::array<float, 2> floats {3.14f, 1.23f} // some float values
       - ex2::NamespaceStruct s{10, 11} // one that we happen to know works
       - double d{9.876e5} // double val
+      - CompWithInit comp // To make sure that the default initializer of the component does what it should

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -339,6 +339,9 @@ TEST_CASE("UserInitialization", "[basics][code-gen]") {
   REQUIRE(elem.s().x == 10);
   REQUIRE(elem.s().y == 11);
   REQUIRE(elem.d() == 9.876e5);
+  REQUIRE(elem.comp().i == 42);
+  REQUIRE(elem.comp().arr[0] == 1.2);
+  REQUIRE(elem.comp().arr[1] == 3.4);
 
   // And obviously when initialized directly
   auto ex = ExampleWithUserInit{};
@@ -348,6 +351,9 @@ TEST_CASE("UserInitialization", "[basics][code-gen]") {
   REQUIRE(ex.s().x == 10);
   REQUIRE(ex.s().y == 11);
   REQUIRE(ex.d() == 9.876e5);
+  REQUIRE(ex.comp().i == 42);
+  REQUIRE(ex.comp().arr[0] == 1.2);
+  REQUIRE(ex.comp().arr[1] == 3.4);
 }
 
 TEST_CASE("NonPresentCollection", "[basics][event-store]") {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -7,7 +7,6 @@
 #include "catch2/catch_test_macros.hpp"
 
 // podio specific includes
-#include "datamodel/ExampleWithVectorMemberCollection.h"
 #include "podio/EventStore.h"
 #include "podio/podioVersion.h"
 
@@ -18,6 +17,8 @@
 #include "datamodel/ExampleForCyclicDependency2Collection.h"
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/ExampleWithOneRelationCollection.h"
+#include "datamodel/ExampleWithUserInitCollection.h"
+#include "datamodel/ExampleWithVectorMemberCollection.h"
 #include "datamodel/MutableExampleWithComponent.h"
 #include "podio/UserDataCollection.h"
 
@@ -326,6 +327,27 @@ TEST_CASE("Equality", "[basics]") {
   auto returned_cluster = rel.cluster();
   REQUIRE(cluster == returned_cluster);
   REQUIRE(returned_cluster == cluster);
+}
+
+TEST_CASE("UserInitialization", "[basics][code-gen]") {
+  ExampleWithUserInitCollection coll;
+  // Default initialization values should work even through the create factory
+  auto elem = coll.create();
+  REQUIRE(elem.i16Val() == 42);
+  REQUIRE(elem.floats()[0] == 3.14f);
+  REQUIRE(elem.floats()[1] == 1.23f);
+  REQUIRE(elem.s().x == 10);
+  REQUIRE(elem.s().y == 11);
+  REQUIRE(elem.d() == 9.876e5);
+
+  // And obviously when initialized directly
+  auto ex = ExampleWithUserInit{};
+  REQUIRE(ex.i16Val() == 42);
+  REQUIRE(ex.floats()[0] == 3.14f);
+  REQUIRE(ex.floats()[1] == 1.23f);
+  REQUIRE(ex.s().x == 10);
+  REQUIRE(ex.s().y == 11);
+  REQUIRE(ex.d() == 9.876e5);
 }
 
 TEST_CASE("NonPresentCollection", "[basics][event-store]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Allow users to define default values for member variables, instead of default initializing all of them.
  - The syntax for specifying a default value is `- <type> <name> {<init-value>} // <description>`.
  - If the `type` is a builtin type or an array of builtin types, the initialization value is validated to yield valid c++. For other types this validation is skipped and it is the users responsibility to provide a valid initialization.
- Remove some of the python2 compatibility now that it is no longer necessary.

ENDRELEASENOTES

See #266 for some initial discussion on the supported use cases

Currently targets the `develop` branch, which simply includes #254 and #253 on top of the current `master` branch.

~This also needs #270 for one of the tests to work.~

- [ ] update documentation
- [ ] stricter validation?
- [x] check impact on time it takes to generate, e.g. edm4hep with the additional checks.