### PR TITLE
Make flag behave as intuition suggests

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -251,8 +251,8 @@ class ClassGenerator:
     datatype['forward_declarations_obj'] = fwd_declarations
     datatype['includes_obj'] = self._sort_includes(includes)
     datatype['includes_cc_obj'] = self._sort_includes(includes_cc)
-    trivial_types = datatype['VectorMembers'] or datatype['OneToManyRelations'] or datatype['OneToOneRelations']
-    datatype['is_trivial_type'] = trivial_types
+    non_trivial_type = datatype['VectorMembers'] or datatype['OneToManyRelations'] or datatype['OneToOneRelations']
+    datatype['is_trivial_type'] = not non_trivial_type
 
   def _preprocess_for_class(self, datatype):
     """Do the preprocessing that is necessary for the classes and Mutable classes"""

--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -43,7 +43,7 @@
 {% endfor %}
 }
 
-{% if is_trivial_type -%}
+{% if not is_trivial_type -%}
 {{ obj_type }}::~{{ obj_type }}() {
 {% with multi_relations = OneToManyRelations + VectorMembers %}
 {%- if multi_relations %}

--- a/python/templates/Obj.h.jinja2
+++ b/python/templates/Obj.h.jinja2
@@ -33,9 +33,9 @@ public:
   /// No assignment operator
   {{ obj_type }}& operator=(const {{ obj_type }}&) = delete;
 {% if is_trivial_type %}
-  virtual ~{{ obj_type }}();
-{% else %}
   virtual ~{{ obj_type }}() = default;
+{% else %}
+  virtual ~{{ obj_type }}();
 {% endif %}
 
 public:


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the `is_trivial_type` flag available in the template engine behave as expected (it behaved exactly oppositely to what was documented and what one would intuitively expect). The flag was originally introduced in #288 

ENDRELEASENOTES