### PR TITLE
Fix version preprocessor macro and make it usable

### DIFF
--- a/podioVersion.in.h
+++ b/podioVersion.in.h
@@ -13,7 +13,7 @@
 
 /// Define a version to be used in podio.
 #define PODIO_VERSION(major, minor, patch)                                                                             \
-  (((unsigned long)(major) << 32) | ((unsigned long)(minor) << 16) | ((unsigned long)(patch)))
+  ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | UINT64_C(patch))
 /// Get the major version from a preprocessor defined version
 #define PODIO_MAJOR_VERSION(v) (((v) & (-1UL >> 16)) >> 32)
 /// Get the minor version from a preprocessor defined version
@@ -22,10 +22,10 @@
 #define PODIO_PATCH_VERSION(v) ((v) & (-1UL >> 48))
 
 // Some helper constants that are populated by the cmake configure step
-#define podio_VERSION @podio_VERSION@
 #define podio_VERSION_MAJOR @podio_VERSION_MAJOR@
 #define podio_VERSION_MINOR @podio_VERSION_MINOR@
 #define podio_VERSION_PATCH @podio_VERSION_PATCH@
+#define podio_VERSION PODIO_VERSION(podio_VERSION_MAJOR, podio_VERSION_MINOR, podio_VERSION_PATCH)
 
 /// The encoded version with which podio has been built
 #define PODIO_BUILD_VERSION PODIO_VERSION(podio_VERSION_MAJOR, podio_VERSION_MINOR, podio_VERSION_PATCH)

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -883,8 +883,13 @@ TEST_CASE("Version tests", "[versioning]") {
 TEST_CASE("Preprocessor version tests", "[versioning]") {
   SECTION("Basic functionality") {
     using namespace podio::version;
-    // Check that preprocessor comparisons work
-    STATIC_REQUIRE(PODIO_BUILD_VERSION == PODIO_VERSION(build_version.major, build_version.minor, build_version.patch));
+    // Check that preprocessor comparisons work by actually invoking the
+    // preprocessor
+#if PODIO_BUILD_VERSION == PODIO_VERSION(podio_VERSION_MAJOR, podio_VERSION_MINOR, podio_VERSION_PATCH)
+    STATIC_REQUIRE(true);
+#else
+    STATIC_REQUIRE(false);
+#endif
 
     // Make sure that we can actually decode 64 bit versions
     STATIC_REQUIRE(decode_version(PODIO_BUILD_VERSION) == build_version);


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the `PODIO_VERSION` preprocessor macro to be actually usable in a preprocessor context. Fixes [#374](https://github.com/AIDASoft/podio/issues/374)
- Make `podio_VERSION` preprocessor constant something that can be used in a preprocessor context (now the same as `PODIO_BUILD_VERSION`
- Add test that ensures that the macro and the constant are actually used in a preprocessor context.

ENDRELEASENOTES