### PR TITLE
Fix a few smaller issues flagged by newer versions of clang-tidy

### DIFF
--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -13,7 +13,20 @@ namespace podio {
 class ICollectionProvider;
 
 class CollectionBase {
+protected:
+  /// default constructor
+  CollectionBase() = default;
+  /// Move constructor
+  CollectionBase(CollectionBase&&) = default;
+  /// Move assignment
+  CollectionBase& operator=(CollectionBase&&) = default;
+
 public:
+  /// No copy c'tor because collections are move-only
+  CollectionBase(const CollectionBase&) = delete;
+  /// No copy assignment because collections are move-only
+  CollectionBase& operator=(const CollectionBase&) = delete;
+
   /// prepare buffers for serialization
   virtual void prepareForWrite() = 0;
 

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -174,7 +174,11 @@ std::vector<std::string> SIOBlockLibraryLoader::getLibNames() {
   std::vector<std::string> libs;
 
   std::string dir;
-  std::istringstream stream(std::getenv("LD_LIBRARY_PATH"));
+  const auto ldLibPath = std::getenv("LD_LIBRARY_PATH");
+  if (!ldLibPath) {
+    return libs;
+  }
+  std::istringstream stream(ldLibPath);
   while (std::getline(stream, dir, ':')) {
     if (not fs::exists(dir)) {
       continue;


### PR DESCRIPTION

BEGINRELEASENOTES
- Explicitly add constructors to `CollectionBase`
- Make sure to not use an unset `LD_LIBRARY_PATH` for detecting sio blocks shared libraries.

ENDRELEASENOTES

Fixes #297 

@soumilbaldota could you check and verify that this indeed fixes the clang-tidy problems you observe?