### PR TITLE
Update github checkout action to latest version

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'AIDASoft/podio'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -12,6 +12,16 @@ jobs:
               "LCG_102/x86_64-ubuntu2004-gcc9-opt"]
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: podio
+      - uses: actions/checkout@v3
+        with:
+          repository: key4hep/EDM4hep
+          path: edm4hep
+      - uses: actions/checkout@v3
+        with:
+          repository: catchorg/Catch2
+          path: catch2
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: aidasoft/run-lcg-view@v4
         with:
@@ -19,17 +29,14 @@ jobs:
           run: |
             STARTDIR=$(pwd)
             echo "::group::Build Catch2"
-            cd /home/runner/work/podio/
-            git clone --branch v3.1.0 --depth 1 https://github.com/catchorg/Catch2
-            cd Catch2
+            cd $STARTDIR/catch2
             mkdir build && cd build
             cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=../install -G Ninja ..
             ninja -k0 install
-            cd ..
-            export CMAKE_PREFIX_PATH=$(pwd)/install:$CMAKE_PREFIX_PATH
+            export CMAKE_PREFIX_PATH=$STARTDIR/catch2/install:$CMAKE_PREFIX_PATH
             echo "::endgroup::"
             echo "::group::Build podio"
-            cd $STARTDIR
+            cd $STARTDIR/podio
             mkdir build && cd build
             cmake -DENABLE_SIO=ON \
               -DCMAKE_INSTALL_PREFIX=../install \
@@ -42,16 +49,13 @@ jobs:
             echo "::group::Test and install podio"
             ctest --output-on-failure
             ninja install
-            cd ..
-            export ROOT_INCLUDE_PATH=$(pwd)/install/include:$ROOT_INCLUDE_PATH:$CPATH
+            export ROOT_INCLUDE_PATH=$STARTDIR/podio/install/include:$ROOT_INCLUDE_PATH:$CPATH
             unset CPATH
-            export CMAKE_PREFIX_PATH=$(pwd)/install:$CMAKE_PREFIX_PATH
-            export LD_LIBRARY_PATH=$(pwd)/install/lib:$(pwd)/install/lib64:$LD_LIBRARY_PATH
+            export CMAKE_PREFIX_PATH=$STARTDIR/podio/install:$CMAKE_PREFIX_PATH
+            export LD_LIBRARY_PATH=$STARTDIR/podio/install/lib:$STARTDIR/podio/install/lib64:$LD_LIBRARY_PATH
             echo "::endgroup::"
             echo "::group::Build and test EDM4hep"
-            cd /home/runner/work/podio
-            git clone --depth 1 https://github.com/key4hep/EDM4hep
-            cd EDM4hep
+            cd $STARTDIR/edm4hep
             mkdir build && cd build
             cmake -DCMAKE_CXX_STANDARD=17 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -11,7 +11,7 @@ jobs:
         LCG: ["LCG_102/x86_64-centos7-gcc11-opt",
               "LCG_102/x86_64-ubuntu2004-gcc9-opt"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: aidasoft/run-lcg-view@v4
         with:

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -10,7 +10,7 @@ jobs:
         release: ["sw.hsf.org/key4hep",
                   "sw-nightlies.hsf.org/key4hep"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -22,7 +22,7 @@ jobs:
         #   - compiler: clang10
         #     sanitizer: MemoryWithOrigin
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: aidasoft/run-lcg-view@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
               "dev4/x86_64-centos7-gcc11-opt",
               "dev4/x86_64-centos7-clang12-opt"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
         LCG: ["dev3/x86_64-ubuntu2004-gcc9-opt",
               "dev4/x86_64-ubuntu2004-gcc9-opt"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:


### PR DESCRIPTION

BEGINRELEASENOTES
- Migrate to `actions/checkout@v3` as advised by [github](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- Use the checkout action to clone the dependencies in the edm4hep workflow instead of doing an explicit clone in the body of the action

ENDRELEASENOTES