### PR TITLE
Fetch the Catch2 3.0.1 release now that it is available

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,7 +84,7 @@ else()
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        037ddbc75cc5e58b93cf5a010a94b32333ad824d
+    GIT_TAG        v3.0.1
     )
   FetchContent_MakeAvailable(Catch2)
   set(CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras ${CMAKE_MODULE_PATH})


### PR DESCRIPTION

BEGINRELEASENOTES
- Use the releases v3.0.1 version of Catch2 instead of an unreleased commit

ENDRELEASENOTES