### PR TITLE
Make workflows not trigger twice on pushes to PRs

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -1,6 +1,11 @@
 name: edm4hep
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,6 +1,12 @@
 name: key4hep
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,11 @@
 name: pre-commit
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -1,6 +1,12 @@
 name: sanitizers
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: linux
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,11 @@
 name: ubuntu
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ After compilation you can run rudimentary tests with
 
     make test
 
+## Running workflows
+To run workflows manually (for example, when working on your own fork) go to
+`Actions` then click on the workflow that you want to run (for example
+`edm4hep`). Then if the workflow has the `workflow_dispatch` trigger you will be
+able to run it by clicking `Run workflow` and selecting on which branch it will
+run.
+
 ## Advanced build topics
 
 It is possible to instrument the complete podio build with sanitizers using the


### PR DESCRIPTION
BEGINRELEASENOTES
- Make workflows not trigger twice on pushes to PRs

ENDRELEASENOTES
by adding a rule to only trigger on pushes to the master branch. With the current behaviour, workflows trigger twice when someone pushes to their branch and they have a PR open, now the workflows will only trigger once in that case, saving some minutes. Workflows won't trigger on pushes to branches in the main repo but opening a PR will solve that and I think there aren't that many branches where that would be useful (?)