### PR TITLE
Add an argument to exclude SIO files from some tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -270,8 +270,8 @@ set_tests_properties(
 
 set(sio_roundtrip_tests "")
 if (TARGET read_sio)
-  add_test(datamodel_def_store_roundtrip_sio ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel)
-  add_test(datamodel_def_store_roundtrip_sio_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel extension_datamodel)
+  add_test(datamodel_def_store_roundtrip_sio ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel)
+  add_test(datamodel_def_store_roundtrip_sio_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel extension_datamodel)
 
   set(sio_roundtrip_tests
     datamodel_def_store_roundtrip_sio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -252,11 +252,11 @@ endif()
 # Add tests for storing and retrieving the EDM definitions into the produced
 # files
 if(ENABLE_SIO)
-add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel)
-add_test(datamodel_def_store_roundtrip_root_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel extension_datamodel)
-else()
 add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel)
 add_test(datamodel_def_store_roundtrip_root_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel extension_datamodel)
+else()
+add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel)
+add_test(datamodel_def_store_roundtrip_root_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel extension_datamodel)
 endif()
 
 
@@ -270,8 +270,8 @@ set_tests_properties(
 
 set(sio_roundtrip_tests "")
 if (TARGET read_sio)
-  add_test(datamodel_def_store_roundtrip_sio ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel)
-  add_test(datamodel_def_store_roundtrip_sio_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel extension_datamodel)
+  add_test(datamodel_def_store_roundtrip_sio ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel)
+  add_test(datamodel_def_store_roundtrip_sio_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel extension_datamodel)
 
   set(sio_roundtrip_tests
     datamodel_def_store_roundtrip_sio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -251,14 +251,19 @@ endif()
 
 # Add tests for storing and retrieving the EDM definitions into the produced
 # files
-if(ENABLE_SIO)
-add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel)
-add_test(datamodel_def_store_roundtrip_root_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel extension_datamodel)
-else()
-add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel)
-add_test(datamodel_def_store_roundtrip_root_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel extension_datamodel)
-endif()
-
+add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh
+  ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root
+  datamodel
+  ${CMAKE_CURRENT_LIST_DIR}
+  )
+# The extension model needs to know about the upstream model for generation
+add_test(datamodel_def_store_roundtrip_root_extension
+  ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh
+  ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root
+  extension_model
+  ${CMAKE_CURRENT_LIST_DIR}/extension_model
+  --upstream-edm=datamodel:${CMAKE_CURRENT_LIST_DIR}/datalayout.yaml
+  )
 
 # Need the input files that are produced by other tests
 set_tests_properties(
@@ -269,9 +274,21 @@ set_tests_properties(
   )
 
 set(sio_roundtrip_tests "")
-if (TARGET read_sio)
-  add_test(datamodel_def_store_roundtrip_sio ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel)
-  add_test(datamodel_def_store_roundtrip_sio_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel extension_datamodel)
+if (ENABLE_SIO)
+  add_test(datamodel_def_store_roundtrip_sio
+    ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh
+    ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio
+    datamodel
+    ${CMAKE_CURRENT_LIST_DIR}
+    )
+  # The extension model needs to know about the upstream model for generation
+  add_test(datamodel_def_store_roundtrip_sio_extension
+    ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh
+    ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio
+    extension_model
+    ${CMAKE_CURRENT_LIST_DIR}/extension_model
+    --upstream-edm=datamodel:${CMAKE_CURRENT_LIST_DIR}/datalayout.yaml
+    )
 
   set(sio_roundtrip_tests
     datamodel_def_store_roundtrip_sio
@@ -295,5 +312,5 @@ set_tests_properties(
   PROPERTIES
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENVIRONMENT
-  "PODIO_BASE=${CMAKE_SOURCE_DIR};IO_HANDLERS=${IO_HANDLERS};LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_SOURCE_DIR}/python:$ENV{PYTHONPATH};ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/tests/datamodel:${CMAKE_SOURCE_DIR}/include:$ENV{ROOT_INCLUDE_PATH}"
+  "PODIO_BASE=${CMAKE_SOURCE_DIR};IO_HANDLERS=${IO_HANDLERS};ENABLE_SIO=${ENABLE_SIO};LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_SOURCE_DIR}/python:$ENV{PYTHONPATH};ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/tests/datamodel:${CMAKE_SOURCE_DIR}/include:$ENV{ROOT_INCLUDE_PATH}"
   )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -255,6 +255,7 @@ add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/du
   ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root
   datamodel
   ${CMAKE_CURRENT_LIST_DIR}
+  ${PODIO_USE_CLANG_FORMAT}
   )
 # The extension model needs to know about the upstream model for generation
 add_test(datamodel_def_store_roundtrip_root_extension
@@ -262,6 +263,7 @@ add_test(datamodel_def_store_roundtrip_root_extension
   ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root
   extension_model
   ${CMAKE_CURRENT_LIST_DIR}/extension_model
+  ${PODIO_USE_CLANG_FORMAT}
   --upstream-edm=datamodel:${CMAKE_CURRENT_LIST_DIR}/datalayout.yaml
   )
 
@@ -312,5 +314,5 @@ set_tests_properties(
   PROPERTIES
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENVIRONMENT
-  "PODIO_BASE=${CMAKE_SOURCE_DIR};IO_HANDLERS=${IO_HANDLERS};ENABLE_SIO=${ENABLE_SIO};LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_SOURCE_DIR}/python:$ENV{PYTHONPATH};ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/tests/datamodel:${CMAKE_SOURCE_DIR}/include:$ENV{ROOT_INCLUDE_PATH}"
+  "PODIO_BASE=${CMAKE_SOURCE_DIR};IO_HANDLERS=${IO_HANDLERS};ENABLE_SIO=${ENABLE_SIO};PODIO_USE_CLANG_FORMAT=${PODIO_USE_CLANG_FORMAT};LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_SOURCE_DIR}/python:$ENV{PYTHONPATH};ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/tests/datamodel:${CMAKE_SOURCE_DIR}/include:$ENV{ROOT_INCLUDE_PATH}"
   )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -251,8 +251,13 @@ endif()
 
 # Add tests for storing and retrieving the EDM definitions into the produced
 # files
-add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel)
-add_test(datamodel_def_store_roundtrip_root_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel extension_datamodel)
+if(ENABLE_SIO)
+add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel)
+add_test(datamodel_def_store_roundtrip_root_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh true ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel extension_datamodel)
+else()
+add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel)
+add_test(datamodel_def_store_roundtrip_root_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root datamodel extension_datamodel)
+endif()
 
 
 # Need the input files that are produced by other tests
@@ -265,8 +270,8 @@ set_tests_properties(
 
 set(sio_roundtrip_tests "")
 if (TARGET read_sio)
-  add_test(datamodel_def_store_roundtrip_sio ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel)
-  add_test(datamodel_def_store_roundtrip_sio_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel extension_datamodel)
+  add_test(datamodel_def_store_roundtrip_sio ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel)
+  add_test(datamodel_def_store_roundtrip_sio_extension ${CMAKE_CURRENT_LIST_DIR}/scripts/dumpModelRoundTrip.sh false ${CMAKE_CURRENT_BINARY_DIR}/example_frame.sio datamodel extension_datamodel)
 
   set(sio_roundtrip_tests
     datamodel_def_store_roundtrip_sio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -255,7 +255,6 @@ add_test(datamodel_def_store_roundtrip_root ${CMAKE_CURRENT_LIST_DIR}/scripts/du
   ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root
   datamodel
   ${CMAKE_CURRENT_LIST_DIR}
-  ${PODIO_USE_CLANG_FORMAT}
   )
 # The extension model needs to know about the upstream model for generation
 add_test(datamodel_def_store_roundtrip_root_extension
@@ -263,7 +262,6 @@ add_test(datamodel_def_store_roundtrip_root_extension
   ${CMAKE_CURRENT_BINARY_DIR}/example_frame.root
   extension_model
   ${CMAKE_CURRENT_LIST_DIR}/extension_model
-  ${PODIO_USE_CLANG_FORMAT}
   --upstream-edm=datamodel:${CMAKE_CURRENT_LIST_DIR}/datalayout.yaml
   )
 

--- a/tests/scripts/dumpModelRoundTrip.sh
+++ b/tests/scripts/dumpModelRoundTrip.sh
@@ -3,14 +3,18 @@
 # the original definition. Essentially does not check that the YAML file is the
 # same, but rather that the generated code is the same
 
-set -eu
+set -e
 
-INPUT_FILE=${1}  # the datafile
-EDM_NAME=${2}  # the name of the EDM
+ENABLE_SIO=${1}  # SIO enabled or not
+INPUT_FILE=${2}  # the datafile
+EDM_NAME=${3}  # the name of the EDM
 COMP_BASE_FOLDER=""  # where the source to compare against is
-if [ -$# -gt 2 ]; then
-    COMP_BASE_FOLDER=${3}
+if [ -$# -gt 3 ]; then
+    COMP_BASE_FOLDER=${4}
 fi
+
+echo ${ENABLE_SIO}
+
 
 # Create a few temporary but unique files and directories to store output
 DUMPED_MODEL=${INPUT_FILE}.dumped_${EDM_NAME}.yaml
@@ -20,7 +24,7 @@ mkdir -p ${OUTPUT_FOLDER}
 # Dump the model to a yaml file
 ${PODIO_BASE}/tools/podio-dump --dump-edm ${EDM_NAME} ${INPUT_FILE} > ${DUMPED_MODEL}
 
-# Regenerate the code via the class generator and the freshly dumped modl
+# Regenerate the code via the class generator and the freshly dumped model
 ${PODIO_BASE}/python/podio_class_generator.py \
     --clangformat \
     ${DUMPED_MODEL} \
@@ -31,6 +35,11 @@ ${PODIO_BASE}/python/podio_class_generator.py \
 # Compare to the originally generated code, that has been used to write the data
 # file. Need to diff subfolders explitly here because $PODIO_BASE/tests contains
 # more stuff
-diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/${EDM_NAME}
+if [ ${ENABLE_SIO} = "false" ]; then
+diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/${EDM_NAME} --exclude='*SIO*'
+diff -ru ${OUTPUT_FOLDER}/src ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/src --exclude='*SIO*'
+else
+diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/${EDM_NAME} 
 diff -ru ${OUTPUT_FOLDER}/src ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/src
+fi
 diff -u ${OUTPUT_FOLDER}/podio_generated_files.cmake ${PODIO_BASE}/tests/podio_generated_files.cmake

--- a/tests/scripts/dumpModelRoundTrip.sh
+++ b/tests/scripts/dumpModelRoundTrip.sh
@@ -8,8 +8,13 @@ set -eux
 INPUT_FILE=${1}  # the datafile
 EDM_NAME=${2}  # the name of the EDM
 COMP_BASE_FOLDER=${3}  # where the source to compare against is
-shift 3
+CLANG_FORMAT=${4}  # whether to use clang-format
+shift 4
 EXTRA_GEN_ARGS=${@}
+
+if [ ${CLANG_FORMAT} = "ON" ]; then
+    EXTRA_GEN_ARGS="${EXTRA_GEN_ARGS} --clangformat"
+fi
 
 # Create a few temporary but unique files and directories to store output
 DUMPED_MODEL=${INPUT_FILE}.dumped_${EDM_NAME}.yaml
@@ -21,7 +26,6 @@ ${PODIO_BASE}/tools/podio-dump --dump-edm ${EDM_NAME} ${INPUT_FILE} > ${DUMPED_M
 
 # Regenerate the code via the class generator and the freshly dumped model
 ${PODIO_BASE}/python/podio_class_generator.py \
-    --clangformat \
     ${EXTRA_GEN_ARGS} \
     ${DUMPED_MODEL} \
     ${OUTPUT_FOLDER} \

--- a/tests/scripts/dumpModelRoundTrip.sh
+++ b/tests/scripts/dumpModelRoundTrip.sh
@@ -12,8 +12,6 @@ CLANG_FORMAT=${4}  # whether to use clang-format
 shift 4
 EXTRA_GEN_ARGS=${@}
 
-
-
 if [ ${CLANG_FORMAT} = "ON"] || [ ${CLANG_FORMAT} = "AUTO" ]; then
     EXTRA_GEN_ARGS="${EXTRA_GEN_ARGS} --clangformat"
 fi

--- a/tests/scripts/dumpModelRoundTrip.sh
+++ b/tests/scripts/dumpModelRoundTrip.sh
@@ -5,16 +5,13 @@
 
 set -e
 
-ENABLE_SIO=${1}  # SIO enabled or not
+EXCLUDE_SIO=${1}  # SIO excluded or not
 INPUT_FILE=${2}  # the datafile
 EDM_NAME=${3}  # the name of the EDM
 COMP_BASE_FOLDER=""  # where the source to compare against is
 if [ -$# -gt 3 ]; then
     COMP_BASE_FOLDER=${4}
 fi
-
-echo ${ENABLE_SIO}
-
 
 # Create a few temporary but unique files and directories to store output
 DUMPED_MODEL=${INPUT_FILE}.dumped_${EDM_NAME}.yaml
@@ -35,7 +32,7 @@ ${PODIO_BASE}/python/podio_class_generator.py \
 # Compare to the originally generated code, that has been used to write the data
 # file. Need to diff subfolders explitly here because $PODIO_BASE/tests contains
 # more stuff
-if [ ${ENABLE_SIO} = "false" ]; then
+if [ ${EXCLUDE_SIO} = "true" ]; then
 diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/${EDM_NAME} --exclude='*SIO*'
 diff -ru ${OUTPUT_FOLDER}/src ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/src --exclude='*SIO*'
 else

--- a/tests/scripts/dumpModelRoundTrip.sh
+++ b/tests/scripts/dumpModelRoundTrip.sh
@@ -12,7 +12,9 @@ CLANG_FORMAT=${4}  # whether to use clang-format
 shift 4
 EXTRA_GEN_ARGS=${@}
 
-if [ ${CLANG_FORMAT} = "ON" ]; then
+
+
+if [ ${CLANG_FORMAT} = "ON"] || [ ${CLANG_FORMAT} = "AUTO" ]; then
     EXTRA_GEN_ARGS="${EXTRA_GEN_ARGS} --clangformat"
 fi
 

--- a/tests/scripts/dumpModelRoundTrip.sh
+++ b/tests/scripts/dumpModelRoundTrip.sh
@@ -8,11 +8,10 @@ set -eux
 INPUT_FILE=${1}  # the datafile
 EDM_NAME=${2}  # the name of the EDM
 COMP_BASE_FOLDER=${3}  # where the source to compare against is
-CLANG_FORMAT=${4}  # whether to use clang-format
-shift 4
+shift 3
 EXTRA_GEN_ARGS=${@}
 
-if [ ${CLANG_FORMAT} = "ON"] || [ ${CLANG_FORMAT} = "AUTO" ]; then
+if [ ${PODIO_USE_CLANG_FORMAT} = "ON" ] || [ ${PODIO_USE_CLANG_FORMAT} = "AUTO" ]; then
     EXTRA_GEN_ARGS="${EXTRA_GEN_ARGS} --clangformat"
 fi
 

--- a/tests/scripts/dumpModelRoundTrip.sh
+++ b/tests/scripts/dumpModelRoundTrip.sh
@@ -3,15 +3,13 @@
 # the original definition. Essentially does not check that the YAML file is the
 # same, but rather that the generated code is the same
 
-set -e
+set -eux
 
-EXCLUDE_SIO=${1}  # SIO excluded or not
-INPUT_FILE=${2}  # the datafile
-EDM_NAME=${3}  # the name of the EDM
-COMP_BASE_FOLDER=""  # where the source to compare against is
-if [ -$# -gt 3 ]; then
-    COMP_BASE_FOLDER=${4}
-fi
+INPUT_FILE=${1}  # the datafile
+EDM_NAME=${2}  # the name of the EDM
+COMP_BASE_FOLDER=${3}  # where the source to compare against is
+shift 3
+EXTRA_GEN_ARGS=${@}
 
 # Create a few temporary but unique files and directories to store output
 DUMPED_MODEL=${INPUT_FILE}.dumped_${EDM_NAME}.yaml
@@ -24,6 +22,7 @@ ${PODIO_BASE}/tools/podio-dump --dump-edm ${EDM_NAME} ${INPUT_FILE} > ${DUMPED_M
 # Regenerate the code via the class generator and the freshly dumped model
 ${PODIO_BASE}/python/podio_class_generator.py \
     --clangformat \
+    ${EXTRA_GEN_ARGS} \
     ${DUMPED_MODEL} \
     ${OUTPUT_FOLDER} \
     ${EDM_NAME} \
@@ -32,11 +31,11 @@ ${PODIO_BASE}/python/podio_class_generator.py \
 # Compare to the originally generated code, that has been used to write the data
 # file. Need to diff subfolders explitly here because $PODIO_BASE/tests contains
 # more stuff
-if [ ${EXCLUDE_SIO} = "true" ]; then
-diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/${EDM_NAME} --exclude='*SIO*'
-diff -ru ${OUTPUT_FOLDER}/src ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/src --exclude='*SIO*'
-else
-diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/${EDM_NAME} 
-diff -ru ${OUTPUT_FOLDER}/src ${PODIO_BASE}/tests/${COMP_BASE_FOLDER}/src
+DIFF_EXTRA_ARGS=""
+if [ ${ENABLE_SIO} = "OFF" ]; then
+    DIFF_EXTRA_ARGS=--exclude='*SIO*'
 fi
-diff -u ${OUTPUT_FOLDER}/podio_generated_files.cmake ${PODIO_BASE}/tests/podio_generated_files.cmake
+
+diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${COMP_BASE_FOLDER}/${EDM_NAME} ${DIFF_EXTRA_ARGS}
+diff -ru ${OUTPUT_FOLDER}/src ${COMP_BASE_FOLDER}/src ${DIFF_EXTRA_ARGS}
+diff -u ${OUTPUT_FOLDER}/podio_generated_files.cmake ${COMP_BASE_FOLDER}/podio_generated_files.cmake


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that the dump model round trip tests work without `ENABLE_SIO`
- Actually test the extension model dumping

ENDRELEASENOTES

This allows not to have to cleanup a few folders in `test` in case the SIO files are present, which would break the tests. Useful in case one is switching between SIO and non-SIO for example