### PR TITLE
Do not change the ID for objects in subset collections

### DIFF
--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -101,9 +101,11 @@ public:
 
   void setID(unsigned ID) final {
     m_collectionID = ID;
-    std::for_each(m_storage.entries.begin(), m_storage.entries.end(),
+    if (!m_isSubsetColl) {
+      std::for_each(m_storage.entries.begin(), m_storage.entries.end(),
                   [ID] ({{ class.bare_type }}Obj* obj) { obj->id = {obj->id.index, static_cast<int>(ID)}; }
-    );
+      );
+    }
     m_isValid = true;
   };
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -449,6 +449,19 @@ TEST_CASE("Subset collection can handle subsets", "[subset-colls]") {
   // Also in the other directon
   clusterRef.energy(-42);
   REQUIRE(cluster.energy() == -42);
+
+  clusters.setID(42);
+  for (auto c : clusters) {
+    REQUIRE(c.getObjectID().collectionID == 42);
+  }
+
+  // Setting the ID on a subset collection should not change the IDs of the
+  // reference objects as otherwise we cannot use them in I/O
+  clusterRefs.setID(314);
+  REQUIRE(clusterRefs.getID() == 314);
+  for (auto c : clusterRefs) {
+    REQUIRE(c.getObjectID().collectionID == 42);
+  }
 }
 
 TEST_CASE("Collection iterators work with subset collections", "[LEAK-FAIL][subset-colls]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix potential bug in setting the collection ID for subset collections

ENDRELEASENOTES

When calling `setID` on a collection, all the `collectionID`s in the stored objects will be updated to the passed `ID`. This is the correct behavior for normal collections. On the other hand for subset collection this is not what we want, because those objects should still point to their original collection. For the `EventStore` based workflow this has not surfaced yet, because in the call to `create` the collection is still empty and has no effect. For `Frame` based workflows this becomes a problem because the call to `setID` happens only when a collection is put into the Frame.