### PR TITLE
Make scripts POSIX compliant and fix mix of tabs and spaces

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -25,7 +25,7 @@ elif [[ "$unamestr" = 'Darwin' ]]; then
     fi
 fi
 
-if [ "$(echo $PYTHONPATH | grep -o $PODIO/python)" = "" ]; then
+if ! echo $PYTHONPATH | grep -o $PODIO/python > /dev/null 2>&1; then
   export PYTHONPATH=$PODIO/python:$PYTHONPATH
 fi
 

--- a/env.sh
+++ b/env.sh
@@ -9,8 +9,7 @@ fi
 
 unamestr=`uname`
 if [[ "$unamestr" = 'Linux' ]]; then
-  echo $LD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
-  if [ $? = "1" ]; then
+  if [ "$(echo $LD_LIBRARY_PATH | grep -o $PODIO/lib)" = "" ]; then
     # RedHat based put the libraries into lib64
     if [ -d $PODIO/lib64 ]; then
       export LD_LIBRARY_PATH=$PODIO/lib64:$LD_LIBRARY_PATH
@@ -21,12 +20,15 @@ if [[ "$unamestr" = 'Linux' ]]; then
 elif [[ "$unamestr" = 'Darwin' ]]; then
   # This currenty does not work on OS X as DYLD_LIBRARY_PATH is ignored
   # in recent OS X versions
-  echo $DYLD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
-  if [ $? = "1" ]; then
+  if [ "$(echo $DYLD_LIBRARY_PATH | grep -o $PODIO/lib)" = "" ]; then
       export DYLD_LIBRARY_PATH=$PODIO/lib:$DYLD_LIBRARY_PATH
     fi
 fi
-echo $PYTHONPATH | grep $PODIO/python >& /dev/null
-if [ $? = "1" ]; then
+
+if [ "$(echo $PYTHONPATH | grep -o $PODIO/python)" = "" ]; then
   export PYTHONPATH=$PODIO/python:$PYTHONPATH
+fi
+
+if [ "$(echo $ROOT_INCLUDE_PATH | grep -o $PODIO/include)" = "" ]; then
+  export ROOT_INCLUDE_PATH=$PODIO/include:$ROOT_INCLUDE_PATH
 fi

--- a/env.sh
+++ b/env.sh
@@ -8,25 +8,25 @@ if [ -z "$PODIO" ]; then
 fi
 
 unamestr=`uname`
-if [[ "$unamestr" == 'Linux' ]]; then
-	echo $LD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
-	if [ $? == "1" ]; then
+if [[ "$unamestr" = 'Linux' ]]; then
+  echo $LD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
+  if [ $? = "1" ]; then
     # RedHat based put the libraries into lib64
     if [ -d $PODIO/lib64 ]; then
       export LD_LIBRARY_PATH=$PODIO/lib64:$LD_LIBRARY_PATH
     else
       export LD_LIBRARY_PATH=$PODIO/lib:$LD_LIBRARY_PATH
     fi
-	fi
-elif [[ "$unamestr" == 'Darwin' ]]; then
+  fi
+elif [[ "$unamestr" = 'Darwin' ]]; then
   # This currenty does not work on OS X as DYLD_LIBRARY_PATH is ignored
   # in recent OS X versions
-	echo $DYLD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
-	if [ $? == "1" ]; then
-    	export DYLD_LIBRARY_PATH=$PODIO/lib:$DYLD_LIBRARY_PATH
+  echo $DYLD_LIBRARY_PATH | grep $PODIO/lib >& /dev/null
+  if [ $? = "1" ]; then
+      export DYLD_LIBRARY_PATH=$PODIO/lib:$DYLD_LIBRARY_PATH
     fi
 fi
 echo $PYTHONPATH | grep $PODIO/python >& /dev/null
-if [ $? == "1" ]; then
-	export PYTHONPATH=$PODIO/python:$PYTHONPATH
+if [ $? = "1" ]; then
+  export PYTHONPATH=$PODIO/python:$PYTHONPATH
 fi

--- a/env.sh
+++ b/env.sh
@@ -29,6 +29,6 @@ if ! echo $PYTHONPATH | grep -o $PODIO/python > /dev/null 2>&1; then
   export PYTHONPATH=$PODIO/python:$PYTHONPATH
 fi
 
-if [ "$(echo $ROOT_INCLUDE_PATH | grep -o $PODIO/include)" = "" ]; then
+if ! echo $ROOT_INCLUDE_PATH | grep -o $PODIO/include > /dev/null 2>&1; then
   export ROOT_INCLUDE_PATH=$PODIO/include:$ROOT_INCLUDE_PATH
 fi

--- a/env.sh
+++ b/env.sh
@@ -20,7 +20,7 @@ if [[ "$unamestr" = 'Linux' ]]; then
 elif [[ "$unamestr" = 'Darwin' ]]; then
   # This currenty does not work on OS X as DYLD_LIBRARY_PATH is ignored
   # in recent OS X versions
-  if [ "$(echo $DYLD_LIBRARY_PATH | grep -o $PODIO/lib)" = "" ]; then
+  if ! echo $DYLD_LIBRARY_PATH | grep -o $PODIO/lib > /dev/null 2>&1; then
       export DYLD_LIBRARY_PATH=$PODIO/lib:$DYLD_LIBRARY_PATH
     fi
 fi

--- a/env.sh
+++ b/env.sh
@@ -9,7 +9,7 @@ fi
 
 unamestr=`uname`
 if [[ "$unamestr" = 'Linux' ]]; then
-  if [ "$(echo $LD_LIBRARY_PATH | grep -o $PODIO/lib)" = "" ]; then
+  if ! echo $LD_LIBRARY_PATH | grep $PODIO/lib > /dev/null 2>&1; then
     # RedHat based put the libraries into lib64
     if [ -d $PODIO/lib64 ]; then
       export LD_LIBRARY_PATH=$PODIO/lib64:$LD_LIBRARY_PATH

--- a/init.sh
+++ b/init.sh
@@ -11,14 +11,14 @@
 
 # First see if PODIO is already set
 if [ -n "$PODIO" -a "$1" != "-r" ]; then
-	echo "PODIO already set - use '-r' if you want to reinitialise it"
-	return
+  echo "PODIO already set - use '-r' if you want to reinitialise it"
+  return
 fi
 
 export PODIO=$(pwd)/install
 
 if [ -e env.sh ]; then
-	source ./env.sh
+  source ./env.sh
 else
-	echo "To complete PODIO setup please source the 'env.sh' script"
+  echo "To complete PODIO setup please source the 'env.sh' script"
 fi


### PR DESCRIPTION
BEGINRELEASENOTES

- Make `env.sh` setup script POSIX compliant to run in shells other than bash
  - Change `==` to `=`
  - Change tabs to spaces (two) to avoid mix of spaces and tabs for indenting
  - Add `<prefix>/include` to `ROOT_INCLUDE_PATH` (as it is required since #343)

ENDRELEASENOTES

For the second one it's a bit of a matter of taste and I personally prefer spaces to tabs but it's true that there was a mix of tabs and spaces and it looked ugly, now it will be consistent in every editor.