### PR TITLE
hotfix for https://github.com/AIDASoft/podio/issues/290

### DIFF
--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -35,7 +35,8 @@ class ROOTReader : public IReader {
 
 public:
   ROOTReader() = default;
-  ~ROOTReader() = default;
+  // todo: see https://github.com/AIDASoft/podio/issues/290
+  ~ROOTReader(); //NOLINT
 
   // non-copyable
   ROOTReader(const ROOTReader&) = delete;

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -15,6 +15,9 @@
 #include <memory>
 
 namespace podio {
+  
+// todo: see https://github.com/AIDASoft/podio/issues/290
+ROOTReader::~ROOTReader() {} // NOLINT
 
 std::pair<TTree*, unsigned> ROOTReader::getLocalTreeAndEntry(const std::string& treename) {
   auto localEntry = m_chain->LoadTree(m_eventNumber);


### PR DESCRIPTION




BEGINRELEASENOTES
- hotfix for https://github.com/AIDASoft/podio/issues/290: revert a clang-format change to make sure that there are no unknown symbols in podioDict

ENDRELEASENOTES