### PR TITLE
Make SIO collection id writing independent of EventStore

### DIFF
--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -72,7 +72,7 @@ public:
   void write(sio::write_device& device) override;
 
   podio::CollectionIDTable* getTable() {
-    return _table;
+    return new podio::CollectionIDTable(std::move(_ids), std::move(_names));
   }
   const std::vector<std::string>& getTypeNames() const {
     return _types;
@@ -85,7 +85,8 @@ public:
   }
 
 private:
-  podio::CollectionIDTable* _table{nullptr};
+  std::vector<std::string> _names{};
+  std::vector<int> _ids{};
   std::vector<std::string> _types{};
   std::vector<short> _isSubsetColl{};
   podio::version::Version podioVersion{podio::version::build_version};

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -60,7 +60,7 @@ protected:
  */
 class SIOCollectionIDTableBlock : public sio::block {
 public:
-  SIOCollectionIDTableBlock() : sio::block("CollectionIDs", sio::version::encode_version(0, 3)) {
+  SIOCollectionIDTableBlock() : sio::block("CollectionIDs", sio::version::encode_version(0, 4)) {
   }
 
   SIOCollectionIDTableBlock(podio::EventStore* store);
@@ -80,16 +80,31 @@ public:
   const std::vector<short>& getSubsetCollectionBits() const {
     return _isSubsetColl;
   }
-  podio::version::Version getPodioVersion() const {
-    return podioVersion;
-  }
 
 private:
   std::vector<std::string> _names{};
   std::vector<int> _ids{};
   std::vector<std::string> _types{};
   std::vector<short> _isSubsetColl{};
-  podio::version::Version podioVersion{podio::version::build_version};
+};
+
+struct SIOVersionBlock : public sio::block {
+  SIOVersionBlock() : sio::block("podio_version", sio::version::encode_version(1, 0)) {
+  }
+
+  SIOVersionBlock(podio::version::Version v) :
+      sio::block("podio_version", sio::version::encode_version(1, 0)), version(v) {
+  }
+
+  void write(sio::write_device& device) override {
+    device.data(version);
+  }
+
+  void read(sio::read_device& device, sio::version_type) override {
+    device.data(version);
+  }
+
+  podio::version::Version version{};
 };
 
 /**

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -63,11 +63,7 @@ public:
   SIOCollectionIDTableBlock() : sio::block("CollectionIDs", sio::version::encode_version(0, 3)) {
   }
 
-  SIOCollectionIDTableBlock(podio::EventStore* store) :
-      sio::block("CollectionIDs", sio::version::encode_version(0, 3)),
-      _store(store),
-      _table(store->getCollectionIDTable()) {
-  }
+  SIOCollectionIDTableBlock(podio::EventStore* store);
 
   SIOCollectionIDTableBlock(const SIOCollectionIDTableBlock&) = delete;
   SIOCollectionIDTableBlock& operator=(const SIOCollectionIDTableBlock&) = delete;
@@ -89,7 +85,6 @@ public:
   }
 
 private:
-  podio::EventStore* _store{nullptr};
   podio::CollectionIDTable* _table{nullptr};
   std::vector<std::string> _types{};
   std::vector<short> _isSubsetColl{};

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -14,7 +14,6 @@
 namespace podio {
 SIOCollectionIDTableBlock::SIOCollectionIDTableBlock(podio::EventStore* store) :
     sio::block("CollectionIDs", sio::version::encode_version(0, 3)),
-    // _store(store),
     _table(store->getCollectionIDTable()) {
   _types.reserve(_table->names().size());
   _isSubsetColl.reserve(_table->names().size());

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -13,8 +13,7 @@
 
 namespace podio {
 SIOCollectionIDTableBlock::SIOCollectionIDTableBlock(podio::EventStore* store) :
-    sio::block("CollectionIDs", sio::version::encode_version(0, 3)),
-    _table(store->getCollectionIDTable()) {
+    sio::block("CollectionIDs", sio::version::encode_version(0, 3)), _table(store->getCollectionIDTable()) {
   _types.reserve(_table->names().size());
   _isSubsetColl.reserve(_table->names().size());
   for (const int id : _table->ids()) {

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -39,12 +39,6 @@ void SIOCollectionIDTableBlock::read(sio::read_device& device, sio::version_type
   if (version >= sio::version::encode_version(0, 2)) {
     device.data(_isSubsetColl);
   }
-
-  if (version >= sio::version::encode_version(0, 3)) {
-    device.data(podioVersion.major);
-    device.data(podioVersion.minor);
-    device.data(podioVersion.patch);
-  }
 }
 
 void SIOCollectionIDTableBlock::write(sio::write_device& device) {
@@ -53,10 +47,6 @@ void SIOCollectionIDTableBlock::write(sio::write_device& device) {
 
   device.data(_types);
   device.data(_isSubsetColl);
-
-  device.data(podioVersion.major);
-  device.data(podioVersion.minor);
-  device.data(podioVersion.patch);
 }
 
 template <typename MappedT>

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -12,6 +12,25 @@
 #endif
 
 namespace podio {
+SIOCollectionIDTableBlock::SIOCollectionIDTableBlock(podio::EventStore* store) :
+    sio::block("CollectionIDs", sio::version::encode_version(0, 3)),
+    // _store(store),
+    _table(store->getCollectionIDTable()) {
+  _types.reserve(_table->names().size());
+  _isSubsetColl.reserve(_table->names().size());
+  for (const int id : _table->ids()) {
+    CollectionBase* tmp;
+    if (!store->get(id, tmp)) {
+      std::cerr
+          << "PODIO-ERROR cannot construct CollectionIDTableBlock because a collection is missing from the store (id: "
+          << id << ", name: " << _table->name(id) << ")" << std::endl;
+    }
+
+    _types.push_back(tmp->getValueTypeName());
+    _isSubsetColl.push_back(tmp->isSubsetCollection());
+  }
+}
+
 void SIOCollectionIDTableBlock::read(sio::read_device& device, sio::version_type version) {
   std::vector<std::string> names;
   std::vector<int> ids;
@@ -35,19 +54,8 @@ void SIOCollectionIDTableBlock::write(sio::write_device& device) {
   device.data(_table->names());
   device.data(_table->ids());
 
-  std::vector<std::string> typeNames;
-  std::vector<short> isSubsetColl;
-  typeNames.reserve(_table->ids().size());
-  for (const int id : _table->ids()) {
-    CollectionBase* tmp;
-    if (!_store->get(id, tmp)) {
-      std::cerr << "ERROR during writing of CollectionID table" << std::endl;
-    }
-    typeNames.push_back(tmp->getValueTypeName());
-    isSubsetColl.push_back(tmp->isSubsetCollection());
-  }
-  device.data(typeNames);
-  device.data(isSubsetColl);
+  device.data(_types);
+  device.data(_isSubsetColl);
 
   device.data(podioVersion.major);
   device.data(podioVersion.minor);

--- a/src/SIOReader.cc
+++ b/src/SIOReader.cc
@@ -135,13 +135,14 @@ void SIOReader::readCollectionIDTable() {
 
   sio::block_list blocks;
   blocks.emplace_back(std::make_shared<SIOCollectionIDTableBlock>());
+  blocks.emplace_back(std::make_shared<SIOVersionBlock>());
   sio::api::read_blocks(m_unc_buffer.span(), blocks);
 
   auto* idTableBlock = static_cast<SIOCollectionIDTableBlock*>(blocks[0].get());
   m_table = idTableBlock->getTable();
   m_typeNames = idTableBlock->getTypeNames();
   m_subsetCollectionBits = idTableBlock->getSubsetCollectionBits();
-  m_fileVersion = idTableBlock->getPodioVersion();
+  m_fileVersion = static_cast<SIOVersionBlock*>(blocks[1].get())->version;
 }
 
 void SIOReader::readMetaDataRecord(const std::shared_ptr<SIONumberedMetaDataBlock>& mdBlock) {

--- a/src/SIOWriter.cc
+++ b/src/SIOWriter.cc
@@ -143,8 +143,9 @@ void SIOWriter::writeCollectionIDTable() {
   m_com_buffer.clear();
   sio::block_list blocks;
   blocks.emplace_back(std::make_shared<SIOCollectionIDTableBlock>(m_store));
+  blocks.emplace_back(std::make_shared<SIOVersionBlock>(podio::version::build_version));
 
-  auto rec_info = sio::api::write_record("CollectionIDs", m_buffer, blocks, 0);
+  auto rec_info = sio::api::write_record("file_metadata", m_buffer, blocks, 0);
 
   sio::zlib_compression compressor;
   compressor.set_level(6);
@@ -152,7 +153,7 @@ void SIOWriter::writeCollectionIDTable() {
 
   sio::api::write_record(m_stream, m_buffer.span(0, rec_info._header_length), m_com_buffer.span(), rec_info);
 
-  m_tocRecord.addRecord("CollectionIDs", rec_info._file_start);
+  m_tocRecord.addRecord("file_metadata", rec_info._file_start);
 }
 
 } // namespace podio


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the `EventStore`, `CollectionIDTable` and `version::Version` members from the `SIOCollectionIDTableBlock` to make it easier to use in the `Frame` context
- Move the `podio:version::build_version` into its own `SIOVersionBlock`
- **This is a breaking change for the SIO backend and it will not be able to read files that have been written prior to this**

ENDRELEASENOTES

Preparatory work for SIO Frame writing that can easily be split from the rest. Additionally, the build version really should not have been put into the collection id table block in the first place.