### PR TITLE
Add std::string deprecation warning and make sure warnings are printed

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -131,6 +131,10 @@ class ClassGenerator:
     print("     'Homage to the Square' - Josef Albers")
     print()
 
+    for warning in self.reader.warnings:
+      print(warning)
+    print()
+
   def _eval_template(self, template, data):
     """Fill the specified template"""
     return self.env.get_template(template).render(data)

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -199,6 +199,8 @@ class ClassDefinitionValidator:
       for stl_type in self.allowed_stl_types:
         if member.full_type.startswith('std::' + stl_type):
           self.warnings.add(f"{classname} defines a std::{stl_type} member ('{member.name}') that spoils PODness")
+          self.warnings.add('Deprecation warning: Support for std::string members in datatypes will be removed'
+                            ' in the near future')
 
       is_builtin = member.is_builtin or member.is_builtin_array
       in_definitions = member.full_type in all_types or member.array_type in all_types


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure generator warnings are printed
- Add a deprecation warning for the upcoming removal of support of `std::string` in data types. (See also #276)

ENDRELEASENOTES