### PR TITLE
Improve the output of the SIOBlocks lib loading

### DIFF
--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <tuple>
 
 namespace podio {
 
@@ -185,15 +186,20 @@ public:
 class SIOBlockLibraryLoader {
 private:
   SIOBlockLibraryLoader();
+
+  /// Status code for loading shared SIOBlocks libraries
+  enum class LoadStatus : short { Success = 0, AlreadyLoaded = 1, Error = 2 };
+
   /**
    * Load a library with the given name via dlopen
    */
-  void loadLib(const std::string& libname);
+  LoadStatus loadLib(const std::string& libname);
+
   /**
    * Get all files that are found on LD_LIBRARY_PATH and that have "SioBlocks"
-   * in their name
+   * in their name together with the directory they are in
    */
-  static std::vector<std::string> getLibNames();
+  static std::vector<std::tuple<std::string, std::string>> getLibNames();
 
   std::map<std::string, void*> _loadedLibs{};
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the log output of loading the SIOBlock libraries more informative by also providing the absolute paths to the loaded (and rejected) shared libraries.

ENDRELEASENOTES