### PR TITLE
Fix the pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,8 +15,9 @@ jobs:
           echo "::group::Setup pre-commit"
           export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
           export PATH=/root/.local/bin:$PATH
-          pip install argparse --user
-          pip install pre-commit --user
+          pip install pre-commit
+          # Use virtualenv from the LCG release
+          pip uninstall --yes virtualenv
           echo "::endgroup::"
           echo "::group::Run CMake"
           mkdir build


### PR DESCRIPTION
As it can be seen in #364 or #355, the `pre-commit` workflow isn't working. The reason is that `pre-commit` requires a more recent version of the python package `virtualenv` than the available in the LCG release and it seems this creates conflicts. Uninstalling the local version so that the LCG `virtualenv` is used fixes the workflow. Alternatively we could fix the version of `pre-commit` to one that doesn't have this requirement. Edit: From doing a bit of digging, it seems the new version of `virtualenv` is required to avoid problems in python 3.10 (see the [pre-commit changelog](https://github.com/pre-commit/pre-commit/commit/40c5bdad65da4015af0e5ffe88227053109aecf3)) so if we fix the version it will break for python 3.10.
Version requirement:
``` shell
$ curl -L 'https://pypi.python.org/pypi/pre-commit/json' | jq '.info.requires_dist'
[
  "cfgv (>=2.0.0)",
  "identify (>=1.0.0)",
  "nodeenv (>=0.11.1)",
  "pyyaml (>=5.1)",
  "virtualenv (>=20.10.0)",
  "importlib-metadata ; python_version < \"3.8\""
]
```

From the LCG release:
``` shell
$ pip list | grep virtualenv
virtualenv                        20.4.3
```

BEGINRELEASENOTES
- Fix the pre-commit workflow

ENDRELEASENOTES