### PR TITLE
Frame in memory interface

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -1,0 +1,119 @@
+#ifndef PODIO_FRAME_H
+#define PODIO_FRAME_H
+
+#include "podio/CollectionBase.h"
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+namespace podio {
+/**
+ * Frame class that serves as a container of collection and meta data.
+ */
+class Frame {
+  /**
+   * Internal abstract interface for the type-erased implementation of the Frame
+   * class
+   */
+  struct FrameConcept {
+    virtual ~FrameConcept() = default;
+    virtual const podio::CollectionBase* get(const std::string& name) const = 0;
+    virtual const podio::CollectionBase* put(std::unique_ptr<podio::CollectionBase> coll, const std::string& name) = 0;
+  };
+
+  /**
+   * The interface implementation of the abstract FrameConcept that is necessary
+   * for a type-erased implementation of the Frame class
+   */
+  struct FrameModel final : FrameConcept {
+
+    FrameModel() = default;
+    ~FrameModel() = default;
+    FrameModel(const FrameModel&) = delete;
+    FrameModel& operator=(const FrameModel&) = delete;
+    FrameModel(FrameModel&&) = default;
+    FrameModel& operator=(FrameModel&&) = default;
+
+    /** Try and get the collection from the internal storage and return a
+     * pointer to it if found. Otherwise return a nullptr
+     */
+    const podio::CollectionBase* get(const std::string& name) const final;
+
+    /** Try and place the collection into the internal storage and return a
+     * pointer to it. If a collection already exists or insertion fails, return
+     * a nullptr
+     */
+    const podio::CollectionBase* put(std::unique_ptr<CollectionBase> coll, const std::string& name) final;
+
+  private:
+    using CollectionMapT = std::unordered_map<std::string, std::unique_ptr<podio::CollectionBase>>;
+
+    CollectionMapT m_collections{};
+  };
+
+  std::unique_ptr<FrameConcept> m_self;
+
+public:
+  Frame();
+
+  /** Get a collection from the Frame
+   */
+  template <typename CollT>
+  const CollT& get(const std::string& name) const;
+
+  /** (Destructively) move a collection into the Frame and get a const reference
+   * back for further use
+   */
+  template <typename CollT, typename = std::enable_if_t<!std::is_lvalue_reference_v<CollT>>>
+  const CollT& put(CollT&& coll, const std::string& name);
+};
+
+// implementations below
+
+Frame::Frame() : m_self(std::make_unique<FrameModel>()) {
+}
+
+template <typename CollT>
+const CollT& Frame::get(const std::string& name) const {
+  const auto* coll = dynamic_cast<const CollT*>(m_self->get(name));
+  if (coll) {
+    return *coll;
+  }
+  // TODO: Handle non-existing collections
+  static const auto emptyColl = CollT();
+  return emptyColl;
+}
+
+template <typename CollT, typename>
+const CollT& Frame::put(CollT&& coll, const std::string& name) {
+  const auto* retColl = static_cast<const CollT*>(m_self->put(std::make_unique<CollT>(std::move(coll)), name));
+  if (retColl) {
+    return *retColl;
+  }
+  // TODO: Handle collision case
+  static const auto emptyColl = CollT();
+  return emptyColl;
+}
+
+const podio::CollectionBase* Frame::FrameModel::get(const std::string& name) const {
+  if (const auto it = m_collections.find(name); it != m_collections.end()) {
+    return it->second.get();
+  }
+
+  return nullptr;
+}
+
+const podio::CollectionBase* Frame::FrameModel::put(std::unique_ptr<podio::CollectionBase> coll,
+                                                    const std::string& name) {
+  auto [it, success] = m_collections.try_emplace(name, std::move(coll));
+  if (success) {
+    return it->second.get();
+  }
+
+  return nullptr;
+}
+} // namespace podio
+
+#endif // PODIO_FRAME_H

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -12,6 +12,15 @@
 #include <unordered_map>
 
 namespace podio {
+
+/// Alias template for enabling overloads only for Collections
+template <typename T>
+using EnableIfCollection = typename std::enable_if_t<isCollection<T>>;
+
+/// Alias template for enabling overloads only for Collection r-values
+template <typename T>
+using EnableIfCollectionRValue = typename std::enable_if_t<isCollection<T> && !std::is_lvalue_reference_v<T>>;
+
 /**
  * Frame class that serves as a container of collection and meta data.
  */
@@ -85,13 +94,13 @@ public:
 
   /** Get a collection from the Frame
    */
-  template <typename CollT>
+  template <typename CollT, typename = EnableIfCollection<CollT>>
   const CollT& get(const std::string& name) const;
 
   /** (Destructively) move a collection into the Frame and get a const reference
    * back for further use
    */
-  template <typename CollT, typename = std::enable_if_t<!std::is_lvalue_reference_v<CollT>>>
+  template <typename CollT, typename = EnableIfCollectionRValue<CollT>>
   const CollT& put(CollT&& coll, const std::string& name);
 
   /** Add a value to the parameters of the Frame (if the type is supported).
@@ -139,7 +148,7 @@ public:
 Frame::Frame() : m_self(std::make_unique<FrameModel>()) {
 }
 
-template <typename CollT>
+template <typename CollT, typename>
 const CollT& Frame::get(const std::string& name) const {
   const auto* coll = dynamic_cast<const CollT*>(m_self->get(name));
   if (coll) {

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -66,10 +66,22 @@ class Frame {
     podio::GenericParameters m_parameters{}; ///< The generic parameter store for this frame
   };
 
-  std::unique_ptr<FrameConcept> m_self;
+  std::unique_ptr<FrameConcept> m_self; ///< The internal concept pointer through which all the work is done
 
 public:
+  /** Empty Frame constructor
+   */
   Frame();
+
+  // The frame is a non-copyable type
+  Frame(const Frame&) = delete;
+  Frame& operator=(const Frame&) = delete;
+
+  Frame(Frame&&) = default;
+  Frame& operator=(Frame&&) = default;
+
+  /** Frame destructor */
+  ~Frame() = default;
 
   /** Get a collection from the Frame
    */

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -62,9 +62,13 @@ class Frame {
      */
     const podio::CollectionBase* put(std::unique_ptr<CollectionBase> coll, const std::string& name) final;
 
+    /** Get a reference to the internally used GenericParameters
+     */
     podio::GenericParameters& parameters() override {
       return m_parameters;
     }
+    /** Get a const reference to the internally used GenericParameters
+     */
     const podio::GenericParameters& parameters() const override {
       return m_parameters;
     };
@@ -105,7 +109,7 @@ public:
   template <typename CollT, typename = EnableIfCollectionRValue<CollT>>
   const CollT& put(CollT&& coll, const std::string& name);
 
-  /** Move a collection into the Frame
+  /** Move a collection into the Frame handing over ownership to the Frame
    */
   void put(std::unique_ptr<podio::CollectionBase> coll, const std::string& name);
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -105,6 +105,10 @@ public:
   template <typename CollT, typename = EnableIfCollectionRValue<CollT>>
   const CollT& put(CollT&& coll, const std::string& name);
 
+  /** Move a collection into the Frame
+   */
+  void put(std::unique_ptr<podio::CollectionBase> coll, const std::string& name);
+
   /** Add a value to the parameters of the Frame (if the type is supported).
    * Copy the value into the internal store
    */
@@ -159,6 +163,13 @@ const CollT& Frame::get(const std::string& name) const {
   // TODO: Handle non-existing collections
   static const auto emptyColl = CollT();
   return emptyColl;
+}
+
+void Frame::put(std::unique_ptr<podio::CollectionBase> coll, const std::string& name) {
+  const auto* retColl = m_self->put(std::move(coll), name);
+  if (!retColl) {
+    // TODO: Handle collisions
+  }
 }
 
 template <typename CollT, typename>

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -101,6 +101,16 @@ namespace detail {
   static constexpr bool isVector = IsVectorHelper<T>::value;
 
 } // namespace detail
+
+// forward declaration to be able to use it below
+class CollectionBase;
+
+/**
+ * Alias template for checking whether a passed type T inherits from podio::CollectionBase
+ */
+template <typename T>
+static constexpr bool isCollection = std::is_base_of_v<CollectionBase, T>;
+
 } // namespace podio
 
 #endif // PODIO_UTILITIES_TYPEHELPERS_H

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -4,6 +4,23 @@
 
 namespace podio {
 
+GenericParameters::GenericParameters(const GenericParameters& other) :
+    m_intMtx(std::make_unique<std::mutex>()),
+    m_floatMtx(std::make_unique<std::mutex>()),
+    m_stringMtx(std::make_unique<std::mutex>()) {
+  {
+    // acquire all three locks at once to make sure all three internal maps are
+    // copied at the same "state" of the GenericParameters
+    auto& intMtx = other.getMutex<int>();
+    auto& floatMtx = other.getMutex<float>();
+    auto& stringMtx = other.getMutex<std::string>();
+    std::scoped_lock lock(intMtx, floatMtx, stringMtx);
+    _intMap = other._intMap;
+    _floatMap = other._floatMap;
+    _stringMap = other._stringMap;
+  }
+}
+
 int GenericParameters::getIntVal(const std::string& key) const {
   return getValue<int>(key);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,7 +151,7 @@ set_property(TEST pyunittest PROPERTY DEPENDS write)
 configure_file(CTestCustom.cmake ${CMAKE_BINARY_DIR}/CTestCustom.cmake)
 
 find_package(Threads REQUIRED)
-add_executable(unittest unittest.cpp)
+add_executable(unittest unittest.cpp frame.cpp)
 target_link_libraries(unittest PUBLIC TestDataModel PRIVATE Catch2::Catch2WithMain Threads::Threads)
 
 # The unittests are a bit better and they are labelled so we can put together a

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -227,7 +227,8 @@ TEST_CASE("Frame movability", "[frame][move-semantics]") {
   }
 
   SECTION("Use after move construction") {
-    auto otherFrame = std::move(frame);
+    auto otherFrame = std::move(frame); // NOLINT(clang-analyzer-cplusplus.Move) clang-tidy and the Catch2 sections
+                                        // setup do not go along here
     otherFrame.putParameter("aString", "Can add strings after move-constructing");
     REQUIRE(otherFrame.getParameter<std::string>("aString") == "Can add strings after move-constructing");
 

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -3,6 +3,7 @@
 #include "catch2/catch_test_macros.hpp"
 
 #include "datamodel/ExampleClusterCollection.h"
+#include "datamodel/ExampleHitCollection.h"
 
 TEST_CASE("Frame collections", "[frame][basics]") {
   auto event = podio::Frame();
@@ -35,4 +36,104 @@ TEST_CASE("Frame parameters", "[frame][basics]") {
   REQUIRE(strings[0] == "one");
   REQUIRE(strings[1] == "two");
   REQUIRE(strings[2] == "three");
+}
+
+// Helper function to create a frame in the tests below
+auto createFrame() {
+  auto frame = podio::Frame();
+
+  frame.put(ExampleClusterCollection(), "emptyClusters");
+
+  // Create a few hits inline (to avoid having to have two identifiers)
+  auto& hits = frame.put(
+      []() {
+        auto coll = ExampleHitCollection();
+        auto hit = coll.create(0x42ULL, 0., 0., 0., 0.);
+        auto hit2 = coll.create(0x123ULL, 1., 1., 1., 1.);
+        return coll;
+      }(),
+      "hits");
+
+  auto clusters = ExampleClusterCollection();
+  auto cluster = clusters.create(3.14f);
+  cluster.addHits(hits[0]);
+  auto cluster2 = clusters.create(42.0f);
+  cluster2.addHits(hits[1]);
+  cluster2.addClusters(cluster);
+
+  // Create a few clustes inline and relate them to the hits from above
+  frame.put(std::move(clusters), "clusters");
+
+  frame.putParameter("anInt", 42);
+  frame.putParameter("someFloats", {1.23f, 2.34f, 3.45f});
+
+  return frame;
+}
+
+// Helper function to keep the tests below a bit easier to read and not having
+// to repeat this bit all the time. This checks that the contents are the ones
+// that would be expected from the createFrame above
+void checkFrame(const podio::Frame& frame) {
+  auto& hits = frame.get<ExampleHitCollection>("hits");
+  REQUIRE(hits.size() == 2);
+  REQUIRE(hits[0].energy() == 0);
+  REQUIRE(hits[0].cellID() == 0x42ULL);
+  REQUIRE(hits[1].energy() == 1);
+  REQUIRE(hits[1].cellID() == 0x123ULL);
+
+  REQUIRE(frame.get<ExampleClusterCollection>("emptyClusters").size() == 0);
+
+  auto& clusters = frame.get<ExampleClusterCollection>("clusters");
+  REQUIRE(clusters.size() == 2);
+  REQUIRE(clusters[0].energy() == 3.14f);
+  REQUIRE(clusters[0].Hits().size() == 1);
+  REQUIRE(clusters[0].Hits()[0] == hits[0]);
+  REQUIRE(clusters[0].Clusters().empty());
+
+  REQUIRE(clusters[1].energy() == 42.f);
+  REQUIRE(clusters[1].Hits().size() == 1);
+  REQUIRE(clusters[1].Hits()[0] == hits[1]);
+  REQUIRE(clusters[1].Clusters()[0] == clusters[0]);
+
+  REQUIRE(frame.getParameter<int>("anInt") == 42);
+  auto& floats = frame.getParameter<std::vector<float>>("someFloats");
+  REQUIRE(floats.size() == 3);
+  REQUIRE(floats[0] == 1.23f);
+  REQUIRE(floats[1] == 2.34f);
+  REQUIRE(floats[2] == 3.45f);
+}
+
+TEST_CASE("Frame movability", "[frame][move-semantics]") {
+  auto frame = createFrame();
+  checkFrame(frame); // just to ensure that the setup is as expected
+
+  SECTION("Move constructor") {
+    auto otherFrame = std::move(frame);
+    checkFrame(otherFrame);
+  }
+
+  SECTION("Move assignment operator") {
+    auto otherFrame = podio::Frame();
+    otherFrame = std::move(frame);
+    checkFrame(otherFrame);
+  }
+
+  SECTION("Use after move construction") {
+    auto otherFrame = std::move(frame);
+    otherFrame.putParameter("aString", "Can add strings after move-constructing");
+    REQUIRE(otherFrame.getParameter<std::string>("aString") == "Can add strings after move-constructing");
+
+    otherFrame.put(
+        []() {
+          auto coll = ExampleHitCollection();
+          coll.create();
+          coll.create();
+          coll.create();
+          return coll;
+        }(),
+        "moreHits");
+
+    auto& hits = otherFrame.get<ExampleHitCollection>("moreHits");
+    REQUIRE(hits.size() == 3);
+  }
 }

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -144,7 +144,7 @@ TEST_CASE("Frame collections multithreaded insert and read", "[frame][basics][mu
           auto clusters = ExampleClusterCollection();
           clusters.create(j * 3.14);
           clusters.create(j * 3.14);
-          frame.put(std::move(clusters), "clusters_" + std::to_string(j));
+          frame.put(std::move(clusters), makeName("clusters", j));
 
           // Retrieve a few collections in between and do just a very basic testing
           auto& existingClu = frame.get<ExampleClusterCollection>("clusters");
@@ -156,7 +156,7 @@ TEST_CASE("Frame collections multithreaded insert and read", "[frame][basics][mu
           hits.create(j * 100ULL);
           hits.create(j * 100ULL);
           hits.create(j * 100ULL);
-          frame.put(std::move(hits), "hits_" + std::to_string(j));
+          frame.put(std::move(hits), makeName("hits", j));
 
           // Fill in a lot of new collections to trigger a rehashing of the
           // internal map, which invalidates iterators
@@ -174,13 +174,13 @@ TEST_CASE("Frame collections multithreaded insert and read", "[frame][basics][mu
 
   // Check the frame contents after all threads have finished
   for (int i = 0; i < nThreads; ++i) {
-    auto& hits = frame.get<ExampleHitCollection>("hits_" + std::to_string(i));
+    auto& hits = frame.get<ExampleHitCollection>(makeName("hits", i));
     REQUIRE(hits.size() == 3);
     for (const auto h : hits) {
       REQUIRE(h.cellID() == i * 100ULL);
     }
 
-    auto& clusters = frame.get<ExampleClusterCollection>("clusters_" + std::to_string(i));
+    auto& clusters = frame.get<ExampleClusterCollection>(makeName("clusters", i));
     REQUIRE(clusters.size() == 2);
     for (const auto c : clusters) {
       REQUIRE(c.energy() == i * 3.14);

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -306,6 +306,8 @@ TEST_CASE("Frame parameters multithread insert and read", "[frame][basics][multi
       REQUIRE(frame.getParameter<float>(makeName("float", i)) == (float)i);
 
       frame.putParameter(makeName("string", i), std::to_string(i));
+      REQUIRE(frame.getParameter<std::string>("string_par") == "some string");
+
       const auto& floatPars = frame.getParameter<std::vector<float>>("float_pars");
       REQUIRE(floatPars.size() == 3);
       REQUIRE(floatPars[0] == 1.23f);
@@ -320,8 +322,6 @@ TEST_CASE("Frame parameters multithread insert and read", "[frame][basics][multi
         frame.putParameter(makeName("floatPar", i) + std::to_string(k), (float)i * k);
         frame.putParameter(makeName("stringPar", i) + std::to_string(k), std::to_string(i * k));
       }
-
-      REQUIRE(frame.getParameter<std::string>("string_par") == "some string");
     });
   }
 

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -135,5 +135,6 @@ TEST_CASE("Frame movability", "[frame][move-semantics]") {
 
     auto& hits = otherFrame.get<ExampleHitCollection>("moreHits");
     REQUIRE(hits.size() == 3);
+    checkFrame(otherFrame);
   }
 }

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -1,0 +1,18 @@
+#include "podio/Frame.h"
+
+#include "catch2/catch_test_macros.hpp"
+
+#include "datamodel/ExampleClusterCollection.h"
+
+TEST_CASE("Frame", "[frame][basics]") {
+  auto event = podio::Frame();
+  auto clusters = ExampleClusterCollection();
+  clusters.create(3.14f);
+  clusters.create(42.0f);
+
+  event.put(std::move(clusters), "clusters");
+
+  auto& coll = event.get<ExampleClusterCollection>("clusters");
+  REQUIRE(coll[0].energy() == 3.14f);
+  REQUIRE(coll[1].energy() == 42.0f);
+}

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -4,7 +4,7 @@
 
 #include "datamodel/ExampleClusterCollection.h"
 
-TEST_CASE("Frame", "[frame][basics]") {
+TEST_CASE("Frame collections", "[frame][basics]") {
   auto event = podio::Frame();
   auto clusters = ExampleClusterCollection();
   clusters.create(3.14f);
@@ -15,4 +15,24 @@ TEST_CASE("Frame", "[frame][basics]") {
   auto& coll = event.get<ExampleClusterCollection>("clusters");
   REQUIRE(coll[0].energy() == 3.14f);
   REQUIRE(coll[1].energy() == 42.0f);
+}
+
+TEST_CASE("Frame parameters", "[frame][basics]") {
+  auto event = podio::Frame();
+
+  event.putParameter("aString", "from a string literal");
+  REQUIRE(event.getParameter<std::string>("aString") == "from a string literal");
+
+  event.putParameter("someInts", {42, 123});
+  const auto& ints = event.getParameter<std::vector<int>>("someInts");
+  REQUIRE(ints.size() == 2);
+  REQUIRE(ints[0] == 42);
+  REQUIRE(ints[1] == 123);
+
+  event.putParameter("someStrings", {"one", "two", "three"});
+  const auto& strings = event.getParameter<std::vector<std::string>>("someStrings");
+  REQUIRE(strings.size() == 3);
+  REQUIRE(strings[0] == "one");
+  REQUIRE(strings[1] == "two");
+  REQUIRE(strings[2] == "three");
 }

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -90,7 +90,7 @@ void processEvent(podio::EventStore& store, int eventNum, podio::version::Versio
 
   // read collection meta data
   auto& hits = store.get<ExampleHitCollection>("hits");
-  auto colMD = store.getCollectionMetaData(hits.getID());
+  const auto& colMD = store.getCollectionMetaData(hits.getID());
   const auto& es = colMD.getValue<std::string>("CellIDEncodingString");
   if (es != std::string("system:8,barrel:3,layer:6,slice:5,x:-16,y:-16")) {
     std::cout << " meta data from collection 'hits' with id = " << hits.getID() << " read CellIDEncodingString: " << es


### PR DESCRIPTION
BEGINRELEASENOTES
- Introduce the `podio::Frame` as a generalized (event) data container with the necessary prerequisites to extend this basic implementation with all the planned functionality later.
  - This version does not yet include any I/O functionality but only introduces the thread-safe in-memory interface.

ENDRELEASENOTES

This is a first version of the in-memory interface of the `Frame` proposal. I am putting this here to gather early feedback, mainly on the user interface and on some of the proposed functionality. At this point only the basic skeleton for the `podio::Frame` is present and much of the foreseen functionality is still missing. However, the interface should be somewhat stable already as most of that functionality should be hidden, or not observable through the interface. One thing that could still influence the interface could be the choice of policies that we want to offer. I have put some of my proposals below.

Having this discussion early enough might make it possible to split this feature into several pull requests instead of having one extremely large one.

### `podio::Frame` interface

The Frame is implemented via type-erasure. This allows us to have different policies but only one user facing class with value semantics and the possibility to construct from different raw data types [^1]. The current public interface of the Frame looks essentially like this:
```cpp
class Frame {
public:
  template<typename CollT>
  const CollT& get(const std::string& name) const;

  template<typename CollT>
  const CollT& put(CollT&& coll, const std::string& name);

  template<typename T>
  void putParameter(const std::string& key, T value);
  
  template<typename T>
  const T& getParameter(const std::string& key) const;
};
```

Some notes (about the actual implementation that are not visible in the above version):
- The `put` and `get` methods use `std::enable_if` to only be available for collections added by podio. 
- The `put` method uses `std::enable_if` to force users to explicitly pass a temporary or relinquish ownership via `std::move`.
- The `{put|get}Parameter` functionality provides the extra data / meta data functionality and is using the `GenericParameters` class under the hood.
  - The templates are using `std::enable_if` to only be available for the types that are actually supported (`int`, `float`, `std::string` and `std::vectors` of those)
  - The return value of `getParameter` is either a `const T&` or a `T` (for `int` and `float`).
  - There are a few dedicated overloads for `putParameter` to enhance the usability, e.g. for passing raw string literals or initializer lists.

### Planned policies
There are a few policies that I have already in mind, but this is still open for discussion
- Unpacking policy that controls how the raw data that are passed are unpacked. E.g. could be eagerly on Frame construction or lazily on demand. Would be completely invisible for users.
- Handling of collisions when putting collections into the Frame. E.g. could throw an exception, silently drop the new collection or replace the existing collection. Could potentially also be part of the `put` interface to have more fine grained control, instead of having a "global" policy
- Handling of missing collections. E.g. could throw an exception or simply return an empty new collection. Could potentially become part of the `get` interface to have more fine grained control, instead of a "global" policy.
- Locking policy. E.g. could drop all (externally observable) locking if the Frame is only used from one thread or to read only, or could go with the default locking which might have an impact on single threaded use.

[^1]: This first proposal is still missing these features at the moment.

### Preliminary TODO list
- [x] Policies -> **postponed to later PR**
- [x] I/O functionality -> Done in #287 
- [x] Thread safe get/set functionality
- [x] Thread safe parameters access
- [x] documentation
- [x] Combined c++20 concepts and c++17 compatible implementation of type constraints? Not sure how easily possible that is. Probably can be added later. -> **postponed to later PR**
- [x] Release notes
- [x] ~~Targets develop~~
- [x] Need #262 ~on top of develop~ [diff of once that is merged](https://github.com/tmadlener/podio/compare/templated-generic-param-access...tmadlener:frame?expand=1)