### PR TITLE
Unset ROOT_INCLUDE_PATH for tests

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -20,7 +20,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
-            -DUSE_EXTERNAL_CATCH2=OFF \
+            -DUSE_EXTERNAL_CATCH2=ON \
             -G Ninja ..
           ninja -k0
           ctest --output-on-failure

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -6,13 +6,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        release: ["sw.hsf.org/key4hep",
+                  "sw-nightlies.hsf.org/key4hep"]
     steps:
     - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - uses: aidasoft/run-lcg-view@v3
       with:
         container: centos7
-        view-path: /cvmfs/sw.hsf.org/key4hep
+        view-path: /cvmfs/${{ matrix.release }}
         run: |
           mkdir build install
           cd build

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,9 @@ function(CREATE_PODIO_TEST sourcefile additional_libs)
   target_link_libraries(${name} TestDataModel ${additional_libs})
   set_property(TEST ${name} PROPERTY ENVIRONMENT
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH}
+      # Clear the ROOT_INCLUDE_PATH for the tests, to avoid potential conflicts
+      # with existing headers from other installations
+      ROOT_INCLUDE_PATH=
     )
 endfunction()
 
@@ -48,6 +51,7 @@ else()
 
   set_property(TEST read-legacy-files PROPERTY ENVIRONMENT
     LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH}
+    ROOT_INCLUDE_PATH=
   )
 endif()
 
@@ -123,7 +127,8 @@ set_property(TEST pyunittest
              PROPERTY ENVIRONMENT
                       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$<TARGET_FILE_DIR:ROOT::Tree>:$ENV{LD_LIBRARY_PATH}
                       PYTHONPATH=${CMAKE_SOURCE_DIR}/python:$ENV{PYTHONPATH}
-                      ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/tests/datamodel:${ROOT_INCLUDE_PATH})
+                      ROOT_INCLUDE_PATH=
+                      )
 set_property(TEST pyunittest PROPERTY DEPENDS write)
 
 # Customize CTest to potentially disable some of the tests with known problems


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix test environment to work again in newest Key4hep release by unsetting `ROOT_INCLUDE_PATH` in the test environment to avoid potential clashes with existing other installations in the environment.
- Add CI build against the Key4hep nightlies.
- Switch to use the Catch2 installation from Key4hep for the workflows.

ENDRELEASENOTES

See key4hep/key4hep-spack#336 for some related discussion