### PR TITLE
Remove duplicated printing of component members

### DIFF
--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -181,11 +181,6 @@ std::ostream& operator<<(std::ostream& o, const {{ type }}& value) {
 {% else %}
   o << " {{ member.name }} : " << value.{{ member.getter_name(get_syntax) }}() << '\n';
 {% endif %}
-{% if member.sub_members %}
-{% for sub_member in member.sub_members %}
-  o << " {{ member.name }}: " << value.{{ sub_member.getter_name(get_syntax) }}() << '\n';
-{% endfor %}
-{% endif %}
 {% endfor %}
 
 {% for relation in single_relations %}

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -101,6 +101,12 @@ datatypes :
     OneToOneRelations:
      - ExampleCluster cluster // a particular cluster
 
+  ExampleWithArrayComponent:
+    Description: "A type that has a component with an array"
+    Author: "Thomas Madlener"
+    Members:
+      - SimpleStruct s // a component that has an array
+
   ExampleWithComponent :
     Description : "Type with one component"
     Author : "Benedikt Hegner"


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove duplicated printing of component members in the `std::ostream& operator<<` overloads of the datatypes. Fixes #269 
- Add an example datatype that broke compilation before these fixes.

ENDRELEASENOTES