### PR TITLE
Add `double` to the supported types of `GenericParameters`

### DIFF
--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -129,7 +129,7 @@ struct SIOVersionBlock : public sio::block {
  */
 class SIOEventMetaDataBlock : public sio::block {
 public:
-  SIOEventMetaDataBlock() : sio::block("EventMetaData", sio::version::encode_version(0, 1)) {
+  SIOEventMetaDataBlock() : sio::block("EventMetaData", sio::version::encode_version(0, 2)) {
   }
 
   SIOEventMetaDataBlock(const SIOEventMetaDataBlock&) = delete;
@@ -146,7 +146,7 @@ public:
  */
 class SIONumberedMetaDataBlock : public sio::block {
 public:
-  SIONumberedMetaDataBlock(const std::string& name) : sio::block(name, sio::version::encode_version(0, 1)) {
+  SIONumberedMetaDataBlock(const std::string& name) : sio::block(name, sio::version::encode_version(0, 2)) {
   }
 
   SIONumberedMetaDataBlock(const SIONumberedMetaDataBlock&) = delete;

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -10,49 +10,52 @@ ROOT.gInterpreter.LoadFile('podio/Frame.h')  # noqa: E402
 from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
 
 
-def _determine_supported_parameter_types(lang):
+def _determine_supported_parameter_types():
   """Determine the supported types for the parameters.
 
-  Args:
-      lang (str): Language for which the type names should be returned. Either
-          'c++' or 'py'.
-
   Returns:
-      tuple (str): the tuple with the string representation of all **c++**
-          classes that are supported
+      tuple(tuple(str, str)): the tuple with the string representation of all
+          c++ and their corresponding python types that are supported
   """
   types_tuple = podio.SupportedGenericDataTypes()
   n_types = cppyy.gbl.std.tuple_size[podio.SupportedGenericDataTypes].value
 
   # Get the python types with the help of cppyy and the STL
-  py_types = (type(cppyy.gbl.std.get[i](types_tuple)).__name__ for i in range(n_types))
-  if lang == 'py':
-    return tuple(py_types)
-  if lang == 'c++':
-    # Map of types that need special care when going from python to c++
-    py_to_cpp_type_map = {
-        'str': 'std::string'
-        }
-    # Convert them to the corresponding c++ types
-    return tuple(py_to_cpp_type_map.get(t, t) for t in py_types)
+  py_types = [type(cppyy.gbl.std.get[i](types_tuple)).__name__ for i in range(n_types)]
 
-  raise ValueError(f"lang needs to be 'py' or 'c++' (got {lang})")
+  def _determine_cpp_type(idx_and_type):
+    """Determine the actual c++ type from the python type name.
+
+    Mainly maps 'str' to 'std::string', and also determines whether a python
+    'float' is actually a 'double' or a 'float' in c++. The latter is necessary
+    since python doesn't only has float (corresponding to double in c++) and we
+    need the exact c++ type
+    """
+    idx, typename = idx_and_type
+    if typename == 'float':
+      cpp_type = cppyy.gbl.std.tuple_element[idx, podio.SupportedGenericDataTypes].type
+      if cppyy.typeid(cpp_type).name() == 'd':
+        return 'double'
+      return 'float'
+    if typename == 'str':
+      return 'std::string'
+    return typename
+
+  cpp_types = list(map(_determine_cpp_type, enumerate(py_types)))
+  return tuple(zip(cpp_types, py_types))
 
 
-SUPPORTED_PARAMETER_TYPES = _determine_supported_parameter_types('c++')
-SUPPORTED_PARAMETER_PY_TYPES = _determine_supported_parameter_types('py')
+SUPPORTED_PARAMETER_TYPES = _determine_supported_parameter_types()
 
 
-# Map that is necessary for easier disambiguation of parameters that are
-# available with more than one type under the same name. Maps a python type to
-# a c++ vector of the corresponding type or a c++ type to the vector
-_PY_TO_CPP_TYPE_MAP = {
-    pytype: f'std::vector<{cpptype}>' for (pytype, cpptype) in zip(SUPPORTED_PARAMETER_PY_TYPES,
-                                                                     SUPPORTED_PARAMETER_TYPES)
-    }
-_PY_TO_CPP_TYPE_MAP.update({
-    f'{cpptype}': f'std::vector<{cpptype}>' for cpptype in SUPPORTED_PARAMETER_TYPES
-    })
+def _get_cpp_vector_types(type_str):
+  """Get the possible std::vector<cpp_type> from the passed py_type string."""
+  # Gather a list of all types that match the type_str (c++ or python)
+  types = list(filter(lambda t: type_str in t, SUPPORTED_PARAMETER_TYPES))
+  if not types:
+    raise ValueError(f'{type_str} cannot be mapped to a valid parameter type')
+
+  return [f'std::vector<{t}>' for t in map(lambda x: x[0], types)]
 
 
 class Frame:
@@ -130,7 +133,6 @@ class Frame:
         ValueError: If there are multiple parameters with the same name, but
             multiple types and no type specifier to disambiguate between them
             has been passed.
-
     """
     def _get_param_value(par_type, name):
       par_value = self._frame.getParameter[par_type](name)
@@ -146,16 +148,20 @@ class Frame:
 
     if as_type is None:
       raise ValueError(f'{name} parameter has {len(par_type)} different types available, '
-                       'but no as_type argument to disambiguate')
+                       f'but no as_type argument to disambiguate')
 
-    req_type = _PY_TO_CPP_TYPE_MAP.get(as_type, None)
-    if req_type is None:
-      raise ValueError(f'as_type value {as_type} cannot be mapped to a valid parameter type')
-
-    if req_type not in par_type:
+    # Get all possible c++ vector types and see if we can unambiguously map them
+    # to the available types for this parameter
+    vec_types = _get_cpp_vector_types(as_type)
+    vec_types = [t for t in vec_types if t in par_type]
+    if len(vec_types) == 0:
       raise ValueError(f'{name} parameter is not available as type {as_type}')
 
-    return _get_param_value(req_type, name)
+    if len(vec_types) > 1:
+      raise ValueError(f'{name} parameter cannot be unambiguously mapped to a c++ type with '
+                       f'{as_type=}. Consider passing in the c++ type instead of the python type')
+
+    return _get_param_value(vec_types[0], name)
 
   def get_parameters(self):
     """Get the complete podio::GenericParameters object stored in this Frame.
@@ -202,7 +208,7 @@ class Frame:
     """
     params = self._frame.getParameters()
     keys_dict = {}
-    for par_type in SUPPORTED_PARAMETER_TYPES:
+    for par_type, _ in SUPPORTED_PARAMETER_TYPES:
       keys = params.getKeys[par_type]()
       for key in keys:
         # Make sure to convert to a python string here to not have a dangling

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -28,7 +28,7 @@ def _determine_supported_parameter_types():
 
     Mainly maps 'str' to 'std::string', and also determines whether a python
     'float' is actually a 'double' or a 'float' in c++. The latter is necessary
-    since python doesn't only has float (corresponding to double in c++) and we
+    since python only has float (corresponding to double in c++) and we
     need the exact c++ type
     """
     idx, typename = idx_and_type
@@ -148,7 +148,7 @@ class Frame:
 
     if as_type is None:
       raise ValueError(f'{name} parameter has {len(par_type)} different types available, '
-                       f'but no as_type argument to disambiguate')
+                       'but no as_type argument to disambiguate')
 
     # Get all possible c++ vector types and see if we can unambiguously map them
     # to the available types for this parameter

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -97,5 +97,7 @@ class FrameReadTest(unittest.TestCase):
 
     self.assertEqual(self.event.get_parameter('SomeVectorData', as_type='int'), [1, 2, 3, 4])
     self.assertEqual(self.event.get_parameter('SomeVectorData', as_type='str'), ["just", "some", "strings"])
+    # as_type='float' will also retrieve double values (if the name is unambiguous)
+    self.assertEqual(self.event.get_parameter('SomeVectorData', as_type='float'), [0.0, 0.0])
     # Avoid float comparison here and only check the size
     self.assertEqual(len(self.event.get_parameter('SomeVectorData', as_type='float')), 2)

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -99,5 +99,3 @@ class FrameReadTest(unittest.TestCase):
     self.assertEqual(self.event.get_parameter('SomeVectorData', as_type='str'), ["just", "some", "strings"])
     # as_type='float' will also retrieve double values (if the name is unambiguous)
     self.assertEqual(self.event.get_parameter('SomeVectorData', as_type='float'), [0.0, 0.0])
-    # Avoid float comparison here and only check the size
-    self.assertEqual(len(self.event.get_parameter('SomeVectorData', as_type='float')), 2)

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -19,7 +19,7 @@ EXPECTED_COLL_NAMES = {
 EXPECTED_EXTENSION_COLL_NAMES = {"extension_Contained", "extension_ExternalComponent", "extension_ExternalRelation"}
 
 # The expected parameter names in each frame
-EXPECTED_PARAM_NAMES = {'anInt', 'UserEventWeight', 'UserEventName', 'SomeVectorData'}
+EXPECTED_PARAM_NAMES = {'anInt', 'UserEventWeight', 'UserEventName', 'SomeVectorData', 'SomeValue'}
 
 
 class FrameTest(unittest.TestCase):
@@ -93,7 +93,9 @@ class FrameReadTest(unittest.TestCase):
 
     with self.assertRaises(ValueError):
       # Parameter not available as float (only int and string)
-      _ = self.event.get_parameter('SomeVectorData', as_type='float')
+      _ = self.event.get_parameter('SomeValue', as_type='float')
 
     self.assertEqual(self.event.get_parameter('SomeVectorData', as_type='int'), [1, 2, 3, 4])
     self.assertEqual(self.event.get_parameter('SomeVectorData', as_type='str'), ["just", "some", "strings"])
+    # Avoid float comparison here and only check the size
+    self.assertEqual(len(self.event.get_parameter('SomeVectorData', as_type='float')), 2)

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -138,6 +138,8 @@ void GenericParameters::print(std::ostream& os, bool flush) {
   printMap(getMap<int>(), os);
   os << "\nfloat parameters\n";
   printMap(getMap<float>(), os);
+  os << "\ndouble parameters\n";
+  printMap(getMap<double>(), os);
   os << "\nstd::string parameters\n";
   printMap(getMap<std::string>(), os);
 

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -8,23 +8,27 @@ namespace podio {
 GenericParameters::GenericParameters() :
     m_intMtx(std::make_unique<std::mutex>()),
     m_floatMtx(std::make_unique<std::mutex>()),
-    m_stringMtx(std::make_unique<std::mutex>()) {
+    m_stringMtx(std::make_unique<std::mutex>()),
+    m_doubleMtx(std::make_unique<std::mutex>()) {
 }
 
 GenericParameters::GenericParameters(const GenericParameters& other) :
     m_intMtx(std::make_unique<std::mutex>()),
     m_floatMtx(std::make_unique<std::mutex>()),
-    m_stringMtx(std::make_unique<std::mutex>()) {
+    m_stringMtx(std::make_unique<std::mutex>()),
+    m_doubleMtx(std::make_unique<std::mutex>()) {
   {
     // acquire all three locks at once to make sure all three internal maps are
     // copied at the same "state" of the GenericParameters
     auto& intMtx = other.getMutex<int>();
     auto& floatMtx = other.getMutex<float>();
     auto& stringMtx = other.getMutex<std::string>();
-    std::scoped_lock lock(intMtx, floatMtx, stringMtx);
+    auto& doubleMtx = other.getMutex<double>();
+    std::scoped_lock lock(intMtx, floatMtx, stringMtx, doubleMtx);
     _intMap = other._intMap;
     _floatMap = other._floatMap;
     _stringMap = other._stringMap;
+    _doubleMap = other._doubleMap;
   }
 }
 

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -75,12 +75,14 @@ void writeGenericParameters(sio::write_device& device, const GenericParameters& 
   writeParamMap(device, params.getIntMap());
   writeParamMap(device, params.getFloatMap());
   writeParamMap(device, params.getStringMap());
+  writeParamMap(device, params.getDoubleMap());
 }
 
 void readGenericParameters(sio::read_device& device, GenericParameters& params) {
   readParamMap(device, params.getIntMap());
   readParamMap(device, params.getFloatMap());
   readParamMap(device, params.getStringMap());
+  readParamMap(device, params.getDoubleMap());
 }
 
 void SIOEventMetaDataBlock::read(sio::read_device& device, sio::version_type) {

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -78,29 +78,31 @@ void writeGenericParameters(sio::write_device& device, const GenericParameters& 
   writeParamMap(device, params.getDoubleMap());
 }
 
-void readGenericParameters(sio::read_device& device, GenericParameters& params) {
+void readGenericParameters(sio::read_device& device, GenericParameters& params, sio::version_type version) {
   readParamMap(device, params.getIntMap());
   readParamMap(device, params.getFloatMap());
   readParamMap(device, params.getStringMap());
-  readParamMap(device, params.getDoubleMap());
+  if (version >= sio::version::encode_version(0, 2)) {
+    readParamMap(device, params.getDoubleMap());
+  }
 }
 
-void SIOEventMetaDataBlock::read(sio::read_device& device, sio::version_type) {
-  readGenericParameters(device, *metadata);
+void SIOEventMetaDataBlock::read(sio::read_device& device, sio::version_type version) {
+  readGenericParameters(device, *metadata, version);
 }
 
 void SIOEventMetaDataBlock::write(sio::write_device& device) {
   writeGenericParameters(device, *metadata);
 }
 
-void SIONumberedMetaDataBlock::read(sio::read_device& device, sio::version_type) {
+void SIONumberedMetaDataBlock::read(sio::read_device& device, sio::version_type version) {
   int size;
   device.data(size);
   while (size--) {
     int id;
     device.data(id);
     GenericParameters params;
-    readGenericParameters(device, params);
+    readGenericParameters(device, params, version);
 
     data->emplace(id, std::move(params));
   }

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -3,6 +3,7 @@
     <class name="podio::GenericParameters">
         <field name="m_intMtx" transient="true"/>
         <field name="m_floatMtx" transient="true"/>
+        <field name="m_doubleMtx" transient="true"/>
         <field name="m_stringMtx" transient="true"/>
     </class>
     <class name="podio::IntVec"/>
@@ -10,6 +11,7 @@
     <class name="podio::StringVec"/>
     <class name="podio::GenericParameters::MapType<int>"/>
     <class name="podio::GenericParameters::MapType<float>"/>
+    <class name="podio::GenericParameters::MapType<double>"/>
     <class name="podio::GenericParameters::MapType<std::string>"/>
     <class name="std::map<int,podio::GenericParameters>"/>
     <class name="std::vector<std::tuple<int, std::string, bool>>"/>

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -90,6 +90,15 @@ void processEvent(StoreT& store, int eventNum, podio::version::Version fileVersi
     }
   }
 
+  if constexpr (!isEventStore<StoreT>) {
+    if (fileVersion > podio::version::Version{0, 16, 2}) {
+      const auto doubleParams = store.template getParameter<std::vector<double>>("SomeVectorData");
+      if (doubleParams.size() != 2 || doubleParams[0] != eventNum * 1.1 || doubleParams[1] != eventNum * 2.2) {
+        throw std::runtime_error("Could not read event parameter: 'SomeDoubleValues' correctly");
+      }
+    }
+  }
+
   try {
     // not assigning to a variable, because it will remain unused, we just want
     // the exception here

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1031,7 +1031,7 @@ TEST_CASE("GenericParameters constructors", "[generic-parameters]") {
   }
 }
 
-// helper alias template "macro" to get the return type of calling
+// Helper alias template "macro" to get the return type of calling
 // GenericParameters::getValue with the desired template type
 template <typename T>
 using GPGetValue = decltype(std::declval<podio::GenericParameters>().getValue<T>(std::declval<std::string>()));

--- a/tests/write_frame.h
+++ b/tests/write_frame.h
@@ -420,6 +420,9 @@ podio::Frame makeFrame(int iFrame) {
   frame.putParameter("UserEventName", " event_number_" + std::to_string(iFrame));
   frame.putParameter("SomeVectorData", {1, 2, 3, 4});
   frame.putParameter("SomeVectorData", {"just", "some", "strings"});
+  frame.putParameter("SomeVectorData", {iFrame * 1.1, iFrame * 2.2});
+  frame.putParameter("SomeValue", "string value");
+  frame.putParameter("SomeValue", 42);
 
   // An empty collection
   frame.put(ExampleClusterCollection(), "emptyCollection");

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -87,6 +87,7 @@ void write(podio::EventStore& store, WriterT& writer) {
     ss << " event_number_" << i;
     evtMD.setValue("UserEventName", ss.str());
     evtMD.setValue("SomeVectorData", {1, 2, 3, 4});
+    evtMD.setValue("SomeVectorData", {i * 1.1, i * 2.2});
 
     auto& colMD = store.getCollectionMetaData(hits.getID());
     colMD.setValue("CellIDEncodingString", "system:8,barrel:3,layer:6,slice:5,x:-16,y:-16");


### PR DESCRIPTION

BEGINRELEASENOTES
- Make `double` a supported type of `GenericParameters`. A similar thing has been added to LCIO in [iLCSoft/LCIO#143](https://github.com/iLCSoft/LCIO/pull/143) to support storing event weights that need double precision.
- Add more unittests to the `GenericParameters` covering also the available constructors.

ENDRELEASENOTES

The majority of the work was necessary for the python bindings, since python only has `float` (which is double precision), but we need to be able to disambiguate between `float` and `double` in order to call the correct overload for retrieving the values.
