### PR TITLE
Fixed cmake message for code generation

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -30,7 +30,7 @@ REPORT_TEXT = """
   in
     {installdir}/
   Read instructions in
-  the HOWTO.TXT to run
+  the README.md to run
   your first example!
 """
 


### PR DESCRIPTION
When building EDM4hep I noticed a message pointing to a non-existent "HOWTO.txt" file so I fixed it to point to the PODIO readme

BEGINRELEASENOTES
- Fixed the text in the cmake message for code generation to point to the correct readme file

ENDRELEASENOTES