### PR TITLE
Replace obj_needs_destructor by more general concept

### DIFF
--- a/doc/templates.md
+++ b/doc/templates.md
@@ -100,7 +100,8 @@ The following keys / variables are filled for each datatype
 | `forward_declarations`        | The forward declarations for the user facing classes header files. This is a nested dict, where the keys are namespaces and the leaf values are classes. |
 | `forward_declarations_obj`     | The forward declarations for the `Obj` classes header files.                                                                                             |
 | `is_pod`                      | Flag value indicating whether the `Data` class of this datatype is a POD or if it contains an STL member                                                 |
-| `obj_needs_destructor`        | Flag indicating whether the `Obj` class needs a dedicated destructor for the datatype or whether `= default` is enough.                                  |
+| `obj_needs_destructor`        | Flag indicating whether the `Obj` class needs a dedicated destructor for the datatype or whether `= default` is enough.          
+| `is_trivial_type`        | Describes a general class of data types i.e. ones which have no relations or vector members.                            |
 | `ostream_collection_settings` | A dict with a single `header_contents` key that is necessary for the output stream overload implementation of collections                                |
 
 

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -100,7 +100,6 @@ The following keys / variables are filled for each datatype
 | `forward_declarations`        | The forward declarations for the user facing classes header files. This is a nested dict, where the keys are namespaces and the leaf values are classes. |
 | `forward_declarations_obj`     | The forward declarations for the `Obj` classes header files.                                                                                             |
 | `is_pod`                      | Flag value indicating whether the `Data` class of this datatype is a POD or if it contains an STL member                                                 |
-| `obj_needs_destructor`        | Flag indicating whether the `Obj` class needs a dedicated destructor for the datatype or whether `= default` is enough.          
 | `is_trivial_type`        | Describes a general class of data types i.e. ones which have no relations or vector members.                            |
 | `ostream_collection_settings` | A dict with a single `header_contents` key that is necessary for the output stream overload implementation of collections                                |
 

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -100,7 +100,7 @@ The following keys / variables are filled for each datatype
 | `forward_declarations`        | The forward declarations for the user facing classes header files. This is a nested dict, where the keys are namespaces and the leaf values are classes. |
 | `forward_declarations_obj`     | The forward declarations for the `Obj` classes header files.                                                                                             |
 | `is_pod`                      | Flag value indicating whether the `Data` class of this datatype is a POD or if it contains an STL member                                                 |
-| `is_trivial_type`        | Describes a general class of data types i.e. ones which have no relations or vector members.                            |
+| `is_trivial_type`        | Flag that indicates that this is a *trivial* data type, i.e. one without relations or vector members.                            |
 | `ostream_collection_settings` | A dict with a single `header_contents` key that is necessary for the output stream overload implementation of collections                                |
 
 

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -256,8 +256,8 @@ class ClassGenerator:
     datatype['forward_declarations_obj'] = fwd_declarations
     datatype['includes_obj'] = self._sort_includes(includes)
     datatype['includes_cc_obj'] = self._sort_includes(includes_cc)
-    needs_destructor = datatype['VectorMembers'] or datatype['OneToManyRelations'] or datatype['OneToOneRelations']
-    datatype['obj_needs_destructor'] = needs_destructor
+    trivial_types = datatype['VectorMembers'] or datatype['OneToManyRelations'] or datatype['OneToOneRelations']
+    datatype['is_trivial_type'] = trivial_types
 
   def _preprocess_for_class(self, datatype):
     """Do the preprocessing that is necessary for the classes and Mutable classes"""

--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -43,7 +43,7 @@
 {% endfor %}
 }
 
-{% if obj_needs_destructor -%}
+{% if is_trivial_type -%}
 {{ obj_type }}::~{{ obj_type }}() {
 {% with multi_relations = OneToManyRelations + VectorMembers %}
 {%- if multi_relations %}

--- a/python/templates/Obj.h.jinja2
+++ b/python/templates/Obj.h.jinja2
@@ -32,7 +32,7 @@ public:
   {{ obj_type }}(const podio::ObjectID id, {{ class.bare_type }}Data data);
   /// No assignment operator
   {{ obj_type }}& operator=(const {{ obj_type }}&) = delete;
-{% if obj_needs_destructor %}
+{% if is_trivial_type %}
   virtual ~{{ obj_type }}();
 {% else %}
   virtual ~{{ obj_type }}() = default;


### PR DESCRIPTION
BEGINRELEASENOTES

- The name of obj_needs_destructor should be changed to something that better reflects this more general condition. E.g. is_trivial_type

- The condition in the generator describes a rather general class of datatypes, i.e. ones that have no relations or vector members.

ENDRELEASENOTES

Fixes #288 