### PR TITLE
Allow for extending datamodels with an upstream datamodel

### DIFF
--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -121,6 +121,8 @@ set_property(CACHE PODIO_USE_CLANG_FORMAT PROPERTY STRINGS AUTO ON OFF)
 #   Parameters:
 #      OUTPUT_FOLDER        OPTIONAL: The folder in which the output files should be placed
 #                           Default is ${CMAKE_CURRENT_SOURCE_DIR}
+#      UPSTREAM_EDM         OPTIONAL: The upstream edm and its package name that are passed to the
+#                           generator via --upstream-edm
 #      IO_BACKEND_HANDLERS  OPTIONAL: The I/O backend handlers that should be generated. The list is
 #                           passed directly to podio_class_generator.py and validated there
 #                           Default is ROOT
@@ -130,10 +132,15 @@ set_property(CACHE PODIO_USE_CLANG_FORMAT PROPERTY STRINGS AUTO ON OFF)
 # this is essentially a no-op, and should not cause re-compilation.
 #---------------------------------------------------------------------------------------------------
 function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOURCES)
-  CMAKE_PARSE_ARGUMENTS(ARG "" "OUTPUT_FOLDER" "IO_BACKEND_HANDLERS" ${ARGN})
+  CMAKE_PARSE_ARGUMENTS(ARG "" "OUTPUT_FOLDER;UPSTREAM_EDM" "IO_BACKEND_HANDLERS" ${ARGN})
   IF(NOT ARG_OUTPUT_FOLDER)
     SET(ARG_OUTPUT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR})
   ENDIF()
+  SET(UPSTREAM_EDM_ARG "")
+  IF (ARG_UPSTREAM_EDM)
+    SET(UPSTREAM_EDM_ARG "--upstream-edm=${ARG_UPSTREAM_EDM}")
+  ENDIF()
+
   IF(NOT ARG_IO_BACKEND_HANDLERS)
     # At least build the ROOT selection.xml by default for now
     SET(ARG_IO_BACKEND_HANDLERS "ROOT")
@@ -182,7 +189,7 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
   message(STATUS "Creating '${datamodel}' datamodel")
   # we need to boostrap the data model, so this has to be executed in the cmake run
   execute_process(
-    COMMAND ${Python_EXECUTABLE} ${podio_PYTHON_DIR}/podio_class_generator.py ${CLANG_FORMAT_ARG} ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
+    COMMAND ${Python_EXECUTABLE} ${podio_PYTHON_DIR}/podio_class_generator.py ${CLANG_FORMAT_ARG} ${UPSTREAM_EDM_ARG} ${YAML_FILE} ${ARG_OUTPUT_FOLDER} ${datamodel} ${ARG_IO_BACKEND_HANDLERS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE podio_generate_command_retval
     )

--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -144,6 +144,17 @@ Some customization of the generated code is possible through flags. These flags 
 - `exposePODMembers`: whether get and set methods are also generated for members of a member-component. In the example corresponding methods would be generated to directly set / get `x` through `ExampleType`.
 
 
+## Extending a datamodel / using types from an upstream datamodel
+It is possible to extend another datamodel with your own types, resp. use some datatypes or components from an upstream datamodel in your own datamodel.
+This can be useful for prototyping new datatypes or for accomodating special requirements without having to reimplement / copy a complete datamodel.
 
+To pass an upstream datamodel to the class generator use the `--upstream-edm` option that takes the package name as well as the yaml definition file of the upstream datamodel separated by a colon (':').
+This will effectively make all components and datatpes of the upstream datamodel available to the current definition for validation and generation of the necessary includes.
+Nevertheless, only the code for the datatypes and components defined in the current yaml file will be generated.
+The podio `PODIO_GENERATE_DATAMODEL` cmake macro has gained an additional parameter `UPSTREAM_EDM` to pass the arguments to the generator via the cmake macros.
 
+### Potential pitfalls
+- The cmake macros do not handle linking against an upstream datamodel automatically. It is the users responsibility to explicitly link against the upstream datamodel.
+- When generating two datamodels side-by-side and into the same output directory and using the `ROOT` backend, the generated `selection.xml` file might be overwritten if both datamodels are generated into the same output directory.
 
+Limiting this functionality to one upstream datamodel is a conscious choice to limit the potential for abuse of this feature.

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -182,3 +182,18 @@ class MemberVariable:
     if not get_syntax:
       return self.name
     return _prefix_name(self.name, 'set')
+
+
+class DataModel:
+  """A class for holding a complete datamodel read from a configuration file"""
+  def __init__(self, datatypes=None, components=None, options=None):
+    self.datatypes = datatypes or {}
+    self.components = components or {}
+    self.options = options or {
+        # should getters / setters be prefixed with get / set?
+        "getSyntax": False,
+        # should POD members be exposed with getters/setters in classes that have them as members?
+        "exposePODMembers": True,
+        # use subfolder when including package header files
+        "includeSubfolder": False,
+        }

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -184,7 +184,7 @@ class MemberVariable:
     return _prefix_name(self.name, 'set')
 
 
-class DataModel:
+class DataModel:  # pylint: disable=too-few-public-methods
   """A class for holding a complete datamodel read from a configuration file"""
   def __init__(self, datatypes=None, components=None, options=None):
     self.datatypes = datatypes or {}

--- a/python/generator_utils.py
+++ b/python/generator_utils.py
@@ -123,9 +123,6 @@ class MemberVariable:
       self.includes.add('#include <array>')
 
     self.is_builtin = self.full_type in BUILTIN_TYPES
-    # Check if this is a string and add the corresponding include
-    if self.full_type == 'std::string':
-      self.includes.add('#include <string>')
 
     # We still have to check if this type is a valid fixed width type that we
     # also consider to be builtin types

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -247,7 +247,7 @@ class ClassGenerator:
     for relation in datatype['VectorMembers'] + datatype['OneToManyRelations']:
       if not relation.is_builtin:
         if relation.full_type == datatype['class'].full_type:
-          includes_cc.add(self._build_include_for_class(datatype['class'].bare_type, self._needs_include(datatype['class'].full_type)))
+          includes_cc.add(self._build_include(datatype['class']))
         else:
           includes.add(self._build_include(relation))
 
@@ -477,6 +477,7 @@ def verify_io_handlers(handler):
   if handler in valid_handlers:
     return handler
   raise argparse.ArgumentTypeError(f'{handler} is not a valid io handler')
+
 
 def read_upstream_edm(name_path):
   """Read an upstream EDM yaml definition file to make the types that are defined

--- a/python/podio_config_reader.py
+++ b/python/podio_config_reader.py
@@ -413,4 +413,4 @@ class PodioConfigReader:
         'components': self.components,
         'datatypes': self.datatypes,
         }
-    validator.validate(datamodel, False)
+    validator.validate(datamodel, self.options.get('exposePODMembers', False))

--- a/python/test_ClassDefinitionValidator.py
+++ b/python/test_ClassDefinitionValidator.py
@@ -9,15 +9,13 @@ import unittest
 from copy import deepcopy
 
 from podio_config_reader import ClassDefinitionValidator, MemberVariable, DefinitionError
+from generator_utils import DataModel
 
 
-def make_dm(components, datatypes):
+def make_dm(components, datatypes, options=None):
   """Small helper function to turn things into a datamodel dict as expected by
   the validator"""
-  return {
-      'components': components,
-      'datatypes': datatypes,
-      }
+  return DataModel(datatypes, components, options)
 
 
 class ClassDefinitionValidatorTest(unittest.TestCase):
@@ -62,6 +60,9 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
             }
         }
 
+    # The default options that should be used for validation
+    self.def_opts = {'exposePODMembers': False}
+
     self.validator = ClassDefinitionValidator()
     self.validate = self.validator.validate
 
@@ -101,11 +102,12 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
     self._assert_no_exception(DefinitionError, '{} should not raise for a valid component',
                               self.validate, make_dm(self.valid_component, {}), False)
 
-    self.valid_component['SecondComponent'] = {
+    components = deepcopy(self.valid_component)
+    components['SecondComponent'] = {
         'Members': [MemberVariable(array_type='Component', array_size='10', name='referToOtheComponent')]
         }
     self._assert_no_exception(DefinitionError, '{} should allow for component members in components',
-                              self.validate, make_dm(self.valid_component, {}), False)
+                              self.validate, make_dm(components, {}), False)
 
   def test_component_invalid_field(self):
     self.valid_component['Component']['Author'] = 'An invalid field for a component'
@@ -114,13 +116,13 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
 
   def test_datatype_valid_members(self):
     self._assert_no_exception(DefinitionError, '{} should not raise for a valid datatype',
-                              self.validate, make_dm({}, self.valid_datatype), False)
+                              self.validate, make_dm({}, self.valid_datatype, self.def_opts))
 
     # things should still work if we add a component member
     self.valid_datatype['DataType']['Members'].append(MemberVariable(type='Component', name='comp'))
     self._assert_no_exception(DefinitionError, '{} should allow for members that are components',
                               self.validate,
-                              make_dm(self.valid_component, self.valid_datatype), False)
+                              make_dm(self.valid_component, self.valid_datatype, self.def_opts))
 
     # also when we add an array of components
     self.valid_datatype['DataType']['Members'].append(MemberVariable(array_type='Component',
@@ -128,14 +130,14 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
                                                                      name='arrComp'))
     self._assert_no_exception(DefinitionError, '{} should allow for arrays of components as members',
                               self.validate,
-                              make_dm(self.valid_component, self.valid_datatype), False)
+                              make_dm(self.valid_component, self.valid_datatype, self.def_opts))
 
     # pod members can be redefined if they are note exposed
     self.valid_datatype['DataType']['Members'].append(MemberVariable(type='double', name='aFloat'))
     self._assert_no_exception(DefinitionError,
                               '{} should allow for re-use of component names if the components are not exposed',
                               self.validate,
-                              make_dm(self.valid_component, self.valid_datatype), False)
+                              make_dm(self.valid_component, self.valid_datatype, self.def_opts))
 
     datatype = {
         'DataTypeWithoutMembers': {
@@ -143,7 +145,7 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
             }
         }
     self._assert_no_exception(DefinitionError, '{} should allow for almost empty datatypes',
-                              self.validate, make_dm({}, datatype), False)
+                              self.validate, make_dm({}, datatype, self.def_opts))
 
   def test_datatype_invalid_definitions(self):
     for required in ('Author', 'Description'):
@@ -166,20 +168,20 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
     datatype = deepcopy(self.valid_datatype)
     datatype['DataType']['Members'].append(MemberVariable(type='NonDeclaredType', name='foo'))
     with self.assertRaises(DefinitionError):
-      self.validate(make_dm({}, datatype), False)
+      self.validate(make_dm({}, datatype, self.def_opts))
 
     datatype = deepcopy(self.valid_datatype)
     datatype['DataType']['Members'].append(MemberVariable(type='float', name='definedTwice'))
     datatype['DataType']['Members'].append(MemberVariable(type='int', name='definedTwice'))
     with self.assertRaises(DefinitionError):
-      self.validate(make_dm({}, datatype), False)
+      self.validate(make_dm({}, datatype, self.def_opts))
 
     # Re-definition of a member present in a component and pod members are exposed
     datatype = deepcopy(self.valid_datatype)
     datatype['DataType']['Members'].append(MemberVariable(type='Component', name='aComponent'))
     datatype['DataType']['Members'].append(MemberVariable(type='float', name='aFloat'))
     with self.assertRaises(DefinitionError):
-      self.validate(make_dm(self.valid_component, datatype), True)
+      self.validate(make_dm(self.valid_component, datatype, {'exposePODMembers': True}))
 
     datatype = deepcopy(self.valid_datatype)
     datatype['AnotherType'] = {
@@ -190,7 +192,7 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
         MemberVariable(type='AnotherType', name='impossibleType',
                        description='Another datatype cannot be a member'))
     with self.assertRaises(DefinitionError):
-      self.validate(make_dm(self.valid_component, datatype), False)
+      self.validate(make_dm(self.valid_component, datatype, self.def_opts))
 
   def _test_datatype_valid_relations(self, rel_type):
     self.valid_datatype['DataType'][rel_type] = [
@@ -276,6 +278,112 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
                        description='not working because component will not be part of the datamodel we pass')]
     with self.assertRaises(DefinitionError):
       self.validate(make_dm({}, datatype), False)
+
+  def test_component_valid_upstream(self):
+    """Test that a component from an upstream datamodel passes here"""
+    component = {
+        'DownstreamComponent': {
+            'Members': [
+                MemberVariable(type='Component', name='UpstreamComponent'),
+                MemberVariable(array_type='Component', array_size='42', name='upstreamArray')
+                ]
+            }
+        }
+
+    upstream_dm = make_dm(self.valid_component, {})
+
+    self._assert_no_exception(DefinitionError, '{} should allow to use upstream components in components',
+                              self.validate, make_dm(component, {}, self.def_opts), upstream_dm)
+
+  def test_component_invalid_upstream(self):
+    """Test that a component does not pass if it is not available upstream or in the
+    current definition"""
+    # Valid non-array component, invalid array
+    component = {
+        'DownstreamComponent': {
+            'Members': [
+                MemberVariable(type='Component', name='UpstreamComponent'),
+                MemberVariable(array_type='NotAvailComponent', array_size='42', name='upstreamArray')
+                ]
+            }
+        }
+
+    upstream_dm = make_dm(self.valid_component, {})
+
+    with self.assertRaises(DefinitionError):
+      self.validate(make_dm(component, {}, self.def_opts), upstream_dm)
+
+    # invalid non-array component, valid array
+    component = {
+        'DownstreamComponent': {
+            'Members': [
+                MemberVariable(type='NotAvailComponent', name='UpstreamComponent'),
+                MemberVariable(array_type='Component', array_size='42', name='upstreamArray')
+                ]
+            }
+        }
+
+    with self.assertRaises(DefinitionError):
+      self.validate(make_dm(component, {}, self.def_opts), upstream_dm)
+
+  def test_datatype_valid_upstream(self):
+    """Test that a datatype from an upstream datamodel passes here"""
+    datatype = {
+        'DownstreamDatatype': {
+            'Members': [
+                MemberVariable(type='Component', name='UpstreamComponent', description='upstream component')
+                ],
+            'Description': 'A datatype with upstream components and relations',
+            'Author': 'Sophisticated datamodel authors',
+            'OneToOneRelations': [
+                MemberVariable(type='DataType', name='upSingleRel', description='upstream single relation')
+                ],
+            'OneToManyRelations': [
+                MemberVariable(type='DataType', name='upManyRel', description='upstream many relation')
+                ],
+            'VectorMembers': [
+                MemberVariable(type='Component', name='upVector', description='upstream component as vector member')
+                ]
+            }
+        }
+
+    upstream_dm = make_dm(self.valid_component, self.valid_datatype, self.def_opts)
+    self._assert_no_exception(DefinitionError, '{} should allow to use to use upstream datatypes and components',
+                              self.validate, make_dm({}, datatype, self.def_opts), upstream_dm)
+
+  def test_datatype_invalid_upstream(self):
+    """Test that datatypes that are not from upstream cannot be used"""
+    basetype = {
+        'DsType': {
+            'Author': 'Less sophisticated datamodel authors',
+            'Description': 'A datatype trying to use non-existant upstream content'
+            }
+        }
+
+    upstream_dm = make_dm(self.valid_component, self.valid_datatype, self.def_opts)
+
+    # Check for invalid members
+    dtype = deepcopy(basetype)
+    dtype['DsType']['Members'] = [MemberVariable(type='InvalidType', name='foo', description='non existant upstream')]
+    with self.assertRaises(DefinitionError):
+      self.validate(make_dm({}, dtype, self.def_opts), upstream_dm)
+
+    # Check relations
+    dtype = deepcopy(basetype)
+    dtype['DsType']['OneToOneRelations'] = [MemberVariable(type='InvalidType', name='foo', description='invalid')]
+    with self.assertRaises(DefinitionError):
+      self.validate(make_dm({}, dtype, self.def_opts), upstream_dm)
+
+    dtype = deepcopy(basetype)
+    dtype['DsType']['OneToManyRelations'] = [MemberVariable(type='InvalidType', name='foo', description='invalid')]
+    with self.assertRaises(DefinitionError):
+      self.validate(make_dm({}, dtype, self.def_opts), upstream_dm)
+
+    # vector members
+    dtype = deepcopy(basetype)
+    dtype['DsType']['VectorMembers'] = [MemberVariable(type='InvalidType', name='foo', description='invalid')]
+    with self.assertRaises(DefinitionError):
+      self.validate(make_dm({}, dtype, self.def_opts), upstream_dm)
 
 
 if __name__ == '__main__':

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -185,3 +185,18 @@ else()
       TEST_SPEC ${filter_tests} # discover only tests that are known to not fail
   )
 endif()
+
+# Build the extension data model and link it against the upstream model
+PODIO_GENERATE_DATAMODEL(extension_model datalayout_extension.yaml ext_headers ext_sources
+  UPSTREAM_EDM datamodel:datalayout.yaml
+  IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS}
+  OUTPUT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/extension_model)
+
+PODIO_ADD_DATAMODEL_CORE_LIB(ExtensionDataModel "${ext_headers}" "${ext_sources}"
+  OUTPUT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/extension_model)
+target_link_libraries(ExtensionDataModel PUBLIC TestDataModel)
+
+PODIO_ADD_ROOT_IO_DICT(ExtensionDataModelDict ExtensionDataModel "${ext_headers}" ${CMAKE_CURRENT_SOURCE_DIR}/extension_model/src/selection.xml
+  OUTPUT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/extension_model)
+
+PODIO_ADD_SIO_IO_BLOCKS(ExtensionDataModel "${ext_headers}" "${ext_sources}")

--- a/tests/datalayout_extension.yaml
+++ b/tests/datalayout_extension.yaml
@@ -1,0 +1,45 @@
+---
+options:
+  getSyntax: True
+  exposePODMembers: False
+  includeSubfolder: True
+
+components:
+  extension::PolarVector:
+    Members:
+      - float r
+      - float phi
+      - float rho
+
+  extension::ExtComponent:
+    Members:
+      - NotSoSimpleStruct aStruct
+      - ex2::NamespaceStruct nspStruct
+
+datatypes:
+  extenstion::ContainedType:
+    Author: "T. Madlener"
+    Description: "A datatype in the extension that is self-contained"
+    Members:
+      - extension::PolarVector aVector // a polar vector defined in this datamodel
+
+  extension::ExternalComponentType:
+    Author: "T. Madlener"
+    Description: "A datatype in the extension with components from an upstream datamodel"
+    Members:
+      - SimpleStruct aStruct // a simple struct defined upstream
+      - extension::PolarVector aVector // an included component
+      - extension::ExtComponent aComponent // a component with an external component internally
+
+  extension::ExternalRelationType:
+    Author: "T. Madlener"
+    Description: "A datatype with relations to external datatypes"
+    Members:
+      - float weight // an arbitrary weight
+    OneToOneRelations:
+      - ExampleHit singleHit // a Hit from the upstream datamodel
+    OneToManyRelations:
+      - ExampleCluster clusters // clusters from the upstream datamodel
+      - ex42::ExampleWithARelation relationType // a namespaced type from upstream
+    VectorMembers:
+      - SimpleStruct someStructs // a vector member component from upstream


### PR DESCRIPTION

BEGINRELEASENOTES
- Make it possible to pass an upstream datamodel to the class generator such that datatypes and components defined there can be used in an unrelated datamodel. This makes it possible to extend datamodels and to prototype new datatypes with the aim of upstreaming them eventually without having to redefine all the necessary components.
- Refactor the internals of the config reader / class generator slightly to make it possible to hold multiple datamodels in memory

ENDRELEASENOTES

Fixes #263

Turned out to be a little more work than originally anticipated due to some additional refactoring that was necessary.

@vvolkl @wdconinc @hegner does this solve our issues with extending datamodels?