### PR TITLE
Cmake tweaks

### DIFF
--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -31,7 +31,8 @@ else()
   find_dependency(Python COMPONENTS Interpreter)
 endif()
 
-if(@ENABLE_SIO@)
+SET(ENABLE_SIO @ENABLE_SIO@)
+if(ENABLE_SIO)
   find_dependency(SIO)
   # Targets from SIO only become available with v00-01 so we rig them here to be
   # able to use them

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,7 +90,7 @@ CREATE_PODIO_TEST(ostream_operator.cpp "")
 CREATE_PODIO_TEST(write_ascii.cpp "")
 
 if(USE_EXTERNAL_CATCH2)
-  find_package(Catch2 REQUIRED)
+  find_package(Catch2 3 REQUIRED)
 else()
   message(STATUS "Fetching local copy of Catch2 library for unit-tests...")
   # Build Catch2 with the default flags, to avoid generating warnings when we


### PR DESCRIPTION
Just some things I found slightly annoying

BEGINRELEASENOTES
- podioConfig.cmake: silence warning about cmake policy CMP00012
- CMake: explicitly look for catch2 version 3 and fail at cmake instead of compile step

ENDRELEASENOTES