### PR TITLE
Fix missing setting of relations in nested get calls

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -352,7 +352,7 @@ bool Frame::FrameModel<FrameDataT>::get(int collectionID, CollectionBase*& colle
   const auto& name = m_idTable.name(collectionID);
   const auto& [_, inserted] = m_retrievedIDs.insert(collectionID);
 
-  if (!inserted) {
+  if (inserted) {
     auto coll = doGet(name);
     if (coll) {
       collection = coll;

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -136,6 +136,32 @@ void processEvent(StoreT& store, int eventNum, podio::version::Version fileVersi
     throw std::runtime_error("Collection 'clusters' should be present");
   }
 
+  if (fileVersion >= podio::version::Version{0, 13, 2}) {
+    // Read the mcParticleRefs before reading any of the other collections that
+    // are referenced to make sure that all the necessary relations are handled
+    // correctly
+    auto& mcpRefs = store.template get<ExampleMCCollection>("mcParticleRefs");
+    if (!mcpRefs.isValid()) {
+      throw std::runtime_error("Collection 'mcParticleRefs' should be present");
+    }
+
+    // Only doing a very basic check here, that mainly just ensures that the
+    // RelationRange is valid and does not segfault.
+    for (auto ref : mcpRefs) {
+      const auto daughters = ref.daughters();
+      if (!daughters.empty()) {
+        // This will segfault in case things are not working
+        auto d [[maybe_unused]] = daughters[0];
+      }
+
+      const auto parents = ref.parents();
+      if (!parents.empty()) {
+        // This will segfault in case things are not working
+        auto d [[maybe_unused]] = parents[0];
+      }
+    }
+  }
+
   auto& mcps = store.template get<ExampleMCCollection>("mcparticles");
   if (!mcps.isValid()) {
     throw std::runtime_error("Collection 'mcparticles' should be present");


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix bug in setting relations in nested get calls in `podio::Frame`. Fixes #348 
- Adapt the read test to actually check this. Previously this went unnoticed, because the necessary relations were already set in a previous call.

ENDRELEASENOTES