### PR TITLE
Make prepareForWrite thread safe and mark it as const

### DIFF
--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -15,7 +15,7 @@ class ICollectionProvider;
 class CollectionBase {
 public:
   /// prepare buffers for serialization
-  virtual void prepareForWrite() = 0;
+  virtual void prepareForWrite() const = 0;
 
   /// re-create collection from buffers after read
   virtual void prepareAfterRead() = 0;

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -75,7 +75,7 @@ public:
   ~UserDataCollection() = default;
 
   /// prepare buffers for serialization
-  void prepareForWrite() override {
+  void prepareForWrite() const override {
   }
 
   /// re-create collection from buffers after read

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -74,8 +74,20 @@ void {{ collection_type }}::clear() {
   m_isPrepared = false;
 }
 
-void {{ collection_type }}::prepareForWrite() {
-  // If the collection has been prepared already there is nothing to do
+void {{ collection_type }}::prepareForWrite() const {
+  // TODO: Replace this double locking pattern here with an atomic and only one
+  // lock. Problem: std::atomic is not default movable.
+  {
+    std::lock_guard lock{*m_storageMtx};
+    // If the collection has been prepared already there is nothing to do
+    if (m_isPrepared) {
+      return;
+    }
+  }
+
+  std::lock_guard lock{*m_storageMtx};
+  // by the time we acquire the lock another thread might have already
+  // succeeded, so we need to check again now
   if (m_isPrepared) {
     return;
   }

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -24,6 +24,8 @@
 #include <array>
 #include <algorithm>
 #include <ostream>
+#include <mutex>
+#include <memory>
 
 {{ utils.namespace_open(class.namespace) }}
 
@@ -92,7 +94,7 @@ public:
   /// Append object to the collection
   void push_back({{class.bare_type}} object);
 
-  void prepareForWrite() final;
+  void prepareForWrite() const final;
   void prepareAfterRead() final;
   bool setReferences(const podio::ICollectionProvider* collectionProvider) final;
 
@@ -143,10 +145,11 @@ private:
   friend class {{ class.bare_type }}CollectionData;
 
   bool m_isValid{false};
-  bool m_isPrepared{false};
+  mutable bool m_isPrepared{false};
   bool m_isSubsetColl{false};
   int m_collectionID{0};
-  {{ class.bare_type }}CollectionData m_storage{};
+  mutable std::unique_ptr<std::mutex> m_storageMtx{std::make_unique<std::mutex>()};
+  mutable {{ class.bare_type }}CollectionData m_storage{};
 };
 
 std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}Collection& v);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,9 +150,9 @@ set_property(TEST pyunittest PROPERTY DEPENDS write)
 # Customize CTest to potentially disable some of the tests with known problems
 configure_file(CTestCustom.cmake ${CMAKE_BINARY_DIR}/CTestCustom.cmake)
 
-
+find_package(Threads REQUIRED)
 add_executable(unittest unittest.cpp)
-target_link_libraries(unittest PUBLIC TestDataModel PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(unittest PUBLIC TestDataModel PRIVATE Catch2::Catch2WithMain Threads::Threads)
 
 # The unittests are a bit better and they are labelled so we can put together a
 # list of labels that we want to ignore

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -282,7 +282,7 @@ TEST_CASE("thread-safe prepareForWrite", "[basics][multithread]") {
   threads.reserve(nThreads);
 
   for (int i = 0; i < nThreads; ++i) {
-    threads.emplace_back([&hits, &userInts, i]() {
+    threads.emplace_back([&hits, &userInts]() {
       hits.prepareForWrite();
       userInts.prepareForWrite();
     });


### PR DESCRIPTION

BEGINRELEASENOTES
- Mark `CollectionBase::prepareForWrite` as `const` and make sure that the generated implementations are thread safe.

ENDRELEASENOTES

Preparatory work for the Frame and useful in general. Currently implemented via double locking. This could potentially be optimized slightly further by using a more sophisticated implementation, but I would wait with that to see if this is actually a bottle neck.