### PR TITLE
Make the notebook pattern use vectors instead of arrays

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -88,12 +88,14 @@ copy of only the data that are needed for a particular calculation. This
 pattern is supported by providing access like
 
 ```cpp
-    auto x_array = hits.x<10>(); // returning values of
-    auto y_array = hits.y<10>(); // the first 10 elements
+    auto x_array = hits.x();   // returning all values
+    auto y_array = hits.y(10); // or only the first 10 elements
 ```
 
-The resulting `std::array` can then be used in (auto-)vectorizable code.
-If less objects than requested are contained in the collection, the remaining entries are default initialized.
+The resulting `std::vector` can then be used in (auto-)vectorizable code.
+Passing in a size argument is optional; If no argument is passed all elements will be returned,
+if an argument is passed only as many elements as requested will be returned.
+If the collection holds less elements than are requested, only as elements as are available will be returned.
 
 ### EventStore functionality
 

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -174,6 +174,10 @@ podio::CollectionReadBuffers {{ collection_type }}::createBuffers() /*const*/ {
   return readBuffers;
 }
 
+{% for member in Members %}
+{{ macros.vectorized_access(class, member) }}
+{% endfor %}
+
 #ifdef PODIO_JSON_OUTPUT
 void to_json(nlohmann::json& j, const {{ collection_type }}& collection) {
   j = nlohmann::json::array();

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -145,8 +145,7 @@ public:
   }
 
 {% for member in Members %}
-  template<size_t arraysize>
-  const std::array<{{ member.full_type }}, arraysize> {{ member.name }}() const;
+  std::vector<{{ member.full_type }}> {{ member.name }}(const size_t nElem = 0) const;
 {% endfor %}
 
 private:
@@ -183,10 +182,6 @@ Mutable{{ class.bare_type }} {{ class.bare_type }}Collection::create(Args&&... a
 {% endif %}
   return Mutable{{ class.bare_type }}(obj);
 }
-
-{% for member in Members %}
-{{ macros.vectorized_access(class, member) }}
-{% endfor %}
 
 #ifdef PODIO_JSON_OUTPUT
 void to_json(nlohmann::json& j, const {{ class.bare_type }}Collection& collection);

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -1,10 +1,10 @@
 {% macro vectorized_access(class, member) %}
-template<size_t arraysize>
-const std::array<{{ member.full_type }}, arraysize> {{ class.bare_type }}Collection::{{ member.name }}() const {
-  std::array<{{ member.full_type }}, arraysize> tmp{};
-  const auto valid_size = std::min(arraysize, m_storage.entries.size());
-  for (unsigned i = 0; i < valid_size; ++i) {
-    tmp[i] = m_storage.entries[i]->data.{{ member.name }};
+std::vector<{{ member.full_type }}> {{ class.bare_type }}Collection::{{ member.name }}(const size_t nElem) const {
+  std::vector<{{ member.full_type }}> tmp;
+  const auto valid_size = nElem != 0 ? std::min(nElem, m_storage.entries.size()) : m_storage.entries.size();
+  tmp.reserve(valid_size);
+  for (size_t i = 0; i < valid_size; ++i) {
+    tmp.emplace_back(m_storage.entries[i]->data.{{ member.name }});
   }
   return tmp;
 }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -177,21 +177,24 @@ TEST_CASE("Looping", "[basics]") {
 }
 
 TEST_CASE("Notebook", "[basics]") {
-  bool success = true;
   auto store = podio::EventStore();
   auto& hits = store.create<ExampleHitCollection>("hits");
   for (unsigned i = 0; i < 12; ++i) {
     auto hit = hits.create(0xcaffeeULL, 0., 0., 0., double(i));
   }
-  auto energies = hits.energy<10>();
+
+  // Request only subset
+  auto energies = hits.energy(10);
+  REQUIRE(energies.size() == 10);
   int index = 0;
   for (auto energy : energies) {
-    if (double(index) != energy) {
-      success = false;
-    }
+    REQUIRE(double(index) == energy);
     ++index;
   }
-  REQUIRE(success);
+
+  // Make sure there are no "invented" values
+  REQUIRE(hits.energy(24).size() == hits.size());
+  REQUIRE(hits.energy().size() == hits.size());
 }
 
 TEST_CASE("OneToOneRelations", "[basics][relations]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the notebook pattern functionality return `std::vector`s instead of `std::array` to avoid having to specify a static size. Fixes #332 
- **Backwards incompatible change** as the return type as well as the call signature for the notebook pattern change.

ENDRELEASENOTES

@wdconinc very simple approach, but should in principle fix the original issue, I think.