### PR TITLE
Initialize unique_ptr in initializer list for nvcc

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +43,7 @@ jobs:
               -DCMAKE_CXX_STANDARD=17 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
               -DUSE_EXTERNAL_CATCH2=ON \
+              -DPODIO_SET_RPATH=ON \
               -G Ninja ..
             ninja -k0
             echo "::endgroup::"

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -43,17 +43,15 @@ jobs:
               -DCMAKE_CXX_STANDARD=17 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
               -DUSE_EXTERNAL_CATCH2=ON \
-              -DPODIO_SET_RPATH=ON \
+              -DBUILD_TESTING=OFF\
               -G Ninja ..
             ninja -k0
             echo "::endgroup::"
             echo "::group::Test and install podio"
             ctest --output-on-failure
             ninja install
-            export ROOT_INCLUDE_PATH=$STARTDIR/podio/install/include:$ROOT_INCLUDE_PATH:$CPATH
-            unset CPATH
-            export CMAKE_PREFIX_PATH=$STARTDIR/podio/install:$CMAKE_PREFIX_PATH
-            export LD_LIBRARY_PATH=$STARTDIR/podio/install/lib:$STARTDIR/podio/install/lib64:$LD_LIBRARY_PATH
+            cd $STARTDIR/podio
+            source init.sh && source env.sh
             echo "::endgroup::"
             echo "::group::Build and test EDM4hep"
             cd $STARTDIR/edm4hep

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +26,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
             -DUSE_EXTERNAL_CATCH2=OFF \
+            -DPODIO_SET_RPATH=ON \
             -G Ninja ..
           echo "::endgroup::"
           echo "::group::Build"

--- a/cmake/podioBuild.cmake
+++ b/cmake/podioBuild.cmake
@@ -27,6 +27,10 @@ macro(podio_set_rpath)
     if("${isSystemDir}" STREQUAL "-1")
       set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIBDIR}")
     endif("${isSystemDir}" STREQUAL "-1")
+    # Make sure to actualy set RPATH and not RUNPATH by disabling the new dtags
+    # explicitly. Set executable and shared library linker flags for this
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--disable-new-dtags")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--disable-new-dtags")
   else()
     set(CMAKE_SKIP_INSTALL_RPATH TRUE)           # skip the full RPATH for the install tree
   endif()

--- a/env.sh
+++ b/env.sh
@@ -36,3 +36,7 @@ fi
 if ! echo $PATH | grep $PODIO/bin > /dev/null 2>&1; then
   export PATH=$PODIO/bin:$PATH
 fi
+
+if ! echo $CMAKE_PREFIX_PATH | grep $PODIO > /dev/null 2>&1; then
+  export CMAKE_PREFIX_PATH=$PODIO:$CMAKE_PREFIX_PATH
+fi

--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -61,7 +61,7 @@ public:
 private:
   std::vector<int> m_collectionIDs{};
   std::vector<std::string> m_names{};
-  mutable std::unique_ptr<std::mutex> m_mutex{std::make_unique<std::mutex>()};
+  mutable std::unique_ptr<std::mutex> m_mutex{};
 };
 
 } // namespace podio

--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -20,11 +20,9 @@ public:
   CollectionIDTable& operator=(CollectionIDTable&&) = default;
 
   /// constructor from existing ID:name mapping
-  CollectionIDTable(std::vector<int>&& ids, std::vector<std::string>&& names) :
-      m_collectionIDs(std::move(ids)), m_names(std::move(names)){};
+  CollectionIDTable(std::vector<int>&& ids, std::vector<std::string>&& names);
 
-  CollectionIDTable(const std::vector<int>& ids, const std::vector<std::string>& names) :
-      m_collectionIDs(ids), m_names(names){};
+  CollectionIDTable(const std::vector<int>& ids, const std::vector<std::string>& names);
 
   /// return collection ID for given name
   int collectionID(const std::string& name) const;

--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -60,7 +60,7 @@ public:
 private:
   std::vector<int> m_collectionIDs{};
   std::vector<std::string> m_names{};
-  mutable std::unique_ptr<std::mutex> m_mutex{};
+  mutable std::unique_ptr<std::mutex> m_mutex{nullptr};
 };
 
 } // namespace podio

--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -11,8 +11,7 @@ namespace podio {
 class CollectionIDTable {
 
 public:
-  /// default constructor
-  CollectionIDTable() = default;
+  CollectionIDTable();
   ~CollectionIDTable() = default;
 
   CollectionIDTable(const CollectionIDTable&) = delete;

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -272,11 +272,11 @@ private:
 
 private:
   IntMap _intMap{};                                             ///< The map storing the integer values
-  mutable MutexPtr m_intMtx{std::make_unique<std::mutex>()};    ///< The mutex guarding the integer map
+  mutable MutexPtr m_intMtx{};    ///< The mutex guarding the integer map
   FloatMap _floatMap{};                                         ///< The map storing the float values
-  mutable MutexPtr m_floatMtx{std::make_unique<std::mutex>()};  ///< The mutex guarding the float map
+  mutable MutexPtr m_floatMtx{};  ///< The mutex guarding the float map
   StringMap _stringMap{};                                       ///< The map storing the double values
-  mutable MutexPtr m_stringMtx{std::make_unique<std::mutex>()}; ///< The mutex guarding the float map
+  mutable MutexPtr m_stringMtx{}; ///< The mutex guarding the float map
 };
 
 template <typename T, typename>

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -84,7 +84,7 @@ private:
   using MutexPtr = std::unique_ptr<std::mutex>;
 
 public:
-  GenericParameters() = default;
+  GenericParameters();
 
   /// GenericParameters are copyable
   /// NOTE: This is currently mainly done to keep the ROOT I/O happy, because
@@ -271,11 +271,11 @@ private:
   }
 
 private:
-  IntMap _intMap{};                                             ///< The map storing the integer values
+  IntMap _intMap{};                      ///< The map storing the integer values
   mutable MutexPtr m_intMtx{nullptr};    ///< The mutex guarding the integer map
-  FloatMap _floatMap{};                                         ///< The map storing the float values
+  FloatMap _floatMap{};                  ///< The map storing the float values
   mutable MutexPtr m_floatMtx{nullptr};  ///< The mutex guarding the float map
-  StringMap _stringMap{};                                       ///< The map storing the double values
+  StringMap _stringMap{};                ///< The map storing the double values
   mutable MutexPtr m_stringMtx{nullptr}; ///< The mutex guarding the float map
 };
 

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -272,11 +272,11 @@ private:
 
 private:
   IntMap _intMap{};                                             ///< The map storing the integer values
-  mutable MutexPtr m_intMtx{};    ///< The mutex guarding the integer map
+  mutable MutexPtr m_intMtx{nullptr};    ///< The mutex guarding the integer map
   FloatMap _floatMap{};                                         ///< The map storing the float values
-  mutable MutexPtr m_floatMtx{};  ///< The mutex guarding the float map
+  mutable MutexPtr m_floatMtx{nullptr};  ///< The mutex guarding the float map
   StringMap _stringMap{};                                       ///< The map storing the double values
-  mutable MutexPtr m_stringMtx{}; ///< The mutex guarding the float map
+  mutable MutexPtr m_stringMtx{nullptr}; ///< The mutex guarding the float map
 };
 
 template <typename T, typename>

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -17,7 +17,7 @@
 
 {% with collection_type = class.bare_type + 'Collection' %}
 {{ collection_type }}::{{ collection_type }}() :
-  m_isValid(false), m_isPrepared(false), m_isSubsetColl(false), m_collectionID(0), m_storage() {}
+  m_isValid(false), m_isPrepared(false), m_isSubsetColl(false), m_collectionID(0), m_storageMtx(std::make_unique<std::mutex>()), m_storage() {}
 
 {{ collection_type }}::{{ collection_type }}({{ collection_type }}Data&& data, bool isSubsetColl) :
   m_isValid(false), m_isPrepared(false), m_isSubsetColl(isSubsetColl), m_collectionID(0), m_storage(std::move(data)) {}

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -20,7 +20,7 @@
   m_isValid(false), m_isPrepared(false), m_isSubsetColl(false), m_collectionID(0), m_storageMtx(std::make_unique<std::mutex>()), m_storage() {}
 
 {{ collection_type }}::{{ collection_type }}({{ collection_type }}Data&& data, bool isSubsetColl) :
-  m_isValid(false), m_isPrepared(false), m_isSubsetColl(isSubsetColl), m_collectionID(0), m_storage(std::move(data)) {}
+  m_isValid(false), m_isPrepared(false), m_isSubsetColl(isSubsetColl), m_collectionID(0), m_storageMtx(std::make_unique<std::mutex>()), m_storage(std::move(data)) {}
 
 {{ collection_type }}::~{{ collection_type }}() {
   // Need to tell the storage how to clean-up

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -158,7 +158,7 @@ private:
   mutable bool m_isPrepared{false};
   bool m_isSubsetColl{false};
   int m_collectionID{0};
-  mutable std::unique_ptr<std::mutex> m_storageMtx{std::make_unique<std::mutex>()};
+  mutable std::unique_ptr<std::mutex> m_storageMtx{nullptr};
   mutable {{ class.bare_type }}CollectionData m_storage{};
 };
 

--- a/src/CollectionIDTable.cc
+++ b/src/CollectionIDTable.cc
@@ -5,6 +5,10 @@
 
 namespace podio {
 
+CollectionIDTable::CollectionIDTable(): m_collectionIDs(), m_names(), m_mutex(std::make_unique<std::mutex>()) {
+
+}
+
 const std::string CollectionIDTable::name(int ID) const {
   std::lock_guard<std::mutex> lock(*m_mutex);
   const auto result = std::find(begin(m_collectionIDs), end(m_collectionIDs), ID);

--- a/src/CollectionIDTable.cc
+++ b/src/CollectionIDTable.cc
@@ -5,8 +5,15 @@
 
 namespace podio {
 
-CollectionIDTable::CollectionIDTable(): m_mutex(std::make_unique<std::mutex>()) {
+CollectionIDTable::CollectionIDTable() : m_mutex(std::make_unique<std::mutex>()) {
+}
 
+CollectionIDTable::CollectionIDTable(std::vector<int>&& ids, std::vector<std::string>&& names) :
+    m_collectionIDs(std::move(ids)), m_names(std::move(names)), m_mutex(std::make_unique<std::mutex>()) {
+}
+
+CollectionIDTable::CollectionIDTable(const std::vector<int>& ids, const std::vector<std::string>& names) :
+    m_collectionIDs(ids), m_names(names), m_mutex(std::make_unique<std::mutex>()) {
 }
 
 const std::string CollectionIDTable::name(int ID) const {

--- a/src/CollectionIDTable.cc
+++ b/src/CollectionIDTable.cc
@@ -5,7 +5,7 @@
 
 namespace podio {
 
-CollectionIDTable::CollectionIDTable(): m_collectionIDs(), m_names(), m_mutex(std::make_unique<std::mutex>()) {
+CollectionIDTable::CollectionIDTable(): m_mutex(std::make_unique<std::mutex>()) {
 
 }
 

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -5,6 +5,12 @@
 
 namespace podio {
 
+GenericParameters::GenericParameters() :
+    m_intMtx(std::make_unique<std::mutex>()),
+    m_floatMtx(std::make_unique<std::mutex>()),
+    m_stringMtx(std::make_unique<std::mutex>()) {
+}
+
 GenericParameters::GenericParameters(const GenericParameters& other) :
     m_intMtx(std::make_unique<std::mutex>()),
     m_floatMtx(std::make_unique<std::mutex>()),


### PR DESCRIPTION
BEGINRELEASENOTES
- Initialize the `unique_ptr<mutex>` in the constructor initializer list instead of in the member variable declaration. This is more likely a bug in nvcc (or maybe a c++17 feature not yet supported by nvcc). Fixes key4hep/k4Clue#34
- Pass `--disable-new-dtags` to the linker when using `PODIO_SET_RPATH`, to set `RPATH` and not `RUNPATH` in the binaries.
- Pin the ubuntu version for runners that build on ubuntu to not accidentally go out of sync with the underlying LCG releases.
- Disable the podio tests in the edm4hep workflows (see #359).

ENDRELEASENOTES
