### PR TITLE
Add an option to enable or disable the clang-format.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set(USE_SANITIZER ""
 ADD_SANITIZER_FLAGS()
 option(FORCE_RUN_ALL_TESTS "Run all the tests even those with known problems" OFF)
 
+option(CLANG_FORMAT "Enable or disable clang-format." OFF)
 option(CLANG_TIDY "Run clang-tidy after compilation." OFF)
 ADD_CLANG_TIDY()
 

--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -141,7 +141,7 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
   set(CLANG_FORMAT_ARG "")
   find_program(CLANG_FORMAT_EXE NAMES "clang-format")
   find_file(CLANG_FORMAT_FILE .clang-format PATH ${PROJECT_SOURCE_DIR} NO_DEFAULT_PATH)
-  if(CLANG_FORMAT_EXE AND CLANG_FORMAT_FILE)
+  if(CLANG_FORMAT AND CLANG_FORMAT_EXE AND CLANG_FORMAT_FILE)
     message(STATUS "Found .clang-format file and clang-format executable. Will pass it to podio class generator")
     set(CLANG_FORMAT_ARG "--clangformat")
   endif()


### PR DESCRIPTION

BEGINRELEASENOTES
- Add an option to enable or disable the clang-format in `PODIO_GENERATE_DATAMODEL`

ENDRELEASENOTES

There is an old clang installed in the system. If I use the LCG release without clang, the system clang (v3.4.2) is then found by CMake. So I need an option to disable the clang-format. 

The information:

```
$ clang --version
clang version 3.4.2 (tags/RELEASE_34/dot2-final)
Target: x86_64-redhat-linux-gnu
Thread model: posix

$ cmake -S . -B build-with-clangformat -DCLANG_FORMAT=ON
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /cvmfs/sft.cern.ch/lcg/releases/gcc/8.3.0-cebb0/x86_64-centos7/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /cvmfs/sft.cern.ch/lcg/releases/gcc/8.3.0-cebb0/x86_64-centos7/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting C++ standard: '17'.
-- Performing Test CXX_FLAG_WORKS__Wshadow
-- Performing Test CXX_FLAG_WORKS__Wshadow - Success
-- Adding -Wshadow to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wformat_security
-- Performing Test CXX_FLAG_WORKS__Wformat_security - Success
-- Adding -Wformat-security to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wno_long_long
-- Performing Test CXX_FLAG_WORKS__Wno_long_long - Success
-- Adding -Wno-long-long to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wdeprecated
-- Performing Test CXX_FLAG_WORKS__Wdeprecated - Success
-- Adding -Wdeprecated to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__fdiagnostics_color=auto
-- Performing Test CXX_FLAG_WORKS__fdiagnostics_color=auto - Success
-- Adding -fdiagnostics-color=auto to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wall
-- Performing Test CXX_FLAG_WORKS__Wall - Success
-- Adding -Wall to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__Wextra
-- Performing Test CXX_FLAG_WORKS__Wextra - Success
-- Adding -Wextra to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__pedantic
-- Performing Test CXX_FLAG_WORKS__pedantic - Success
-- Adding -pedantic to CXX_FLAGS
-- Performing Test CXX_FLAG_WORKS__WeffcPP
-- Performing Test CXX_FLAG_WORKS__WeffcPP - Success
-- Adding -Weffc++ to CXX_FLAGS
-- Detected GNU compatible linker
-- Found nlohmann_json: /cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc8-opt/lib64/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found suitable version "3.9.1", minimum required is "3.9.1")
-- Python version used for building ROOT 3.9.6
-- Required python version 3.9.6
-- Found Python: /cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc8-opt/bin/python3.9 (found suitable exact version "3.9.6") found components: Development Interpreter Development.Module Development.Embed
-- Found .clang-format file and clang-format executable. Will pass it to podio class generator
-- Creating 'datamodel' datamodel
clang-format: Unknown command line argument '-fallback-style=llvm'.  Try: '/usr/bin/clang-format -help'
clang-format: Did you mean '-warn-stack-size=llvm'?
clang-format: Unknown command line argument '-fallback-style=llvm'.  Try: '/usr/bin/clang-format -help'
clang-format: Did you mean '-warn-stack-size=llvm'?
clang-format: Unknown command line argument '-fallback-style=llvm'.  Try: '/usr/bin/clang-format -help'
clang-format: Did you mean '-warn-stack-size=llvm'?
clang-format: Unknown command line argument '-fallback-style=llvm'.  Try: '/usr/bin/clang-format -help'
clang-format: Did you mean '-warn-stack-size=llvm'?
clang-format: Unknown command line argument '-fallback-style=llvm'.  Try: '/usr/bin/clang-format -help'
clang-format: Did you mean '-warn-stack-size=llvm'?
...


```