### PR TITLE
Add support for conversion to JSON

### DIFF
--- a/doc/advanced_topics.md
+++ b/doc/advanced_topics.md
@@ -53,6 +53,33 @@ If not taking advantage of this implementation, the data reader or the event sto
 
 The strong assumption here is that all references are being followed up directly and no later on-demand reading is done.
 
+### Dumping JSON
+
+It is possible to turn on an automatic conversion to JSON for podio generated datamodels using the [nlohmann/json](https://github.com/nlohmann/json) library.
+To enable this feature the **core datamodel library** has to be compiled with the `PODIO_JSON_OUTPUT` and linked against the nlohmann/json library (needs at least version 3.10).
+In cmake the necessary steps are (assuming that `datamodel` is the datamodel core library)
+```cmake
+find_library(nlohmann_json 3.10 REQUIRED)
+target_link_library(datamodel PUBLIC nlohmann_json::nlohmann_json)
+target_compile_definitions(datamodel PUBLIC PODIO_JSON_OUTPUT)
+```
+
+With JSON support enabled it is possible to convert collections (or single objects) to JSON simply via
+```cpp
+#include "nlohmann/json.hpp"
+
+auto collection = // get collection from somewhere
+
+nlohmann::json json{
+   {"collectionName", collection}
+};
+```
+
+Each element of the collection will be converted to a JSON object, where the keys are the same as in the datamodel definiton.
+Components contained in the objects will similarly be similarly converted.
+
+**JSON is not foreseen as a mode for persistency, i.e. there is no plan to add the conversion from JSON to the in memory representation of the datamodel.**
+
 ## Thread-safety
 
 PODIO was written with thread-safety in mind and avoids the usage of globals and statics.

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -146,6 +146,15 @@ podio::CollectionBuffers {{ collection_type }}::getBuffers() {
   return m_storage.getCollectionBuffers(m_isSubsetColl);
 }
 
+#ifdef PODIO_JSON_OUTPUT
+void to_json(nlohmann::json& j, const {{ collection_type }}& collection) {
+  j = nlohmann::json::array();
+  for (auto&& elem : collection) {
+    j.emplace_back(elem);
+  }
+}
+#endif
+
 {% endwith %}
 
 {{ iterator_definitions(class) }}

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -18,6 +18,10 @@
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
 
+#ifdef PODIO_JSON_OUTPUT
+#include "nlohmann/json.hpp"
+#endif
+
 #include <string>
 #include <vector>
 #include <deque>
@@ -176,6 +180,10 @@ Mutable{{ class.bare_type }} {{ class.bare_type }}Collection::create(Args&&... a
 {% for member in Members %}
 {{ macros.vectorized_access(class, member) }}
 {% endfor %}
+
+#ifdef PODIO_JSON_OUTPUT
+void to_json(nlohmann::json& j, const {{ class.bare_type }}Collection& collection);
+#endif
 
 {{ utils.namespace_close(class.namespace) }}
 

--- a/python/templates/Component.h.jinja2
+++ b/python/templates/Component.h.jinja2
@@ -9,6 +9,10 @@
 {% endfor %}
 #include <ostream>
 
+#ifdef PODIO_JSON_OUTPUT
+#include "nlohmann/json.hpp"
+#endif
+
 {{ utils.namespace_open(class.namespace) }}
 
 class {{ class.bare_type }} {
@@ -35,7 +39,17 @@ inline std::ostream& operator<<(std::ostream& o, const {{class.full_type}}& valu
   return o;
 }
 
-{{ utils.namespace_close(class.namespace) }}
+#ifdef PODIO_JSON_OUTPUT
+inline void to_json(nlohmann::json& j, const {{ class.bare_type }}& value) {
+  j = nlohmann::json{
+{% set comma = joiner(",") %}
+{% for member in Members %}
+  {{ comma() }}{"{{ member.name }}", value.{{ member.name }}}
+{% endfor %}
+  };
+}
+#endif
 
+{{ utils.namespace_close(class.namespace) }}
 
 #endif

--- a/python/templates/MutableObject.cc.jinja2
+++ b/python/templates/MutableObject.cc.jinja2
@@ -26,4 +26,8 @@ Mutable{{ class.bare_type }}::operator {{ class.bare_type }}() const { return {{
 
 {{ macros.common_object_funcs(class, prefix='Mutable') }}
 
+{{ macros.json_output(class, Members,
+                      OneToOneRelations, OneToManyRelations,
+                      VectorMembers, use_get_syntax, prefix='Mutable')}}
+
 {{ utils.namespace_close(class.namespace) }}

--- a/python/templates/MutableObject.h.jinja2
+++ b/python/templates/MutableObject.h.jinja2
@@ -15,6 +15,10 @@
 #include "podio/ObjectID.h"
 #include <ostream>
 
+#ifdef PODIO_JSON_OUTPUT
+#include "nlohmann/json.hpp"
+#endif
+
 {{ utils.forward_decls(forward_declarations) }}
 
 {{ utils.namespace_open(class.namespace) }}
@@ -46,6 +50,8 @@ public:
 private:
   {{ class.bare_type }}Obj* m_obj;
 };
+
+{{ macros.json_output(class.bare_type, prefix='Mutable') }}
 
 {{ utils.namespace_close(class.namespace) }}
 

--- a/python/templates/Object.cc.jinja2
+++ b/python/templates/Object.cc.jinja2
@@ -26,4 +26,8 @@
                            OneToOneRelations, OneToManyRelations + VectorMembers,
                            use_get_syntax) }}
 
+{{ macros.json_output(class, Members,
+                      OneToOneRelations, OneToManyRelations,
+                      VectorMembers, use_get_syntax)}}
+
 {{ utils.namespace_close(class.namespace) }}

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -13,6 +13,10 @@
 #include "podio/ObjectID.h"
 #include <ostream>
 
+#ifdef PODIO_JSON_OUTPUT
+#include "nlohmann/json.hpp"
+#endif
+
 {{ utils.forward_decls(forward_declarations) }}
 
 {{ utils.namespace_open(class.namespace) }}
@@ -41,6 +45,8 @@ private:
 };
 
 std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}& value);
+
+{{ macros.json_output(class.bare_type) }}
 
 {{ utils.namespace_close(class.namespace) }}
 

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -132,3 +132,9 @@
   podio::RelationRange<{{ relation.full_type }}> {{ relation.getter_name(get_syntax) }}() const;
 {% endfor %}
 {%- endmacro %}
+
+{% macro json_output(type, prefix='') %}
+#ifdef PODIO_JSON_OUTPUT
+void to_json(nlohmann::json& j, const {{ prefix }}{{ type }}& value);
+#endif
+{% endmacro %}

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -231,7 +231,7 @@ void to_json(nlohmann::json& j, const {{ prefix }}{{ class.bare_type }}& value) 
 
 {% for relation in multi_relations %}
   j["{{ relation.name }}"] = nlohmann::json::array();
-  for (const auto v : value.{{ relation.getter_name(get_syntax) }}()) {
+  for (const auto& v : value.{{ relation.getter_name(get_syntax) }}()) {
     j["{{ relation.name }}"].emplace_back(nlohmann::json{
       {"collectionID", v.getObjectID().collectionID },
       {"index", v.getObjectID().index }});

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -208,3 +208,36 @@ std::ostream& operator<<(std::ostream& o, const {{ type }}& value) {
   return o;
 }
 {%- endmacro %}
+
+{% macro json_output(class, members, single_relations, multi_relations, vector_members, get_syntax, prefix='') %}
+#ifdef PODIO_JSON_OUTPUT
+void to_json(nlohmann::json& j, const {{ prefix }}{{ class.bare_type }}& value) {
+  j = nlohmann::json{
+{% set comma = joiner(",") %}
+{% for member in members %}
+    {{ comma() }}{"{{ member.name }}", value.{{ member.getter_name(get_syntax)}}()}
+{% endfor %}
+{% for member in vector_members %}
+    {{ comma() }}{"{{ member.name }}", value.{{ member.getter_name(get_syntax) }}()}
+{% endfor %}
+  };
+
+{% for relation in single_relations %}
+    j["{{ relation.name }}"] = nlohmann::json{
+      {"collectionID", value.{{ relation.getter_name(get_syntax) }}().getObjectID().collectionID },
+      {"index", value.{{ relation.getter_name(get_syntax) }}().getObjectID().index }};
+
+{% endfor %}
+
+{% for relation in multi_relations %}
+  j["{{ relation.name }}"] = nlohmann::json::array();
+  for (const auto v : value.{{ relation.getter_name(get_syntax) }}()) {
+    j["{{ relation.name }}"].emplace_back(nlohmann::json{
+      {"collectionID", v.getObjectID().collectionID },
+      {"index", v.getObjectID().index }});
+  }
+
+{% endfor %}
+}
+#endif
+{% endmacro %}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ PODIO_GENERATE_DATAMODEL(datamodel datalayout.yaml headers sources
 
 # Use the cmake building blocks to add the different parts (conditionally)
 PODIO_ADD_DATAMODEL_CORE_LIB(TestDataModel "${headers}" "${sources}")
+find_package(nlohmann_json REQUIRED)
+target_compile_definitions(TestDataModel PUBLIC PODIO_JSON_OUTPUT)
+target_link_libraries(TestDataModel PUBLIC nlohmann_json::nlohmann_json)
+
 PODIO_ADD_ROOT_IO_DICT(TestDataModelDict TestDataModel "${headers}" src/selection.xml)
 PODIO_ADD_SIO_IO_BLOCKS(TestDataModel "${headers}" "${sources}")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,12 @@ PODIO_GENERATE_DATAMODEL(datamodel datalayout.yaml headers sources
 
 # Use the cmake building blocks to add the different parts (conditionally)
 PODIO_ADD_DATAMODEL_CORE_LIB(TestDataModel "${headers}" "${sources}")
-find_package(nlohmann_json REQUIRED)
-target_compile_definitions(TestDataModel PUBLIC PODIO_JSON_OUTPUT)
-target_link_libraries(TestDataModel PUBLIC nlohmann_json::nlohmann_json)
+find_package(nlohmann_json 3.10)
+if (nlohmann_json_FOUND)
+  message(STATUS "Found compatible version of JSON library, will add JSON support to test datamodel")
+  target_compile_definitions(TestDataModel PUBLIC PODIO_JSON_OUTPUT)
+  target_link_libraries(TestDataModel PUBLIC nlohmann_json::nlohmann_json)
+endif()
 
 PODIO_ADD_ROOT_IO_DICT(TestDataModelDict TestDataModel "${headers}" src/selection.xml)
 PODIO_ADD_SIO_IO_BLOCKS(TestDataModel "${headers}" "${sources}")

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -916,3 +916,42 @@ TEST_CASE("GenericParameters return types", "[generic-parameters][static-checks]
                                                                                                          // vectors of
                                                                                                          // strings
 }
+
+#ifdef PODIO_JSON_OUTPUT
+  #include "nlohmann/json.hpp"
+
+TEST_CASE("JSON", "[json]") {
+  const auto& [hitColl, clusterColl, vecMemColl, userDataColl] = createCollections();
+  const nlohmann::json json{
+      {"clusters", clusterColl}, {"hits", hitColl}, {"vectors", vecMemColl}, {"userData", userDataColl}};
+
+  REQUIRE(json["clusters"].size() == 3);
+
+  int i = 0;
+  for (const auto& clu : json["clusters"]) {
+    REQUIRE(clu["Hits"][0]["index"] == i++);
+  }
+
+  i = 0;
+  REQUIRE(json["hits"].size() == 3);
+  for (const auto& hit : json["hits"]) {
+    REQUIRE(hit["cellID"] == i);
+    REQUIRE(hit["energy"] == 100.f * i);
+    i++;
+  }
+
+  i = 0;
+  REQUIRE(json["vectors"].size() == 3);
+  for (const auto& vec : json["vectors"]) {
+    REQUIRE(vec["count"].size() == 2);
+    REQUIRE(vec["count"][0] == i);
+    REQUIRE(vec["count"][1] == i + 42);
+    i++;
+  }
+
+  REQUIRE(json["userData"].size() == 3);
+  for (size_t j = 0; j < 3; ++j) {
+    REQUIRE(json["userData"][j] == 3.14f * j);
+  }
+}
+#endif


### PR DESCRIPTION

BEGINRELEASENOTES
- Add support for converting objects and collections to JSON using [nlohmann/json](https://github.com/nlohmann/json).
  - To enable JSON support it is necessary to build the datamodel with `PODIO_JSON_OUTPUT` and to link against the nlohmann/json library.

ENDRELEASENOTES

Inspired by the brief discussion in key4hep/EDM4hep#163

This makes it possible to convert objects and collections into JSON by generating a `to_json` function that is necessary for serialization of arbitrary types in the nlohmann/json library (see [documentation](https://json.nlohmann.me/features/arbitrary_types/)).

Converting a collection to JSON is as simple as
```cpp
#include "nlohmann/json.hpp"
#include "edm4hep/ReconstructedParticleCollection.h"

// get a collection from somewhere (or fill one yourself)
auto& recos = store.get<edm4hep::ReconstructedParticleCollection>("recos");

nlohmann::json json{
  {"recos", recos}
};
```

Each element of the collection will be converted to a JSON object, where the keys are the same as in the datamodel definition file. Relations are stored as objects with a 'collectionID' and 'index' key for each relation.