### PR TITLE
Add option to allow relaxing the required match of python versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,9 @@ option(CLANG_TIDY "Run clang-tidy after compilation." OFF)
 ADD_CLANG_TIDY()
 
 #--- Declare options -----------------------------------------------------------
-option(CREATE_DOC "Whether or not to create doxygen doc target." OFF)
-option(ENABLE_SIO "Build SIO I/O support" OFF)
+option(CREATE_DOC        "Whether or not to create doxygen doc target." OFF)
+option(ENABLE_SIO        "Build SIO I/O support" OFF)
+option(PODIO_RELAX_PYVER "Do not require exact python version match with ROOT" OFF)
 
 
 #--- Declare ROOT dependency ---------------------------------------------------
@@ -90,10 +91,23 @@ IF((TARGET ROOT::PyROOT OR TARGET ROOT::ROOTTPython) AND ${ROOT_VERSION} VERSION
   ENDIF()
   message( STATUS "Python version used for building ROOT ${ROOT_PYTHON_VERSION}" )
   message( STATUS "Required python version ${REQUIRE_PYTHON_VERSION}")
-  FIND_PACKAGE(Python ${REQUIRE_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Development Interpreter)
-ELSE()
-  FIND_PACKAGE(Python COMPONENTS Development Interpreter)
-ENDIF()
+
+  if(NOT PODIO_RELAX_PYVER)
+    find_package(Python ${REQUIRE_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Development Interpreter)
+  else()
+    find_package(Python ${REQUIRE_PYTHON_VERSION} REQUIRED COMPONENTS Development Interpreter)
+    string(REPLACE "." ";" _root_pyver_tuple ${REQUIRE_PYTHON_VERSION})
+    list(GET _root_pyver_tuple 0 _root_pyver_major)
+    list(GET _root_pyver_tuple 1 _root_pyver_minor)
+    if(NOT "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}" VERSION_EQUAL "${_root_pyver_major}.${_root_pyver_minor}")
+      message(FATAL_ERROR "There is a mismatch between the major and minor versions in Python"
+        " (found ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}) and ROOT, compiled with "
+        "Python ${_root_pyver_major}.${_root_pyver_minor}")
+    endif()
+  endif()
+else()
+  find_package(Python COMPONENTS Development Interpreter)
+endif()
 
 # ROOT only sets usage requirements from 6.14, so for
 # earlier versions need to hack in INTERFACE_INCLUDE_DIRECTORIES


### PR DESCRIPTION
BEGINRELEASENOTES
- CMAKE: Add option PODIO_RELAX_PYVER to allow relaxing the required match of python version with the one that ROOT has been built with to only check major and minor versions

ENDRELEASENOTES

`find_package` will let everything go through but a later check will only allow mismatches in the patch version and throw and error if there is a mismatch in the major or minor versions. Does it make sense to have it ON by default since it's only the patch version? The error message looks like this:
```
CMake Error at CMakeLists.txt:102 (message):
  There is a mismatch between the major and minor versions in Python (found
  3.10) and ROOT, compiled with Python 3.9
```
in red, and stops `cmake`.

<strike>Also a few changes to lower case to be more consistent across the file</strike>

Closes #366