### PR TITLE
Fix tests without SIO

### DIFF
--- a/python/podio/reading.py
+++ b/python/podio/reading.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
   def _is_frame_sio_file(filename):
     """Stub raising a ValueError"""
-    raise ValueError('podio has not been built with SIO support, which is necessary to read this file')
+    raise ValueError('podio has not been built with SIO support, which is necessary to read this file, or there is a version mismatch')
 
 
 def _is_frame_root_file(filename):

--- a/python/podio/reading.py
+++ b/python/podio/reading.py
@@ -18,8 +18,8 @@ try:
 except ImportError:
   def _is_frame_sio_file(filename):
     """Stub raising a ValueError"""
-    raise ValueError('podio has not been built with SIO support, '\
-                     'which is necessary to read this file, '\
+    raise ValueError('podio has not been built with SIO support, '
+                     'which is necessary to read this file, '
                      'or there is a version mismatch')
 
 

--- a/python/podio/reading.py
+++ b/python/podio/reading.py
@@ -18,7 +18,9 @@ try:
 except ImportError:
   def _is_frame_sio_file(filename):
     """Stub raising a ValueError"""
-    raise ValueError('podio has not been built with SIO support, which is necessary to read this file, or there is a version mismatch')
+    raise ValueError('podio has not been built with SIO support, '\
+                     'which is necessary to read this file, '\
+                     'or there is a version mismatch')
 
 
 def _is_frame_root_file(filename):

--- a/python/podio/sio_io.py
+++ b/python/podio/sio_io.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python3
 """Python module for reading sio files containing podio Frames"""
 
-from podio.base_reader import BaseReaderMixin
 
 from ROOT import gSystem
 ret = gSystem.Load('libpodioSioIO')  # noqa: 402
 # Return values: -1 when it doesn't exist and -2 when there is a version mismatch
-if ret == -1:
-  raise ImportError('Unable to find libpodioSioIO')
-if ret == -2:
-  raise ImportError('Version mismatch for libpodioSioIO')
+if ret < 0:
+  raise ImportError('Error when importing libpodioSioIO')
 from ROOT import podio  # noqa: 402 # pylint: disable=wrong-import-position
-
-Writer = podio.SIOFrameWriter
+from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
 
 
 class Reader(BaseReaderMixin):

--- a/python/podio/sio_io.py
+++ b/python/podio/sio_io.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Python module for reading sio files containing podio Frames"""
 
+from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
 
 from ROOT import gSystem
 ret = gSystem.Load('libpodioSioIO')  # noqa: 402
@@ -8,7 +9,8 @@ ret = gSystem.Load('libpodioSioIO')  # noqa: 402
 if ret < 0:
   raise ImportError('Error when importing libpodioSioIO')
 from ROOT import podio  # noqa: 402 # pylint: disable=wrong-import-position
-from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
+
+Writer = podio.SIOFrameWriter
 
 
 class Reader(BaseReaderMixin):

--- a/python/podio/sio_io.py
+++ b/python/podio/sio_io.py
@@ -8,7 +8,7 @@ ret = gSystem.Load('libpodioSioIO')  # noqa: 402
 # Return values: -1 when it doesn't exist and -2 when there is a version mismatch
 if ret == -1:
   raise ImportError('Unable to find libpodioSioIO')
-elif ret == -2:
+if ret == -2:
   raise ImportError('Version mismatch for libpodioSioIO')
 from ROOT import podio  # noqa: 402 # pylint: disable=wrong-import-position
 

--- a/python/podio/sio_io.py
+++ b/python/podio/sio_io.py
@@ -4,7 +4,12 @@
 from podio.base_reader import BaseReaderMixin
 
 from ROOT import gSystem
-gSystem.Load('libpodioSioIO')  # noqa: 402
+ret = gSystem.Load('libpodioSioIO')  # noqa: 402
+# Return values: -1 when it doesn't exist and -2 when there is a version mismatch
+if ret == -1:
+  raise ImportError('Unable to find libpodioSioIO')
+elif ret == -2:
+  raise ImportError('Version mismatch for libpodioSioIO')
 from ROOT import podio  # noqa: 402 # pylint: disable=wrong-import-position
 
 Writer = podio.SIOFrameWriter

--- a/python/podio/test_ReaderSio.py
+++ b/python/podio/test_ReaderSio.py
@@ -3,10 +3,6 @@
 
 import unittest
 
-try:
-  from podio.sio_io import Reader, LegacyReader
-except ImportError:
-  print('Unable to load SIO for this unit test, aborting the test...')
 from podio.test_Reader import ReaderTestCaseMixin, LegacyReaderTestCaseMixin
 from podio.test_utils import SKIP_SIO_TESTS
 
@@ -16,6 +12,7 @@ class SioReaderTestCase(ReaderTestCaseMixin, unittest.TestCase):
   """Test cases for root input files"""
   def setUp(self):
     """Setup the corresponding reader"""
+    from podio.sio_io import Reader  # pylint: disable=import-outside-toplevel
     self.reader = Reader('example_frame.sio')
 
 
@@ -24,4 +21,5 @@ class SIOLegacyReaderTestCase(LegacyReaderTestCaseMixin, unittest.TestCase):
   """Test cases for the legacy root input files and reader."""
   def setUp(self):
     """Setup a reader, reading from the example files"""
+    from podio.sio_io import LegacyReader  # pylint: disable=import-outside-toplevel
     self.reader = LegacyReader('example.sio')

--- a/python/podio/test_ReaderSio.py
+++ b/python/podio/test_ReaderSio.py
@@ -3,7 +3,10 @@
 
 import unittest
 
-from podio.sio_io import Reader, LegacyReader
+try:
+  from podio.sio_io import Reader, LegacyReader
+except ImportError:
+  print('Unable to load SIO for this unit test, aborting the test...')
 from podio.test_Reader import ReaderTestCaseMixin, LegacyReaderTestCaseMixin
 from podio.test_utils import SKIP_SIO_TESTS
 


### PR DESCRIPTION
When running tests without SIO some python tests fail because they are trying to access `podio.SIOFrameWriter` in an import which doesn't exist without SIO. With this change I don't get any failures in the tests without and with SIO enabled.

BEGINRELEASENOTES
- Fix tests without SIO

ENDRELEASENOTES