### PR TITLE
Add .cache to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ spack*
 # Tooling
 /.clangd/
 /compile_commands.json
+/.cache/
 
 # Generated files
 *podio_generated_files.cmake


### PR DESCRIPTION
BEGINRELEASENOTES
- Add .cache to the gitignore

ENDRELEASENOTES

from `clangd` indexing.