### PR TITLE
Fix ROOT warnings for non-streamable mutexes

### DIFF
--- a/src/selection.xml
+++ b/src/selection.xml
@@ -1,6 +1,10 @@
 <lcgdict>
   <selection>
-    <class name="podio::GenericParameters"/>
+    <class name="podio::GenericParameters">
+        <field name="m_intMtx" transient="true"/>
+        <field name="m_floatMtx" transient="true"/>
+        <field name="m_stringMtx" transient="true"/>
+    </class>
     <class name="podio::IntVec"/>
     <class name="podio::FloatVec"/>
     <class name="podio::StringVec"/>


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a warning/error message from ROOT from attempts to stream the `std::mutex` members of `GenericParameters` by marking them as transient for the dictionary generation.

ENDRELEASENOTES