### PR TITLE
Remove support for having std::string members in datatypes and components

### DIFF
--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -41,14 +41,13 @@ class DefinitionError(Exception):
 BUILTIN_TYPES = ["int", "long", "float", "double",
                  "unsigned int", "unsigned", "unsigned long",
                  "char", "short", "bool", "long long",
-                 "unsigned long long", "std::string"]
+                 "unsigned long long"]
 
 # Fixed width types defined in <cstdint>. Omitting int8_t and uint8_t since they
 # are often only aliases for signed char and unsigned char, which tends to break
 # expectations towards the behavior of integer types. Also omitting the _fastN_t
 # and leastN_t since those are probably already covered by the usual integer
-# types. These fixed width types should only be used when necessary (e.g. as
-# basis for bit fields)
+# types.
 ALLOWED_FIXED_WIDTH_TYPES = ["int16_t", "int32_t", "int64_t",
                              "uint16_t", "uint32_t", "uint64_t"]
 

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -359,7 +359,6 @@ class ClassGenerator:
     data = deepcopy(definition)
     data['class'] = DataType(name)
     data['includes_data'] = self._get_member_includes(definition["Members"])
-    data['is_pod'] = self._is_pod_type(definition["Members"])
     self._preprocess_for_class(data)
     self._preprocess_for_obj(data)
     self._preprocess_for_collection(data)
@@ -373,10 +372,6 @@ class ClassGenerator:
     for member in members:
       if member.is_array and not member.is_builtin_array:
         includes.add(self._build_include(member.array_bare_type))
-
-      for stl_type in ClassDefinitionValidator.allowed_stl_types:
-        if member.full_type == 'std::' + stl_type:
-          includes.add(f"#include <{stl_type}>")
 
       if self._needs_include(member):
         includes.add(self._build_include(member.bare_type))
@@ -418,16 +413,6 @@ class ClassGenerator:
     write_file_if_changed(f'{self.install_dir}/podio_generated_files.cmake',
                           '\n'.join(full_contents),
                           self.any_changes)
-
-  @staticmethod
-  def _is_pod_type(members):
-    """Check if the members of the class define a POD type"""
-    for stl_type in ClassDefinitionValidator.allowed_stl_types:
-      full_stl_type = 'std::' + stl_type
-      if any(m.full_type.startswith(full_stl_type) for m in members):
-        return False
-
-    return True
 
   def _needs_include(self, member):
     """Check whether the member needs an include from within the datamodel"""

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -14,7 +14,7 @@ from itertools import zip_longest
 
 import jinja2
 
-from podio_config_reader import PodioConfigReader, ClassDefinitionValidator
+from podio_config_reader import PodioConfigReader
 from generator_utils import DataType, DefinitionError
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -130,9 +130,6 @@ class ClassGenerator:
       print(figline + summaryline)
     print("     'Homage to the Square' - Josef Albers")
     print()
-
-    for warning in self.reader.warnings:
-      print(warning)
     print()
 
   def _eval_template(self, template, data):

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -133,19 +133,12 @@ class ClassDefinitionValidator:
     self.components = None
     self.datatypes = None
     self.expose_pod_members = False
-    self.warnings = set()
-
-  def _clear(self):
-    """Reset all the internal state such that one instance can be used for multiple
-    validations"""
-    self.warnings = set()
 
   def validate(self, datamodel, expose_pod_members):
     """Validate the datamodel"""
     self.components = datamodel['components']
     self.datatypes = datamodel['datatypes']
     self.expose_pod_members = expose_pod_members
-    self._clear()
 
     self._check_components()
     self._check_datatypes()
@@ -298,7 +291,6 @@ class PodioConfigReader:
         # use subfolder when including package header files
         "includeSubfolder": False,
         }
-    self.warnings = set()
 
   @staticmethod
   def _handle_extracode(definition):
@@ -418,4 +410,3 @@ class PodioConfigReader:
         'datatypes': self.datatypes,
         }
     validator.validate(datamodel, False)
-    self.warnings = validator.warnings

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -129,9 +129,6 @@ class ClassDefinitionValidator:
   # documented but not yet implemented
   not_yet_implemented_extra_code = ('declarationFile', 'implementationFile')
 
-  # stl types that are allowed to appear (other than array)
-  allowed_stl_types = ('string',)
-
   def __init__(self):
     self.components = None
     self.datatypes = None
@@ -196,12 +193,6 @@ class ClassDefinitionValidator:
 
     all_members = {}
     for member in members:
-      for stl_type in self.allowed_stl_types:
-        if member.full_type.startswith('std::' + stl_type):
-          self.warnings.add(f"{classname} defines a std::{stl_type} member ('{member.name}') that spoils PODness")
-          self.warnings.add('Deprecation warning: Support for std::string members in datatypes will be removed'
-                            ' in the near future')
-
       is_builtin = member.is_builtin or member.is_builtin_array
       in_definitions = member.full_type in all_types or member.array_type in all_types
 

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -9,25 +9,6 @@
 #include <sio/io_device.h>
 #include <sio/version.h>
 
-{% if not is_pod %}
-namespace podio {
-// Write a dedicated overload to operate on this class, since it defines non-pod members
-template<typename devT>
-void handlePODDataSIO(devT& device, {{ class.namespace }}::{{ class.bare_type }}Data* data, size_t size) {
-  for (size_t i = 0; i < size; ++i) {
-{% for member in Members %}
-    device.data(data[i].{{ member.name }});
-{% endfor %}
-
-{% for member in VectorMembers + OneToManyRelations %}
-    device.data(data[i].{{ member.name }}_begin);
-    device.data(data[i].{{ member.name }}_end);
-{% endfor %}
-  }
-}
-}
-{% endif %}
-
 {{ utils.namespace_open(class.namespace) }}
 {% with block_class = class.bare_type + 'SIOBlock' %}
 

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -227,6 +227,13 @@ void ROOTReader::createCollectionBranches(const std::vector<root_utils::Collecti
     root_utils::CollectionBranches branches{};
     const auto collectionClass = TClass::GetClass(collType.c_str());
 
+    // Make sure that ROOT actually knows about this datatype before running
+    // into a potentially cryptic segmentation fault by accessing the nullptr
+    if (!collectionClass) {
+      std::cerr << "PODIO: Cannot create the collection type \'" << collType << "\' stored in branch \'" << name
+                << "\'. Contents of this branch cannot be read." << std::endl;
+      continue;
+    }
     // Need the collection here to setup all the branches. Have to manage the
     // temporary collection ourselves
     auto collection =

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -131,12 +131,6 @@ datatypes :
 #    Members:
 #      - std::array<int,33> array // the array
 
-  ExampleWithString :
-    Description : "Type with a string"
-    Author : "Benedikt Hegner"
-    Members:
-      - std::string theString // the string
-
   ex42::ExampleWithNamespace :
     Description : "Type with namespace and namespaced member"
     Author : "Joschka Lingemann"

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -11,7 +11,6 @@
 #include "datamodel/ExampleWithFixedWidthIntegersCollection.h"
 #include "datamodel/ExampleWithNamespace.h"
 #include "datamodel/ExampleWithOneRelationCollection.h"
-#include "datamodel/ExampleWithStringCollection.h"
 #include "datamodel/ExampleWithVectorMemberCollection.h"
 
 // podio specific includes
@@ -76,16 +75,6 @@ void processEvent(podio::EventStore& store, int eventNum, podio::version::Versio
     if (std::string(err.what()) != "No collection \'notthere\' is present in the EventStore") {
       throw std::runtime_error("Trying to get non present collection \'notthere' should throw an exception");
     }
-  }
-
-  auto& strings = store.get<ExampleWithStringCollection>("strings");
-  if (strings.isValid()) {
-    auto string = strings[0];
-    if (string.theString() != "SomeString") {
-      throw std::runtime_error("Couldn't read string properly");
-    }
-  } else {
-    throw std::runtime_error("Collection 'strings' should be present.");
   }
 
   // read collection meta data

--- a/tests/write_ascii.cpp
+++ b/tests/write_ascii.cpp
@@ -8,7 +8,6 @@
 #include "datamodel/ExampleWithComponentCollection.h"
 #include "datamodel/ExampleWithNamespaceCollection.h"
 #include "datamodel/ExampleWithOneRelationCollection.h"
-#include "datamodel/ExampleWithStringCollection.h"
 #include "datamodel/ExampleWithVectorMemberCollection.h"
 
 // STL
@@ -37,7 +36,6 @@ int main() {
   auto& vecs = store.create<ExampleWithVectorMemberCollection>("WithVectorMember");
   auto& namesps = store.create<ex42::ExampleWithNamespaceCollection>("WithNamespaceMember");
   auto& namesprels = store.create<ex42::ExampleWithARelationCollection>("WithNamespaceRelation");
-  auto& strings = store.create<ExampleWithStringCollection>("strings");
   writer.registerForWrite<EventInfoCollection>("info");
   writer.registerForWrite<ExampleMCCollection>("mcparticles");
   writer.registerForWrite<ExampleHitCollection>("hits");
@@ -49,7 +47,6 @@ int main() {
   writer.registerForWrite<ExampleWithVectorMemberCollection>("WithVectorMember");
   writer.registerForWrite<ex42::ExampleWithNamespaceCollection>("WithNamespaceMember");
   writer.registerForWrite<ex42::ExampleWithARelationCollection>("WithNamespaceRelation");
-  writer.registerForWrite<ExampleWithStringCollection>("strings");
 
   unsigned nevents = 1; // 2000;
 
@@ -194,9 +191,6 @@ int main() {
     auto rel = ex42::MutableExampleWithARelation();
     rel.ref(namesp);
     namesprels.push_back(rel);
-
-    auto string = ExampleWithString("SomeString");
-    strings.push_back(string);
 
     writer.writeEvent();
     store.clearCollections();

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -13,7 +13,6 @@
 #include "datamodel/ExampleWithFixedWidthIntegersCollection.h"
 #include "datamodel/ExampleWithNamespaceCollection.h"
 #include "datamodel/ExampleWithOneRelationCollection.h"
-#include "datamodel/ExampleWithStringCollection.h"
 #include "datamodel/ExampleWithVectorMemberCollection.h"
 
 #include "podio/EventStore.h"
@@ -46,7 +45,6 @@ void write(podio::EventStore& store, WriterT& writer) {
   auto& namesps = store.create<ex42::ExampleWithNamespaceCollection>("WithNamespaceMember");
   auto& namesprels = store.create<ex42::ExampleWithARelationCollection>("WithNamespaceRelation");
   auto& cpytest = store.create<ex42::ExampleWithARelationCollection>("WithNamespaceRelationCopy");
-  auto& strings = store.create<ExampleWithStringCollection>("strings");
   auto& arrays = store.create<ExampleWithArrayCollection>("arrays");
   auto& fixedWidthInts = store.create<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
   auto& usrInts = store.create<podio::UserDataCollection<uint64_t>>("userInts");
@@ -67,7 +65,6 @@ void write(podio::EventStore& store, WriterT& writer) {
   writer.registerForWrite("WithNamespaceMember");
   writer.registerForWrite("WithNamespaceRelation");
   writer.registerForWrite("WithNamespaceRelationCopy");
-  writer.registerForWrite("strings");
   writer.registerForWrite("arrays");
   writer.registerForWrite("fixedWidthInts");
   writer.registerForWrite("userInts");
@@ -284,9 +281,6 @@ void write(podio::EventStore& store, WriterT& writer) {
     for (auto&& namesprel : namesprels) {
       cpytest.push_back(namesprel.clone());
     }
-
-    auto string = ExampleWithString("SomeString");
-    strings.push_back(string);
 
     std::array<int, 4> arrayTest = {0, 0, 2, 3};
     std::array<int, 4> arrayTest2 = {4, 4, 2 * static_cast<int>(i)};


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove support for having std::string members in datatypes and components, as they break PODness and it seems that this feature was not in use in any case.
- Make ROOTReader slightly more robust against missing datatypes in dictionaries when reading files.

ENDRELEASENOTES

Fixes #267 
- [x] Targeting `develop` for now, for cleaner diff.