### PR TITLE
Mark EventStore based I/O as deprecated

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -46,7 +46,7 @@ jobs:
             cmake -DENABLE_SIO=ON \
               -DCMAKE_INSTALL_PREFIX=../install \
               -DCMAKE_CXX_STANDARD=17 \
-              -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
+              -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
               -DUSE_EXTERNAL_CATCH2=ON \
               -DBUILD_TESTING=OFF\
               -G Ninja ..

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -29,7 +29,7 @@ jobs:
           cmake -DENABLE_SIO=ON \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
+            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DUSE_EXTERNAL_CATCH2=ON \
             -G Ninja ..
           echo "::endgroup::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           cmake -DENABLE_SIO=${{ matrix.sio }} \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
+            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja ..
           echo "::endgroup::"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
           cmake -DENABLE_SIO=${{ matrix.sio }} \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
-            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
+            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -DPODIO_SET_RPATH=ON \
             -G Ninja ..

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: clang-tidy
         name: clang-tidy
-        entry: clang-tidy -warnings-as-errors='*' -p compile_commands.json
+        entry: clang-tidy -warnings-as-errors='*,-clang-diagnostic-deprecated-declarations' -p compile_commands.json
         types: [c++]
         exclude: (tests/(datamodel|src)/.*(h|cc)|podioVersion.in.h)
         language: system

--- a/include/podio/ASCIIWriter.h
+++ b/include/podio/ASCIIWriter.h
@@ -2,6 +2,7 @@
 #define PODIO_ASCIIWRITER_H
 
 #include "podio/EventStore.h"
+#include "podio/utilities/Deprecated.h"
 
 #include <fstream>
 #include <functional>
@@ -30,7 +31,7 @@ struct ColWriter : public ColWriterBase {
 
 typedef std::map<std::string, ColWriterBase*> FunMap;
 
-class ASCIIWriter {
+class DEPR_EVTSTORE ASCIIWriter {
 
 public:
   ASCIIWriter(const std::string& filename, EventStore* store);

--- a/include/podio/EventStore.h
+++ b/include/podio/EventStore.h
@@ -13,6 +13,7 @@
 #include "podio/GenericParameters.h"
 #include "podio/ICollectionProvider.h"
 #include "podio/IMetaDataProvider.h"
+#include "podio/utilities/Deprecated.h"
 
 /**
 This is an *example* event store
@@ -33,7 +34,7 @@ class IReader;
 typedef std::map<int, GenericParameters> RunMDMap;
 typedef std::map<int, GenericParameters> ColMDMap;
 
-class EventStore : public ICollectionProvider, public IMetaDataProvider {
+class DEPR_EVTSTORE EventStore : public ICollectionProvider, public IMetaDataProvider {
 public:
   /// Make non-copyable
   EventStore(const EventStore&) = delete;

--- a/include/podio/IMetaDataProvider.h
+++ b/include/podio/IMetaDataProvider.h
@@ -2,6 +2,7 @@
 #define PODIO_IMETADATAPROVIDER_H
 
 #include "podio/GenericParameters.h"
+#include "podio/utilities/Deprecated.h"
 
 namespace podio {
 
@@ -9,7 +10,7 @@ namespace podio {
  * @author F. Gaede, DESY
  * @date Apr 2020
  */
-class IMetaDataProvider {
+class DEPR_EVTSTORE IMetaDataProvider {
 
 public:
   /// destructor

--- a/include/podio/IReader.h
+++ b/include/podio/IReader.h
@@ -2,6 +2,7 @@
 #define PODIO_IREADER_H
 
 #include "podio/podioVersion.h"
+#include "podio/utilities/Deprecated.h"
 
 #include <algorithm>
 #include <map>
@@ -22,7 +23,7 @@ class CollectionBase;
 class CollectionIDTable;
 class GenericParameters;
 
-class IReader {
+class DEPR_EVTSTORE IReader {
 public:
   virtual ~IReader() = default;
   /// Read Collection of given name

--- a/include/podio/PythonEventStore.h
+++ b/include/podio/PythonEventStore.h
@@ -4,12 +4,13 @@
 #include "podio/EventStore.h"
 #include "podio/GenericParameters.h"
 #include "podio/IReader.h"
+#include "podio/utilities/Deprecated.h"
 
 #include <memory>
 
 namespace podio {
 
-class PythonEventStore {
+class DEPR_EVTSTORE PythonEventStore {
 public:
   /// constructor from filename
   PythonEventStore(const char* filename);

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -4,6 +4,7 @@
 #include "podio/CollectionBase.h"
 #include "podio/CollectionBranches.h"
 #include "podio/EventStore.h"
+#include "podio/utilities/Deprecated.h"
 
 #include "TBranch.h"
 
@@ -18,7 +19,7 @@ class TFile;
 class TTree;
 
 namespace podio {
-class ROOTWriter {
+class DEPR_EVTSTORE ROOTWriter {
 
 public:
   ROOTWriter(const std::string& filename, EventStore* store);

--- a/include/podio/SIOWriter.h
+++ b/include/podio/SIOWriter.h
@@ -4,6 +4,7 @@
 #include "podio/CollectionBase.h"
 #include "podio/EventStore.h"
 #include "podio/SIOBlock.h"
+#include "podio/utilities/Deprecated.h"
 
 // SIO specific includes
 #include <sio/definitions.h>
@@ -15,7 +16,7 @@
 // forward declarations
 
 namespace podio {
-class SIOWriter {
+class DEPR_EVTSTORE SIOWriter {
 
 public:
   SIOWriter(const std::string& filename, EventStore* store);

--- a/include/podio/TimedWriter.h
+++ b/include/podio/TimedWriter.h
@@ -3,6 +3,7 @@
 
 #include "podio/BenchmarkRecorder.h"
 #include "podio/BenchmarkUtil.h"
+#include "podio/utilities/Deprecated.h"
 
 #include <chrono>
 #include <string>
@@ -10,7 +11,7 @@
 namespace podio {
 
 template <class WrappedWriter>
-class TimedWriter {
+class DEPR_EVTSTORE TimedWriter {
   using ClockT = benchmark::ClockT;
 
 public:

--- a/include/podio/utilities/Deprecated.h
+++ b/include/podio/utilities/Deprecated.h
@@ -1,0 +1,7 @@
+#ifndef PODIO_UTILITIES_DEPRECATED_H
+#define PODIO_UTILITIES_DEPRECATED_H
+
+#define DEPR_EVTSTORE                                                                                                  \
+  [[deprecated("The EventStore based I/O model is deprecated and will be removed. Switch to the Frame based model.")]]
+
+#endif // PODIO_UTILITIES_DEPRECATED_H

--- a/python/podio/EventStore.py
+++ b/python/podio/EventStore.py
@@ -1,7 +1,10 @@
 """Python EventStore for reading files with podio generated datamodels"""
 
+import warnings
+warnings.warn("The EventStore based I/O model is deprecated and will be removed. Switch to the Frame based model.",
+              FutureWarning)
 
-from ROOT import gSystem
+from ROOT import gSystem  # pylint: disable=wrong-import-position
 gSystem.Load("libpodioPythonStore")  # noqa: E402
 from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Introduce deprecation warnings for the **EventStore based I/O model** as it **will be removed in favor of the `Frame` based one**

ENDRELEASENOTES

In order to pass CI deprecation warnings are temporarily accepted and this exception has to be taken back again when the EventStore code is removed.
