### PR TITLE
Add a Frame reader for legacy files

### DIFF
--- a/include/podio/ROOTLegacyReader.h
+++ b/include/podio/ROOTLegacyReader.h
@@ -1,0 +1,125 @@
+#ifndef PODIO_ROOTLEGACYREADER_H
+#define PODIO_ROOTLEGACYREADER_H
+
+#include "podio/CollectionBranches.h"
+#include "podio/ROOTFrameData.h"
+#include "podio/podioVersion.h"
+
+#include "TChain.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+// forward declarations
+class TClass;
+// class TChain;
+class TFile;
+class TTree;
+
+namespace podio {
+
+namespace detail {
+  // Information about the data vector as wall as the collection class type
+  // and the index in the collection branches cache vector
+  using CollectionInfo = std::tuple<const TClass*, const TClass*, size_t>;
+
+} // namespace detail
+
+class EventStore;
+class CollectionBase;
+class CollectionIDTable;
+class GenericParameters;
+struct CollectionReadBuffers;
+
+/**
+ * A root reader for reading legacy podio root files that have been written
+ * using the legacy, non Frame based I/O model. This reader grants Frame based
+ * access to those files, by mimicking the Frame I/O functionality and the
+ * interfaces of those readers.
+ *
+ * NOTE: Since there was only one category ("events") for those legacy podio
+ * files this reader will really only work if you try to read that category, and
+ * will simply return no data if you try to read anything else.
+ */
+class ROOTLegacyReader {
+
+public:
+  ROOTLegacyReader() = default;
+  ~ROOTLegacyReader() = default;
+
+  // non-copyable
+  ROOTLegacyReader(const ROOTLegacyReader&) = delete;
+  ROOTLegacyReader& operator=(const ROOTLegacyReader&) = delete;
+
+  void openFile(const std::string& filename);
+
+  void openFiles(const std::vector<std::string>& filenames);
+
+  /**
+   * Read the next data entry from which a Frame can be constructed. In case
+   * there are no more entries left, this returns a nullptr.
+   *
+   * NOTE: the category name is completely ignored in this case, as legacy only
+   * had events.
+   */
+  std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string&);
+
+  /**
+   * Read the specified data entry from which a Frame can be constructed In case
+   * the entry does not exist, this returns a nullptr.
+   *
+   * NOTE: the category name is completely ignored in this case, as legacy only
+   * had events.
+   */
+  std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string&, const unsigned entry);
+
+  /// Returns number of events
+  unsigned getEntries(const std::string&) const;
+
+  /// Get the build version of podio that has been used to write the current file
+  podio::version::Version currentFileVersion() const {
+    return m_fileVersion;
+  }
+
+  /// Get the names of all the availalable Frame categories in the current file(s)
+  std::vector<std::string_view> getAvailableCategories() const;
+
+private:
+  std::pair<TTree*, unsigned> getLocalTreeAndEntry(const std::string& treename);
+
+  void createCollectionBranches(const std::vector<std::tuple<int, std::string, bool>>& collInfo);
+
+  podio::GenericParameters readEventMetaData();
+
+  podio::CollectionReadBuffers getCollectionBuffers(const std::pair<std::string, detail::CollectionInfo>& collInfo);
+
+  std::unique_ptr<podio::ROOTFrameData> readEntry();
+
+  // cache the necessary information to more quickly construct and read each
+  // collection after it has been read the very first time
+  std::vector<std::pair<std::string, detail::CollectionInfo>> m_storedClasses{};
+
+  std::shared_ptr<CollectionIDTable> m_table{nullptr};
+  std::unique_ptr<TChain> m_chain{nullptr};
+  unsigned m_eventNumber{0};
+
+  // Similar to writing we cache the branches that belong to each collection
+  // in order to not having to look them up every event. However, for the
+  // reader we cannot guarantee a fixed order of collections as they are read
+  // on demand. Hence, we give each collection an index the first time it is
+  // read and we start caching the branches.
+  std::vector<root_utils::CollectionBranches> m_collectionBranches{};
+
+  podio::version::Version m_fileVersion{0, 0, 0};
+
+  /// The **only** category name that is available from legacy files
+  constexpr static auto m_categoryName = "events";
+};
+
+} // namespace podio
+
+#endif // PODIO_ROOTLEGACYREADER_H

--- a/include/podio/ROOTLegacyReader.h
+++ b/include/podio/ROOTLegacyReader.h
@@ -63,8 +63,8 @@ public:
    * Read the next data entry from which a Frame can be constructed. In case
    * there are no more entries left, this returns a nullptr.
    *
-   * NOTE: the category name is completely ignored in this case, as legacy only
-   * had events.
+   * NOTE: the category name has to be "events" in this case, as only that
+   * category is available for legacy files.
    */
   std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string&);
 
@@ -72,12 +72,12 @@ public:
    * Read the specified data entry from which a Frame can be constructed In case
    * the entry does not exist, this returns a nullptr.
    *
-   * NOTE: the category name is completely ignored in this case, as legacy only
-   * had events.
+   * NOTE: the category name has to be "events" in this case, as only that
+   * category is available for legacy files.
    */
   std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string&, const unsigned entry);
 
-  /// Returns number of events
+  /// Returns number of entries for a given category
   unsigned getEntries(const std::string&) const;
 
   /// Get the build version of podio that has been used to write the current file

--- a/include/podio/SIOLegacyReader.h
+++ b/include/podio/SIOLegacyReader.h
@@ -1,0 +1,66 @@
+#ifndef PODIO_SIOLEGACYREADER_H
+#define PODIO_SIOLEGACYREADER_H
+
+#include "podio/SIOBlock.h"
+#include "podio/SIOFrameData.h"
+#include "podio/podioVersion.h"
+
+#include <sio/definitions.h>
+
+#include <memory>
+#include <string_view>
+#include <vector>
+
+namespace podio {
+
+class CollectionIDTable;
+
+class SIOLegacyReader {
+
+public:
+  SIOLegacyReader();
+  ~SIOLegacyReader() = default;
+
+  /// Read all collections requested
+  std::unique_ptr<podio::SIOFrameData> readNextEntry(const std::string&);
+
+  /// Read the specified entry
+  std::unique_ptr<podio::SIOFrameData> readEntry(const std::string&, const unsigned entry);
+
+  unsigned getEntries(const std::string& name) const;
+
+  void openFile(const std::string& filename);
+
+  podio::version::Version currentFileVersion() const {
+    return m_fileVersion;
+  }
+
+  std::vector<std::string_view> getAvailableCategories() const;
+
+private:
+  /// read the TOC record
+  bool readFileTOCRecord();
+
+  void readCollectionIDTable();
+
+  sio::ifstream m_stream{};
+
+  // TODO: Move these somewhere else
+  std::vector<std::string> m_typeNames{};
+  std::vector<short> m_subsetCollectionBits{};
+
+  sio::buffer m_tableBuffer{1}; ///< The buffer holding the **compressed** CollectionIDTable
+  unsigned m_tableUncLength{0}; ///< The uncompressed length of the tableBuffer
+
+  std::shared_ptr<podio::CollectionIDTable> m_table{nullptr};
+  unsigned m_eventNumber{0};
+
+  SIOFileTOCRecord m_tocRecord{};
+  podio::version::Version m_fileVersion{0};
+
+  constexpr static auto m_categoryName = "events";
+};
+
+} // namespace podio
+
+#endif // PODIO_SIOFRAMEREADER_H

--- a/include/podio/SIOLegacyReader.h
+++ b/include/podio/SIOLegacyReader.h
@@ -15,26 +15,55 @@ namespace podio {
 
 class CollectionIDTable;
 
+/**
+ * A SIO reader for reading legacy podio .sio files that have been written using
+ * the legacy, non Frame based I/O model. This reader grants Frame based access
+ * to those files, by mimicking Frame I/O functionality and the interfaces of
+ * those readers.
+ *
+ * NOTE: Since there was only one category ("events") for those legacy podio
+ * files this reader will really only work if you try to read that category, and
+ * will simply return no data if you try to read anything else.
+ */
 class SIOLegacyReader {
 
 public:
   SIOLegacyReader();
   ~SIOLegacyReader() = default;
 
-  /// Read all collections requested
+  // non copy-able
+  SIOLegacyReader(const SIOLegacyReader&) = delete;
+  SIOLegacyReader& operator=(const SIOLegacyReader&) = delete;
+
+  /**
+   * Read the next data entry from which a Frame can be constructed. In case
+   * there are no more entries left, this returns a nullptr.
+   *
+   * NOTE: the category name has to be "events" in this case, as only that
+   * category is available for legacy files.
+   */
   std::unique_ptr<podio::SIOFrameData> readNextEntry(const std::string&);
 
-  /// Read the specified entry
+  /**
+   * Read the specified data entry from which a Frame can be constructed In case
+   * the entry does not exist, this returns a nullptr.
+   *
+   * NOTE: the category name has to be "events" in this case, as only that
+   * category is available for legacy files.
+   */
   std::unique_ptr<podio::SIOFrameData> readEntry(const std::string&, const unsigned entry);
 
+  /// Returns the number of
   unsigned getEntries(const std::string& name) const;
 
   void openFile(const std::string& filename);
 
+  /// Get the build version of podio that has been used to write the current file
   podio::version::Version currentFileVersion() const {
     return m_fileVersion;
   }
 
+  /// Get the names of all the availalable Frame categories in the current file(s)
   std::vector<std::string_view> getAvailableCategories() const;
 
 private:

--- a/include/podio/SIOLegacyReader.h
+++ b/include/podio/SIOLegacyReader.h
@@ -63,4 +63,4 @@ private:
 
 } // namespace podio
 
-#endif // PODIO_SIOFRAMEREADER_H
+#endif // PODIO_SIOLEGACYREADER_H

--- a/python/podio/root_io.py
+++ b/python/podio/root_io.py
@@ -26,3 +26,25 @@ class Reader(BaseReaderMixin):
     self._reader.openFiles(filenames)
 
     super().__init__()
+
+
+class LegacyReader(BaseReaderMixin):
+  """Reader class for reading legacy podio root files.
+
+  This reader can be used to read files that have not yet been written using
+  Frame based I/O into Frames for a more seamless transition.
+  """
+
+  def __init__(self, filenames):
+    """Create a reader that reads from the passed file(s).
+
+    Args:
+        filenames (str or list[str]): file(s) to open and read data from
+    """
+    if isinstance(filenames, str):
+      filenames = (filenames,)
+
+    self._reader = podio.ROOTLegacyReader()
+    self._reader.openFiles(filenames)
+
+    super().__init__()

--- a/python/podio/sio_io.py
+++ b/python/podio/sio_io.py
@@ -23,3 +23,22 @@ class Reader(BaseReaderMixin):
     self._reader.openFile(filename)
 
     super().__init__()
+
+
+class LegacyReader(BaseReaderMixin):
+  """Reader class for reading legcy podio sio files.
+
+  This reader can be used to read files that have not yet been written using the
+  Frame based I/O into Frames for a more seamless transition.
+  """
+
+  def __init__(self, filename):
+    """Create a reader that reads from the passed file.
+
+    Args:
+        filename (str): File to open and read data from
+    """
+    self._reader = podio.SIOLegacyReader()
+    self._reader.openFile(filename)
+
+    super().__init__()

--- a/python/podio/test_Reader.py
+++ b/python/podio/test_Reader.py
@@ -68,3 +68,36 @@ class ReaderTestCaseMixin:
     for _ in non_existant:
       i += 1
     self.assertEqual(i, 0)
+
+
+class LegacyReaderTestCaseMixin:
+  """Common test cases for the legacy readers python bindings.
+
+  These tests assume that input files are produced with the write_test.h header
+  and that inheriting test cases inherit from unittes.TestCase as well.
+  Additionally they have to have an initialized reader as a member.
+
+  NOTE: Since the legacy readers also use the BaseReaderMixin, many of the
+  invalid access test cases are already covered by the ReaderTestCaseMixin and
+  here we simply focus on the slightly different happy paths
+  """
+  def test_categories(self):
+    """Make sure the legacy reader returns only one category"""
+    cats = self.reader.categories
+    self.assertEqual(("events",), cats)
+
+  def test_frame_iterator(self):
+    """Make sure the FrameIterator works."""
+    frames = self.reader.get('events')
+    self.assertEqual(len(frames), 2000)
+
+    for i, frame in enumerate(frames):
+      # Rudimentary check here only to see whether we got the right frame
+      self.assertEqual(frame.get_parameter('UserEventName'), f' event_number_{i}')
+      # Only check a few Frames here
+      if i > 10:
+        break
+
+    # Index based access
+    frame = frames[123]
+    self.assertEqual(frame.get_parameter('UserEventName'), ' event_number_123')

--- a/python/podio/test_ReaderRoot.py
+++ b/python/podio/test_ReaderRoot.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from podio.root_io import Reader
+from podio.root_io import Reader, LegacyReader
 from podio.test_Reader import ReaderTestCaseMixin
 
 
@@ -12,3 +12,36 @@ class RootReaderTestCase(ReaderTestCaseMixin, unittest.TestCase):
   def setUp(self):
     """Setup the corresponding reader"""
     self.reader = Reader('example_frame.root')
+
+
+class RootLegacyReaderTestCase(unittest.TestCase):
+  """Test cases for the legacy root input files and reader.
+
+  NOTE: Since also the LegacyReader uses the BaseReaderMixin many invalid access
+  test cases are already covered by the ReaderTestCaseMixin and here we focus on
+  the happy paths as this is slightly different.
+  """
+  def setUp(self):
+    """Setup a reader, reading from the example files"""
+    self.reader = LegacyReader('example.root')
+
+  def test_categories(self):
+    """Make sure the legacy reader returns only one category"""
+    cats = self.reader.categories
+    self.assertEqual(("events",), cats)
+
+  def test_frame_iterator(self):
+    """Make sure the FrameIterator works."""
+    frames = self.reader.get('events')
+    self.assertEqual(len(frames), 2000)
+
+    for i, frame in enumerate(frames):
+      # Rudimentary check here only to see whether we got the right frame
+      self.assertEqual(frame.get_parameter('UserEventName'), f' event_number_{i}')
+      # Only check a few Frames here
+      if i > 10:
+        break
+
+    # Index based access
+    frame = frames[123]
+    self.assertEqual(frame.get_parameter('UserEventName'), ' event_number_123')

--- a/python/podio/test_ReaderRoot.py
+++ b/python/podio/test_ReaderRoot.py
@@ -4,7 +4,7 @@
 import unittest
 
 from podio.root_io import Reader, LegacyReader
-from podio.test_Reader import ReaderTestCaseMixin
+from podio.test_Reader import ReaderTestCaseMixin, LegacyReaderTestCaseMixin
 
 
 class RootReaderTestCase(ReaderTestCaseMixin, unittest.TestCase):
@@ -14,34 +14,8 @@ class RootReaderTestCase(ReaderTestCaseMixin, unittest.TestCase):
     self.reader = Reader('example_frame.root')
 
 
-class RootLegacyReaderTestCase(unittest.TestCase):
-  """Test cases for the legacy root input files and reader.
-
-  NOTE: Since also the LegacyReader uses the BaseReaderMixin many invalid access
-  test cases are already covered by the ReaderTestCaseMixin and here we focus on
-  the happy paths as this is slightly different.
-  """
+class RootLegacyReaderTestCase(LegacyReaderTestCaseMixin, unittest.TestCase):
+  """Test cases for the legacy root input files and reader."""
   def setUp(self):
     """Setup a reader, reading from the example files"""
     self.reader = LegacyReader('example.root')
-
-  def test_categories(self):
-    """Make sure the legacy reader returns only one category"""
-    cats = self.reader.categories
-    self.assertEqual(("events",), cats)
-
-  def test_frame_iterator(self):
-    """Make sure the FrameIterator works."""
-    frames = self.reader.get('events')
-    self.assertEqual(len(frames), 2000)
-
-    for i, frame in enumerate(frames):
-      # Rudimentary check here only to see whether we got the right frame
-      self.assertEqual(frame.get_parameter('UserEventName'), f' event_number_{i}')
-      # Only check a few Frames here
-      if i > 10:
-        break
-
-    # Index based access
-    frame = frames[123]
-    self.assertEqual(frame.get_parameter('UserEventName'), ' event_number_123')

--- a/python/podio/test_ReaderSio.py
+++ b/python/podio/test_ReaderSio.py
@@ -3,8 +3,8 @@
 
 import unittest
 
-from podio.sio_io import Reader
-from podio.test_Reader import ReaderTestCaseMixin
+from podio.sio_io import Reader, LegacyReader
+from podio.test_Reader import ReaderTestCaseMixin, LegacyReaderTestCaseMixin
 from podio.test_utils import SKIP_SIO_TESTS
 
 
@@ -14,3 +14,11 @@ class SioReaderTestCase(ReaderTestCaseMixin, unittest.TestCase):
   def setUp(self):
     """Setup the corresponding reader"""
     self.reader = Reader('example_frame.sio')
+
+
+@unittest.skipIf(SKIP_SIO_TESTS, "no SIO support")
+class SIOLegacyReaderTestCase(LegacyReaderTestCaseMixin, unittest.TestCase):
+  """Test cases for the legacy root input files and reader."""
+  def setUp(self):
+    """Setup a reader, reading from the example files"""
+    self.reader = LegacyReader('example.sio')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,10 +109,12 @@ if(ENABLE_SIO)
     SIOFrameReader.cc
     SIOFrameData.cc
     sioUtils.h
+    SIOLegacyReader.cc
     )
 
   SET(sio_headers
     ${CMAKE_SOURCE_DIR}/include/podio/SIOFrameReader.h
+    ${CMAKE_SOURCE_DIR}/include/podio/SIOLegacyReader.h
     ${CMAKE_SOURCE_DIR}/include/podio/SIOFrameWriter.h
     )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ if(ENABLE_SIO)
     SIOFrameWriter.cc
     SIOFrameReader.cc
     SIOFrameData.cc
+    sioUtils.h
     )
 
   SET(sio_headers

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,10 +72,12 @@ SET(root_sources
   ROOTReader.cc
   ROOTFrameWriter.cc
   ROOTFrameReader.cc
+  ROOTLegacyReader.cc
 )
 
 SET(root_headers
   ${CMAKE_SOURCE_DIR}/include/podio/ROOTFrameReader.h
+  ${CMAKE_SOURCE_DIR}/include/podio/ROOTLegacyReader.h
   ${CMAKE_SOURCE_DIR}/include/podio/ROOTFrameWriter.h
   )
 

--- a/src/ROOTLegacyReader.cc
+++ b/src/ROOTLegacyReader.cc
@@ -1,0 +1,233 @@
+#include "podio/CollectionBuffers.h"
+#include "podio/ROOTFrameData.h"
+#include "rootUtils.h"
+
+// podio specific includes
+#include "podio/CollectionBase.h"
+#include "podio/CollectionIDTable.h"
+#include "podio/GenericParameters.h"
+#include "podio/ROOTLegacyReader.h"
+
+// ROOT specific includes
+#include "TChain.h"
+#include "TClass.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TTreeCache.h"
+
+#include <unordered_map>
+
+namespace podio {
+
+std::unique_ptr<ROOTFrameData> ROOTLegacyReader::readNextEntry(const std::string& name) {
+  if (name != m_categoryName) {
+    return nullptr;
+  }
+  return readEntry();
+}
+
+std::unique_ptr<podio::ROOTFrameData> ROOTLegacyReader::readEntry(const std::string& name, unsigned entry) {
+  if (name != m_categoryName) {
+    return nullptr;
+  }
+  m_eventNumber = entry;
+  return readEntry();
+}
+
+std::unique_ptr<podio::ROOTFrameData> ROOTLegacyReader::readEntry() {
+  ROOTFrameData::BufferMap buffers;
+  for (const auto& collInfo : m_storedClasses) {
+    buffers.emplace(collInfo.first, getCollectionBuffers(collInfo));
+  }
+
+  auto parameters = readEventMetaData();
+
+  m_eventNumber++;
+  return std::make_unique<ROOTFrameData>(std::move(buffers), m_table, std::move(parameters));
+}
+
+podio::CollectionReadBuffers
+ROOTLegacyReader::getCollectionBuffers(const std::pair<std::string, detail::CollectionInfo>& collInfo) {
+  const auto& name = collInfo.first;
+  const auto& [theClass, collectionClass, index] = collInfo.second;
+  auto& branches = m_collectionBranches[index];
+
+  // Create empty collection buffers, and connect them to the right branches
+  auto collBuffers = podio::CollectionReadBuffers();
+  // If we have a valid data buffer class we know that have to read data,
+  // otherwise we are handling a subset collection
+  const bool isSubsetColl = theClass == nullptr;
+  if (!isSubsetColl) {
+    collBuffers.data = theClass->New();
+  }
+
+  {
+    auto collection =
+        std::unique_ptr<podio::CollectionBase>(static_cast<podio::CollectionBase*>(collectionClass->New()));
+    collection->setSubsetCollection(isSubsetColl);
+
+    auto tmpBuffers = collection->createBuffers();
+    collBuffers.createCollection = std::move(tmpBuffers.createCollection);
+    collBuffers.recast = std::move(tmpBuffers.recast);
+
+    if (auto* refs = tmpBuffers.references) {
+      collBuffers.references = new podio::CollRefCollection(refs->size());
+    }
+    if (auto* vminfo = tmpBuffers.vectorMembers) {
+      collBuffers.vectorMembers = new podio::VectorMembersInfo();
+      collBuffers.vectorMembers->reserve(vminfo->size());
+
+      for (const auto& [type, _] : (*vminfo)) {
+        const auto* vecClass = TClass::GetClass(("vector<" + type + ">").c_str());
+        collBuffers.vectorMembers->emplace_back(type, vecClass->New());
+      }
+    }
+  }
+
+  const auto localEntry = m_chain->LoadTree(m_eventNumber);
+  // After switching trees in the chain, branch pointers get invalidated so
+  // they need to be reassigned.
+  // NOTE: root 6.22/06 requires that we get completely new branches here,
+  // with 6.20/04 we could just re-set them
+  if (localEntry == 0) {
+    branches.data = root_utils::getBranch(m_chain.get(), name.c_str());
+
+    // reference collections
+    if (auto* refCollections = collBuffers.references) {
+      for (size_t i = 0; i < refCollections->size(); ++i) {
+        const auto brName = root_utils::refBranch(name, i);
+        branches.refs[i] = root_utils::getBranch(m_chain.get(), brName.c_str());
+      }
+    }
+
+    // vector members
+    if (auto* vecMembers = collBuffers.vectorMembers) {
+      for (size_t i = 0; i < vecMembers->size(); ++i) {
+        const auto brName = root_utils::vecBranch(name, i);
+        branches.vecs[i] = root_utils::getBranch(m_chain.get(), brName.c_str());
+      }
+    }
+  }
+
+  // set the addresses and read the data
+  root_utils::setCollectionAddresses(collBuffers, branches);
+  root_utils::readBranchesData(branches, localEntry);
+
+  collBuffers.recast(collBuffers);
+
+  return collBuffers;
+}
+
+podio::GenericParameters ROOTLegacyReader::readEventMetaData() {
+  GenericParameters params;
+  auto [tree, entry] = getLocalTreeAndEntry("evt_metadata");
+  auto* branch = root_utils::getBranch(tree, "evtMD");
+  auto* emd = &params;
+  branch->SetAddress(&emd);
+  branch->GetEntry(entry);
+  return params;
+}
+
+void ROOTLegacyReader::openFile(const std::string& filename) {
+  openFiles({filename});
+}
+
+void ROOTLegacyReader::openFiles(const std::vector<std::string>& filenames) {
+  m_chain = std::make_unique<TChain>("events");
+  for (const auto& filename : filenames) {
+    m_chain->Add(filename.c_str());
+  }
+
+  // read the meta data and build the collectionBranches cache
+  // NOTE: This is a small pessimization, if we do not read all collections
+  // afterwards, but it makes the handling much easier in general
+  auto metadatatree = static_cast<TTree*>(m_chain->GetFile()->Get("metadata"));
+  m_table = std::make_shared<CollectionIDTable>();
+  auto* table = m_table.get();
+  metadatatree->SetBranchAddress("CollectionIDs", &table);
+
+  podio::version::Version* versionPtr{nullptr};
+  if (auto* versionBranch = root_utils::getBranch(metadatatree, "PodioVersion")) {
+    versionBranch->SetAddress(&versionPtr);
+  }
+
+  // Check if the CollectionTypeInfo branch is there and assume that the file
+  // has been written with with podio pre #197 (<0.13.1) if that is not the case
+  if (auto* collInfoBranch = root_utils::getBranch(metadatatree, "CollectionTypeInfo")) {
+    auto collectionInfo = new std::vector<root_utils::CollectionInfoT>;
+    collInfoBranch->SetAddress(&collectionInfo);
+    metadatatree->GetEntry(0);
+    createCollectionBranches(*collectionInfo);
+    delete collectionInfo;
+  } else {
+    std::cout << "PODIO: Reconstructing CollectionTypeInfo branch from other sources in file: \'"
+              << m_chain->GetFile()->GetName() << "\'" << std::endl;
+    metadatatree->GetEntry(0);
+    const auto collectionInfo = root_utils::reconstructCollectionInfo(m_chain.get(), *m_table);
+    createCollectionBranches(collectionInfo);
+  }
+
+  m_fileVersion = versionPtr ? *versionPtr : podio::version::Version{0, 0, 0};
+  delete versionPtr;
+}
+
+unsigned ROOTLegacyReader::getEntries(const std::string& name) const {
+  if (name != m_categoryName) {
+    return 0;
+  }
+  return m_chain->GetEntries();
+}
+
+void ROOTLegacyReader::createCollectionBranches(const std::vector<root_utils::CollectionInfoT>& collInfo) {
+  size_t collectionIndex{0};
+
+  for (const auto& [collID, collType, isSubsetColl] : collInfo) {
+    // We only write collections that are in the collectionIDTable, so no need
+    // to check here
+    const auto name = m_table->name(collID);
+
+    root_utils::CollectionBranches branches{};
+    const auto collectionClass = TClass::GetClass(collType.c_str());
+
+    // Need the collection here to setup all the branches. Have to manage the
+    // temporary collection ourselves
+    auto collection =
+        std::unique_ptr<podio::CollectionBase>(static_cast<podio::CollectionBase*>(collectionClass->New()));
+    collection->setSubsetCollection(isSubsetColl);
+
+    if (!isSubsetColl) {
+      // This branch is guaranteed to exist since only collections that are
+      // also written to file are in the info metadata that we work with here
+      branches.data = root_utils::getBranch(m_chain.get(), name.c_str());
+    }
+
+    const auto buffers = collection->getBuffers();
+    for (size_t i = 0; i < buffers.references->size(); ++i) {
+      const auto brName = root_utils::refBranch(name, i);
+      branches.refs.push_back(root_utils::getBranch(m_chain.get(), brName.c_str()));
+    }
+
+    for (size_t i = 0; i < buffers.vectorMembers->size(); ++i) {
+      const auto brName = root_utils::vecBranch(name, i);
+      branches.vecs.push_back(root_utils::getBranch(m_chain.get(), brName.c_str()));
+    }
+
+    const std::string bufferClassName = "std::vector<" + collection->getDataTypeName() + ">";
+    const auto bufferClass = isSubsetColl ? nullptr : TClass::GetClass(bufferClassName.c_str());
+
+    m_storedClasses.emplace_back(name, std::make_tuple(bufferClass, collectionClass, collectionIndex++));
+    m_collectionBranches.push_back(branches);
+  }
+}
+
+std::pair<TTree*, unsigned> ROOTLegacyReader::getLocalTreeAndEntry(const std::string& treename) {
+  auto localEntry = m_chain->LoadTree(m_eventNumber);
+  auto* tree = static_cast<TTree*>(m_chain->GetFile()->Get(treename.c_str()));
+  return {tree, localEntry};
+}
+
+std::vector<std::string_view> ROOTLegacyReader::getAvailableCategories() const {
+  return {m_categoryName};
+}
+
+} // namespace podio

--- a/src/SIOFrameReader.cc
+++ b/src/SIOFrameReader.cc
@@ -1,34 +1,14 @@
 #include "podio/SIOFrameReader.h"
 #include "podio/SIOBlock.h"
 
+#include "sioUtils.h"
+
 #include <sio/api.h>
-#include <sio/compression/zlib.h>
 #include <sio/definitions.h>
 
 #include <utility>
 
 namespace podio {
-
-namespace sio_utils {
-  // Read the record into a buffer and potentially uncompress it
-  std::pair<sio::buffer, sio::record_info> readRecord(sio::ifstream& stream, bool decompress = true,
-                                                      std::size_t initBufferSize = sio::mbyte) {
-    sio::record_info recInfo;
-    sio::buffer infoBuffer{sio::max_record_info_len};
-    sio::buffer recBuffer{initBufferSize};
-    sio::api::read_record_info(stream, recInfo, infoBuffer);
-    sio::api::read_record_data(stream, recInfo, recBuffer);
-
-    if (decompress) {
-      sio::buffer uncBuffer{recInfo._uncompressed_length};
-      sio::zlib_compression compressor;
-      compressor.uncompress(recBuffer.span(), uncBuffer);
-      return std::make_pair(std::move(uncBuffer), recInfo);
-    }
-
-    return std::make_pair(std::move(recBuffer), recInfo);
-  }
-} // namespace sio_utils
 
 SIOFrameReader::SIOFrameReader() {
   auto& libLoader [[maybe_unused]] = SIOBlockLibraryLoader::instance();

--- a/src/SIOLegacyReader.cc
+++ b/src/SIOLegacyReader.cc
@@ -1,0 +1,132 @@
+#include "podio/SIOLegacyReader.h"
+#include "podio/SIOBlock.h"
+
+#include "sioUtils.h"
+
+#include <sio/api.h>
+#include <sio/compression/zlib.h>
+#include <sio/definitions.h>
+
+namespace podio {
+
+SIOLegacyReader::SIOLegacyReader() {
+  auto& libLoader [[maybe_unused]] = SIOBlockLibraryLoader::instance();
+}
+
+void SIOLegacyReader::openFile(const std::string& filename) {
+  m_stream.open(filename, std::ios::binary);
+  if (!m_stream.is_open()) {
+    SIO_THROW(sio::error_code::not_open, "Cannot open input file '" + filename + "' for reading");
+  }
+
+  // NOTE: reading TOC record first because that jumps back to the start of the file!
+  readFileTOCRecord();
+  readCollectionIDTable();
+}
+
+std::unique_ptr<SIOFrameData> SIOLegacyReader::readNextEntry(const std::string& name) {
+  if (name != m_categoryName) {
+    return nullptr;
+  }
+  // skip possible intermediate records that are not event data
+  try {
+    sio::api::go_to_record(m_stream, "event_record");
+  } catch (sio::exception&) {
+    // If anything goes wrong, return a nullptr
+    return nullptr;
+  }
+
+  auto [dataBuffer, dataInfo] = sio_utils::readRecord(m_stream, false);
+  // Need to work around the fact that sio::buffers are not copyable by copying
+  // the underlying buffer (vector<byte>) and then using that to move construct
+  // a new buffer
+  sio::buffer::container bufferBytes{m_tableBuffer.data(), m_tableBuffer.data() + m_tableBuffer.size()};
+  auto tableBuffer = sio::buffer(std::move(bufferBytes));
+
+  m_eventNumber++;
+  return std::make_unique<SIOFrameData>(std::move(dataBuffer), dataInfo._uncompressed_length, std::move(tableBuffer),
+                                        m_tableUncLength);
+}
+
+std::unique_ptr<podio::SIOFrameData> SIOLegacyReader::readEntry(const std::string& name, const unsigned entry) {
+  if (name != m_categoryName) {
+    return nullptr;
+  }
+
+  // Setting the event number to the desired one here and putting the stream to
+  // the right position is the necessary setup before simply handing off to readNextEntry
+  m_eventNumber = entry;
+  // NOTE: In legacy files the "events" are stored in "event_record" records
+  const auto recordPos = m_tocRecord.getPosition("event_record", entry);
+  if (recordPos == 0) {
+    return nullptr;
+  }
+  m_stream.seekg(recordPos);
+
+  return readNextEntry(name);
+}
+
+unsigned SIOLegacyReader::getEntries(const std::string& name) const {
+  if (name != "events") {
+    return 0;
+  }
+  return m_tocRecord.getNRecords("event_record");
+}
+
+void SIOLegacyReader::readCollectionIDTable() {
+  // Need to decompress the buffers here, because in this record not only the
+  // collectionID table is stored, but also the version information...
+  auto [infoBuffer, _] = sio_utils::readRecord(m_stream, true);
+
+  sio::block_list blocks;
+  blocks.emplace_back(std::make_shared<SIOCollectionIDTableBlock>());
+  blocks.emplace_back(std::make_shared<SIOVersionBlock>());
+  sio::api::read_blocks(infoBuffer.span(), blocks);
+
+  m_fileVersion = static_cast<SIOVersionBlock*>(blocks[1].get())->version;
+
+  // recompress the collection ID table block...
+  blocks.resize(1); // remove the SIOVersionBlock
+  auto tmpUncBuffer = sio::buffer{sio::mbyte};
+  auto tmpRecInfo = sio::api::write_record("dummy", tmpUncBuffer, blocks, 0);
+  sio::zlib_compression compressor;
+  compressor.set_level(6);
+  sio::api::compress_record(tmpRecInfo, tmpUncBuffer, m_tableBuffer, compressor);
+  m_tableUncLength = tmpRecInfo._uncompressed_length;
+}
+
+bool SIOLegacyReader::readFileTOCRecord() {
+  // Check if there is a dedicated marker at the end of the file that tells us
+  // where the TOC actually starts
+  m_stream.seekg(-sio_helpers::SIOTocInfoSize, std::ios_base::end);
+  uint64_t firstWords{0};
+  m_stream.read(reinterpret_cast<char*>(&firstWords), sizeof(firstWords));
+
+  const uint32_t marker = (firstWords >> 32) & 0xffffffff;
+  if (marker == sio_helpers::SIOTocMarker) {
+    const uint32_t position = firstWords & 0xffffffff;
+    m_stream.seekg(position);
+
+    const auto& [uncBuffer, _] = sio_utils::readRecord(m_stream);
+
+    sio::block_list blocks;
+    auto tocBlock = std::make_shared<SIOFileTOCRecordBlock>();
+    tocBlock->record = &m_tocRecord;
+    blocks.push_back(tocBlock);
+
+    sio::api::read_blocks(uncBuffer.span(), blocks);
+
+    m_stream.seekg(0);
+    return true;
+  }
+
+  m_stream.clear();
+  m_stream.seekg(0);
+  return false;
+}
+
+std::vector<std::string_view> SIOLegacyReader::getAvailableCategories() const {
+  return {m_categoryName};
+}
+
+} // namespace podio

--- a/src/root_selection.xml
+++ b/src/root_selection.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   <selection>
     <class name="podio::ROOTFrameReader"/>
+    <class name="podio::ROOTLegacyReader"/>
     <class name="podio::ROOTFrameWriter"/>
   </selection>
 </lcgdict>

--- a/src/sioUtils.h
+++ b/src/sioUtils.h
@@ -1,3 +1,6 @@
+#ifndef PODIO_SIO_UTILS_H // NOLINT(llvm-header-guard): internal headers confuse clang-tidy
+#define PODIO_SIO_UTILS_H // NOLINT(llvm-header-guard): internal headers confuse clang-tidy
+
 #include <sio/api.h>
 #include <sio/compression/zlib.h>
 #include <sio/definitions.h>
@@ -26,3 +29,5 @@ namespace sio_utils {
   }
 } // namespace sio_utils
 } // namespace podio
+
+#endif

--- a/src/sioUtils.h
+++ b/src/sioUtils.h
@@ -1,0 +1,28 @@
+#include <sio/api.h>
+#include <sio/compression/zlib.h>
+#include <sio/definitions.h>
+
+#include <utility>
+
+namespace podio {
+namespace sio_utils {
+  // Read the record into a buffer and potentially uncompress it
+  inline std::pair<sio::buffer, sio::record_info> readRecord(sio::ifstream& stream, bool decompress = true,
+                                                             std::size_t initBufferSize = sio::mbyte) {
+    sio::record_info recInfo;
+    sio::buffer infoBuffer{sio::max_record_info_len};
+    sio::buffer recBuffer{initBufferSize};
+    sio::api::read_record_info(stream, recInfo, infoBuffer);
+    sio::api::read_record_data(stream, recInfo, recBuffer);
+
+    if (decompress) {
+      sio::buffer uncBuffer{recInfo._uncompressed_length};
+      sio::zlib_compression compressor;
+      compressor.uncompress(recBuffer.span(), uncBuffer);
+      return std::make_pair(std::move(uncBuffer), recInfo);
+    }
+
+    return std::make_pair(std::move(recBuffer), recInfo);
+  }
+} // namespace sio_utils
+} // namespace podio

--- a/src/sio_selection.xml
+++ b/src/sio_selection.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   <selection>
     <class name="podio::SIOFrameReader"/>
+    <class name="podio::SIOLegacyReader"/>
     <class name="podio::SIOFrameWriter"/>
   </selection>
 </lcgdict>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,7 +129,8 @@ if (TARGET TestDataModelSioBlocks)
     write_timed_sio.cpp
     read_timed_sio.cpp
     read_frame_sio.cpp
-    write_frame_sio.cpp)
+    write_frame_sio.cpp
+    read_frame_legacy_sio.cpp)
   set(sio_libs podio::podioSioIO)
   foreach( sourcefile ${sio_dependent_tests} )
     CREATE_PODIO_TEST(${sourcefile} "${sio_libs}")
@@ -161,6 +162,7 @@ if (TARGET read_sio)
   set_property(TEST read_and_write_sio PROPERTY DEPENDS write_sio)
   set_property(TEST read_timed_sio PROPERTY DEPENDS write_timed_sio)
   set_property(TEST read_frame_sio PROPERTY DEPENDS write_frame_sio)
+  set_property(TEST read_frame_legacy_sio PROPERTY DEPENDS write_sio)
 
   add_test(NAME check_benchmark_outputs_sio COMMAND check_benchmark_outputs write_benchmark_sio.root read_benchmark_sio.root)
   set_property(TEST check_benchmark_outputs_sio PROPERTY DEPENDS read_timed_sio write_timed_sio)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,7 +45,8 @@ set(root_dependent_tests
   write_timed.cpp
   read_timed.cpp
   read_frame.cpp
-  write_frame_root.cpp)
+  write_frame_root.cpp
+  read_frame_legacy_root.cpp)
 set(root_libs TestDataModelDict podio::podioRootIO)
 foreach( sourcefile ${root_dependent_tests} )
   CREATE_PODIO_TEST(${sourcefile} "${root_libs}")
@@ -145,6 +146,7 @@ endif()
 set_property(TEST read PROPERTY DEPENDS write)
 set_property(TEST read-multiple PROPERTY DEPENDS write)
 set_property(TEST read_and_write PROPERTY DEPENDS write)
+set_property(TEST read_frame_legacy_root PROPERTY DEPENDS write)
 set_property(TEST read_timed PROPERTY DEPENDS write_timed)
 set_property(TEST read_frame PROPERTY DEPENDS write_frame_root)
 

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -20,6 +20,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     check_benchmark_outputs
     read-multiple
     read-legacy-files
+    read_frame_legacy_root
 
     write_frame_root
     read_frame

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -33,6 +33,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     check_benchmark_outputs_sio
     write_frame_sio
     read_frame_sio
+    read_frame_legacy_sio
 
     write_ascii
 

--- a/tests/read_frame_legacy_root.cpp
+++ b/tests/read_frame_legacy_root.cpp
@@ -1,0 +1,43 @@
+#include "read_test.h"
+
+#include "podio/Frame.h"
+#include "podio/ROOTLegacyReader.h"
+
+#include <iostream>
+
+int main() {
+  auto reader = podio::ROOTLegacyReader();
+  reader.openFile("example.root");
+
+  if (reader.currentFileVersion() != podio::version::build_version) {
+    std::cerr << "The podio build version could not be read back correctly. "
+              << "(expected:" << podio::version::build_version << ", actual: " << reader.currentFileVersion() << ")"
+              << std::endl;
+    return 1;
+  }
+
+  if (reader.getEntries("events") != 2000) {
+    std::cerr << "Could not read back the number of events correctly. "
+              << "(expected:" << 2000 << ", actual: " << reader.getEntries("events") << ")" << std::endl;
+    return 1;
+  }
+
+  for (size_t i = 0; i < reader.getEntries("events"); ++i) {
+    const auto frame = podio::Frame(reader.readNextEntry("events"));
+    processEvent(frame, i, reader.currentFileVersion());
+  }
+
+  // Reading specific entries
+  {
+    auto frame = podio::Frame(reader.readEntry("events", 4));
+    processEvent(frame, 4, reader.currentFileVersion());
+
+    auto nextFrame = podio::Frame(reader.readNextEntry("events"));
+    processEvent(nextFrame, 5, reader.currentFileVersion());
+
+    auto previousFrame = podio::Frame(reader.readEntry("events", 2));
+    processEvent(previousFrame, 2, reader.currentFileVersion());
+  }
+
+  return 0;
+}

--- a/tests/read_frame_legacy_sio.cpp
+++ b/tests/read_frame_legacy_sio.cpp
@@ -1,0 +1,43 @@
+#include "read_test.h"
+
+#include "podio/Frame.h"
+#include "podio/SIOLegacyReader.h"
+
+#include <iostream>
+
+int main() {
+  auto reader = podio::SIOLegacyReader();
+  reader.openFile("example.sio");
+
+  if (reader.currentFileVersion() != podio::version::build_version) {
+    std::cerr << "The podio build version could not be read back correctly. "
+              << "(expected:" << podio::version::build_version << ", actual: " << reader.currentFileVersion() << ")"
+              << std::endl;
+    return 1;
+  }
+
+  if (reader.getEntries("events") != 2000) {
+    std::cerr << "Could not read back the number of events correctly. "
+              << "(expected:" << 2000 << ", actual: " << reader.getEntries("events") << ")" << std::endl;
+    return 1;
+  }
+
+  for (size_t i = 0; i < reader.getEntries("events"); ++i) {
+    const auto frame = podio::Frame(reader.readNextEntry("events"));
+    processEvent(frame, i, reader.currentFileVersion());
+  }
+
+  // Reading specific entries
+  {
+    auto frame = podio::Frame(reader.readEntry("events", 4));
+    processEvent(frame, 4, reader.currentFileVersion());
+
+    auto nextFrame = podio::Frame(reader.readNextEntry("events"));
+    processEvent(nextFrame, 5, reader.currentFileVersion());
+
+    auto previousFrame = podio::Frame(reader.readEntry("events", 2));
+    processEvent(previousFrame, 2, reader.currentFileVersion());
+  }
+
+  return 0;
+}


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a `ROOTLegacyReader` and a `SIOLegacyReader` that read files that have been written prior to #287 into `podio::Frame`s and offers the same interface as the frame readers
  - Also including python bindings for it

ENDRELEASENOTES

The implementations have been largely lifted from my git history, where a prototype for this has existed. The current version is essentially simply brushed up from there and with the same interface as the other frame readers. Given that the actual frame readers are largely based on these prototypes some of the internals are very similar, but at some points have to work around some issues introduced by the slightly different file formats.

- [x] Do we want / need an `SIOLegacyReader`?
- [x] needs #343 (relies on CMake refactoring and python binding basics)