### PR TITLE
Make it possible to define default initialization values in the yaml definition

### DIFF
--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -75,7 +75,16 @@ The definition of a member is done in the `Members` section in the form:
       <type> <name> // <comment>
 ```
 
-where `type` can be any buildin-type or a `component`.
+where `type` can be any builtin-type or a `component`.
+
+It is also possible to specify default values for members via
+```yaml
+    Members:
+      <type> <name>{<default-value>} // <comment>
+```
+Note that in this case it is extremely expensive to check whether the provided `default-value` results in valid c++.
+Hence, there is only a very basic syntax check, but no actual type check, and wrong default values will be caught only when trying to compile the datamodel.
+
 
 ### Definition of references between objects:
 There can be one-to-one-relations and one-to-many relations being stored in a particular class. This happens either in the `OneToOneRelations` or `OneToManyRelations` section of the data definition. The definition has again the form:

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Module holding some generator utility functions
 """
@@ -124,6 +124,10 @@ class MemberVariable:
       self.includes.add('#include <array>')
 
     self.is_builtin = self.full_type in BUILTIN_TYPES
+    # Check if this is a string and add the corresponding include
+    if self.full_type == 'std::string':
+      self.includes.add('#include <string>')
+
     # We still have to check if this type is a valid fixed width type that we
     # also consider to be builtin types
     if not self.is_builtin:

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -103,7 +103,7 @@ class MemberVariable:
     self.includes = set()
 
     if kwargs:
-      raise ValueError(f"Unused kwargs in MemberVariable: {kwargs.keys()}")
+      raise ValueError(f"Unused kwargs in MemberVariable: {list(kwargs.keys())}")
 
     if self.array_type is not None and self.array_size is not None:
       self.is_array = True

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -90,6 +90,7 @@ class MemberVariable:
     self.name = name
     self.full_type = kwargs.pop('type', '')
     self.description = kwargs.pop('description', '')
+    self.default_val = kwargs.pop('default_val', None)
     self.is_builtin = False
     self.is_builtin_array = False
     self.is_array = False
@@ -156,7 +157,11 @@ class MemberVariable:
     else:
       scoped_type = self.full_type
 
-    definition = rf'{scoped_type} {self.name}{{}};'
+    if self.default_val:
+      definition = rf'{scoped_type} {self.name}{{{self.default_val}}};'
+    else:
+      definition = rf'{scoped_type} {self.name}{{}};'
+
     if self.description:
       definition += rf' ///< {self.description}'
     return definition

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Podio class generator script"""
 

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -3,10 +3,22 @@
 
 import copy
 import re
+import subprocess
 import warnings
 import yaml
 
 from generator_utils import MemberVariable, DefinitionError, BUILTIN_TYPES
+
+
+def _validate_syntax(snippet, compiler="gcc", flags=None):
+  """Validate the passed snippet via -fsyntax-only."""
+  flags = flags or ["-std=c++17"]
+  try:
+    args = [compiler, "-fsyntax-only", "-x", "c++", "-"] + flags
+    subprocess.run(args, input=snippet.encode(), check=True, capture_output=True)
+    return None
+  except subprocess.CalledProcessError as err:
+    return err.stderr.decode()
 
 
 class MemberParser:
@@ -41,12 +53,12 @@ class MemberParser:
   def_val_str = r'(?:{(.+)})?'
 
   array_re = re.compile(array_str)
-  full_array_re = re.compile(rf'{array_str} *{name_str} *{comment_str}')
+  full_array_re = re.compile(rf'{array_str} *{name_str} *{def_val_str} *{comment_str}')
   member_re = re.compile(rf' *{type_str} +{name_str} *{def_val_str} *{comment_str}')
 
   # For cases where we don't require a description
   bare_member_re = re.compile(rf' *{type_str} +{name_str} *{def_val_str}')
-  bare_array_re = re.compile(rf' *{array_str} +{name_str}')
+  bare_array_re = re.compile(rf' *{array_str} +{name_str} *{def_val_str}')
 
   @staticmethod
   def _parse_with_regexps(string, regexps_callbacks):
@@ -62,26 +74,48 @@ class MemberParser:
   @staticmethod
   def _full_array_conv(match):
     """MemberVariable construction for array members with a docstring"""
-    typ, size, name, comment = match.groups()
-    return MemberVariable(name=name, array_type=typ, array_size=size, description=comment.strip())
+    typ, size, name, def_val, comment = match.groups()
+    return MemberParser.validate_init(
+        MemberVariable(name=name, array_type=typ, array_size=size, description=comment.strip(), default_val=def_val))
 
   @staticmethod
   def _full_member_conv(match):
     """MemberVariable construction for members with a docstring"""
     klass, name, def_val, comment = match.groups()
-    return MemberVariable(name=name, type=klass, description=comment.strip(), default_val=def_val)
+    return MemberParser.validate_init(
+        MemberVariable(name=name, type=klass, description=comment.strip(), default_val=def_val))
 
   @staticmethod
   def _bare_array_conv(match):
     """MemberVariable construction for array members without docstring"""
-    typ, size, name = match.groups()
-    return MemberVariable(name=name, array_type=typ, array_size=size)
+    typ, size, name, def_val = match.groups()
+    return MemberParser.validate_init(MemberVariable(name=name, array_type=typ, array_size=size, default_val=def_val))
 
   @staticmethod
   def _bare_member_conv(match):
     """MemberVarible construction for members without docstring"""
     klass, name, def_val = match.groups()
-    return MemberVariable(name=name, type=klass, default_val=def_val)
+    return MemberParser.validate_init(MemberVariable(name=name, type=klass, default_val=def_val))
+
+  @staticmethod
+  def validate_init(member_var: MemberVariable):
+    """Validate the passed in member variable also checking if the user defined
+    initialization is valid (for cases where that is possible without further
+    context)
+    """
+    # We can only check if an initialization is possible from the member
+    # declaration alone without further context, if we have a builtin type or an
+    # array of builtin types. For cases we cannot handle, we go with "user knows
+    # best"
+    if not member_var.is_builtin and not member_var.is_builtin_array:
+      return member_var
+
+    includes = '\n'.join(member_var.includes)
+    validation_err = _validate_syntax(f'{includes}\n{member_var}')
+    if validation_err:
+      raise DefinitionError(f'{member_var.name} does not pass syntax validation:\n{validation_err}')
+
+    return member_var
 
   def parse(self, string, require_description=True):
     """Parse the passed string"""

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -103,6 +103,10 @@ class MemberParser:
     initialization is valid (for cases where that is possible without further
     context)
     """
+    # Checks are quite expensive. Only run them if really necessary
+    if member_var.default_val is None:
+      return member_var
+
     # We can only check if an initialization is possible from the member
     # declaration alone without further context, if we have a builtin type or an
     # array of builtin types. For cases we cannot handle, we go with "user knows

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -3,22 +3,10 @@
 
 import copy
 import re
-import subprocess
 import warnings
 import yaml
 
 from generator_utils import MemberVariable, DefinitionError, BUILTIN_TYPES
-
-
-def _validate_syntax(snippet, compiler="gcc", flags=None):
-  """Validate the passed snippet via -fsyntax-only."""
-  flags = flags or ["-std=c++17"]
-  try:
-    args = [compiler, "-fsyntax-only", "-x", "c++", "-"] + flags
-    subprocess.run(args, input=snippet.encode(), check=True, capture_output=True)
-    return None
-  except subprocess.CalledProcessError as err:
-    return err.stderr.decode()
 
 
 class MemberParser:
@@ -75,51 +63,25 @@ class MemberParser:
   def _full_array_conv(match):
     """MemberVariable construction for array members with a docstring"""
     typ, size, name, def_val, comment = match.groups()
-    return MemberParser.validate_init(
-        MemberVariable(name=name, array_type=typ, array_size=size, description=comment.strip(), default_val=def_val))
+    return MemberVariable(name=name, array_type=typ, array_size=size, description=comment.strip(), default_val=def_val)
 
   @staticmethod
   def _full_member_conv(match):
     """MemberVariable construction for members with a docstring"""
     klass, name, def_val, comment = match.groups()
-    return MemberParser.validate_init(
-        MemberVariable(name=name, type=klass, description=comment.strip(), default_val=def_val))
+    return MemberVariable(name=name, type=klass, description=comment.strip(), default_val=def_val)
 
   @staticmethod
   def _bare_array_conv(match):
     """MemberVariable construction for array members without docstring"""
     typ, size, name, def_val = match.groups()
-    return MemberParser.validate_init(MemberVariable(name=name, array_type=typ, array_size=size, default_val=def_val))
+    return MemberVariable(name=name, array_type=typ, array_size=size, default_val=def_val)
 
   @staticmethod
   def _bare_member_conv(match):
     """MemberVarible construction for members without docstring"""
     klass, name, def_val = match.groups()
-    return MemberParser.validate_init(MemberVariable(name=name, type=klass, default_val=def_val))
-
-  @staticmethod
-  def validate_init(member_var: MemberVariable):
-    """Validate the passed in member variable also checking if the user defined
-    initialization is valid (for cases where that is possible without further
-    context)
-    """
-    # Checks are quite expensive. Only run them if really necessary
-    if member_var.default_val is None:
-      return member_var
-
-    # We can only check if an initialization is possible from the member
-    # declaration alone without further context, if we have a builtin type or an
-    # array of builtin types. For cases we cannot handle, we go with "user knows
-    # best"
-    if not member_var.is_builtin and not member_var.is_builtin_array:
-      return member_var
-
-    includes = '\n'.join(member_var.includes)
-    validation_err = _validate_syntax(f'{includes}\n{member_var}')
-    if validation_err:
-      raise DefinitionError(f'{member_var.name} does not pass syntax validation:\n{validation_err}')
-
-    return member_var
+    return MemberVariable(name=name, type=klass, default_val=def_val)
 
   def parse(self, string, require_description=True):
     """Parse the passed string"""

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -1,4 +1,4 @@
-"""Datamodel yaml configuration file reading and validation utilities"""
+"""Datamodel yaml configuration file reading and validation utilities."""
 
 
 import copy

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -20,6 +20,7 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.full_type, r'float')
     self.assertEqual(parsed.name, r'someFloat')
     self.assertEqual(parsed.description, r'with an additional comment')
+    self.assertTrue(parsed.default_val is None)
 
     parsed = parser.parse(r'float float2 // with numbers')
     self.assertEqual(parsed.full_type, r'float')
@@ -87,6 +88,7 @@ class MemberParserTest(unittest.TestCase):
     self.assertTrue(parsed.is_builtin_array)
     self.assertEqual(int(parsed.array_size), 4)
     self.assertEqual(parsed.array_type, r'double')
+    self.assertTrue(parsed.default_val is None)
 
     # an array definition as terse as possible
     parsed = parser.parse(r'std::array<int,2>anArray//with a comment')
@@ -120,6 +122,36 @@ class MemberParserTest(unittest.TestCase):
     self.assertTrue(parsed.is_builtin_array)
     self.assertEqual(parsed.array_type, r'std::uint32_t')
 
+  def test_parse_valid_default_value(self):
+    """Test that member variables can be parsed correctly if they have a user
+    defined default value"""
+    parser = MemberParser()
+
+    parsed = parser.parse(r'int fortyTwo{43} // default values can lie')
+    self.assertEqual(parsed.full_type, r'int')
+    self.assertEqual(parsed.name, r'fortyTwo')
+    self.assertEqual(parsed.description, 'default values can lie')
+    self.assertEqual(parsed.default_val, r'43')
+    self.assertEqual(str(parsed), 'int fortyTwo{43}; ///< default values can lie')
+
+    parsed = parser.parse(r'float f{3.14f}', require_description=False)
+    self.assertEqual(parsed.full_type, 'float')
+    self.assertEqual(parsed.name, 'f')
+    self.assertEqual(parsed.default_val, '3.14f')
+
+    parsed = parser.parse('nsp::SomeValue val {42} // default values can have space')
+    self.assertEqual(parsed.full_type, 'nsp::SomeValue')
+    self.assertEqual(parsed.name, 'val')
+    self.assertEqual(parsed.default_val, '42')
+    self.assertEqual(parsed.namespace, 'nsp')
+    self.assertEqual(parsed.bare_type, 'SomeValue')
+
+    # NOTE: The default values do not have to make sense at the moment!
+    parsed = parser.parse(r'int weirdDefault{whatever, even space} // same')
+    self.assertEqual(parsed.full_type, r'int')
+    self.assertEqual(parsed.name, r'weirdDefault')
+    self.assertEqual(parsed.default_val, r'whatever, even space')
+
   def test_parse_invalid(self):
     """Test that invalid member variable definitions indeed fail during parsing"""
     # setup an empty parser
@@ -135,7 +167,8 @@ class MemberParserTest(unittest.TestCase):
         r'std::array<int, 2> anArrayWithoutDescription',
         r'std::array<__foo, 3> anArray // with invalid type',
         r'std::array<double, N> array // with invalid size',
-        r'int another ill formed name // some comment'
+        r'int another ill formed name // some comment',
+        r'float illFormedDefault {',
 
         # Some examples of valid c++ that are rejected by the validation
         r'unsigned long int uLongInt // technically valid c++, but not in our builtin list',
@@ -147,7 +180,13 @@ class MemberParserTest(unittest.TestCase):
         r'uint_fast64_t disallowed // only allow fixed width integers with exact widths',
         r'std::int_least16_t disallowed // also adding a std namespace here does not make these allowed',
         r'std::uint_fast16_t disallowed // also adding a std namespace here does not make these allowed',
-        r'std::array<uint_fast16_t, 42> disallowedArray // arrays should not accept disallowed fixed width types'
+        r'std::array<uint_fast16_t, 42> disallowedArray // arrays should not accept disallowed fixed width types',
+
+        # Default values cannot be empty
+        r'int emptyDefault{} // valid c++, but we want an explicit default value here',
+        # Arrays cannot be user initialized
+        r'std::array<int, 3> array{1, 2, 3} // We do not allow user initialization for arrays',
+        r'std::array<int, 1> array{1, 2, 3} // because validating this is really non-trivial',
         ]
 
     for inp in invalid_inputs:

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -144,6 +144,10 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.default_val, '1, 2, 3')
     self.assertEqual(parsed.name, 'array')
 
+    parsed = parser.parse(r'std::array<int, 25> array{1, 2, 3} // we do not have to init the complete array')
+    self.assertEqual(parsed.full_type, r'std::array<int, 25>')
+    self.assertEqual(parsed.default_val, r'1, 2, 3')
+
     # These are cases where we cannot really decide whether the initialization
     # is valid just from the member declaration. We let them pass here
     parsed = parser.parse('nsp::SomeValue val {42} // default values can have space')

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -139,6 +139,13 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.name, 'f')
     self.assertEqual(parsed.default_val, '3.14f')
 
+    parsed = parser.parse(r'std::array<int, 3> array{1, 2, 3} // arrays can be initialized')
+    self.assertEqual(parsed.full_type, r'std::array<int, 3>')
+    self.assertEqual(parsed.default_val, '1, 2, 3')
+    self.assertEqual(parsed.name, 'array')
+
+    # These are cases where we cannot really decide whether the initialization
+    # is valid just from the member declaration. We let them pass here
     parsed = parser.parse('nsp::SomeValue val {42} // default values can have space')
     self.assertEqual(parsed.full_type, 'nsp::SomeValue')
     self.assertEqual(parsed.name, 'val')
@@ -146,11 +153,12 @@ class MemberParserTest(unittest.TestCase):
     self.assertEqual(parsed.namespace, 'nsp')
     self.assertEqual(parsed.bare_type, 'SomeValue')
 
-    # NOTE: The default values do not have to make sense at the moment!
-    parsed = parser.parse(r'int weirdDefault{whatever, even space} // same')
-    self.assertEqual(parsed.full_type, r'int')
-    self.assertEqual(parsed.name, r'weirdDefault')
-    self.assertEqual(parsed.default_val, r'whatever, even space')
+    parsed = parser.parse(r'edm4hep::Vector3d v{1, 2, 3, 4} // for aggregates we do not validate init values')
+    self.assertEqual(parsed.full_type, 'edm4hep::Vector3d')
+    self.assertEqual(parsed.default_val, '1, 2, 3, 4')
+
+    parsed = parser.parse(r'AggType bogusInit{here, we can even put invalid c++}', False)
+    self.assertEqual(parsed.default_val, 'here, we can even put invalid c++')
 
   def test_parse_invalid(self):
     """Test that invalid member variable definitions indeed fail during parsing"""
@@ -184,14 +192,19 @@ class MemberParserTest(unittest.TestCase):
 
         # Default values cannot be empty
         r'int emptyDefault{} // valid c++, but we want an explicit default value here',
-        # Arrays cannot be user initialized
-        r'std::array<int, 3> array{1, 2, 3} // We do not allow user initialization for arrays',
-        r'std::array<int, 1> array{1, 2, 3} // because validating this is really non-trivial',
+
+        # Some cases which should be caught by the -fsyntax-only checks
+        r'std::array<int, 1> array{1, 2, 3} // too many values provided',
+        # Invalid user default value initialization
+        r'int weirdDefault{whatever, even space} // invalid c++ should not pass',
+        r'int initFromFloat{3.14f} // implicit conversions are not allowed'
         ]
 
     for inp in invalid_inputs:
-      with self.assertRaises(DefinitionError):
-        parser.parse(inp)
+      try:
+        self.assertRaises(DefinitionError, parser.parse, inp)
+      except AssertionError:
+        raise AssertionError(f"'{inp}' should raise a DefinitionError from the MemberParser")
 
   def test_parse_valid_no_description(self):
     """Test that member variable definitions are OK without description"""

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -181,3 +181,12 @@ datatypes :
       - uint32_t fixedU32 // unsigned int with exactly 32 bits
       - StructWithFixedWithTypes fixedWidthStruct // struct with more fixed width types
       - std::array<int16_t, 2> fixedWidthArray // 32 bits split into two times 16 bits
+
+  ExampleWithUserInit:
+    Description: "Datatype with user defined initialization values"
+    Author: "Thomas Madlener"
+    Members:
+      - std::int16_t i16Val{42} // some int16 value
+      - std::array<float, 2> floats {3.14f, 1.23f} // some float values
+      - ex2::NamespaceStruct s{10, 11} // one that we happen to know works
+      - double d{9.876e5} // double val

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -40,6 +40,11 @@ components :
       - std::int64_t fixedInteger64 // int with exactly 64 bits
       - int32_t fixedInteger32 // int with exactly 32 bits
 
+  CompWithInit:
+    Members:
+      - int i{42} // is there even another value to initialize ints to?
+      - std::array<double, 10> arr {1.2, 3.4} // half initialized double array
+
 datatypes :
 
   EventInfo:
@@ -190,3 +195,4 @@ datatypes :
       - std::array<float, 2> floats {3.14f, 1.23f} // some float values
       - ex2::NamespaceStruct s{10, 11} // one that we happen to know works
       - double d{9.876e5} // double val
+      - CompWithInit comp // To make sure that the default initializer of the component does what it should

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -390,6 +390,9 @@ TEST_CASE("UserInitialization", "[basics][code-gen]") {
   REQUIRE(elem.s().x == 10);
   REQUIRE(elem.s().y == 11);
   REQUIRE(elem.d() == 9.876e5);
+  REQUIRE(elem.comp().i == 42);
+  REQUIRE(elem.comp().arr[0] == 1.2);
+  REQUIRE(elem.comp().arr[1] == 3.4);
 
   // And obviously when initialized directly
   auto ex = ExampleWithUserInit{};
@@ -399,6 +402,9 @@ TEST_CASE("UserInitialization", "[basics][code-gen]") {
   REQUIRE(ex.s().x == 10);
   REQUIRE(ex.s().y == 11);
   REQUIRE(ex.d() == 9.876e5);
+  REQUIRE(ex.comp().i == 42);
+  REQUIRE(ex.comp().arr[0] == 1.2);
+  REQUIRE(ex.comp().arr[1] == 3.4);
 }
 
 TEST_CASE("NonPresentCollection", "[basics][event-store]") {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -9,7 +9,6 @@
 #include "catch2/catch_test_macros.hpp"
 
 // podio specific includes
-#include "datamodel/ExampleWithVectorMemberCollection.h"
 #include "podio/EventStore.h"
 #include "podio/GenericParameters.h"
 #include "podio/podioVersion.h"
@@ -21,6 +20,8 @@
 #include "datamodel/ExampleForCyclicDependency2Collection.h"
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/ExampleWithOneRelationCollection.h"
+#include "datamodel/ExampleWithUserInitCollection.h"
+#include "datamodel/ExampleWithVectorMemberCollection.h"
 #include "datamodel/MutableExampleWithComponent.h"
 #include "podio/UserDataCollection.h"
 
@@ -377,6 +378,27 @@ TEST_CASE("Equality", "[basics]") {
   auto returned_cluster = rel.cluster();
   REQUIRE(cluster == returned_cluster);
   REQUIRE(returned_cluster == cluster);
+}
+
+TEST_CASE("UserInitialization", "[basics][code-gen]") {
+  ExampleWithUserInitCollection coll;
+  // Default initialization values should work even through the create factory
+  auto elem = coll.create();
+  REQUIRE(elem.i16Val() == 42);
+  REQUIRE(elem.floats()[0] == 3.14f);
+  REQUIRE(elem.floats()[1] == 1.23f);
+  REQUIRE(elem.s().x == 10);
+  REQUIRE(elem.s().y == 11);
+  REQUIRE(elem.d() == 9.876e5);
+
+  // And obviously when initialized directly
+  auto ex = ExampleWithUserInit{};
+  REQUIRE(ex.i16Val() == 42);
+  REQUIRE(ex.floats()[0] == 3.14f);
+  REQUIRE(ex.floats()[1] == 1.23f);
+  REQUIRE(ex.s().x == 10);
+  REQUIRE(ex.s().y == 11);
+  REQUIRE(ex.d() == 9.876e5);
 }
 
 TEST_CASE("NonPresentCollection", "[basics][event-store]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Allow users to define default values for member variables, instead of default initializing all of them.
  - The syntax for specifying a default value is `- <type> <name>{<init-value>} // <description>`.
  - The passed value is not validated in any way. **Apart from a very basic syntax check, there is no validation that the provided default initialization values are actually valid**. This means that generated code might not compile.
- Remove some of the python2 compatibility and do some cleanup 

ENDRELEASENOTES

Supersedes #268 
Fixes #266 

It would be possible to run the individual members through a syntax-only check of the compiler to see if the initialization is actually valid. This would catch probably almost all issues before we generate any code. However, this has proven to increase generation time quite significantly (see https://github.com/AIDASoft/podio/pull/268#issuecomment-1076425296). Since invalid default values will in any case be caught by the compiler after code generation, we decided to skip validation of default values and keep this as a sort of "expert feature".

A few of the things that are not valid but pass validation have been put into the tests as examples (and documentation).