### PR TITLE
Decouple the collection buffer creation from the collection

### DIFF
--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -52,9 +52,9 @@ public:
 
   /// Create (empty) collection buffers from which a collection can be constructed
   /// Versioned to support schema evolution
-  virtual podio::CollectionReadBuffers createSchemaEvolvableBuffers(int readSchemaVersion,
-                                                                    podio::Backend backend) /*const*/
-      = 0;
+  // virtual podio::CollectionReadBuffers createSchemaEvolvableBuffers(int readSchemaVersion,
+  //                                                                   podio::Backend backend) /*const*/
+  //     = 0;
 
   /// check for validity of the container after read
   virtual bool isValid() const = 0;

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -47,15 +47,6 @@ public:
   /// Get the collection buffers for this collection
   virtual podio::CollectionWriteBuffers getBuffers() = 0;
 
-  /// Create (empty) collection buffers from which a collection can be constructed
-  virtual podio::CollectionReadBuffers createBuffers() /*const*/ = 0;
-
-  /// Create (empty) collection buffers from which a collection can be constructed
-  /// Versioned to support schema evolution
-  // virtual podio::CollectionReadBuffers createSchemaEvolvableBuffers(int readSchemaVersion,
-  //                                                                   podio::Backend backend) /*const*/
-  //     = 0;
-
   /// check for validity of the container after read
   virtual bool isValid() const = 0;
 

--- a/include/podio/CollectionBufferFactory.h
+++ b/include/podio/CollectionBufferFactory.h
@@ -12,35 +12,71 @@
 namespace podio {
 
 /**
- * Registry like type that provides empty buffers for collections
+ * The CollectionBufferFactory allows to create buffers of known datatypes,
+ * which can then be populated by e.g. readers. In order to support schema
+ * evolution, the buffers have a version and this factory will also require a
+ * schema version to create buffers.
+ *
+ * It is implemented as a singleton, which is populated at the time a shared
+ * datamodel library is loaded. It is assumed that that happens early on in the
+ * startup of an appliation, such that only a single thread will access the
+ * factory instance for registering datatypes. Since the necessary creation
+ * functions are part of the core datamodel library, this should be very easy to
+ * achieve by simply linking to that library. Once the factory is populated it
+ * can be safely accessed from multiple threads concurrently to obtain buffers.
  */
 class CollectionBufferFactory {
   /// Internal storage is a map to an array of creation functions, where the
   /// version determines the place in that array. This should be a viable
-  /// approach because we now the "latest and greatest" schema version
+  /// approach because we know the "latest and greatest" schema version
   using CreationFuncT = std::function<podio::CollectionReadBuffers(bool)>;
   using VersionMapT = std::vector<CreationFuncT>;
   using MapT = std::unordered_map<std::string, VersionMapT>;
 
 public:
+  /// The buffer factory is a singleton so we disable all copy and move
+  /// constructors explicitly
   CollectionBufferFactory(CollectionBufferFactory const&) = delete;
   CollectionBufferFactory& operator=(CollectionBufferFactory const&) = delete;
   CollectionBufferFactory(CollectionBufferFactory&&) = delete;
   CollectionBufferFactory& operator=(CollectionBufferFactory&&) = delete;
   ~CollectionBufferFactory() = default;
 
+  /// Mutable instance only used for the initial registration of functions
+  /// during library loading
   static CollectionBufferFactory& mutInstance();
+  /// Get the factory instance
   static CollectionBufferFactory const& instance();
 
+  /**
+   * Create buffers for a given collection type of a given schema version.
+   *
+   * @param collType The collection type name (e.g. from collection->getTypeName())
+   * @param version The schema version the created buffers should have
+   * @param susbsetColl Should the buffers be for a subset collection or not
+   *
+   * @return CollectionReadBuffers if a creation function for this collection
+   * type has been registered, otherwise an empty optional
+   */
   std::optional<podio::CollectionReadBuffers> createBuffers(const std::string& collType, SchemaVersionT version,
                                                             bool subsetColl) const;
-
+  /**
+   * Register a creation function for a given collection type and schema version.
+   *
+   * @param collType The collection type name (i.e. what
+   * collection->getTypeName() returns)
+   * @param version The schema version for which this creation function is valid
+   * @param creationFunc The function that when invoked returns buffers for this
+   * collection type and schema version. The signature has to be
+   * podio::CollectionReadBuffers(bool) where the boolean parameter steers
+   * whether the buffers are for a subset collection or not.
+   */
   void registerCreationFunc(const std::string& collType, SchemaVersionT version, const CreationFuncT& creationFunc);
 
 private:
   CollectionBufferFactory() = default;
 
-  MapT m_funcMap{};
+  MapT m_funcMap{}; ///< Map to the creation functions
 };
 
 } // namespace podio

--- a/include/podio/CollectionBufferFactory.h
+++ b/include/podio/CollectionBufferFactory.h
@@ -1,0 +1,48 @@
+#ifndef PODIO_COLLECTIONBUFFERFACTORY_H
+#define PODIO_COLLECTIONBUFFERFACTORY_H
+
+#include "podio/CollectionBuffers.h"
+#include "podio/SchemaEvolution.h"
+
+#include <functional>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace podio {
+
+/**
+ * Registry like type that provides empty buffers for collections
+ */
+class CollectionBufferFactory {
+  /// Internal storage is a map to an array of creation functions, where the
+  /// version determines the place in that array. This should be a viable
+  /// approach because we now the "latest and greatest" schema version
+  using CreationFuncT = std::function<podio::CollectionReadBuffers(bool)>;
+  using VersionMapT = std::vector<CreationFuncT>;
+  using MapT = std::unordered_map<std::string, VersionMapT>;
+
+public:
+  CollectionBufferFactory(CollectionBufferFactory const&) = delete;
+  CollectionBufferFactory& operator=(CollectionBufferFactory const&) = delete;
+  CollectionBufferFactory(CollectionBufferFactory&&) = delete;
+  CollectionBufferFactory& operator=(CollectionBufferFactory&&) = delete;
+  ~CollectionBufferFactory() = default;
+
+  static CollectionBufferFactory& mutInstance();
+  static CollectionBufferFactory const& instance();
+
+  std::optional<podio::CollectionReadBuffers> createBuffers(const std::string& collType, SchemaVersionT version,
+                                                            bool subsetColl) const;
+
+  void registerCreationFunc(const std::string& collType, SchemaVersionT version, const CreationFuncT& creationFunc);
+
+private:
+  CollectionBufferFactory() = default;
+
+  MapT m_funcMap{};
+};
+
+} // namespace podio
+
+#endif // PODIO_COLLECTIONBUFFERFACTORY_H

--- a/include/podio/ROOTFrameReader.h
+++ b/include/podio/ROOTFrameReader.h
@@ -25,9 +25,10 @@ class TTree;
 namespace podio {
 
 namespace detail {
-  // Information about the data vector as wall as the collection class type
-  // and the index in the collection branches cache vector
-  using CollectionInfo = std::tuple<const TClass*, const TClass*, size_t>;
+  // Information about the collection class type, whether it is a subset, the
+  // schema version on file and the index in the collection branches cache
+  // vector
+  using CollectionInfo = std::tuple<std::string, bool, SchemaVersionT, size_t>;
 
 } // namespace detail
 

--- a/include/podio/ROOTLegacyReader.h
+++ b/include/podio/ROOTLegacyReader.h
@@ -23,10 +23,10 @@ class TTree;
 namespace podio {
 
 namespace detail {
-  // Information about the data vector as wall as the collection class type
-  // and the index in the collection branches cache vector
-  using CollectionInfo = std::tuple<const TClass*, const TClass*, size_t>;
-
+  // Information about the collection class type, whether it is a subset, the
+  // schema version on file and the index in the collection branches cache
+  // vector
+  using CollectionInfo = std::tuple<std::string, bool, SchemaVersionT, size_t>;
 } // namespace detail
 
 class EventStore;

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -78,15 +78,16 @@ public:
     return sio::block::name();
   }
 
+  void setSubsetCollection(bool subsetColl) {
+    m_subsetColl = subsetColl;
+  }
+
   void setCollection(podio::CollectionBase* col) {
     m_subsetColl = col->isSubsetCollection();
     m_buffers = col->getBuffers();
   }
 
   virtual SIOBlock* create(const std::string& name) const = 0;
-
-  // create a new collection for this block
-  virtual void createBuffers(const bool subsetCollection = false) = 0;
 
 protected:
   bool m_subsetColl{false};

--- a/include/podio/SIOBlockUserData.h
+++ b/include/podio/SIOBlockUserData.h
@@ -1,6 +1,7 @@
 #ifndef PODIO_SIOBLOCKUSERDATA_H
 #define PODIO_SIOBLOCKUSERDATA_H
 
+#include "podio/CollectionBufferFactory.h"
 #include "podio/CollectionBuffers.h"
 #include "podio/SIOBlock.h"
 #include "podio/UserDataCollection.h"
@@ -29,17 +30,22 @@ namespace podio {
 template <typename BasicType, typename = EnableIfSupportedUserType<BasicType>>
 class SIOBlockUserData : public podio::SIOBlock {
 public:
-  SIOBlockUserData() : SIOBlock(::sio_name<BasicType>(), sio::version::encode_version(0, 1)) {
+  SIOBlockUserData() :
+      SIOBlock(::sio_name<BasicType>(), sio::version::encode_version(UserDataCollection<BasicType>::schemaVersion, 0)) {
 
     podio::SIOBlockFactory::instance().registerBlockForCollection(podio::userDataTypeName<BasicType>(), this);
   }
 
-  SIOBlockUserData(const std::string& name) : SIOBlock(name, sio::version::encode_version(0, 1)) {
+  SIOBlockUserData(const std::string& name) :
+      SIOBlock(name, sio::version::encode_version(UserDataCollection<BasicType>::schemaVersion, 0)) {
   }
 
-  void read(sio::read_device& device, sio::version_type /*version*/) override {
+  void read(sio::read_device& device, sio::version_type version) override {
     const auto& bufferFactory = podio::CollectionBufferFactory::instance();
-    m_buffers = bufferFactory.createBuffers(podio::userDataCollTypeName<BasicType>(), 1, false).value();
+    m_buffers =
+        bufferFactory
+            .createBuffers(podio::userDataCollTypeName<BasicType>(), sio::version::major_version(version), false)
+            .value();
 
     auto* dataVec = new std::vector<BasicType>();
     unsigned size(0);

--- a/include/podio/SIOBlockUserData.h
+++ b/include/podio/SIOBlockUserData.h
@@ -38,6 +38,9 @@ public:
   }
 
   void read(sio::read_device& device, sio::version_type /*version*/) override {
+    const auto& bufferFactory = podio::CollectionBufferFactory::instance();
+    m_buffers = bufferFactory.createBuffers(podio::userDataCollTypeName<BasicType>(), 1, false).value();
+
     auto* dataVec = new std::vector<BasicType>();
     unsigned size(0);
     device.data(size);
@@ -51,17 +54,6 @@ public:
     unsigned size = dataVec->size();
     device.data(size);
     podio::handlePODDataSIO(device, &(*dataVec)[0], size);
-  }
-
-  void createBuffers(bool) override {
-
-    m_buffers.references = new podio::CollRefCollection();
-    m_buffers.vectorMembers = new podio::VectorMembersInfo();
-
-    // Nothing to do here since UserDataCollections cannot be subset collections
-    m_buffers.createCollection = [](podio::CollectionReadBuffers buffers, bool) {
-      return std::make_unique<UserDataCollection<BasicType>>(std::move(*buffers.dataAsVector<BasicType>()));
-    };
   }
 
   SIOBlock* create(const std::string& name) const override {

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -118,9 +118,7 @@ public:
             }};
   }
 
-  podio::CollectionReadBuffers createSchemaEvolvableBuffers(__attribute__((unused)) int readSchemaVersion,
-                                                            __attribute__((unused))
-                                                            podio::Backend backend) /*const*/ final {
+  podio::CollectionReadBuffers createSchemaEvolvableBuffers(int, podio::Backend) /*const*/ final {
     return createBuffers();
   }
 

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -119,15 +119,6 @@ public:
     return {&_vecPtr, &m_refCollections, &m_vecmem_info};
   }
 
-  podio::CollectionReadBuffers createBuffers() /*const*/ final {
-    const auto type = std::string("podio::UserDataCollection<") + userDataTypeName<BasicType>() + ">";
-    return CollectionBufferFactory::instance().createBuffers(type, 1, false).value();
-  }
-
-  // podio::CollectionReadBuffers createSchemaEvolvableBuffers(int, podio::Backend) /*const*/ final {
-  //   return createBuffers();
-  // }
-
   /// check for validity of the container after read
   bool isValid() const override {
     return true;

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -124,9 +124,9 @@ public:
     return CollectionBufferFactory::instance().createBuffers(type, 1, false).value();
   }
 
-  podio::CollectionReadBuffers createSchemaEvolvableBuffers(int, podio::Backend) /*const*/ final {
-    return createBuffers();
-  }
+  // podio::CollectionReadBuffers createSchemaEvolvableBuffers(int, podio::Backend) /*const*/ final {
+  //   return createBuffers();
+  // }
 
   /// check for validity of the container after read
   bool isValid() const override {

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -2,9 +2,9 @@
 #define PODIO_USERDATACOLLECTION_H
 
 #include "podio/CollectionBase.h"
-#include "podio/CollectionBufferFactory.h"
 #include "podio/CollectionBuffers.h"
 #include "podio/DatamodelRegistry.h"
+#include "podio/SchemaEvolution.h"
 #include "podio/utilities/TypeHelpers.h"
 
 #include <map>
@@ -90,6 +90,9 @@ public:
   UserDataCollection& operator=(UserDataCollection&&) = default;
   ~UserDataCollection() = default;
 
+  /// The schema version of UserDataCollections
+  static constexpr SchemaVersionT schemaVersion = 1;
+
   /// prepare buffers for serialization
   void prepareForWrite() const override {
   }
@@ -160,7 +163,7 @@ public:
 
   /// The schema version is fixed manually
   SchemaVersionT getSchemaVersion() const final {
-    return 1;
+    return schemaVersion;
   }
 
   /// Print this collection to the passed stream

--- a/python/podio/generator_utils.py
+++ b/python/podio/generator_utils.py
@@ -71,10 +71,9 @@ def _is_fixed_width_type(type_name):
 class DataType:
   """Simple class to hold information about a datatype or component that is
   defined in the datamodel."""
-  def __init__(self, klass, schema_version):
+  def __init__(self, klass):
     self.full_type = klass
     self.namespace, self.bare_type = _get_namespace_class(self.full_type)
-    self.schema_version = schema_version
 
   def __str__(self):
     if self.namespace:

--- a/python/podio/podio_config_reader.py
+++ b/python/podio/podio_config_reader.py
@@ -412,10 +412,12 @@ class PodioConfigReader:
 
     if "schema_version" in model_dict:
       schema_version = model_dict["schema_version"]
+      if int(schema_version) <= 0:
+        raise DefinitionError(f"schema_version has to be larger than 0 (is {schema_version})")
     else:
-      warnings.warn("Please provide a schema_version entry. It will become mandatory. Setting it to 0 as default",
+      warnings.warn("Please provide a schema_version entry. It will become mandatory. Setting it to 1 as default",
                     FutureWarning, stacklevel=3)
-      schema_version = 0
+      schema_version = 1
 
     components = {}
     if "components" in model_dict:

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -118,7 +118,6 @@ class ClassGenerator:
     self.incfolder = self.datamodel.options['includeSubfolder']
     self.expose_pod_members = self.datamodel.options["exposePODMembers"]
     self.upstream_edm = upstream_edm
-    self.schema_version = self.datamodel.schema_version
 
     self.clang_format = []
     self.generated_files = []
@@ -264,7 +263,7 @@ have resolvable schema evolution incompatibilities:")
     includes.update(component.get("ExtraCode", {}).get("includes", "").split('\n'))
 
     component['includes'] = self._sort_includes(includes)
-    component['class'] = DataType(name, self.schema_version)
+    component['class'] = DataType(name)
 
     self._fill_templates('Component', component)
 
@@ -411,7 +410,7 @@ have resolvable schema evolution incompatibilities:")
     # Make a copy here and add the preprocessing steps to that such that the
     # original definition can be left untouched
     data = deepcopy(definition)
-    data['class'] = DataType(name, self.schema_version)
+    data['class'] = DataType(name)
     data['includes_data'] = self._get_member_includes(definition["Members"])
     self._preprocess_for_class(data)
     self._preprocess_for_obj(data)
@@ -495,9 +494,9 @@ have resolvable schema evolution incompatibilities:")
 
   def _create_selection_xml(self):
     """Create the selection xml that is necessary for ROOT I/O"""
-    data = {'components': [DataType(c, self.schema_version) for c in self.datamodel.components],
-            'datatypes': [DataType(d, self.schema_version) for d in self.datamodel.datatypes],
-            'old_schema_components': [DataType(d, self.schema_version) for d in
+    data = {'components': [DataType(c) for c in self.datamodel.components],
+            'datatypes': [DataType(d) for d in self.datamodel.datatypes],
+            'old_schema_components': [DataType(d) for d in
                                       self.old_datamodels_datatypes | self.old_datamodels_components]}
     self._write_file('selection.xml', self._eval_template('selection.xml.jinja2', data))
 

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -426,6 +426,7 @@ have resolvable schema evolution incompatibilities:")
         'package_name': self.package_name,
         'edm_definition': model_encoder.encode(self.datamodel),
         'incfolder': self.incfolder,
+        'schema_version': self.datamodel.schema_version,
         }
 
     self._write_file('DatamodelDefinition.h',

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -177,7 +177,7 @@ podio::CollectionReadBuffers {{ collection_type }}::createBuffers() /*const*/ {
 
 podio::CollectionReadBuffers {{ collection_type }}::createSchemaEvolvableBuffers(int readSchemaVersion, podio::Backend /*backend*/) /*const*/ {
   // no version difference -> no-op
-  if (readSchemaVersion == {{ class.schema_version }}) {
+  if (readSchemaVersion == {{ package_name }}::meta::schemaVersion) {
     return createBuffers();
   }
   // default is no-op as well
@@ -191,6 +191,10 @@ podio::CollectionReadBuffers {{ collection_type }}::createSchemaEvolvableBuffers
 
 size_t {{ collection_type }}::getDatamodelRegistryIndex() const {
   return {{ package_name }}::meta::DatamodelRegistryIndex::value();
+}
+
+podio::SchemaVersionT {{ collection_type }}::getSchemaVersion() const {
+  return {{ package_name }}::meta::schemaVersion;
 }
 
 #ifdef PODIO_JSON_OUTPUT

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -175,14 +175,14 @@ podio::CollectionReadBuffers {{ collection_type }}::createBuffers() /*const*/ {
   return readBuffers;
 }
 
-podio::CollectionReadBuffers {{ collection_type }}::createSchemaEvolvableBuffers(int readSchemaVersion, podio::Backend /*backend*/) /*const*/ {
-  // no version difference -> no-op
-  if (readSchemaVersion == {{ package_name }}::meta::schemaVersion) {
-    return createBuffers();
-  }
-  // default is no-op as well
-  return createBuffers();
-}
+// podio::CollectionReadBuffers {{ collection_type }}::createSchemaEvolvableBuffers(int readSchemaVersion, podio::Backend /*backend*/) /*const*/ {
+//   // no version difference -> no-op
+//   if (readSchemaVersion == {{ package_name }}::meta::schemaVersion) {
+//     return createBuffers();
+//   }
+//   // default is no-op as well
+//   return createBuffers();
+// }
 
 
 {% for member in Members %}

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -152,41 +152,6 @@ podio::CollectionWriteBuffers {{ collection_type }}::getBuffers() {
   return m_storage.getCollectionBuffers(m_isSubsetColl);
 }
 
-podio::CollectionReadBuffers {{ collection_type }}::createBuffers() /*const*/ {
-  // Very cumbersome way at the moment. We get the actual buffers to have the
-  // references and vector members sized appropriately (we will use this
-  // information to create new buffers outside)
-  auto collBuffers = m_storage.getCollectionBuffers(m_isSubsetColl);
-  auto readBuffers = podio::CollectionReadBuffers{};
-  readBuffers.references = collBuffers.references;
-  readBuffers.vectorMembers = collBuffers.vectorMembers;
-  readBuffers.createCollection = [](podio::CollectionReadBuffers buffers, bool isSubsetColl) {
-      {{ collection_type }}Data data(buffers, isSubsetColl);
-      return std::make_unique<{{ collection_type }}>(std::move(data), isSubsetColl);
-  };
-  readBuffers.recast = [](podio::CollectionReadBuffers& buffers) {
-    if (buffers.data) {
-      buffers.data = podio::CollectionWriteBuffers::asVector<{{ class.full_type }}Data>(buffers.data);
-    }
-{% if VectorMembers %}
-{% for member in VectorMembers %}
-    (*buffers.vectorMembers)[{{ loop.index0 }}].second = podio::CollectionWriteBuffers::asVector<{{ member.full_type }}>((*buffers.vectorMembers)[{{ loop.index0 }}].second);
-{% endfor %}
-{% endif %}
-  };
-  return readBuffers;
-}
-
-// podio::CollectionReadBuffers {{ collection_type }}::createSchemaEvolvableBuffers(int readSchemaVersion, podio::Backend /*backend*/) /*const*/ {
-//   // no version difference -> no-op
-//   if (readSchemaVersion == {{ package_name }}::meta::schemaVersion) {
-//     return createBuffers();
-//   }
-//   // default is no-op as well
-//   return createBuffers();
-// }
-
-
 {% for member in Members %}
 {{ macros.vectorized_access(class, member) }}
 {% endfor %}

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -3,6 +3,8 @@
 {% from "macros/iterator.jinja2" import iterator_definitions %}
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
+#include "podio/CollectionBufferFactory.h"
+
 #include "{{ incfolder }}{{ class.bare_type }}Collection.h"
 #include "{{ incfolder }}DatamodelDefinition.h"
 
@@ -196,6 +198,56 @@ size_t {{ collection_type }}::getDatamodelRegistryIndex() const {
 podio::SchemaVersionT {{ collection_type }}::getSchemaVersion() const {
   return {{ package_name }}::meta::schemaVersion;
 }
+
+namespace {
+podio::CollectionReadBuffers createBuffers(bool isSubset) {
+  auto readBuffers = podio::CollectionReadBuffers{};
+  readBuffers.data = isSubset ? nullptr : new {{ class.bare_type }}DataContainer;
+
+  // The number of ObjectID vectors is either 1 or the sum of OneToMany and
+  // OneToOne relations
+  const auto nRefs = isSubset ? 1 : {{ OneToManyRelations | length }} + {{ OneToOneRelations | length }};
+  readBuffers.references = new podio::CollRefCollection(nRefs);
+
+  readBuffers.vectorMembers = new podio::VectorMembersInfo();
+  if (!isSubset) {
+    readBuffers.vectorMembers->reserve({{ VectorMembers | length }});
+{% for member in VectorMembers %}
+    readBuffers.vectorMembers->emplace_back("{{ member.full_type }}", new std::vector<{{ member.full_type }}>);
+{% endfor %}
+  }
+
+  readBuffers.createCollection = [](podio::CollectionReadBuffers buffers, bool isSubsetColl) {
+    {{ collection_type }}Data data(buffers, isSubsetColl);
+    return std::make_unique<{{ collection_type }}>(std::move(data), isSubsetColl);
+  };
+
+  readBuffers.recast = [](podio::CollectionReadBuffers& buffers) {
+    if (buffers.data) {
+      buffers.data = podio::CollectionWriteBuffers::asVector<{{ class.full_type }}Data>(buffers.data);
+    }
+{% if VectorMembers %}
+{% for member in VectorMembers %}
+    (*buffers.vectorMembers)[{{ loop.index0 }}].second = podio::CollectionWriteBuffers::asVector<{{ member.full_type }}>((*buffers.vectorMembers)[{{ loop.index0 }}].second);
+{% endfor %}
+{% endif %}
+  };
+
+  return readBuffers;
+}
+
+bool registerCollection() {
+  const static auto reg = []() {
+    auto& factory = podio::CollectionBufferFactory::mutInstance();
+    factory.registerCreationFunc("{{ class.full_type }}Collection", {{ package_name }}::meta::schemaVersion, createBuffers);
+    return true;
+  }();
+  return reg;
+}
+
+const auto registeredCollection = registerCollection();
+} // namespace
+
 
 #ifdef PODIO_JSON_OUTPUT
 void to_json(nlohmann::json& j, const {{ collection_type }}& collection) {

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -164,6 +164,9 @@ podio::SchemaVersionT {{ collection_type }}::getSchemaVersion() const {
   return {{ package_name }}::meta::schemaVersion;
 }
 
+// anonymous namespace for registration with the CollectionBufferFactory. This
+// ensures that we don't have to make up arbitrary namespace names here, since
+// none of this is publicly visible
 namespace {
 podio::CollectionReadBuffers createBuffers(bool isSubset) {
   auto readBuffers = podio::CollectionReadBuffers{};
@@ -205,6 +208,8 @@ podio::CollectionReadBuffers createBuffers(bool isSubset) {
   return readBuffers;
 }
 
+// The usual trick with an IIFE and a static variable inside a funtion and then
+// making sure to call that function during shared library loading
 bool registerCollection() {
   const static auto reg = []() {
     auto& factory = podio::CollectionBufferFactory::mutInstance();

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -173,6 +173,10 @@ podio::CollectionReadBuffers createBuffers(bool isSubset) {
   // OneToOne relations
   const auto nRefs = isSubset ? 1 : {{ OneToManyRelations | length }} + {{ OneToOneRelations | length }};
   readBuffers.references = new podio::CollRefCollection(nRefs);
+  for (auto& ref : *readBuffers.references) {
+    // Make sure to place usable buffer pointers here
+    ref = std::make_unique<std::vector<podio::ObjectID>>();
+  }
 
   readBuffers.vectorMembers = new podio::VectorMembersInfo();
   if (!isSubset) {

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -84,7 +84,7 @@ public:
   /// fully qualified type name of stored POD elements - with namespace
   std::string getDataTypeName() const final { return std::string("{{ (class | string ).strip(':')+"Data" }}"); }
   /// schema version
-  unsigned int getSchemaVersion() const final { return {{ class.schema_version }}; };
+  podio::SchemaVersionT getSchemaVersion() const final;
 
   bool isSubsetCollection() const final {
     return m_isSubsetColl;

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -117,7 +117,7 @@ public:
 
   /// Create (empty) collection buffers from which a collection can be constructed
   /// Versioned to support schema evolution
-  podio::CollectionReadBuffers createSchemaEvolvableBuffers(int readSchemaVersion, podio::Backend backend) /*const*/ final;
+  // podio::CollectionReadBuffers createSchemaEvolvableBuffers(int readSchemaVersion, podio::Backend backend) /*const*/ final;
 
 
   void setID(unsigned ID) final {

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -112,14 +112,6 @@ public:
   /// Get the collection buffers for this collection
   podio::CollectionWriteBuffers getBuffers() final;
 
-  /// Create (empty) collection buffers from which a collection can be constructed
-  podio::CollectionReadBuffers createBuffers() /*const*/ final;
-
-  /// Create (empty) collection buffers from which a collection can be constructed
-  /// Versioned to support schema evolution
-  // podio::CollectionReadBuffers createSchemaEvolvableBuffers(int readSchemaVersion, podio::Backend backend) /*const*/ final;
-
-
   void setID(unsigned ID) final {
     m_collectionID = ID;
     if (!m_isSubsetColl) {

--- a/python/templates/DatamodelDefinition.h.jinja2
+++ b/python/templates/DatamodelDefinition.h.jinja2
@@ -1,6 +1,7 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
 #include "podio/DatamodelRegistry.h"
+#include "podio/SchemaEvolution.h"
 
 namespace {{ package_name }}::meta {
 /**
@@ -26,5 +27,7 @@ private:
   DatamodelRegistryIndex(size_t v) : m_value(v) {}
   size_t m_value{podio::DatamodelRegistry::NoDefinitionAvailable};
 };
+
+static constexpr podio::SchemaVersionT schemaVersion = {{ schema_version }};
 
 } // namespace {{ package_name }}::meta

--- a/python/templates/DatamodelDefinition.h.jinja2
+++ b/python/templates/DatamodelDefinition.h.jinja2
@@ -28,6 +28,9 @@ private:
   size_t m_value{podio::DatamodelRegistry::NoDefinitionAvailable};
 };
 
+/**
+ * The schema version at generation time
+ */
 static constexpr podio::SchemaVersionT schemaVersion = {{ schema_version }};
 
 } // namespace {{ package_name }}::meta

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -15,12 +15,11 @@
 {{ utils.namespace_open(class.namespace) }}
 {% with block_class = class.bare_type + 'SIOBlock' %}
 
-void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
+void {{ block_class }}::read(sio::read_device& device, sio::version_type version) {
   const auto& bufferFactory = podio::CollectionBufferFactory::instance();
   // TODO:
-  // - Actually handle schema versions, instead of going for a hardcoded one
   // - Error handling of empty optional
-  auto maybeBuffers = bufferFactory.createBuffers("{{ class.full_type }}Collection", 1, m_subsetColl);
+  auto maybeBuffers = bufferFactory.createBuffers("{{ class.full_type }}Collection", sio::version::major_version(version), m_subsetColl);
   m_buffers = maybeBuffers.value_or(podio::CollectionReadBuffers{});
 
   if (not m_subsetColl) {

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -6,6 +6,7 @@
 #include "{{ incfolder }}{{ class.bare_type }}Collection.h"
 
 #include "podio/CollectionBuffers.h"
+#include "podio/CollectionBufferFactory.h"
 
 #include <sio/block.h>
 #include <sio/io_device.h>
@@ -15,21 +16,12 @@
 {% with block_class = class.bare_type + 'SIOBlock' %}
 
 void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
-  if (m_subsetColl) {
-    m_buffers.references->emplace_back(std::make_unique<std::vector<podio::ObjectID>>());
-  } else {
-{% for relation in OneToManyRelations + OneToOneRelations %}
-    m_buffers.references->emplace_back(std::make_unique<std::vector<podio::ObjectID>>());
-{% endfor %}
-  }
-
   if (not m_subsetColl) {
     unsigned size(0);
     device.data( size );
     m_buffers.data = new std::vector<{{ class.full_type }}Data>(size);
     auto* dataVec = m_buffers.dataAsVector<{{ class.full_type }}Data>();
     podio::handlePODDataSIO(device, dataVec->data(), size);
-    // m_buffers.data = dataVec;
   }
 
   //---- read ref collections -----
@@ -87,15 +79,21 @@ void {{ block_class }}::write(sio::write_device& device) {
 void {{ block_class }}::createBuffers(bool subsetColl) {
   m_subsetColl = subsetColl;
 
+  const auto& bufferFactory = podio::CollectionBufferFactory::instance();
+  // TODO:
+  // - Actually handle schema versions, instead of going for a hardcoded one
+  // - Error handling of empty optional
+  auto maybeBuffers = bufferFactory.createBuffers("{{ class.full_type }}Collection", 1, subsetColl);
+  m_buffers = maybeBuffers.value_or(podio::CollectionReadBuffers{});
 
+}
 
-  m_buffers.references = new podio::CollRefCollection();
-  m_buffers.vectorMembers = new podio::VectorMembersInfo();
-
-  m_buffers.createCollection = [](podio::CollectionReadBuffers buffers, bool isSubsetColl) {
-    {{ class.bare_type }}CollectionData data(buffers, isSubsetColl);
-    return std::make_unique<{{ class.bare_type }}Collection>(std::move(data), isSubsetColl);
-  };
+namespace {
+  // Create one instance of the type in order to ensure that the SioBlock
+  // library actually needs linking to the core library. Otherwise it is
+  // possible that the registry is not populated when the SioBlock library is
+  // loaded, e.g. when using the python bindings.
+  const auto elem = {{ class.full_type }}{};
 }
 
 {% endwith %}

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -25,8 +25,8 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type version
   if (not m_subsetColl) {
     unsigned size(0);
     device.data( size );
-    m_buffers.data = new std::vector<{{ class.full_type }}Data>(size);
     auto* dataVec = m_buffers.dataAsVector<{{ class.full_type }}Data>();
+    dataVec->resize(size);
     podio::handlePODDataSIO(device, dataVec->data(), size);
   }
 

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -16,6 +16,13 @@
 {% with block_class = class.bare_type + 'SIOBlock' %}
 
 void {{ block_class }}::read(sio::read_device& device, sio::version_type) {
+  const auto& bufferFactory = podio::CollectionBufferFactory::instance();
+  // TODO:
+  // - Actually handle schema versions, instead of going for a hardcoded one
+  // - Error handling of empty optional
+  auto maybeBuffers = bufferFactory.createBuffers("{{ class.full_type }}Collection", 1, m_subsetColl);
+  m_buffers = maybeBuffers.value_or(podio::CollectionReadBuffers{});
+
   if (not m_subsetColl) {
     unsigned size(0);
     device.data( size );
@@ -74,18 +81,6 @@ void {{ block_class }}::write(sio::write_device& device) {
 {{ macros.vector_member_write(member, loop.index0) }}
 {% endfor %}
 {% endif %}
-}
-
-void {{ block_class }}::createBuffers(bool subsetColl) {
-  m_subsetColl = subsetColl;
-
-  const auto& bufferFactory = podio::CollectionBufferFactory::instance();
-  // TODO:
-  // - Actually handle schema versions, instead of going for a hardcoded one
-  // - Error handling of empty optional
-  auto maybeBuffers = bufferFactory.createBuffers("{{ class.full_type }}Collection", 1, subsetColl);
-  m_buffers = maybeBuffers.value_or(podio::CollectionReadBuffers{});
-
 }
 
 namespace {

--- a/python/templates/SIOBlock.h.jinja2
+++ b/python/templates/SIOBlock.h.jinja2
@@ -40,9 +40,6 @@ public:
   void createBuffers(bool isSubsetColl) override;
 
   SIOBlock* create(const std::string& name) const override { return new {{ block_class }}(name); }
-
-private:
-  podio::CollectionReadBuffers createBuffers() const;
 };
 
 static {{ block_class }} _dummy{{ block_class }};

--- a/python/templates/SIOBlock.h.jinja2
+++ b/python/templates/SIOBlock.h.jinja2
@@ -4,6 +4,8 @@
 #ifndef {{ package_name.upper() }}_{{ class.bare_type }}SIOBlock_H
 #define {{ package_name.upper() }}_{{ class.bare_type }}SIOBlock_H
 
+#include "{{ incfolder }}DatamodelDefinition.h"
+
 #include "podio/SIOBlock.h"
 
 #include <sio/api.h>
@@ -23,13 +25,12 @@ namespace podio {
 class {{ block_class }}: public podio::SIOBlock {
 public:
   {{ block_class }}() :
-  SIOBlock("{{ class.bare_type }}", sio::version::encode_version(0, 1)) {
+  SIOBlock("{{ class.bare_type }}", sio::version::encode_version({{ package_name }}::meta::schemaVersion, 0)) {
     podio::SIOBlockFactory::instance().registerBlockForCollection("{{class.full_type}}", this);
   }
 
   {{ block_class }}(const std::string& name) :
-  // SIOBlock(name + "__{{ class.bare_type }}", sio::version::encode_version(0, 1)) {}
-  SIOBlock(name, sio::version::encode_version(0, 1)) {}
+  SIOBlock(name, sio::version::encode_version({{ package_name }}::meta::schemaVersion, 0)) {}
 
   // Read the collection data from the device
   void read(sio::read_device& device, sio::version_type version) override;

--- a/python/templates/SIOBlock.h.jinja2
+++ b/python/templates/SIOBlock.h.jinja2
@@ -37,8 +37,6 @@ public:
   // Write the collection data to the device
   void write(sio::write_device& device) override;
 
-  void createBuffers(bool isSubsetColl) override;
-
   SIOBlock* create(const std::string& name) const override { return new {{ block_class }}(name); }
 };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,8 @@ SET(core_sources
   EventStore.cc
   DatamodelRegistry.cc
   DatamodelRegistryIOHelpers.cc
+  UserDataCollection.cc
+  CollectionBufferFactory.cc
   )
 
 SET(core_headers

--- a/src/CollectionBufferFactory.cc
+++ b/src/CollectionBufferFactory.cc
@@ -1,0 +1,59 @@
+#include "podio/CollectionBufferFactory.h"
+#include "podio/CollectionBuffers.h"
+
+namespace podio {
+CollectionBufferFactory& CollectionBufferFactory::mutInstance() {
+  static CollectionBufferFactory factory;
+  return factory;
+}
+
+CollectionBufferFactory const& CollectionBufferFactory::instance() {
+  return mutInstance();
+}
+
+std::optional<podio::CollectionReadBuffers>
+CollectionBufferFactory::createBuffers(const std::string& collType, SchemaVersionT version, bool subsetColl) const {
+  if (const auto typeIt = m_funcMap.find(collType); typeIt != m_funcMap.end()) {
+    const auto& [_, versionMap] = *typeIt;
+    if (versionMap.size() >= version) {
+      return versionMap[version - 1](subsetColl);
+    }
+  }
+
+  return std::nullopt;
+}
+
+void CollectionBufferFactory::registerCreationFunc(const std::string& collType, SchemaVersionT version,
+                                                   const CreationFuncT& creationFunc) {
+  // Try to create an entry for this collection type with a vector that is sized
+  // to hold all creation functions for all versions up to the passed schema
+  // version
+  auto [typeIt, inserted] = m_funcMap.try_emplace(collType, version);
+  auto& versionMap = typeIt->second;
+
+  // If we already have something for this type, make sure to handle all
+  // versions correctly, assuming that all present creation functions are
+  // unchanged and that all non-present creation functions behave the same as
+  // this (assumed latest) version
+  if (!inserted) {
+    const auto prevSize = versionMap.size();
+    if (prevSize < version) {
+      versionMap.resize(version);
+      for (auto i = prevSize; i < version; ++i) {
+        versionMap[i] = creationFunc;
+      }
+    } else {
+      // In this case we are explicitly updating one specific version
+      versionMap[version - 1] = creationFunc;
+    }
+  } else {
+    // If we have a completely new map, than we simply populate all versions
+    // with this creation function
+    versionMap.reserve(version);
+    for (size_t i = 0; i < version; ++i) {
+      versionMap.emplace_back(creationFunc);
+    }
+  }
+}
+
+} // namespace podio

--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -100,7 +100,7 @@ std::shared_ptr<SIOBlock> SIOBlockFactory::createBlock(const std::string& typeSt
 
   if (it != _map.end()) {
     auto blk = std::shared_ptr<SIOBlock>(it->second->create(name));
-    blk->createBuffers(isSubsetColl);
+    blk->setSubsetCollection(isSubsetColl);
     return blk;
   } else {
     return nullptr;

--- a/src/UserDataCollection.cc
+++ b/src/UserDataCollection.cc
@@ -17,16 +17,17 @@ namespace {
   template <typename T>
   int registerUserDataCollection(T) {
     // Register with schema version 1 to allow for potential changes
-    CollectionBufferFactory::mutInstance().registerCreationFunc(userDataCollTypeName<T>(), 1, [](bool) {
-      return podio::CollectionReadBuffers{new std::vector<T>(), nullptr, nullptr,
-                                          [](podio::CollectionReadBuffers buffers, bool) {
-                                            return std::make_unique<UserDataCollection<T>>(
-                                                std::move(*buffers.dataAsVector<T>()));
-                                          },
-                                          [](podio::CollectionReadBuffers& buffers) {
-                                            buffers.data = podio::CollectionWriteBuffers::asVector<T>(buffers.data);
-                                          }};
-    });
+    CollectionBufferFactory::mutInstance().registerCreationFunc(
+        userDataCollTypeName<T>(), UserDataCollection<T>::schemaVersion, [](bool) {
+          return podio::CollectionReadBuffers{new std::vector<T>(), nullptr, nullptr,
+                                              [](podio::CollectionReadBuffers buffers, bool) {
+                                                return std::make_unique<UserDataCollection<T>>(
+                                                    std::move(*buffers.dataAsVector<T>()));
+                                              },
+                                              [](podio::CollectionReadBuffers& buffers) {
+                                                buffers.data = podio::CollectionWriteBuffers::asVector<T>(buffers.data);
+                                              }};
+        });
 
     return 1;
   }

--- a/src/UserDataCollection.cc
+++ b/src/UserDataCollection.cc
@@ -1,0 +1,53 @@
+#include "podio/UserDataCollection.h"
+#include "podio/CollectionBufferFactory.h"
+#include "podio/CollectionBuffers.h"
+
+#include <tuple>
+#include <vector>
+
+namespace podio {
+
+namespace {
+  /**
+   * Helper function to register a UserDataCollection to the
+   * CollectionBufferFactory. Takes the BasicType as template argument.
+   *
+   * Returns an integer so that it can be used with std::apply
+   */
+  template <typename T>
+  int registerUserDataCollection(T) {
+    // Register with schema version 1 to allow for potential changes
+    CollectionBufferFactory::mutInstance().registerCreationFunc(userDataCollTypeName<T>(), 1, [](bool) {
+      return podio::CollectionReadBuffers{new std::vector<T>(), nullptr, nullptr,
+                                          [](podio::CollectionReadBuffers buffers, bool) {
+                                            return std::make_unique<UserDataCollection<T>>(
+                                                std::move(*buffers.dataAsVector<T>()));
+                                          },
+                                          [](podio::CollectionReadBuffers& buffers) {
+                                            buffers.data = podio::CollectionWriteBuffers::asVector<T>(buffers.data);
+                                          }};
+    });
+
+    return 1;
+  }
+
+  /**
+   * Helper function to loop over all types in the SupportedUserDataTypes to
+   * register the UserDataCollection types.
+   */
+  bool registerUserDataCollections() {
+    // Use an IILE here to make sure to do the call exactly once
+    const static auto reg = []() {
+      std::apply([](auto... x) { std::make_tuple(registerUserDataCollection(x)...); }, SupportedUserDataTypes{});
+      return true;
+    }();
+    return reg;
+  }
+
+  /**
+   * Invoke the registration function for user data collections at least once
+   */
+  const auto registeredUserData = registerUserDataCollections();
+} // namespace
+
+} // namespace podio

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -1,5 +1,5 @@
 ---
-schema_version : 1
+schema_version : 2
 
 options :
   # should getters / setters be prefixed with get / set?

--- a/tests/datalayout_old.yaml
+++ b/tests/datalayout_old.yaml
@@ -1,5 +1,5 @@
 ---
-schema_version : 0
+schema_version : 1
 
 options :
   # should getters / setters be prefixed with get / set?

--- a/tests/schema_evolution.yaml
+++ b/tests/schema_evolution.yaml
@@ -1,6 +1,6 @@
 ---
-from_schema_version : 0
-to_schema_version : 1
+from_schema_version : 1
+to_schema_version : 2
 
 evolutions:
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Introduce a `CollectionBufferFactory` that can create the necessary buffers from a collection type, a schema version and a subset collection flag.
  - Use this factory throughout all existing Readers
  - Remove `createBuffers` and `createSchemaEvolvableBuffers` from `podio::CollectionBase` interface
- Make the minimum allowed `schema_version` 1 in the yaml definition files. Default to 1 if no `schema_version` is provided
- Add a `schemaVersion` to the `DatamodelDefinition.h` header that is generated and that can be accessed via `{{ package_name }}::meta::schemaVersion`. Use this to propagate schema information to the necessary places.
- Make `SIOBlocks` write the current schema version, such that on reading they can generate the appropriate buffers for the version on file.

ENDRELEASENOTES

This PR continues the cleanup of internals and the introduction of full schema evolution capabilities. The most important bit is that it completely disentangles the buffer creation from the collection interface, so that it is now possible to create buffers without having to create a collection first. This is achieved via a `CollectionBufferFactory` (singleton) that is populated during datamodel library loading. The rest of this PR is mainly shuffling some parts of existing code around and removing some other bits that were previously necessary to "steal" the buffers from the collection they were created from.

This does not yet address any schema evolution concerns other than providing the possibility to generate different buffers for different schema versions and the basics for populating the factory with versioned creation function. For actual schema evolution functionality this has to be populated accordingly (either by users or via automatic code generation).

@hegner this introduces an other de-facto registry, but I don't see an easy way around that. We could hide the fact that it is a singleton registry behind an interface of global functions if we wanted to.

This should solve the issue that is currently blocking #257. 

TODO:
- [x] Proper writing of schema version for SIO backend (should be possible to use the version mechanism of SIO here)
- [x] Documentation