### PR TITLE
Fix a few smaller issues with Frame python bindings and podio-dump

### DIFF
--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -12,7 +12,8 @@ EXPECTED_COLL_NAMES = {
     'arrays', 'WithVectorMember', 'info', 'fixedWidthInts', 'mcparticles',
     'moreMCs', 'mcParticleRefs', 'hits', 'hitRefs', 'clusters', 'refs', 'refs2',
     'OneRelation', 'userInts', 'userDoubles', 'WithNamespaceMember',
-    'WithNamespaceRelation', 'WithNamespaceRelationCopy'
+    'WithNamespaceRelation', 'WithNamespaceRelationCopy',
+    'emptyCollection', 'emptySubsetColl'
     }
 # The expected parameter names in each frame
 EXPECTED_PARAM_NAMES = {'anInt', 'UserEventWeight', 'UserEventName', 'SomeVectorData'}

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -35,6 +35,15 @@ int read_frames(const std::string& filename) {
   // sure that the writing/reading order does not impose any usage requirements
   for (size_t i = 0; i < reader.getEntries("events"); ++i) {
     auto frame = podio::Frame(reader.readNextEntry("events"));
+    if (frame.get("emptySubsetColl") == nullptr) {
+      std::cerr << "Could not retrieve an empty subset collection" << std::endl;
+      return 1;
+    }
+    if (frame.get("emptyCollection") == nullptr) {
+      std::cerr << "Could not retrieve an empty collection" << std::endl;
+      return 1;
+    }
+
     processEvent(frame, i, reader.currentFileVersion());
 
     auto otherFrame = podio::Frame(reader.readNextEntry("other_events"));

--- a/tests/write_frame.h
+++ b/tests/write_frame.h
@@ -37,7 +37,9 @@ static const std::vector<std::string> collsToWrite = {"mcparticles",
                                                       "userDoubles",
                                                       "WithNamespaceMember",
                                                       "WithNamespaceRelation",
-                                                      "WithNamespaceRelationCopy"};
+                                                      "WithNamespaceRelationCopy",
+                                                      "emptyCollection",
+                                                      "emptySubsetColl"};
 
 auto createMCCollection() {
   auto mcps = ExampleMCCollection();
@@ -367,6 +369,13 @@ podio::Frame makeFrame(int iFrame) {
   frame.putParameter("UserEventName", " event_number_" + std::to_string(iFrame));
   frame.putParameter("SomeVectorData", {1, 2, 3, 4});
   frame.putParameter("SomeVectorData", {"just", "some", "strings"});
+
+  // An empty collection
+  frame.put(ExampleClusterCollection(), "emptyCollection");
+  // An empty subset collection
+  auto emptySubsetColl = ExampleHitCollection();
+  emptySubsetColl.setSubsetCollection();
+  frame.put(std::move(emptySubsetColl), "emptySubsetColl");
 
   return frame;
 }

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -70,7 +70,11 @@ def print_frame(frame, cat_name, ientry, detailed):
 
 def main(args):
   """Main"""
-  reader = get_reader(args.inputfile)
+  try:
+    reader = get_reader(args.inputfile)
+  except ValueError as err:
+    print(f'ERROR: Cannot open file \'{args.inputfile}\': {err}')
+    sys.exit(1)
 
   print_general_info(reader, args.inputfile)
   if args.category not in reader.categories:


### PR DESCRIPTION

BEGINRELEASENOTES
-  Fix bug in Frame python bindings where empty collections were considered as non-existing. Replacing the original check relying on some implicit boolean conversions (which also caught empty collections) to an explicit check against `nullptr`.
- Make `podio-dump` more robust in installations without SIO support, by guarding the corresponding import.

ENDRELEASENOTES