### PR TITLE
Expose more of the GenericParameters interface in the Frame

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -233,6 +233,19 @@ public:
     return m_self->parameters().getValue<T>(key);
   }
 
+  /** Get all parameters that are stored in this Frame
+   */
+  const podio::GenericParameters& getParameters() const {
+    return m_self->parameters();
+  }
+
+  /** Get the keys of all stored parameters for a given type
+   */
+  template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
+  std::vector<std::string> getParameterKeys() const {
+    return m_self->parameters().getKeys<T>();
+  }
+
   /** Get all **currently** available collections (including potentially
    * unpacked ones from raw data)
    */

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -198,7 +198,7 @@ public:
    * Copy the value into the internal store
    */
   template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
-  void putParameter(const std::string& key, T value) {
+  inline void putParameter(const std::string& key, T value) {
     m_self->parameters().setValue(key, value);
   }
 
@@ -221,7 +221,7 @@ public:
    * catching on-the-fly conversions of initializer_lists of values.
    */
   template <typename T, typename = std::enable_if_t<detail::isInTuple<T, SupportedGenericDataTypes>>>
-  void putParameter(const std::string& key, std::initializer_list<T>&& values) {
+  inline void putParameter(const std::string& key, std::initializer_list<T>&& values) {
     putParameter<std::vector<T>>(key, std::move(values));
   }
 
@@ -229,20 +229,20 @@ public:
    * either by a const reference or a value depending on the desired type.
    */
   template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
-  podio::GenericDataReturnType<T> getParameter(const std::string& key) const {
+  inline podio::GenericDataReturnType<T> getParameter(const std::string& key) const {
     return m_self->parameters().getValue<T>(key);
   }
 
   /** Get all parameters that are stored in this Frame
    */
-  const podio::GenericParameters& getParameters() const {
+  inline const podio::GenericParameters& getParameters() const {
     return m_self->parameters();
   }
 
   /** Get the keys of all stored parameters for a given type
    */
   template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
-  std::vector<std::string> getParameterKeys() const {
+  inline std::vector<std::string> getParameterKeys() const {
     return m_self->parameters().getKeys<T>();
   }
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -259,7 +259,7 @@ public:
   /**
    * Get the GenericParameters for writing
    */
-  const podio::GenericParameters& getGenericParametersForWrite() const {
+  [[deprecated("use getParameters instead")]] const podio::GenericParameters& getGenericParametersForWrite() const {
     return m_self->parameters();
   }
 

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -167,7 +167,7 @@ class Frame:
         podio.GenericParameters: The stored generic parameters
     """
     # Going via the not entirely inteded way here
-    return self._frame.getGenericParametersForWrite()
+    return self._frame.getParameters()
 
   def get_param_info(self, name):
     """Get the parameter type information stored under the given name.
@@ -197,13 +197,10 @@ class Frame:
   def _init_param_keys(self):
     """Initialize the param keys dict for easier lookup of the available parameters.
 
-    NOTE: This depends on a "side channel" that is usually reserved for the
-    writers but is currently still in the public interface of the Frame
-
     Returns:
         dict: A dictionary mapping each key to the corresponding c++ type
     """
-    params = self._frame.getGenericParametersForWrite()  # this is the iffy bit
+    params = self._frame.getParameters()
     keys_dict = {}
     for par_type in SUPPORTED_PARAMETER_TYPES:
       keys = params.getKeys[par_type]()

--- a/src/ROOTFrameWriter.cc
+++ b/src/ROOTFrameWriter.cc
@@ -40,11 +40,10 @@ void ROOTFrameWriter::writeFrame(const podio::Frame& frame, const std::string& c
   // We will at least have a parameters branch, even if there are no
   // collections
   if (catInfo.branches.empty()) {
-    initBranches(catInfo, collections, const_cast<podio::GenericParameters&>(frame.getGenericParametersForWrite()));
+    initBranches(catInfo, collections, const_cast<podio::GenericParameters&>(frame.getParameters()));
 
   } else {
-    resetBranches(catInfo.branches, collections,
-                  &const_cast<podio::GenericParameters&>(frame.getGenericParametersForWrite()));
+    resetBranches(catInfo.branches, collections, &const_cast<podio::GenericParameters&>(frame.getParameters()));
   }
 
   catInfo.tree->Fill();

--- a/src/SIOFrameWriter.cc
+++ b/src/SIOFrameWriter.cc
@@ -44,7 +44,7 @@ void SIOFrameWriter::writeFrame(const podio::Frame& frame, const std::string& ca
   tableBlocks.emplace_back(sio_utils::createCollIDBlock(collections, frame.getCollectionIDTableForWrite()));
   m_tocRecord.addRecord(category, sio_utils::writeRecord(tableBlocks, category + "_HEADER", m_stream));
 
-  const auto blocks = sio_utils::createBlocks(collections, frame.getGenericParametersForWrite());
+  const auto blocks = sio_utils::createBlocks(collections, frame.getParameters());
   sio_utils::writeRecord(blocks, category, m_stream);
 }
 

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -40,6 +40,12 @@ TEST_CASE("Frame parameters", "[frame][basics]") {
   REQUIRE(strings[0] == "one");
   REQUIRE(strings[1] == "two");
   REQUIRE(strings[2] == "three");
+
+  const auto stringKeys = event.getParameterKeys<std::string>();
+  REQUIRE(stringKeys.size() == 2);
+  // Can't rely on an insertion order here
+  REQUIRE(std::find(stringKeys.begin(), stringKeys.end(), "aString") != stringKeys.end());
+  REQUIRE(std::find(stringKeys.begin(), stringKeys.end(), "someStrings") != stringKeys.end());
 }
 
 // NOTE: Due to the extremly small tasks that are done in these tests, they will


### PR DESCRIPTION

BEGINRELEASENOTES
- Add `getParameters` method to the `Frame` and deprecate `getGenericParametersForWrite` which offered the exact same functionality.
  - Make it easily possible to get all parameters that are currently stored in a Frame via an "official" channel
  - Replace all internal usages.
- Add a `getParameterKeys` templated method to get the keys for different parameter types that are currently stored in the Frame. 

ENDRELEASENOTES