### PR TITLE
Check for all the arguments that are going to be used for clang-format

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -40,10 +40,14 @@ REPORT_TEXT = """
 def get_clang_format():
   """Check if clang format is available and if so get the list of arguments to
   invoke it via subprocess.Popen"""
-  try:
-    cformat_exe = subprocess.check_output(['which', 'clang-format']).strip()
-    return [cformat_exe, "-style=file", "-fallback-style=llvm"]
-  except subprocess.CalledProcessError:
+  try :
+    out = subprocess.check_output(["clang-format", "-style=file", "-fallback-style=llvm", "--help"], stderr=subprocess.STDOUT)
+    if b'Unknown' in out:
+      print('ERROR: At least one argument was not recognized by clang-format')
+      print('       Most likely the version you are using is old')
+      return []
+    return ["clang-format", "-style=file", "-fallback-style=llvm"]
+  except FileNotFoundError:
     print("ERROR: Cannot find clang-format executable")
     print("       Please make sure it is in the PATH.")
     return []

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -46,6 +46,9 @@ def get_clang_format():
       print('ERROR: At least one argument was not recognized by clang-format')
       print('       Most likely the version you are using is old')
       return []
+    out = subprocess.check_output('echo | clang-format -style=file ', stderr=subprocess.STDOUT, shell=True)
+    if b'.clang-format' in out:
+      return []
     return ["clang-format", "-style=file", "-fallback-style=llvm"]
   except FileNotFoundError:
     print("ERROR: Cannot find clang-format executable")

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -40,8 +40,9 @@ REPORT_TEXT = """
 def get_clang_format():
   """Check if clang format is available and if so get the list of arguments to
   invoke it via subprocess.Popen"""
-  try :
-    out = subprocess.check_output(["clang-format", "-style=file", "-fallback-style=llvm", "--help"], stderr=subprocess.STDOUT)
+  try:
+    out = subprocess.check_output(["clang-format", "-style=file", "-fallback-style=llvm", "--help"],
+                                  stderr=subprocess.STDOUT)
     if b'Unknown' in out:
       print('ERROR: At least one argument was not recognized by clang-format')
       print('       Most likely the version you are using is old')


### PR DESCRIPTION
BEGINRELEASENOTES
- Modify the initial `clang-format` check to try to run with all the arguments that will be used later

ENDRELEASENOTES

Fixes #388. Testing works fine with a recent version of `clang-format`. Should be fine with older versions (we can let the nightly test this).