### PR TITLE
Make sure to only read event meta data once per event

### DIFF
--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -115,6 +115,11 @@ public:
     _stringMap.clear();
   }
 
+  /// Check if no parameter is stored (i.e. if all internal maps are empty)
+  bool empty() const {
+    return _intMap.empty() && _floatMap.empty() && _stringMap.empty();
+  }
+
   /**
    * Get the internal int map (necessary for serialization with SIO)
    */

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -88,8 +88,7 @@ bool EventStore::doGet(const std::string& name, CollectionBase*& collection, boo
 
 GenericParameters& EventStore::getEventMetaData() {
 
-  if (m_reader != nullptr) {
-    m_evtMD.clear();
+  if (m_evtMD.empty() && m_reader != nullptr) {
     GenericParameters* tmp = m_reader->readEventMetaData();
     m_evtMD = std::move(*tmp);
     delete tmp;
@@ -130,6 +129,7 @@ void EventStore::clear() {
     delete coll.second;
   }
 
+  m_evtMD.clear();
   clearCaches();
 }
 

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -41,7 +41,7 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 
 void processEvent(podio::EventStore& store, int eventNum, podio::version::Version fileVersion) {
 
-  auto evtMD = store.getEventMetaData();
+  const auto& evtMD = store.getEventMetaData();
   float evtWeight = evtMD.getFloatVal("UserEventWeight");
   if (evtWeight != (float)100. * eventNum) {
     std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << (float)100. * eventNum << std::endl;
@@ -49,7 +49,8 @@ void processEvent(podio::EventStore& store, int eventNum, podio::version::Versio
   }
   std::stringstream ss;
   ss << " event_number_" << eventNum;
-  const auto& evtName = evtMD.getStringVal("UserEventName");
+  const auto& evtMD2 = store.getEventMetaData();
+  const auto& evtName = evtMD2.getStringVal("UserEventName");
   if (evtName != ss.str()) {
     std::cout << " read UserEventName: " << evtName << " - expected : " << ss.str() << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventName'");


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure the `EventStore` doesn't try to read event meta data multiple times per event
- Add a `empty` method to `GenericParameters` to check if any parameters are stored.

ENDRELEASENOTES

This is the way it should be IMHO, instead of potentially reading the same data multiple times per event if there are multiple calls to `EventStore::getEventMetaData`.

Without these changes the SIO backend breaks because it cannot read the same data twice as easily as the ROOT backend.