### PR TITLE
Update CI workflows and add EDM4hep workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,8 +10,8 @@ jobs:
     if: github.repository == 'AIDASoft/podio'
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         coverity-cmake-command: 'cmake -DCMAKE_CXX_STANDARD=17  -DENABLE_SIO=ON -DUSE_EXTERNAL_CATCH2=OFF ..'
         coverity-project: 'AIDASoft%2Fpodio'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -17,4 +17,4 @@ jobs:
         coverity-project: 'AIDASoft%2Fpodio'
         coverity-project-token: ${{ secrets.PODIO_COVERITY_TOKEN }}
         github-pat: ${{ secrets.READ_COVERITY_IMAGE }}
-        release-platform: "LCG_99/x86_64-centos7-gcc10-opt"
+        release-platform: "LCG_102/x86_64-centos7-gcc11-opt"

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -1,0 +1,62 @@
+name: edm4hep
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        LCG: ["LCG_102/x86_64-centos7-gcc11-opt",
+              "LCG_102/x86_64-ubuntu2004-gcc9-opt"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
+      - uses: aidasoft/run-lcg-view@v4
+        with:
+          release-platform: ${{ matrix.LCG }}
+          run: |
+            STARTDIR=$(pwd)
+            echo "::group::Build Catch2"
+            cd /home/runner/work/podio/
+            git clone --branch v3.1.0 --depth 1 https://github.com/catchorg/Catch2
+            cd Catch2
+            mkdir build && cd build
+            cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=../install -G Ninja ..
+            ninja -k0 install
+            cd ..
+            export CMAKE_PREFIX_PATH=$(pwd)/install:$CMAKE_PREFIX_PATH
+            echo "::endgroup::"
+            echo "::group::Build podio"
+            cd $STARTDIR
+            mkdir build && cd build
+            cmake -DENABLE_SIO=${{ matrix.sio }} \
+              -DCMAKE_INSTALL_PREFIX=../install \
+              -DCMAKE_CXX_STANDARD=17 \
+              -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
+              -DUSE_EXTERNAL_CATCH2=ON \
+              -G Ninja ..
+            ninja -k0
+            echo "::endgroup::"
+            echo "::group::Test and install podio"
+            ctest --output-on-failure
+            ninja install
+            cd ..
+            export ROOT_INCLUDE_PATH=$(pwd)/install/include:$ROOT_INCLUDE_PATH:$CPATH
+            unset CPATH
+            export CMAKE_PREFIX_PATH=$(pwd)/install:$CMAKE_PREFIX_PATH
+            export LD_LIBRARY_PATH=$(pwd)/install/lib:$(pwd)/install/lib64:$LD_LIBRARY_PATH
+            echo "::endgroup::"
+            echo "::group::Build and test EDM4hep"
+            cd /home/runner/work/podio
+            git clone --depth 1 https://github.com/key4hep/EDM4hep
+            cd EDM4hep
+            mkdir build && cd build
+            cmake -DCMAKE_CXX_STANDARD=17 \
+              -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
+              -DUSE_EXTERNAL_CATCH2=ON \
+              -G Ninja ..
+            ninja -k0
+            ctest --output-on-failure
+            echo "::endgroup::"

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -11,12 +11,13 @@ jobs:
                   "sw-nightlies.hsf.org/key4hep"]
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         container: centos7
         view-path: /cvmfs/${{ matrix.release }}
         run: |
+          echo "::group::Run CMake"
           mkdir build install
           cd build
           cmake -DENABLE_SIO=ON \
@@ -25,6 +26,13 @@ jobs:
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
             -DUSE_EXTERNAL_CATCH2=ON \
             -G Ninja ..
+          echo "::endgroup::"
+          echo "::group::Build"
           ninja -k0
+          echo "::endgroup"
+          echo "::group::Run tests"
           ctest --output-on-failure
+          echo "::endgroup::"
+          echo "::group::Install"
           ninja install
+          echo "::endgroup::"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,15 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         release-platform: LCG_99/x86_64-centos7-clang10-opt
         run: |
+          echo "::group::Setup pre-commit"
           export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
           export PATH=/root/.local/bin:$PATH
           pip install argparse --user
           pip install pre-commit --user
+          echo "::endgroup::"
+          echo "::group::Run CMake"
           mkdir build
           cd build
           cmake .. -DENABLE_SIO=ON \
@@ -25,6 +28,9 @@ jobs:
             -DUSE_EXTERNAL_CATCH2=OFF
           ln -s $(pwd)/compile_commands.json ../
           cd ..
+          echo "::endgroup::"
+          echo "::group::Run pre-commit"
           pre-commit run --show-diff-on-failure \
             --color=always \
             --all-files
+          echo "::endgroup::"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_99/x86_64-centos7-clang10-opt
+        release-platform: LCG_102/x86_64-centos7-clang12-opt
         run: |
           echo "::group::Setup pre-commit"
           export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -23,12 +23,12 @@ jobs:
         #     sanitizer: MemoryWithOrigin
     steps:
       - uses: actions/checkout@v2
-      - uses: cvmfs-contrib/github-action-cvmfs@v2
-      - uses: aidasoft/run-lcg-view@v2
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
+      - uses: aidasoft/run-lcg-view@v4
         with:
           release-platform: LCG_99/x86_64-centos7-${{ matrix.compiler }}-opt
           run: |
-            set -x
+            echo "::group::Run CMake"
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Debug \
@@ -38,5 +38,10 @@ jobs:
               -DUSE_EXTERNAL_CATCH2=OFF \
               -DENABLE_SIO=ON \
               -G Ninja ..
+            echo "::endgroup::"
+            echo "::group::Build"
             ninja -k0
+            echo "::endgroup::"
+            echo "::group::Run tests"
             ctest --output-on-failure
+            echo "::endgroup::"

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc10, clang10]
+        compiler: [gcc11, clang12]
         # Since Leak is usually part of Address, we do not run it separately in
         # CI. Keeping Address and Undefined separate for easier debugging
         sanitizer: [Thread,
@@ -26,7 +26,7 @@ jobs:
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: aidasoft/run-lcg-view@v4
         with:
-          release-platform: LCG_99/x86_64-centos7-${{ matrix.compiler }}-opt
+          release-platform: LCG_102/x86_64-centos7-${{ matrix.compiler }}-opt
           run: |
             echo "::group::Run CMake"
             mkdir build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         sio: [ON]
-        LCG: ["LCG_102/x86_64-centos7-gcc11-opt",
-              "LCG_102/x86_64-centos7-clang12-opt",
+        LCG: ["LCG_102/x86_64-centos7-clang12-opt",
               "LCG_102/x86_64-centos8-gcc11-opt",
               "dev3/x86_64-centos7-clang12-opt",
               "dev4/x86_64-centos7-gcc11-opt",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         sio: [ON]
-        LCG: ["LCG_99/x86_64-centos7-gcc8-opt",
-              "LCG_99/x86_64-centos7-clang10-opt",
-              "LCG_99/x86_64-centos8-gcc10-opt",
+        LCG: ["LCG_102/x86_64-centos7-gcc11-opt",
+              "LCG_102/x86_64-centos7-clang12-opt",
+              "LCG_102/x86_64-centos8-gcc11-opt",
               "dev3/x86_64-centos7-clang12-opt",
               "dev4/x86_64-centos7-gcc11-opt",
               "dev4/x86_64-centos7-clang12-opt"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,12 @@ jobs:
               "dev4/x86_64-centos7-clang12-opt"]
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         release-platform: ${{ matrix.LCG }}
         run: |
+          echo "::group::Run CMake"
           mkdir build install
           cd build
           cmake -DENABLE_SIO=${{ matrix.sio }} \
@@ -29,6 +30,13 @@ jobs:
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja ..
+          echo "::endgroup::"
+          echo "::group::Build"
           ninja -k0
+          echo "::endgroup"
+          echo "::group::Run tests"
           ctest --output-on-failure
+          echo "::endgroup::"
+          echo "::group::Install"
           ninja install
+          echo "::endgroup::"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,11 +14,12 @@ jobs:
               "dev4/x86_64-ubuntu2004-gcc9-opt"]
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v2
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         release-platform: ${{ matrix.LCG }}
         run: |
+          echo "::group::Run CMake"
           mkdir build install
           cd build
           cmake -DENABLE_SIO=${{ matrix.sio }} \
@@ -27,6 +28,13 @@ jobs:
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja ..
+          echo "::endgroup::"
+          echo "::group::Build"
           ninja -k0
+          echo "::endgroup"
+          echo "::group::Run tests"
           ctest --output-on-failure
+          echo "::endgroup::"
+          echo "::group::Install"
           ninja install
+          echo "::endgroup::"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         sio: [ON]
-        LCG: ["LCG_99/x86_64-ubuntu2004-gcc9-opt",
+        LCG: ["LCG_102/x86_64-ubuntu2004-gcc9-opt",
               "dev3/x86_64-ubuntu2004-gcc9-opt",
               "dev4/x86_64-ubuntu2004-gcc9-opt"]
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,8 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         sio: [ON]
-        LCG: ["LCG_102/x86_64-ubuntu2004-gcc9-opt",
-              "dev3/x86_64-ubuntu2004-gcc9-opt",
+        LCG: ["dev3/x86_64-ubuntu2004-gcc9-opt",
               "dev4/x86_64-ubuntu2004-gcc9-opt"]
     steps:
     - uses: actions/checkout@v2

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -487,17 +487,17 @@ def read_upstream_edm(name_path):
 
   try:
     name, path = name_path.split(':')
-  except ValueError:
+  except ValueError as err:
     raise argparse.ArgumentTypeError('upstream-edm argument needs to be the upstream package '
-                                     'name and the upstream edm yaml file separated by a colon')
+                                     'name and the upstream edm yaml file separated by a colon') from err
 
   if not os.path.isfile(path):
     raise argparse.ArgumentTypeError(f'{path} needs to be an EDM yaml file')
 
   try:
     return PodioConfigReader.read(path, name)
-  except DefinitionError:
-    raise argparse.ArgumentTypeError(f'{path} does not contain a valid datamodel definition')
+  except DefinitionError as err:
+    raise argparse.ArgumentTypeError(f'{path} does not contain a valid datamodel definition') from err
 
 
 if __name__ == "__main__":

--- a/python/test_MemberParser.py
+++ b/python/test_MemberParser.py
@@ -216,6 +216,7 @@ class MemberParserTest(unittest.TestCase):
       try:
         self.assertRaises(DefinitionError, parser.parse, inp)
       except AssertionError:
+        # pylint: disable-next=raise-missing-from
         raise AssertionError(f"'{inp}' should raise a DefinitionError from the MemberParser")
 
   def test_parse_valid_no_description(self):

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -6,8 +6,8 @@ from EventStore import EventStore
 
 def dump_evt_overview(event, ievt):
   """Print an overview table of the event contents of the given event"""
-  print('{:#^82}'.format(f' Event {ievt} '))
-  print('{:<30} {:<40} {:<10}'.format('Name', 'Type', 'Size'))
+  print('{:#^82}'.format(f' Event {ievt} '))  # pylint: disable=consider-using-f-string
+  print(f'{"Name":<30} {"Type":<40} {"Size":<10}')
   print('-' * 82)
   for name in event.collections():
     coll = event.get(name)
@@ -24,7 +24,7 @@ def dump_overview(store, events):
 def dump_evt_detailed(event, ievt):
   """Dump this event in all its glory"""
   print()
-  print('{:#^82}'.format(f' Event {ievt} '))
+  print('{:#^82}'.format(f' Event {ievt} '))  # pylint: disable=consider-using-f-string
   print()
 
   print('Parameters', flush=True)


### PR DESCRIPTION
BEGINRELEASENOTES
- Update the `github-action-cvmfs` and `run-lcg-view` actions to their latest available version to pick up the latest improvements (caching of dependencies, log groups)
- Introduce log groups in github actions for easier to interpret outputs
- Switch to LCG_102 for lcg based build environments
- Add a workflow that builds and tests EDM4hep after building podio

ENDRELEASENOTES

- [x] Should we also use this opportunity to update some of the environments to more recent LCG releases?
- [x] Should we also introduce (at least) one workflow that also builds EDM4hep@master to make sure we do not break it accidentally?