### PR TITLE
Add support for the new RNTuple format

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -30,7 +30,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
-            -DUSE_EXTERNAL_CATCH2=AUTO \
+            -DUSE_EXTERNAL_CATCH2=ON \
+            -DENABLE_RNTUPLE=ON \
             -G Ninja ..
           echo "::endgroup::"
           echo "::group::Build"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,9 +30,10 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
-            -DUSE_EXTERNAL_CATCH2=OFF \
-            -DPODIO_SET_RPATH=ON \
-            -G Ninja ..
+                 -DUSE_EXTERNAL_CATCH2=OFF \
+                 -DPODIO_SET_RPATH=ON \
+                 -DENABLE_RNTUPLE=ON \
+                 -G Ninja ..
           echo "::endgroup::"
           echo "::group::Build"
           ninja -k0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,12 +68,17 @@ ADD_CLANG_TIDY()
 option(CREATE_DOC        "Whether or not to create doxygen doc target." OFF)
 option(ENABLE_SIO        "Build SIO I/O support" OFF)
 option(PODIO_RELAX_PYVER "Do not require exact python version match with ROOT" OFF)
+option(ENABLE_RNTUPLE    "Build with support for the new ROOT NTtuple format" OFF)
 
 
 #--- Declare ROOT dependency ---------------------------------------------------
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-find_package(ROOT REQUIRED COMPONENTS RIO Tree)
+if(NOT ENABLE_RNTUPLE)
+  find_package(ROOT REQUIRED COMPONENTS RIO Tree)
+else()
+  find_package(ROOT REQUIRED COMPONENTS RIO Tree ROOTNTuple)
+endif()
 
 # Check that root is compiled with a modern enough c++ standard
 get_target_property(ROOT_COMPILE_FEATURES ROOT::Core INTERFACE_COMPILE_FEATURES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ if(NOT ENABLE_RNTUPLE)
   find_package(ROOT REQUIRED COMPONENTS RIO Tree)
 else()
   find_package(ROOT REQUIRED COMPONENTS RIO Tree ROOTNTuple)
+  if(${ROOT_VERSION} VERSION_LESS 6.28.02)
+    message(FATAL_ERROR "You are trying to build podio with support for the new ROOT NTuple format, but your ROOT version is too old. Please update ROOT to at least version 6.28.02")
 endif()
 
 # Check that root is compiled with a modern enough c++ standard

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ else()
   find_package(ROOT REQUIRED COMPONENTS RIO Tree ROOTNTuple)
   if(${ROOT_VERSION} VERSION_LESS 6.28.02)
     message(FATAL_ERROR "You are trying to build podio with support for the new ROOT NTuple format, but your ROOT version is too old. Please update ROOT to at least version 6.28.02")
+  endif()
 endif()
 
 # Check that root is compiled with a modern enough c++ standard

--- a/include/podio/CollectionBuffers.h
+++ b/include/podio/CollectionBuffers.h
@@ -27,6 +27,7 @@ using VectorMembersInfo = std::vector<std::pair<std::string, void*>>;
  */
 struct CollectionWriteBuffers {
   void* data{nullptr};
+  void* vecPtr{nullptr};
   CollRefCollection* references{nullptr};
   VectorMembersInfo* vectorMembers{nullptr};
 

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -18,6 +18,11 @@ class write_device;
 using version_type = uint32_t; // from sio/definitions
 } // namespace sio
 
+namespace podio {
+class ROOTNTupleReader;
+class ROOTNTupleWriter;
+} // namespace podio
+
 #define DEPR_NON_TEMPLATE                                                                                              \
   [[deprecated("Non-templated access will be removed. Switch to templated access functionality")]]
 
@@ -145,6 +150,8 @@ public:
 
   friend void writeGenericParameters(sio::write_device& device, const GenericParameters& parameters);
   friend void readGenericParameters(sio::read_device& device, GenericParameters& parameters, sio::version_type version);
+  friend ROOTNTupleReader;
+  friend ROOTNTupleWriter;
 
   /// Get a reference to the internal map for a given type
   template <typename T>

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -187,6 +187,7 @@ private:
     }
   }
 
+private:
   /// Get the mutex that guards the map for the given type
   template <typename T>
   std::mutex& getMutex() const {

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -93,11 +93,10 @@ private:
    * collection infos and all necessary meta data to be able to read entries
    * with this name
    */
-  void initCategory(const std::string& category);
+  bool initCategory(const std::string& category);
 
   GenericParameters readEventMetaData(const std::string& name);
 
-  std::vector<std::string> m_availCategories{};                 ///< All available categories from this file
   
   podio::version::Version m_fileVersion{0, 0, 0};
   DatamodelDefinitionHolder m_datamodelHolder{};
@@ -112,6 +111,8 @@ private:
   std::map<std::string, std::vector<std::string>> m_collectionType;
   std::map<std::string, std::vector<bool>> m_isSubsetCollection;
 
+  std::map<std::string, int> m_totalEntries;
+  std::vector<std::string> m_availableCategories;
 
 };
 

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -1,0 +1,120 @@
+#ifndef PODIO_ROOTNTUPLEREADER_H
+#define PODIO_ROOTNTUPLEREADER_H
+
+#include "podio/ROOTFrameData.h"
+#include "podio/CollectionBranches.h"
+#include "podio/ICollectionProvider.h"
+#include "podio/podioVersion.h"
+#include "podio/utilities/DatamodelRegistryIOHelpers.h"
+
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+
+
+namespace rnt = ROOT::Experimental;
+// forward declarations
+class TClass;
+class TFile;
+
+namespace podio {
+
+namespace detail {
+  // Information about the data vector as wall as the collection class type
+  // and the index in the collection branches cache vector
+  using CollectionInfo = std::tuple<const TClass*, const TClass*, size_t>;
+
+} // namespace detail
+
+class EventStore;
+class CollectionBase;
+class Registry;
+class CollectionIDTable;
+class GenericParameters;
+/**
+This class has the function to read available data from disk
+and to prepare collections and buffers.
+**/
+class ROOTNTupleReader{
+  friend EventStore;
+
+public:
+  ROOTNTupleReader() = default;
+  ~ROOTNTupleReader() = default;
+
+  // non-copyable
+  ROOTNTupleReader(const ROOTNTupleReader&) = delete;
+  ROOTNTupleReader& operator=(const ROOTNTupleReader&) = delete;
+
+  void openFile(const std::string& filename);
+  void openFiles(const std::vector<std::string>& filename);
+
+  /**
+   * Read the next data entry from which a Frame can be constructed for the
+   * given name. In case there are no more entries left for this name or in
+   * case there is no data for this name, this returns a nullptr.
+   */
+  std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string& name);
+
+  /**
+   * Read the specified data entry from which a Frame can be constructed for
+   * the given name. In case the entry does not exist for this name or in case
+   * there is no data for this name, this returns a nullptr.
+   */
+  std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string& name, const unsigned entry);
+
+  /// Returns number of entries for the given name
+  unsigned getEntries(const std::string& name);
+
+  /// Get the build version of podio that has been used to write the current file
+  podio::version::Version currentFileVersion() const {
+    return m_fileVersion;
+  }
+
+  void closeFile();
+
+private:
+  std::vector<std::unique_ptr<ROOTNTupleReader>> m_files;
+  std::unique_ptr<ROOT::Experimental::RNTupleReader> m_file;
+  std::unique_ptr<ROOT::Experimental::RNTupleReader> m_metadata;
+
+  
+private:
+
+  /**
+   * Initialze the passed CategoryInfo by setting up the necessary branches,
+   * collection infos and all necessary meta data to be able to read entries
+   * with this name
+   */
+  void initCategory(const std::string& category);
+
+  GenericParameters readEventMetaData(const std::string& name);
+
+  std::vector<std::string> m_availCategories{};                 ///< All available categories from this file
+  
+  podio::version::Version m_fileVersion{0, 0, 0};
+  DatamodelDefinitionHolder m_datamodelHolder{};
+
+  std::map<std::string, std::vector<std::unique_ptr<ROOT::Experimental::RNTupleReader>>> m_readers;
+  std::map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleReader>> m_metadata_readers;
+  std::vector<std::string> m_filenames;
+  std::map<std::string, int> m_entries;
+
+  std::map<std::string, std::vector<int>> m_collectionId;
+  std::map<std::string, std::vector<std::string>> m_collectionName;
+  std::map<std::string, std::vector<std::string>> m_collectionType;
+  std::map<std::string, std::vector<bool>> m_isSubsetCollection;
+
+
+};
+
+} // namespace podio
+
+#endif

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -7,11 +7,9 @@
 #include "podio/podioVersion.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 
-#include <algorithm>
 #include <iostream>
 #include <map>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <ROOT/RNTuple.hxx>
@@ -20,10 +18,6 @@
 
 namespace podio {
 
-class CollectionBase;
-class Registry;
-class CollectionIDTable;
-class GenericParameters;
 /**
 This class has the function to read available data from disk
 and to prepare collections and buffers.
@@ -65,36 +59,34 @@ public:
   void closeFile();
 
 private:
-  std::vector<std::unique_ptr<ROOTNTupleReader>> m_files;
-  std::unique_ptr<ROOT::Experimental::RNTupleReader> m_file;
-  std::unique_ptr<ROOT::Experimental::RNTupleReader> m_metadata;
-
-private:
-
   /**
-   * Initialze the passed CategoryInfo by setting up the necessary branches,
-   * collection infos and all necessary meta data to be able to read entries
-   * with this name
+   * Initialize the given category by filling the maps with metadata information
+   * that will be used later
    */
   bool initCategory(const std::string& category);
 
+  /**
+   * Read and reconstruct the generic parameters of the Frame
+   */
   GenericParameters readEventMetaData(const std::string& name, unsigned entNum);
 
-  podio::version::Version m_fileVersion{0, 0, 0};
+  std::unique_ptr<ROOT::Experimental::RNTupleReader> m_metadata{};
+
+  podio::version::Version m_fileVersion{};
   DatamodelDefinitionHolder m_datamodelHolder{};
 
-  std::map<std::string, std::vector<std::unique_ptr<ROOT::Experimental::RNTupleReader>>> m_readers;
-  std::map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleReader>> m_metadata_readers;
-  std::vector<std::string> m_filenames;
-  std::map<std::string, int> m_entries;
+  std::map<std::string, std::vector<std::unique_ptr<ROOT::Experimental::RNTupleReader>>> m_readers{};
+  std::map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleReader>> m_metadata_readers{};
+  std::vector<std::string> m_filenames{};
 
-  std::map<std::string, std::vector<int>> m_collectionId;
-  std::map<std::string, std::vector<std::string>> m_collectionName;
-  std::map<std::string, std::vector<std::string>> m_collectionType;
-  std::map<std::string, std::vector<bool>> m_isSubsetCollection;
+  std::map<std::string, int> m_entries{};
+  std::map<std::string, unsigned> m_totalEntries{};
 
-  std::map<std::string, unsigned> m_totalEntries;
-  std::vector<std::string> m_availableCategories;
+  std::map<std::string, std::vector<int>> m_collectionId{};
+  std::map<std::string, std::vector<std::string>> m_collectionName{};
+  std::map<std::string, std::vector<std::string>> m_collectionType{};
+  std::map<std::string, std::vector<bool>> m_isSubsetCollection{};
+  std::vector<std::string> m_availableCategories{};
 
 };
 

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -4,6 +4,7 @@
 #include "podio/CollectionBranches.h"
 #include "podio/ICollectionProvider.h"
 #include "podio/ROOTFrameData.h"
+#include "podio/SchemaEvolution.h"
 #include "podio/podioVersion.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 
@@ -88,6 +89,7 @@ private:
     std::vector<std::string> name{};
     std::vector<std::string> type{};
     std::vector<short> isSubsetCollection{};
+    std::vector<SchemaVersionT> schemaVersion{};
   };
 
   std::unordered_map<std::string, CollectionInfo> m_collectionInfo{};

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -85,7 +85,7 @@ private:
   std::unordered_map<std::string, unsigned> m_totalEntries{};
 
   struct CollectionInfo {
-    std::vector<int> id{};
+    std::vector<unsigned int> id{};
     std::vector<std::string> name{};
     std::vector<std::string> type{};
     std::vector<short> isSubsetCollection{};

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -90,6 +90,8 @@ private:
   std::unordered_map<std::string, std::vector<short>> m_isSubsetCollection{};
   std::vector<std::string> m_availableCategories{};
 
+  std::shared_ptr<podio::CollectionIDTable> m_table{};
+
 };
 
 } // namespace podio

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <map>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -22,16 +21,8 @@
 namespace rnt = ROOT::Experimental;
 // forward declarations
 class TClass;
-class TFile;
 
 namespace podio {
-
-namespace detail {
-  // Information about the data vector as wall as the collection class type
-  // and the index in the collection branches cache vector
-  using CollectionInfo = std::tuple<const TClass*, const TClass*, size_t>;
-
-} // namespace detail
 
 class EventStore;
 class CollectionBase;
@@ -95,9 +86,8 @@ private:
    */
   bool initCategory(const std::string& category);
 
-  GenericParameters readEventMetaData(const std::string& name);
+  GenericParameters readEventMetaData(const std::string& name, unsigned entNum);
 
-  
   podio::version::Version m_fileVersion{0, 0, 0};
   DatamodelDefinitionHolder m_datamodelHolder{};
 

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -84,10 +84,15 @@ private:
   std::unordered_map<std::string, int> m_entries{};
   std::unordered_map<std::string, unsigned> m_totalEntries{};
 
-  std::unordered_map<std::string, std::vector<int>> m_collectionId{};
-  std::unordered_map<std::string, std::vector<std::string>> m_collectionName{};
-  std::unordered_map<std::string, std::vector<std::string>> m_collectionType{};
-  std::unordered_map<std::string, std::vector<short>> m_isSubsetCollection{};
+  struct CollectionInfo {
+    std::vector<int> id{};
+    std::vector<std::string> name{};
+    std::vector<std::string> type{};
+    std::vector<short> isSubsetCollection{};
+  };
+
+  std::unordered_map<std::string, CollectionInfo> m_collectionInfo{};
+
   std::vector<std::string> m_availableCategories{};
 
   std::shared_ptr<podio::CollectionIDTable> m_table{};

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -18,13 +18,8 @@
 #include <ROOT/RNTupleModel.hxx>
 
 
-namespace rnt = ROOT::Experimental;
-// forward declarations
-class TClass;
-
 namespace podio {
 
-class EventStore;
 class CollectionBase;
 class Registry;
 class CollectionIDTable;
@@ -34,13 +29,11 @@ This class has the function to read available data from disk
 and to prepare collections and buffers.
 **/
 class ROOTNTupleReader{
-  friend EventStore;
 
 public:
   ROOTNTupleReader() = default;
   ~ROOTNTupleReader() = default;
 
-  // non-copyable
   ROOTNTupleReader(const ROOTNTupleReader&) = delete;
   ROOTNTupleReader& operator=(const ROOTNTupleReader&) = delete;
 
@@ -76,7 +69,6 @@ private:
   std::unique_ptr<ROOT::Experimental::RNTupleReader> m_file;
   std::unique_ptr<ROOT::Experimental::RNTupleReader> m_metadata;
 
-  
 private:
 
   /**
@@ -101,7 +93,7 @@ private:
   std::map<std::string, std::vector<std::string>> m_collectionType;
   std::map<std::string, std::vector<bool>> m_isSubsetCollection;
 
-  std::map<std::string, int> m_totalEntries;
+  std::map<std::string, unsigned> m_totalEntries;
   std::vector<std::string> m_availableCategories;
 
 };

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -69,6 +69,9 @@ private:
    */
   GenericParameters readEventMetaData(const std::string& name, unsigned entNum);
 
+  template<typename T>
+  void readParams(const std::string& name, unsigned entNum, GenericParameters& params);
+
   std::unique_ptr<ROOT::Experimental::RNTupleReader> m_metadata{};
 
   podio::version::Version m_fileVersion{};

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -1,19 +1,18 @@
 #ifndef PODIO_ROOTNTUPLEREADER_H
 #define PODIO_ROOTNTUPLEREADER_H
 
-#include "podio/ROOTFrameData.h"
 #include "podio/CollectionBranches.h"
 #include "podio/ICollectionProvider.h"
+#include "podio/ROOTFrameData.h"
 #include "podio/podioVersion.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-
 
 namespace podio {
 
@@ -21,7 +20,7 @@ namespace podio {
 This class has the function to read available data from disk
 and to prepare collections and buffers.
 **/
-class ROOTNTupleReader{
+class ROOTNTupleReader {
 
 public:
   ROOTNTupleReader() = default;
@@ -69,7 +68,7 @@ private:
    */
   GenericParameters readEventMetaData(const std::string& name, unsigned entNum);
 
-  template<typename T>
+  template <typename T>
   void readParams(const std::string& name, unsigned entNum, GenericParameters& params);
 
   std::unique_ptr<ROOT::Experimental::RNTupleReader> m_metadata{};
@@ -96,7 +95,6 @@ private:
   std::vector<std::string> m_availableCategories{};
 
   std::shared_ptr<podio::CollectionIDTable> m_table{};
-
 };
 
 } // namespace podio

--- a/include/podio/ROOTNTupleReader.h
+++ b/include/podio/ROOTNTupleReader.h
@@ -7,8 +7,7 @@
 #include "podio/podioVersion.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 
-#include <iostream>
-#include <map>
+#include <unordered_map>
 #include <string>
 #include <vector>
 
@@ -75,17 +74,17 @@ private:
   podio::version::Version m_fileVersion{};
   DatamodelDefinitionHolder m_datamodelHolder{};
 
-  std::map<std::string, std::vector<std::unique_ptr<ROOT::Experimental::RNTupleReader>>> m_readers{};
-  std::map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleReader>> m_metadata_readers{};
+  std::unordered_map<std::string, std::vector<std::unique_ptr<ROOT::Experimental::RNTupleReader>>> m_readers{};
+  std::unordered_map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleReader>> m_metadata_readers{};
   std::vector<std::string> m_filenames{};
 
-  std::map<std::string, int> m_entries{};
-  std::map<std::string, unsigned> m_totalEntries{};
+  std::unordered_map<std::string, int> m_entries{};
+  std::unordered_map<std::string, unsigned> m_totalEntries{};
 
-  std::map<std::string, std::vector<int>> m_collectionId{};
-  std::map<std::string, std::vector<std::string>> m_collectionName{};
-  std::map<std::string, std::vector<std::string>> m_collectionType{};
-  std::map<std::string, std::vector<bool>> m_isSubsetCollection{};
+  std::unordered_map<std::string, std::vector<int>> m_collectionId{};
+  std::unordered_map<std::string, std::vector<std::string>> m_collectionName{};
+  std::unordered_map<std::string, std::vector<std::string>> m_collectionType{};
+  std::unordered_map<std::string, std::vector<short>> m_isSubsetCollection{};
   std::vector<std::string> m_availableCategories{};
 
 };

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -44,10 +44,15 @@ private:
 
   DatamodelDefinitionCollector m_datamodelCollector{};
 
-  std::unordered_map<std::string, std::vector<int>> m_collectionId{};
-  std::unordered_map<std::string, std::vector<std::string>> m_collectionName{};
-  std::unordered_map<std::string, std::vector<std::string>> m_collectionType{};
-  std::unordered_map<std::string, std::vector<short>> m_isSubsetCollection{};
+  struct CollectionInfo {
+    std::vector<int> id{};
+    std::vector<std::string> name{};
+    std::vector<std::string> type{};
+    std::vector<short> isSubsetCollection{};
+  };
+
+  std::unordered_map<std::string, CollectionInfo> m_collectionInfo{};
+
   std::set<std::string> m_categories{};
 
   bool m_finished{false};

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -45,7 +45,7 @@ private:
   DatamodelDefinitionCollector m_datamodelCollector{};
 
   struct CollectionInfo {
-    std::vector<int> id{};
+    std::vector<unsigned int> id{};
     std::vector<std::string> name{};
     std::vector<std::string> type{};
     std::vector<short> isSubsetCollection{};

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -4,9 +4,9 @@
 #include "podio/CollectionBase.h"
 #include "podio/GenericParameters.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
+#include "podio/Frame.h"
 
 #include "TFile.h"
-#include "podio/Frame.h"
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 
@@ -14,12 +14,6 @@
 #include <vector>
 #include <iostream>
 #include <string_view>
-#include <utility>
-#include <cstdint>
-
-namespace rnt = ROOT::Experimental;
-
-class TFile;
 
 namespace podio {
 
@@ -38,13 +32,11 @@ public:
 private:
 
   using StoreCollection = std::pair<const std::string&, podio::CollectionBase*>;
-  std::unique_ptr<rnt::RNTupleModel> createModels(const std::vector<StoreCollection>& collections,
-                                                  const podio::GenericParameters& params);
+  std::unique_ptr<ROOT::Experimental::RNTupleModel> createModels(const std::vector<StoreCollection>& collections);
 
-  std::unique_ptr<rnt::RNTupleModel> m_metadata {nullptr};
-  rnt::REntry* m_entry;
-  std::map<std::string, std::unique_ptr<rnt::RNTupleWriter>> m_writers;
-  std::unique_ptr<rnt::RNTupleWriter> m_metadataWriter {nullptr};
+  std::unique_ptr<ROOT::Experimental::RNTupleModel> m_metadata {nullptr};
+  std::map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleWriter>> m_writers;
+  std::unique_ptr<ROOT::Experimental::RNTupleWriter> m_metadataWriter {nullptr};
 
   std::unique_ptr<TFile> m_file {nullptr};
 

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -4,6 +4,7 @@
 #include "podio/CollectionBase.h"
 #include "podio/Frame.h"
 #include "podio/GenericParameters.h"
+#include "podio/SchemaEvolution.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 
 #include "TFile.h"
@@ -48,6 +49,7 @@ private:
     std::vector<std::string> name{};
     std::vector<std::string> type{};
     std::vector<short> isSubsetCollection{};
+    std::vector<SchemaVersionT> schemaVersion{};
   };
 
   std::unordered_map<std::string, CollectionInfo> m_collectionInfo{};

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -24,6 +24,9 @@ public:
   ROOTNTupleWriter(const ROOTNTupleWriter&) = delete;
   ROOTNTupleWriter& operator=(const ROOTNTupleWriter&) = delete;
 
+  template<typename T>
+  void fillParams(const std::string& category, GenericParameters& params);
+
   void writeFrame(const podio::Frame& frame, const std::string& category);
   void writeFrame(const podio::Frame& frame, const std::string& category, const std::vector<std::string>& collsToWrite);
   void finish();

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -2,17 +2,17 @@
 #define PODIO_ROOTNTUPLEWRITER_H
 
 #include "podio/CollectionBase.h"
+#include "podio/Frame.h"
 #include "podio/GenericParameters.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
-#include "podio/Frame.h"
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
 
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 namespace podio {
 
@@ -24,7 +24,7 @@ public:
   ROOTNTupleWriter(const ROOTNTupleWriter&) = delete;
   ROOTNTupleWriter& operator=(const ROOTNTupleWriter&) = delete;
 
-  template<typename T>
+  template <typename T>
   void fillParams(const std::string& category, GenericParameters& params);
 
   void writeFrame(const podio::Frame& frame, const std::string& category);
@@ -32,7 +32,6 @@ public:
   void finish();
 
 private:
-
   using StoreCollection = std::pair<const std::string&, podio::CollectionBase*>;
   std::unique_ptr<ROOT::Experimental::RNTupleModel> createModels(const std::vector<StoreCollection>& collections);
 
@@ -56,9 +55,8 @@ private:
   std::set<std::string> m_categories{};
 
   bool m_finished{false};
-
 };
 
-} //namespace podio
+} // namespace podio
 
-#endif //PODIO_ROOTNTUPLEWRITER_H
+#endif // PODIO_ROOTNTUPLEWRITER_H

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -2,12 +2,9 @@
 #define PODIO_ROOTNTUPLEWRITER_H
 
 #include "podio/CollectionBase.h"
-#include "podio/CollectionBranches.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 
-#include "TBranch.h"
 #include "TFile.h"
-#include "TChain.h"
 #include "podio/Frame.h"
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -20,10 +17,8 @@
 #include <cstdint>
 
 namespace rnt = ROOT::Experimental;
-// forward declarations
+
 class TFile;
-class TTree;
-class TChain;
 
 namespace podio {
 
@@ -44,16 +39,22 @@ private:
   using StoreCollection = std::pair<const std::string&, podio::CollectionBase*>;
   std::unique_ptr<rnt::RNTupleModel> createModels(const std::vector<StoreCollection>& collections);
 
-  std::unique_ptr< rnt::RNTupleModel > m_metadata;
+  std::unique_ptr<rnt::RNTupleModel> m_metadata {nullptr};
   rnt::REntry* m_entry;
   std::map<std::string, std::unique_ptr<rnt::RNTupleWriter>> m_writers;
+  std::unique_ptr<rnt::RNTupleWriter> m_metadataWriter {nullptr};
 
-  std::unique_ptr<TFile> m_file;
-
-  std::unique_ptr< rnt::RNTupleWriter > m_metadata_writer;
-  };
+  std::unique_ptr<TFile> m_file {nullptr};
 
   DatamodelDefinitionCollector m_datamodelCollector{};
+
+  std::set<std::string> m_categories;
+  std::map<std::string, std::vector<int>> m_collectionId;
+  std::map<std::string, std::vector<std::string>> m_collectionName;
+  std::map<std::string, std::vector<std::string>> m_collectionType;
+  std::map<std::string, std::vector<bool>> m_isSubsetCollection;
+
+};
 
 } //namespace podio
 

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -1,0 +1,60 @@
+#ifndef PODIO_ROOTNTUPLEWRITER_H
+#define PODIO_ROOTNTUPLEWRITER_H
+
+#include "podio/CollectionBase.h"
+#include "podio/CollectionBranches.h"
+#include "podio/utilities/DatamodelRegistryIOHelpers.h"
+
+#include "TBranch.h"
+#include "TFile.h"
+#include "TChain.h"
+#include "podio/Frame.h"
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <string_view>
+#include <utility>
+#include <cstdint>
+
+namespace rnt = ROOT::Experimental;
+// forward declarations
+class TFile;
+class TTree;
+class TChain;
+
+namespace podio {
+
+class ROOTNTupleWriter {
+public:
+  ROOTNTupleWriter(const std::string& filename);
+  // ~ROOTNTupleWriter();
+
+  ROOTNTupleWriter(const ROOTNTupleWriter&) = delete;
+  ROOTNTupleWriter& operator=(const ROOTNTupleWriter&) = delete;
+
+  void writeFrame(const podio::Frame& frame, const std::string& category);
+  void writeFrame(const podio::Frame& frame, const std::string& category, const std::vector<std::string>& collsToWrite);
+  void finish();
+
+private:
+
+  using StoreCollection = std::pair<const std::string&, podio::CollectionBase*>;
+  std::unique_ptr<rnt::RNTupleModel> createModels(const std::vector<StoreCollection>& collections);
+
+  std::unique_ptr< rnt::RNTupleModel > m_metadata;
+  rnt::REntry* m_entry;
+  std::map<std::string, std::unique_ptr<rnt::RNTupleWriter>> m_writers;
+
+  std::unique_ptr<TFile> m_file;
+
+  std::unique_ptr< rnt::RNTupleWriter > m_metadata_writer;
+  };
+
+  DatamodelDefinitionCollector m_datamodelCollector{};
+
+} //namespace podio
+
+#endif //PODIO_ROOTNTUPLEWRITER_H

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -26,7 +26,7 @@ public:
   ROOTNTupleWriter& operator=(const ROOTNTupleWriter&) = delete;
 
   template <typename T>
-  void fillParams(const std::string& category, GenericParameters& params);
+  void fillParams(GenericParameters& params, ROOT::Experimental::REntry *entry);
 
   void writeFrame(const podio::Frame& frame, const std::string& category);
   void writeFrame(const podio::Frame& frame, const std::string& category, const std::vector<std::string>& collsToWrite);
@@ -57,6 +57,18 @@ private:
   std::set<std::string> m_categories{};
 
   bool m_finished{false};
+
+  std::vector<std::string> m_intkeys{}, m_floatkeys{}, m_doublekeys{}, m_stringkeys{};
+
+  std::vector<std::vector<int>> m_intvalues{};
+  std::vector<std::vector<float>> m_floatvalues{};
+  std::vector<std::vector<double>> m_doublevalues{};
+  std::vector<std::vector<std::string>> m_stringvalues{};
+
+  template <typename T>
+  std::pair<std::vector<std::string>&, std::vector<std::vector<T>>&>
+  getKeyValueVectors();
+
 };
 
 } // namespace podio

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -2,6 +2,7 @@
 #define PODIO_ROOTNTUPLEWRITER_H
 
 #include "podio/CollectionBase.h"
+#include "podio/GenericParameters.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 
 #include "TFile.h"
@@ -37,7 +38,8 @@ public:
 private:
 
   using StoreCollection = std::pair<const std::string&, podio::CollectionBase*>;
-  std::unique_ptr<rnt::RNTupleModel> createModels(const std::vector<StoreCollection>& collections);
+  std::unique_ptr<rnt::RNTupleModel> createModels(const std::vector<StoreCollection>& collections,
+                                                  const podio::GenericParameters& params);
 
   std::unique_ptr<rnt::RNTupleModel> m_metadata {nullptr};
   rnt::REntry* m_entry;

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -20,7 +20,7 @@ namespace podio {
 class ROOTNTupleWriter {
 public:
   ROOTNTupleWriter(const std::string& filename);
-  // ~ROOTNTupleWriter();
+  ~ROOTNTupleWriter();
 
   ROOTNTupleWriter(const ROOTNTupleWriter&) = delete;
   ROOTNTupleWriter& operator=(const ROOTNTupleWriter&) = delete;
@@ -34,19 +34,21 @@ private:
   using StoreCollection = std::pair<const std::string&, podio::CollectionBase*>;
   std::unique_ptr<ROOT::Experimental::RNTupleModel> createModels(const std::vector<StoreCollection>& collections);
 
-  std::unique_ptr<ROOT::Experimental::RNTupleModel> m_metadata {nullptr};
-  std::map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleWriter>> m_writers;
-  std::unique_ptr<ROOT::Experimental::RNTupleWriter> m_metadataWriter {nullptr};
+  std::unique_ptr<ROOT::Experimental::RNTupleModel> m_metadata{};
+  std::map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleWriter>> m_writers{};
+  std::unique_ptr<ROOT::Experimental::RNTupleWriter> m_metadataWriter{};
 
-  std::unique_ptr<TFile> m_file {nullptr};
+  std::unique_ptr<TFile> m_file{};
 
   DatamodelDefinitionCollector m_datamodelCollector{};
 
-  std::set<std::string> m_categories;
-  std::map<std::string, std::vector<int>> m_collectionId;
-  std::map<std::string, std::vector<std::string>> m_collectionName;
-  std::map<std::string, std::vector<std::string>> m_collectionType;
-  std::map<std::string, std::vector<bool>> m_isSubsetCollection;
+  std::map<std::string, std::vector<int>> m_collectionId{};
+  std::map<std::string, std::vector<std::string>> m_collectionName{};
+  std::map<std::string, std::vector<std::string>> m_collectionType{};
+  std::map<std::string, std::vector<bool>> m_isSubsetCollection{};
+  std::set<std::string> m_categories{};
+
+  bool m_finished{false};
 
 };
 

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -26,7 +26,7 @@ public:
   ROOTNTupleWriter& operator=(const ROOTNTupleWriter&) = delete;
 
   template <typename T>
-  void fillParams(GenericParameters& params, ROOT::Experimental::REntry *entry);
+  void fillParams(GenericParameters& params, ROOT::Experimental::REntry* entry);
 
   void writeFrame(const podio::Frame& frame, const std::string& category);
   void writeFrame(const podio::Frame& frame, const std::string& category, const std::vector<std::string>& collsToWrite);
@@ -66,9 +66,7 @@ private:
   std::vector<std::vector<std::string>> m_stringvalues{};
 
   template <typename T>
-  std::pair<std::vector<std::string>&, std::vector<std::vector<T>>&>
-  getKeyValueVectors();
-
+  std::pair<std::vector<std::string>&, std::vector<std::vector<T>>&> getKeyValueVectors();
 };
 
 } // namespace podio

--- a/include/podio/ROOTNTupleWriter.h
+++ b/include/podio/ROOTNTupleWriter.h
@@ -12,8 +12,7 @@
 
 #include <string>
 #include <vector>
-#include <iostream>
-#include <string_view>
+#include <unordered_map>
 
 namespace podio {
 
@@ -35,17 +34,17 @@ private:
   std::unique_ptr<ROOT::Experimental::RNTupleModel> createModels(const std::vector<StoreCollection>& collections);
 
   std::unique_ptr<ROOT::Experimental::RNTupleModel> m_metadata{};
-  std::map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleWriter>> m_writers{};
+  std::unordered_map<std::string, std::unique_ptr<ROOT::Experimental::RNTupleWriter>> m_writers{};
   std::unique_ptr<ROOT::Experimental::RNTupleWriter> m_metadataWriter{};
 
   std::unique_ptr<TFile> m_file{};
 
   DatamodelDefinitionCollector m_datamodelCollector{};
 
-  std::map<std::string, std::vector<int>> m_collectionId{};
-  std::map<std::string, std::vector<std::string>> m_collectionName{};
-  std::map<std::string, std::vector<std::string>> m_collectionType{};
-  std::map<std::string, std::vector<bool>> m_isSubsetCollection{};
+  std::unordered_map<std::string, std::vector<int>> m_collectionId{};
+  std::unordered_map<std::string, std::vector<std::string>> m_collectionName{};
+  std::unordered_map<std::string, std::vector<std::string>> m_collectionType{};
+  std::unordered_map<std::string, std::vector<short>> m_isSubsetCollection{};
   std::set<std::string> m_categories{};
 
   bool m_finished{false};

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -123,7 +123,7 @@ public:
   /// Get the collection buffers for this collection
   podio::CollectionWriteBuffers getBuffers() override {
     _vecPtr = &_vec; // Set the pointer to the correct internal vector
-    return {&_vecPtr, &m_refCollections, &m_vecmem_info};
+    return {&_vecPtr, _vecPtr, &m_refCollections, &m_vecmem_info};
   }
 
   /// check for validity of the container after read

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -92,6 +92,7 @@ podio::CollectionWriteBuffers {{ class_type }}::getCollectionBuffers(bool isSubs
 
   return {
     isSubsetColl ? nullptr : (void*)&m_data,
+    isSubsetColl ? nullptr : (void*)m_data.get(),
     &m_refCollections, // only need to store the ObjectIDs of the referenced objects
     &m_vecmem_info
   };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,8 +86,7 @@ SET(root_sources
   ROOTLegacyReader.cc
 )
 if(ENABLE_RNTUPLE)
-  set(root_sources
-      ${root_sources}
+  list(APPEND root_sources
       ROOTNTupleReader.cc
       ROOTNTupleWriter.cc
      )
@@ -99,8 +98,7 @@ SET(root_headers
   ${CMAKE_SOURCE_DIR}/include/podio/ROOTFrameWriter.h
   )
 if(ENABLE_RNTUPLE)
-  set(root_headers
-      ${root_headers}
+  list(APPEND root_headers
       ${CMAKE_SOURCE_DIR}/include/podio/ROOTNTupleReader.h
       ${CMAKE_SOURCE_DIR}/include/podio/ROOTNTupleWriter.h
      )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,9 @@ FUNCTION(PODIO_ADD_LIB_AND_DICT libname headers sources selection )
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
   target_link_libraries(${dictname} PUBLIC podio::${libname} podio::podio ROOT::Core ROOT::Tree)
+  if(ENABLE_RNTUPLE)
+    target_link_libraries(${dictname} PUBLIC ROOT::ROOTNTuple)
+  endif()
   PODIO_GENERATE_DICTIONARY(${dictname} ${headers} SELECTION ${selection}
     OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}${dictname}${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
@@ -82,15 +85,32 @@ SET(root_sources
   ROOTFrameReader.cc
   ROOTLegacyReader.cc
 )
+if(ENABLE_RNTUPLE)
+  set(root_sources
+      ${root_sources}
+      ROOTNTupleReader.cc
+      ROOTNTupleWriter.cc
+     )
+endif()
 
 SET(root_headers
   ${CMAKE_SOURCE_DIR}/include/podio/ROOTFrameReader.h
   ${CMAKE_SOURCE_DIR}/include/podio/ROOTLegacyReader.h
   ${CMAKE_SOURCE_DIR}/include/podio/ROOTFrameWriter.h
   )
+if(ENABLE_RNTUPLE)
+  set(root_headers
+      ${root_headers}
+      ${CMAKE_SOURCE_DIR}/include/podio/ROOTNTupleReader.h
+      ${CMAKE_SOURCE_DIR}/include/podio/ROOTNTupleWriter.h
+     )
+endif()
 
 PODIO_ADD_LIB_AND_DICT(podioRootIO "${root_headers}" "${root_sources}" root_selection.xml)
 target_link_libraries(podioRootIO PUBLIC podio::podio ROOT::Core ROOT::RIO ROOT::Tree)
+if(ENABLE_RNTUPLE)
+  target_link_libraries(podioRootIO PUBLIC ROOT::ROOTNTuple)
+endif()
 
 
 # --- Python EventStore for enabling (legacy) python bindings

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -123,6 +123,8 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
   ROOTFrameData::BufferMap buffers;
   auto dentry = m_readers[category][0]->GetModel()->GetDefaultEntry();
 
+  // This map is needed to keep the pointers to the vectors that
+  // will be written later alive
   std::map<std::pair<std::string, int>, std::vector<podio::ObjectID>*> tmp;
 
   for (size_t i = 0; i < m_collectionInfo[category].id.size(); ++i) {
@@ -163,13 +165,6 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
     }
     if (auto* refCollections = collBuffers.references) {
       for (size_t j = 0; j < refCollections->size(); ++j) {
-        // // The unique_ptrs are nullptrs at the beginning, we first initialize
-        // // them and then fill the values with the read data since
-        // refCollections->at(j) = std::make_unique<std::vector<podio::ObjectID>>();
-        // const auto brName = root_utils::refBranch(m_collectionName[category][i], j);
-        // std::cout << "brName = " << brName << " " << (refCollections->at(j) == nullptr) << std::endl;
-        // dentry->CaptureValueUnsafe(brName, (*refCollections)[j].get());
-
         auto vec = new std::vector<podio::ObjectID>;
         const auto brName = root_utils::refBranch(m_collectionInfo[category].name[i], j);
         dentry->CaptureValueUnsafe(brName, vec);

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -13,8 +13,8 @@ namespace podio {
 
 template<typename T>
 void ROOTNTupleReader::readParams(const std::string& name, unsigned entNum, GenericParameters& params) {
-  auto keyView   = m_readers[name][0]->GetView<std::vector<std::string>>(root_utils::getGPKey<T>());
-  auto valueView = m_readers[name][0]->GetView<std::vector<std::vector<T>>>(root_utils::getGPValue<T>());
+  auto keyView   = m_readers[name][0]->GetView<std::vector<std::string>>(root_utils::getGPKeyName<T>());
+  auto valueView = m_readers[name][0]->GetView<std::vector<std::vector<T>>>(root_utils::getGPValueName<T>());
 
   auto keys = keyView(entNum);
   auto values = valueView(entNum);

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -207,7 +207,6 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
       dentry->CaptureValueUnsafe(m_collectionName[category][i], collBuffers.data);
     }
     if (auto* refCollections = collBuffers.references) {
-      std::cout << "The number of references is " << refCollections->size() << std::endl;
       for (size_t j = 0; j < refCollections->size(); ++j) {
         // // The unique_ptrs are nullptrs at the beginning, we first initialize
         // // them and then fill the values with the read data since
@@ -218,11 +217,19 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
 
         auto vec = new std::vector<podio::ObjectID>;
         const auto brName = root_utils::refBranch(m_collectionName[category][i], j);
-        std::cout << "brName = " << brName << " " << (refCollections->at(j) == nullptr) << std::endl;
         dentry->CaptureValueUnsafe(brName, vec);
         tmp[{brName, j}] = vec;
       }
     }
+
+    if (auto* vecMembers = collBuffers.vectorMembers) {
+      for (size_t j = 0; j < vecMembers->size(); ++j) {
+        const auto typeName = "vector<" + vecMembers->at(j).first + ">";
+        const auto brName = root_utils::vecBranch(m_collectionName[category][i], j);
+        dentry->CaptureValueUnsafe(brName, vecMembers->at(j).second);
+      }
+    }
+
     std::cout << "CaptureValueUnsafe done" << std::endl;
     buffers.emplace(m_collectionName[category][i], std::move(collBuffers));
   }

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -1,0 +1,193 @@
+#include "podio/ROOTNTupleReader.h"
+#include "podio/CollectionBase.h"
+#include "podio/CollectionBuffers.h"
+#include "podio/CollectionIDTable.h"
+#include "podio/GenericParameters.h"
+#include "rootUtils.h"
+
+// ROOT specific includes
+#include "TClass.h"
+#include "TFile.h"
+#include <memory>
+
+#include "datamodel/ExampleMCData.h"
+
+namespace podio {
+
+GenericParameters ROOTNTupleReader::readEventMetaData(const std::string& name) {
+  // Parameter branch is always the last one
+  // auto& paramBranches = catInfo.branches.back();
+  // auto* branch = paramBranches.data;
+
+  GenericParameters params;
+  // auto* emd = &params;
+  // branch->SetAddress(&emd);
+  // branch->GetEntry(catInfo.entry);
+  return params;
+}
+
+void ROOTNTupleReader::initCategory(const std::string& category) {
+  std::cout << "initCategory(" << category << ")" << std::endl;
+  std::cout << "Getting id" << std::endl;
+  // Assume that the metadata is the same in all files
+  auto filename = m_filenames[0];
+  auto id = m_metadata_readers[filename]->GetView<std::vector<int>>(root_utils::idTableName(category));
+  m_collectionId[category] = id(0);
+
+  std::cout << "Getting collectionName" << std::endl;
+  auto collectionName = m_metadata_readers[filename]->GetView<std::vector<std::string>>(category + "_name");
+  m_collectionName[category] = collectionName(0);
+
+  std::cout << "Getting collectionType" << std::endl;
+  auto collectionType = m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collInfoName(category));
+  m_collectionType[category] = collectionType(0);
+   
+  std::cout << "Getting subsetCollection" << std::endl;
+  auto subsetCollection = m_metadata_readers[filename]->GetView<std::vector<bool>>(category + "_test");
+  m_isSubsetCollection[category] = subsetCollection(0);
+}
+
+void ROOTNTupleReader::openFile(const std::string& filename) {
+  openFiles({filename});
+}
+
+void ROOTNTupleReader::openFiles(const std::vector<std::string>& filenames) {
+
+  m_filenames.insert(m_filenames.end(), filenames.begin(), filenames.end());
+  for (auto& filename : filenames) {
+    if (m_metadata_readers.find(filename) == m_metadata_readers.end()) {
+      m_metadata_readers[filename] = ROOT::Experimental::RNTupleReader::Open(root_utils::metaTreeName, filename);
+    }
+  }
+
+  m_metadata = ROOT::Experimental::RNTupleReader::Open(root_utils::metaTreeName, "example_rntuple.root");
+
+  auto version_view = m_metadata->GetView<std::vector<int>>(root_utils::versionBranchName);
+  auto version = version_view(0);
+
+  m_fileVersion = podio::version::Version{version[0], version[1], version[2]};
+  std::cout << "Version is " << m_fileVersion.major << " " << m_fileVersion.minor << " " << m_fileVersion.patch << std::endl;
+
+  auto edm_view = m_metadata->GetView<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
+  auto edm = edm_view(0);
+
+  // m_datamodelHolder = DatamodelDefinitionHolder(std::move(*datamodelDefs));
+
+  // Do some work up front for setting up categories and setup all the chains
+  // and record the available categories. The rest of the setup follows on
+  // demand when the category is first read
+  // m_availCategories = ::podio::getAvailableCategories2(m_metaChain.get());
+  // for (const auto& cat : m_availCategories) {
+  //   auto [it, _] = m_categories.try_emplace(cat, std::make_unique<TChain>(cat.c_str()));
+  //   for (const auto& fn : filenames) {
+  //     it->second.chain->Add(fn.c_str());
+  //   }
+  // }
+}
+
+unsigned ROOTNTupleReader::getEntries(const std::string& name) {
+  if (m_readers.find(name) == m_readers.end()) {
+    for (auto& filename : m_filenames) {
+      m_readers[name].emplace_back(ROOT::Experimental::RNTupleReader::Open(name, filename));
+    }
+  }
+  return std::accumulate(m_readers[name].begin(), m_readers[name].end(), 0, [](int total, auto& reader) {return total + reader->GetNEntries();});
+}
+
+std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readNextEntry(const std::string& name) {
+  // auto& catInfo = getCategoryInfo(name);
+  int current_entry = m_entries[name];
+
+  return readEntry(name, current_entry);
+}
+
+std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& category, const unsigned entNum) {
+  std::cout << "Calling readEntry " << std::endl;
+
+  if (m_collectionId.find(category) == m_collectionId.end()) {
+    initCategory(category);
+  }
+
+  ROOTFrameData::BufferMap buffers;
+  auto dentry = m_readers[category][0]->GetModel()->GetDefaultEntry();
+
+  for (int i = 0; i < m_collectionId[category].size(); ++i) {
+    std::cout << "i = " << i << " " << m_collectionId[category][i] << " " << m_collectionType[category][i] << " " << m_collectionName[category][i] << std::endl;
+
+    const auto collectionClass = TClass::GetClass(m_collectionType[category][i].c_str());
+
+    auto collection =
+        std::unique_ptr<podio::CollectionBase>(static_cast<podio::CollectionBase*>(collectionClass->New()));
+
+    const std::string bufferClassName = "std::vector<" + collection->getDataTypeName() + ">";
+    const auto bufferClass = m_isSubsetCollection[category][i] ? nullptr : TClass::GetClass(bufferClassName.c_str());
+
+    auto collBuffers = podio::CollectionReadBuffers();
+    // const bool isSubsetColl = bufferClass == nullptr;
+    const bool isSubsetColl = bufferClass == nullptr;
+    if (!isSubsetColl) {
+      collBuffers.data = bufferClass->New();
+    }
+    collection->setSubsetCollection(isSubsetColl);
+
+    auto tmpBuffers = collection->createBuffers();
+    collBuffers.createCollection = std::move(tmpBuffers.createCollection);
+    collBuffers.recast = std::move(tmpBuffers.recast);
+
+    if (auto* refs = tmpBuffers.references) {
+      collBuffers.references = new podio::CollRefCollection(refs->size());
+    }
+    if (auto* vminfo = tmpBuffers.vectorMembers) {
+      collBuffers.vectorMembers = new podio::VectorMembersInfo();
+      collBuffers.vectorMembers->reserve(vminfo->size());
+
+      for (const auto& [type, _] : (*vminfo)) {
+        const auto* vecClass = TClass::GetClass(("vector<" + type + ">").c_str());
+        collBuffers.vectorMembers->emplace_back(type, vecClass->New());
+      }
+    }
+
+    if (!isSubsetColl) {
+      dentry->CaptureValueUnsafe(m_collectionName[category][i], collBuffers.data);
+    }
+    if (auto* refCollections = collBuffers.references) {
+      std::cout << "The number of references is " << refCollections->size() << std::endl;
+      for (size_t j = 0; j < refCollections->size(); ++j) {
+        // The unique_ptrs are nullptrs at the beginning, we first initialize
+        // them and then fill the values with the read data since
+        refCollections->at(j) = std::make_unique<std::vector<podio::ObjectID>>();
+        const auto brName = root_utils::refBranch(m_collectionName[category][i], j);
+        std::cout << "brName = " << brName << " " << (refCollections->at(j) == nullptr) << std::endl;
+        dentry->CaptureValueUnsafe(brName, (*refCollections)[j].get());
+      }
+    }
+    std::cout << "CaptureValueUnsafe done" << std::endl;
+    buffers.emplace(m_collectionName[category][i], std::move(collBuffers));
+  }
+  m_readers[category][0]->LoadEntry(entNum);
+
+  auto buf = buffers["mcparticles"];
+  auto ptr = (std::vector<ExampleMCData>*)(buf.data);
+  std::cout << "Size of MCData is " << ptr->size();
+
+
+  auto parameters = readEventMetaData(category);
+  auto table = std::make_shared<CollectionIDTable>();
+
+  auto names = m_collectionName[category];
+  auto ids = m_collectionId[category];
+
+  std::vector<std::pair<int, std::string>> v;
+  for (int i = 0; i < names.size(); ++i) {
+    v.emplace_back(std::make_pair<int, std::string>(int(ids[i]),std::string(names[i])));
+  }
+  std::sort(v.begin(), v.end());
+
+  for (auto& [name, id] : v) {
+    table->add(std::to_string(name));
+  }
+
+  return std::make_unique<ROOTFrameData>(std::move(buffers), table, std::move(parameters));
+}
+
+} // namespace podio

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -40,7 +40,7 @@ bool ROOTNTupleReader::initCategory(const std::string& category) {
   // Assume that the metadata is the same in all files
   auto filename = m_filenames[0];
 
-  auto id = m_metadata_readers[filename]->GetView<std::vector<int>>(root_utils::idTableName(category));
+  auto id = m_metadata_readers[filename]->GetView<std::vector<unsigned int>>(root_utils::idTableName(category));
   m_collectionInfo[category].id = id(0);
 
   auto collectionName =
@@ -136,9 +136,10 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
     auto collection =
         std::unique_ptr<podio::CollectionBase>(static_cast<podio::CollectionBase*>(collectionClass->New()));
 
-    const std::string bufferClassName = "std::vector<" + collection->getDataTypeName() + ">";
+    // const std::string bufferClassName = "std::vector<" + collection->getDataTypeName() + ">";
+    const auto bufferClassName = collection->getTypeName();
     const auto bufferClass =
-        m_collectionInfo[category].isSubsetCollection[i] ? nullptr : TClass::GetClass(bufferClassName.c_str());
+      m_collectionInfo[category].isSubsetCollection[i] ? nullptr : TClass::GetClass(std::string(bufferClassName).c_str());
 
     const bool isSubsetColl = bufferClass == nullptr;
 

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -54,6 +54,7 @@ bool ROOTNTupleReader::initCategory(const std::string& category) {
   }
   // Assume that the metadata is the same in all files
   auto filename = m_filenames[0];
+
   auto id = m_metadata_readers[filename]->GetView<std::vector<int>>(root_utils::idTableName(category));
   m_collectionId[category] = id(0);
 
@@ -229,8 +230,9 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
   // Sort the ids and collection names to recreate the collection ID table with
   // the names following the order of the IDs
   std::vector<std::pair<int, std::string>> v;
+  v.reserve(names.size());
   for (size_t i = 0; i < names.size(); ++i) {
-    v.emplace_back(std::make_pair<int, std::string>(int(ids[i]),std::string(names[i])));
+    v.emplace_back(std::make_pair<int, std::string>(int(ids[i]), std::string(names[i])));
   }
   std::sort(v.begin(), v.end());
   for (auto& [id, name] : v) {

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -16,11 +16,8 @@ void ROOTNTupleReader::readParams(const std::string& name, unsigned entNum, Gene
   auto keyView   = m_readers[name][0]->GetView<std::vector<std::string>>(root_utils::getGPKeyName<T>());
   auto valueView = m_readers[name][0]->GetView<std::vector<std::vector<T>>>(root_utils::getGPValueName<T>());
 
-  auto keys = keyView(entNum);
-  auto values = valueView(entNum);
-
-  for (size_t i = 0; i < keys.size(); ++i) {
-    params.getMap<T>()[keys[i]] = std::move(values[i]);
+  for (size_t i = 0; i < keyView(entNum).size(); ++i) {
+    params.getMap<T>().emplace(std::move(keyView(entNum)[i]), std::move(valueView(entNum)[i]));
   }
 }
 

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -95,8 +95,8 @@ unsigned ROOTNTupleReader::getEntries(const std::string& name) {
         std::cout << "Category " << name << " not found in file " << filename << std::endl;
       }
     }
+    m_totalEntries[name] = std::accumulate(m_readers[name].begin(), m_readers[name].end(), 0, [](int total, auto& reader) {return total + reader->GetNEntries();});
   }
-  m_totalEntries[name] = std::accumulate(m_readers[name].begin(), m_readers[name].end(), 0, [](int total, auto& reader) {return total + reader->GetNEntries();});
   return m_totalEntries[name];
 }
 

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -138,8 +138,9 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
 
     // const std::string bufferClassName = "std::vector<" + collection->getDataTypeName() + ">";
     const auto bufferClassName = collection->getTypeName();
-    const auto bufferClass =
-      m_collectionInfo[category].isSubsetCollection[i] ? nullptr : TClass::GetClass(std::string(bufferClassName).c_str());
+    const auto bufferClass = m_collectionInfo[category].isSubsetCollection[i]
+        ? nullptr
+        : TClass::GetClass(std::string(bufferClassName).c_str());
 
     const bool isSubsetColl = bufferClass == nullptr;
 

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -11,9 +11,9 @@
 
 namespace podio {
 
-template<typename T>
+template <typename T>
 void ROOTNTupleReader::readParams(const std::string& name, unsigned entNum, GenericParameters& params) {
-  auto keyView   = m_readers[name][0]->GetView<std::vector<std::string>>(root_utils::getGPKeyName<T>());
+  auto keyView = m_readers[name][0]->GetView<std::vector<std::string>>(root_utils::getGPKeyName<T>());
   auto valueView = m_readers[name][0]->GetView<std::vector<std::vector<T>>>(root_utils::getGPValueName<T>());
 
   for (size_t i = 0; i < keyView(entNum).size(); ++i) {
@@ -42,13 +42,16 @@ bool ROOTNTupleReader::initCategory(const std::string& category) {
   auto id = m_metadata_readers[filename]->GetView<std::vector<int>>(root_utils::idTableName(category));
   m_collectionInfo[category].id = id(0);
 
-  auto collectionName = m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collectionName(category));
+  auto collectionName =
+      m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collectionName(category));
   m_collectionInfo[category].name = collectionName(0);
 
-  auto collectionType = m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collInfoName(category));
+  auto collectionType =
+      m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collInfoName(category));
   m_collectionInfo[category].type = collectionType(0);
-   
-  auto subsetCollection = m_metadata_readers[filename]->GetView<std::vector<short>>(root_utils::subsetCollection(category));
+
+  auto subsetCollection =
+      m_metadata_readers[filename]->GetView<std::vector<short>>(root_utils::subsetCollection(category));
   m_collectionInfo[category].isSubsetCollection = subsetCollection(0);
 
   return true;
@@ -79,7 +82,6 @@ void ROOTNTupleReader::openFiles(const std::vector<std::string>& filenames) {
 
   auto availableCategoriesField = m_metadata->GetView<std::vector<std::string>>(root_utils::availableCategories);
   m_availableCategories = availableCategoriesField(0);
-
 }
 
 unsigned ROOTNTupleReader::getEntries(const std::string& name) {
@@ -87,12 +89,12 @@ unsigned ROOTNTupleReader::getEntries(const std::string& name) {
     for (auto& filename : m_filenames) {
       try {
         m_readers[name].emplace_back(ROOT::Experimental::RNTupleReader::Open(name, filename));
-      }
-      catch (const ROOT::Experimental::RException& e) {
+      } catch (const ROOT::Experimental::RException& e) {
         std::cout << "Category " << name << " not found in file " << filename << std::endl;
       }
     }
-    m_totalEntries[name] = std::accumulate(m_readers[name].begin(), m_readers[name].end(), 0, [](int total, auto& reader) {return total + reader->GetNEntries();});
+    m_totalEntries[name] = std::accumulate(m_readers[name].begin(), m_readers[name].end(), 0,
+                                           [](int total, auto& reader) { return total + reader->GetNEntries(); });
   }
   return m_totalEntries[name];
 }
@@ -115,7 +117,7 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
     }
   }
 
-  m_entries[category] = entNum+1;
+  m_entries[category] = entNum + 1;
 
   ROOTFrameData::BufferMap buffers;
   auto dentry = m_readers[category][0]->GetModel()->GetDefaultEntry();
@@ -131,7 +133,8 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
         std::unique_ptr<podio::CollectionBase>(static_cast<podio::CollectionBase*>(collectionClass->New()));
 
     const std::string bufferClassName = "std::vector<" + collection->getDataTypeName() + ">";
-    const auto bufferClass = m_collectionInfo[category].isSubsetCollection[i] ? nullptr : TClass::GetClass(bufferClassName.c_str());
+    const auto bufferClass =
+        m_collectionInfo[category].isSubsetCollection[i] ? nullptr : TClass::GetClass(bufferClassName.c_str());
 
     auto collBuffers = podio::CollectionReadBuffers();
     const bool isSubsetColl = bufferClass == nullptr;
@@ -190,7 +193,6 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
         refCollections->at(j) = std::unique_ptr<std::vector<podio::ObjectID>>(tmp[{brName, j}]);
       }
     }
-
   }
 
   auto parameters = readEventMetaData(category, entNum);

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -143,13 +143,14 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
     const bool isSubsetColl = bufferClass == nullptr;
 
     const auto& bufferFactory = podio::CollectionBufferFactory::instance();
-    auto maybeBuffers = bufferFactory.createBuffers(m_collectionInfo[category].type[i], m_collectionInfo[category].schemaVersion[i], isSubsetColl);
+    auto maybeBuffers = bufferFactory.createBuffers(m_collectionInfo[category].type[i],
+                                                    m_collectionInfo[category].schemaVersion[i], isSubsetColl);
     auto collBuffers = maybeBuffers.value_or(podio::CollectionReadBuffers{});
 
     if (!maybeBuffers) {
-      std::cout << "WARNING: Buffers couldn't be created for collection " << m_collectionInfo[category].name[i] 
-                << " of type " << m_collectionInfo[category].type[i] << " and schema version " << m_collectionInfo[category].schemaVersion[i]
-                << std::endl;
+      std::cout << "WARNING: Buffers couldn't be created for collection " << m_collectionInfo[category].name[i]
+                << " of type " << m_collectionInfo[category].type[i] << " and schema version "
+                << m_collectionInfo[category].schemaVersion[i] << std::endl;
       return nullptr;
     }
 

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -67,7 +67,7 @@ bool ROOTNTupleReader::initCategory(const std::string& category) {
   m_collectionType[category] = collectionType(0);
    
   std::cout << "Getting subsetCollection" << std::endl;
-  auto subsetCollection = m_metadata_readers[filename]->GetView<std::vector<bool>>(root_utils::subsetCollection(category));
+  auto subsetCollection = m_metadata_readers[filename]->GetView<std::vector<short>>(root_utils::subsetCollection(category));
   m_isSubsetCollection[category] = subsetCollection(0);
 
   return true;

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -202,12 +202,13 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
   }
 
   auto parameters = readEventMetaData(category, entNum);
+  if (!m_table) {
+    auto names = m_collectionName[category];
+    auto ids = m_collectionId[category];
+    m_table = std::make_shared<CollectionIDTable>(ids, names);
+  }
 
-  auto names = m_collectionName[category];
-  auto ids = m_collectionId[category];
-  auto table = std::make_shared<CollectionIDTable>(ids, names);
-
-  return std::make_unique<ROOTFrameData>(std::move(buffers), table, std::move(parameters));
+  return std::make_unique<ROOTFrameData>(std::move(buffers), m_table, std::move(parameters));
 }
 
 } // namespace podio

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -20,7 +20,7 @@ void ROOTNTupleReader::readParams(const std::string& name, unsigned entNum, Gene
   auto values = valueView(entNum);
 
   for (size_t i = 0; i < keys.size(); ++i) {
-    params.getMap<T>()[keys[i]] = values[i];
+    params.getMap<T>()[keys[i]] = std::move(values[i]);
   }
 }
 

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -5,13 +5,9 @@
 #include "podio/GenericParameters.h"
 #include "rootUtils.h"
 
-// ROOT specific includes
 #include "TClass.h"
 #include <ROOT/RError.hxx>
 #include <memory>
-
-#include "datamodel/ExampleMCData.h"
-#include "datamodel/ExampleHitData.h"
 
 namespace podio {
 
@@ -47,13 +43,6 @@ namespace podio {
   auto valuesString = stringValueView(entNum);
   for (size_t i = 0; i < keys.size(); ++i) {
     params.getStringMap()[keys[i]] = valuesString[i];
-  }
-  std::cout << "Size of Float map is " << params.getFloatMap().size() << std::endl;
-  for (auto& [k, v] : params.getFloatMap()) {
-    std::cout << k << std::endl;
-    for (auto& x : v)
-      std::cout << x << " ";
-    std::cout << std::endl;
   }
 
   return params;
@@ -112,18 +101,6 @@ void ROOTNTupleReader::openFiles(const std::vector<std::string>& filenames) {
   auto availableCategoriesField = m_metadata->GetView<std::vector<std::string>>("available_categories");
   m_availableCategories = availableCategoriesField(0);
 
-  // m_datamodelHolder = DatamodelDefinitionHolder(std::move(*datamodelDefs));
-
-  // Do some work up front for setting up categories and setup all the chains
-  // and record the available categories. The rest of the setup follows on
-  // demand when the category is first read
-  // m_availCategories = ::podio::getAvailableCategories2(m_metaChain.get());
-  // for (const auto& cat : m_availCategories) {
-  //   auto [it, _] = m_categories.try_emplace(cat, std::make_unique<TChain>(cat.c_str()));
-  //   for (const auto& fn : filenames) {
-  //     it->second.chain->Add(fn.c_str());
-  //   }
-  // }
 }
 
 unsigned ROOTNTupleReader::getEntries(const std::string& name) {
@@ -167,7 +144,7 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
 
   std::map<std::pair<std::string, int>, std::vector<podio::ObjectID>*> tmp;
 
-  for (int i = 0; i < m_collectionId[category].size(); ++i) {
+  for (size_t i = 0; i < m_collectionId[category].size(); ++i) {
     std::cout << "i = " << i << " " << m_collectionId[category][i] << " " << m_collectionType[category][i] << " " << m_collectionName[category][i] << std::endl;
 
     const auto collectionClass = TClass::GetClass(m_collectionType[category][i].c_str());
@@ -237,7 +214,7 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
 
   m_readers[category][0]->LoadEntry(entNum);
 
-  for (int i = 0; i < m_collectionId[category].size(); ++i) {
+  for (size_t i = 0; i < m_collectionId[category].size(); ++i) {
     auto collBuffers = buffers[m_collectionName[category][i]];
     if (auto* refCollections = collBuffers.references) {
       for (size_t j = 0; j < refCollections->size(); ++j) {
@@ -248,39 +225,6 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
 
   }
 
-  // auto buf = buffers["mcparticles"];
-  // auto ptr = (std::vector<ExampleMCData>*)(buf.data);
-  // std::cout << "Size of MCData is " << ptr->size() << std::endl;
-  // for (auto& x : *ptr) {
-  //   std::cout << x.energy << " " << x.PDG << std::endl;
-  // }
-
-  // auto buf = buffers["hits"];
-  // auto ptr = (std::vector<ExampleHitData>*)(buf.data);
-  // std::cout << "Size of HitData is " << ptr->size() << std::endl;
-  // for (auto& x : *ptr) {
-  //   std::cout << x.cellID << " " << x.energy << " " << " " << x.x << " " << x.y << " " << x.z << std::endl;
-  // }
-
-  auto buf = buffers["hitRefs"];
-  auto refCollections = buf.references;
-  for (size_t j = 0; j < refCollections->size(); ++j) {
-    std::cout << "Size of ObjectID is " << refCollections->at(j)->size() << std::endl;
-    auto ptr = (std::vector<podio::ObjectID>*)refCollections->at(j).get();
-    for (auto& x : *ptr) {
-      std::cout << x.index << " " << x.collectionID << std::endl;
-    }
-  }
-
-  // auto nbuf = buffers["hitRefs"];
-  // auto nptr = (std::vector<std::unique_ptr<podio::ObjectID>>*)(buf.references);
-  // std::cout << "Size of ObjectID is " << nptr->size() << std::endl;
-  // for (auto& x : *nptr) {
-  //   auto nnptr = ;
-  //   std::cout << x->index << " " << x->collectionID << std::endl;
-  // }
-
-
   auto parameters = readEventMetaData(category, entNum);
   auto table = std::make_shared<CollectionIDTable>();
 
@@ -288,8 +232,7 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
   auto ids = m_collectionId[category];
 
   std::vector<std::pair<int, std::string>> v;
-  for (int i = 0; i < names.size(); ++i) {
-    std::cout << ids[i] << " " << names[i] << std::endl;
+  for (size_t i = 0; i < names.size(); ++i) {
     v.emplace_back(std::make_pair<int, std::string>(int(ids[i]),std::string(names[i])));
   }
   std::sort(v.begin(), v.end());

--- a/src/ROOTNTupleReader.cc
+++ b/src/ROOTNTupleReader.cc
@@ -138,9 +138,9 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
         std::unique_ptr<podio::CollectionBase>(static_cast<podio::CollectionBase*>(collectionClass->New()));
 
     const auto& bufferFactory = podio::CollectionBufferFactory::instance();
-    auto maybeBuffers = bufferFactory.createBuffers(m_collectionInfo[category].type[i],
-                                                    m_collectionInfo[category].schemaVersion[i],
-                                                    m_collectionInfo[category].isSubsetCollection[i]);
+    auto maybeBuffers =
+        bufferFactory.createBuffers(m_collectionInfo[category].type[i], m_collectionInfo[category].schemaVersion[i],
+                                    m_collectionInfo[category].isSubsetCollection[i]);
     auto collBuffers = maybeBuffers.value_or(podio::CollectionReadBuffers{});
 
     if (!maybeBuffers) {
@@ -155,7 +155,7 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
       auto vec = new std::vector<podio::ObjectID>;
       dentry->CaptureValueUnsafe(brName, vec);
       tmp[{brName, 0}] = vec;
-    } else  {
+    } else {
       dentry->CaptureValueUnsafe(m_collectionInfo[category].name[i], collBuffers.data);
 
       const auto relVecNames = podio::DatamodelRegistry::instance().getRelationNames(collection->getTypeName());
@@ -168,7 +168,7 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
       }
 
       for (size_t j = 0; j < relVecNames.vectorMembers.size(); ++j) {
-        const auto vecName = relVecNames.vectorMembers[j]; 
+        const auto vecName = relVecNames.vectorMembers[j];
         const auto brName = root_utils::vecBranch(m_collectionInfo[category].name[i], vecName);
         dentry->CaptureValueUnsafe(brName, collBuffers.vectorMembers->at(j).second);
       }
@@ -191,16 +191,14 @@ std::unique_ptr<ROOTFrameData> ROOTNTupleReader::readEntry(const std::string& ca
       // If it is a subset collection, only one reference collection is filled
       if (m_collectionInfo[category].isSubsetCollection[i]) {
         maxj = 1;
-      }
-      else {
+      } else {
         maxj = refCollections->size();
       }
       for (size_t j = 0; j < maxj; ++j) {
         std::string brName;
         if (m_collectionInfo[category].isSubsetCollection[i]) {
           brName = root_utils::subsetBranch(m_collectionInfo[category].name[i]);
-        }
-        else {
+        } else {
           brName = root_utils::refBranch(m_collectionInfo[category].name[i], relVecNames.relations[j]);
         }
         refCollections->at(j) = std::unique_ptr<std::vector<podio::ObjectID>>(tmp[{brName, j}]);

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -139,7 +139,7 @@ ROOTNTupleWriter::createModels(const std::vector<StoreCollection>& collections) 
     const auto collBuffers = coll->getBuffers();
 
     if (collBuffers.vecPtr) {
-      auto collClassName = "std::vector<" + coll->getDataTypeName() + ">";
+      auto collClassName = "std::vector<" + std::string(coll->getDataTypeName()) + ">";
       auto field = ROOT::Experimental::Detail::RFieldBase::Create(name, collClassName).Unwrap();
       model->AddField(std::move(field));
     }
@@ -202,7 +202,7 @@ void ROOTNTupleWriter::finish() {
   }
 
   for (auto& category : m_categories) {
-    auto idField = m_metadata->MakeField<std::vector<int>>({root_utils::idTableName(category)});
+    auto idField = m_metadata->MakeField<std::vector<unsigned int>>({root_utils::idTableName(category)});
     *idField = m_collectionInfo[category].id;
     auto collectionNameField = m_metadata->MakeField<std::vector<std::string>>({root_utils::collectionName(category)});
     *collectionNameField = m_collectionInfo[category].name;

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -92,10 +92,10 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
     // entry->CaptureValueUnsafe(root_utils::paramBranchName, &const_cast<podio::GenericParameters&>(frame.getParameters()));
 
     if (new_category) {
-      m_collectionId[category].emplace_back(coll->getID());
-      m_collectionName[category].emplace_back(name);
-      m_collectionType[category].emplace_back(coll->getTypeName());
-      m_isSubsetCollection[category].emplace_back(coll->isSubsetCollection());
+      m_collectionInfo[category].id.emplace_back(coll->getID());
+      m_collectionInfo[category].name.emplace_back(name);
+      m_collectionInfo[category].type.emplace_back(coll->getTypeName());
+      m_collectionInfo[category].isSubsetCollection.emplace_back(coll->isSubsetCollection());
     }
   }
 
@@ -176,19 +176,19 @@ void ROOTNTupleWriter::finish() {
   *edmField = edmDefinitions;
 
   auto availableCategoriesField = m_metadata->MakeField<std::vector<std::string>>(root_utils::availableCategories);
-  for (auto& [c, _] : m_collectionId) {
+  for (auto& [c, _] : m_collectionInfo) {
     availableCategoriesField->push_back(c);
   }
 
   for (auto& category : m_categories) {
     auto idField = m_metadata->MakeField<std::vector<int>>(root_utils::idTableName(category));
-    *idField = m_collectionId[category];
+    *idField = m_collectionInfo[category].id;
     auto collectionNameField = m_metadata->MakeField<std::vector<std::string>>(root_utils::collectionName(category));
-    *collectionNameField = m_collectionName[category];
+    *collectionNameField = m_collectionInfo[category].name;
     auto collectionTypeField = m_metadata->MakeField<std::vector<std::string>>(root_utils::collInfoName(category));
-    *collectionTypeField = m_collectionType[category];
+    *collectionTypeField = m_collectionInfo[category].type;
     auto subsetCollectionField = m_metadata->MakeField<std::vector<short>>(root_utils::subsetCollection(category));
-    *subsetCollectionField = m_isSubsetCollection[category];
+    *subsetCollectionField = m_collectionInfo[category].isSubsetCollection;
   }
 
   m_metadata->Freeze();
@@ -198,7 +198,7 @@ void ROOTNTupleWriter::finish() {
 
   m_file->Write();
 
-  // All the tuple writers have to be deleted before the file so that they flush
+  // All the tuple writers must be deleted before the file so that they flush
   // unwritten output
   m_writers.clear();
   m_metadataWriter.reset();

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -151,15 +151,15 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOTNTupleWriter::createModels
   // model->MakeField<podio::GenericParameters>(root_utils::paramBranchName);
 
   // gp = Generic Parameters
-  auto gpintKeys = model->MakeField<std::vector<std::string>>(root_utils::intKey);
-  auto gpfloatKeys = model->MakeField<std::vector<std::string>>(root_utils::floatKey);
-  auto gpdoubleKeys = model->MakeField<std::vector<std::string>>(root_utils::doubleKey);
-  auto gpstringKeys = model->MakeField<std::vector<std::string>>(root_utils::stringKey);
+  auto gpintKeys = model->MakeField<std::vector<std::string>>(root_utils::intKeyName);
+  auto gpfloatKeys = model->MakeField<std::vector<std::string>>(root_utils::floatKeyName);
+  auto gpdoubleKeys = model->MakeField<std::vector<std::string>>(root_utils::doubleKeyName);
+  auto gpstringKeys = model->MakeField<std::vector<std::string>>(root_utils::stringKeyName);
 
-  auto gpintValues = model->MakeField<std::vector<std::vector<int>>>(root_utils::intValue);
-  auto gpfloatValues = model->MakeField<std::vector<std::vector<float>>>(root_utils::floatValue);
-  auto gpdoubleValues = model->MakeField<std::vector<std::vector<double>>>(root_utils::doubleValue);
-  auto gpstringValues = model->MakeField<std::vector<std::vector<std::string>>>(root_utils::stringValue);
+  auto gpintValues = model->MakeField<std::vector<std::vector<int>>>(root_utils::intValueName);
+  auto gpfloatValues = model->MakeField<std::vector<std::vector<float>>>(root_utils::floatValueName);
+  auto gpdoubleValues = model->MakeField<std::vector<std::vector<double>>>(root_utils::doubleValueName);
+  auto gpstringValues = model->MakeField<std::vector<std::vector<std::string>>>(root_utils::stringValueName);
 
   model->Freeze();
   return model;

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -1,7 +1,7 @@
 #include "podio/ROOTNTupleWriter.h"
 #include "podio/CollectionBase.h"
-#include "podio/GenericParameters.h"
 #include "podio/DatamodelRegistry.h"
+#include "podio/GenericParameters.h"
 #include "podio/SchemaEvolution.h"
 #include "podio/podioVersion.h"
 #include "rootUtils.h"
@@ -146,7 +146,6 @@ ROOTNTupleWriter::createModels(const std::vector<StoreCollection>& collections) 
   auto model = ROOT::Experimental::RNTupleModel::CreateBare();
   for (auto& [name, coll] : collections) {
     const auto collBuffers = coll->getBuffers();
-
 
     if (collBuffers.vecPtr) {
       auto collClassName = "std::vector<" + std::string(coll->getDataTypeName()) + ">";

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -83,9 +83,7 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
       for (auto& [type, vec] : (*vmInfo)) {
         const auto typeName = "vector<" + type + ">";
         const auto brName = root_utils::vecBranch(name, i++);
-        std::cout << typeName << " " << brName << std::endl;
         auto ptr = *(std::vector<int>**)vec;
-        std::cout << "Vector: Size is " << ptr->size();
         entry->CaptureValueUnsafe(brName, ptr);
       }
     }
@@ -118,8 +116,6 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOTNTupleWriter::createModels
 
     if (collBuffers.vecPtr) {
       auto collClassName = "std::vector<" + coll->getDataTypeName() +">";
-      std::cout << name << " " << collClassName << std::endl;
-      std::cout << "Making field with name = " << name << " and collClassName = " << collClassName << std::endl;
       auto field = ROOT::Experimental::Detail::RFieldBase::Create(name, collClassName).Unwrap();
       model->AddField(std::move(field));
     }
@@ -129,7 +125,6 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOTNTupleWriter::createModels
       for (auto& c [[maybe_unused]] : (*refColls)) {
         const auto brName = root_utils::refBranch(name, i);
         auto collClassName = "vector<podio::ObjectID>";
-        std::cout << "Making reference field with name = " << brName << " and collClassName = " << collClassName << std::endl;
         auto field = ROOT::Experimental::Detail::RFieldBase::Create(brName, collClassName).Unwrap();
         model->AddField(std::move(field));
         ++i;

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -211,7 +211,7 @@ void ROOTNTupleWriter::finish() {
     *collectionNameField = m_collectionName[category];
     auto collectionTypeField = m_metadata->MakeField<std::vector<std::string>>(root_utils::collInfoName(category));
     *collectionTypeField = m_collectionType[category];
-    auto subsetCollectionField = m_metadata->MakeField<std::vector<bool>>(root_utils::subsetCollection(category));
+    auto subsetCollectionField = m_metadata->MakeField<std::vector<short>>(root_utils::subsetCollection(category));
     *subsetCollectionField = m_isSubsetCollection[category];
   }
 

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -1,6 +1,7 @@
 #include "podio/ROOTNTupleWriter.h"
 #include "podio/CollectionBase.h"
 #include "podio/GenericParameters.h"
+#include "podio/SchemaEvolution.h"
 #include "podio/podioVersion.h"
 #include "rootUtils.h"
 
@@ -96,6 +97,7 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
       m_collectionInfo[category].name.emplace_back(name);
       m_collectionInfo[category].type.emplace_back(coll->getTypeName());
       m_collectionInfo[category].isSubsetCollection.emplace_back(coll->isSubsetCollection());
+      m_collectionInfo[category].schemaVersion.emplace_back(coll->getSchemaVersion());
     }
   }
 
@@ -188,6 +190,8 @@ void ROOTNTupleWriter::finish() {
     *collectionTypeField = m_collectionInfo[category].type;
     auto subsetCollectionField = m_metadata->MakeField<std::vector<short>>({root_utils::subsetCollection(category)});
     *subsetCollectionField = m_collectionInfo[category].isSubsetCollection;
+    auto schemaVersionField = m_metadata->MakeField<std::vector<SchemaVersionT>>({"schemaVersion_" + category});
+    *schemaVersionField = m_collectionInfo[category].schemaVersion;
   }
 
   m_metadata->Freeze();

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -26,8 +26,8 @@ ROOTNTupleWriter::~ROOTNTupleWriter() {
 
 template<typename T>
 void ROOTNTupleWriter::fillParams(const std::string& category, GenericParameters& params) {
-  auto gpKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::getGPKey<T>());
-  auto gpValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<T>>>(root_utils::getGPValue<T>());
+  auto gpKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::getGPKeyName<T>());
+  auto gpValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<T>>>(root_utils::getGPValueName<T>());
   gpKeys->clear();
   gpValues->clear();
   for (auto& [k, v] : params.getMap<T>()) {

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -29,7 +29,9 @@ void ROOTNTupleWriter::fillParams(const std::string& category, GenericParameters
   auto gpKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::getGPKeyName<T>());
   auto gpValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<T>>>(root_utils::getGPValueName<T>());
   gpKeys->clear();
+  gpKeys->reserve(params.getMap<T>().size());
   gpValues->clear();
+  gpValues->reserve(params.getMap<T>().size());
   for (auto& [k, v] : params.getMap<T>()) {
     gpKeys->emplace_back(k);
     gpValues->emplace_back(v);

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -180,6 +180,11 @@ void ROOTNTupleWriter::finish() {
   auto edm_field = m_metadata->MakeField<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
   *edm_field = edmDefinitions;
 
+  auto availableCategoriesField = m_metadata->MakeField<std::vector<std::string>>("available_categories");
+  for (auto& [c, _] : m_collectionId ) {
+    availableCategoriesField->push_back(c);
+  }
+
   for (auto& category : m_categories) {
     auto idField = m_metadata->MakeField<std::vector<int>>(root_utils::idTableName(category));
     *idField = m_collectionId[category];

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -1,8 +1,8 @@
 #include "podio/ROOTNTupleWriter.h"
-#include "podio/GenericParameters.h"
-#include "rootUtils.h"
 #include "podio/CollectionBase.h"
+#include "podio/GenericParameters.h"
 #include "podio/podioVersion.h"
+#include "rootUtils.h"
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
@@ -13,10 +13,9 @@
 namespace podio {
 
 ROOTNTupleWriter::ROOTNTupleWriter(const std::string& filename) :
-  m_metadata(ROOT::Experimental::RNTupleModel::Create()),
-  m_file(new TFile(filename.c_str(), "RECREATE", "data file"))
-  {
-  }
+    m_metadata(ROOT::Experimental::RNTupleModel::Create()),
+    m_file(new TFile(filename.c_str(), "RECREATE", "data file")) {
+}
 
 ROOTNTupleWriter::~ROOTNTupleWriter() {
   if (!m_finished) {
@@ -24,7 +23,7 @@ ROOTNTupleWriter::~ROOTNTupleWriter() {
   }
 }
 
-template<typename T>
+template <typename T>
 void ROOTNTupleWriter::fillParams(const std::string& category, GenericParameters& params) {
   auto gpKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::getGPKeyName<T>());
   auto gpValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<T>>>(root_utils::getGPValueName<T>());
@@ -89,7 +88,8 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
     }
 
     // Not supported
-    // entry->CaptureValueUnsafe(root_utils::paramBranchName, &const_cast<podio::GenericParameters&>(frame.getParameters()));
+    // entry->CaptureValueUnsafe(root_utils::paramBranchName,
+    // &const_cast<podio::GenericParameters&>(frame.getParameters()));
 
     if (new_category) {
       m_collectionInfo[category].id.emplace_back(coll->getID());
@@ -109,13 +109,14 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
   m_categories.insert(category);
 }
 
-std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOTNTupleWriter::createModels(const std::vector<StoreCollection>& collections) {
+std::unique_ptr<ROOT::Experimental::RNTupleModel>
+ROOTNTupleWriter::createModels(const std::vector<StoreCollection>& collections) {
   auto model = ROOT::Experimental::RNTupleModel::Create();
   for (auto& [name, coll] : collections) {
     const auto collBuffers = coll->getBuffers();
 
     if (collBuffers.vecPtr) {
-      auto collClassName = "std::vector<" + coll->getDataTypeName() +">";
+      auto collClassName = "std::vector<" + coll->getDataTypeName() + ">";
       auto field = ROOT::Experimental::Detail::RFieldBase::Create(name, collClassName).Unwrap();
       model->AddField(std::move(field));
     }
@@ -142,7 +143,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOTNTupleWriter::createModels
       }
     }
   }
-  
+
   // Not supported by ROOT because podio::GenericParameters has map types
   // so we have to split them manually
   // model->MakeField<podio::GenericParameters>(root_utils::paramBranchName);
@@ -169,7 +170,8 @@ void ROOTNTupleWriter::finish() {
   *versionField = {podioVersion.major, podioVersion.minor, podioVersion.patch};
 
   auto edmDefinitions = m_datamodelCollector.getDatamodelDefinitionsToWrite();
-  auto edmField = m_metadata->MakeField<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
+  auto edmField =
+      m_metadata->MakeField<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
   *edmField = edmDefinitions;
 
   auto availableCategoriesField = m_metadata->MakeField<std::vector<std::string>>(root_utils::availableCategories);
@@ -189,7 +191,8 @@ void ROOTNTupleWriter::finish() {
   }
 
   m_metadata->Freeze();
-  m_metadataWriter = ROOT::Experimental::RNTupleWriter::Append(std::move(m_metadata), root_utils::metaTreeName, *m_file, {});
+  m_metadataWriter =
+      ROOT::Experimental::RNTupleWriter::Append(std::move(m_metadata), root_utils::metaTreeName, *m_file, {});
 
   m_metadataWriter->Fill();
 
@@ -203,4 +206,4 @@ void ROOTNTupleWriter::finish() {
   m_finished = true;
 }
 
-} //namespace podio
+} // namespace podio

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -180,13 +180,13 @@ void ROOTNTupleWriter::finish() {
   }
 
   for (auto& category : m_categories) {
-    auto idField = m_metadata->MakeField<std::vector<int>>(root_utils::idTableName(category));
+    auto idField = m_metadata->MakeField<std::vector<int>>({root_utils::idTableName(category)});
     *idField = m_collectionInfo[category].id;
-    auto collectionNameField = m_metadata->MakeField<std::vector<std::string>>(root_utils::collectionName(category));
+    auto collectionNameField = m_metadata->MakeField<std::vector<std::string>>({root_utils::collectionName(category)});
     *collectionNameField = m_collectionInfo[category].name;
-    auto collectionTypeField = m_metadata->MakeField<std::vector<std::string>>(root_utils::collInfoName(category));
+    auto collectionTypeField = m_metadata->MakeField<std::vector<std::string>>({root_utils::collInfoName(category)});
     *collectionTypeField = m_collectionInfo[category].type;
-    auto subsetCollectionField = m_metadata->MakeField<std::vector<short>>(root_utils::subsetCollection(category));
+    auto subsetCollectionField = m_metadata->MakeField<std::vector<short>>({root_utils::subsetCollection(category)});
     *subsetCollectionField = m_collectionInfo[category].isSubsetCollection;
   }
 

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -24,6 +24,18 @@ ROOTNTupleWriter::~ROOTNTupleWriter() {
   }
 }
 
+template<typename T>
+void ROOTNTupleWriter::fillParams(const std::string& category, GenericParameters& params) {
+  auto gpKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::getGPKey<T>());
+  auto gpValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<T>>>(root_utils::getGPValue<T>());
+  gpKeys->clear();
+  gpValues->clear();
+  for (auto& [k, v] : params.getMap<T>()) {
+    gpKeys->emplace_back(k);
+    gpValues->emplace_back(v);
+  }
+}
+
 void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& category) {
   writeFrame(frame, category, frame.getAvailableCollections());
 }
@@ -88,46 +100,10 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
   }
 
   auto params = frame.getParameters();
-  auto intMap = params.getIntMap();
-  auto floatMap = params.getFloatMap();
-  auto doubleMap = params.getDoubleMap();
-  auto stringMap = params.getStringMap();
-
-  auto gpintKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::intKey);
-  auto gpfloatKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::floatKey);
-  auto gpdoubleKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::doubleKey);
-  auto gpstringKeys = m_writers[category]->GetModel()->Get<std::vector<std::string>>(root_utils::stringKey);
-
-  auto gpintValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<int>>>(root_utils::intValue);
-  auto gpfloatValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<float>>>(root_utils::floatValue);
-  auto gpdoubleValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<double>>>(root_utils::doubleValue);
-  auto gpstringValues = m_writers[category]->GetModel()->Get<std::vector<std::vector<std::string>>>(root_utils::stringValue);
-
-  gpintKeys->clear();
-  gpintValues->clear();
-  for (auto& [k, v] : intMap) {
-    gpintKeys->emplace_back(k);
-    gpintValues->emplace_back(v);
-  }
-
-  gpfloatKeys->clear();
-  gpfloatValues->clear();
-  for (auto& [k, v] : floatMap) {
-    gpfloatKeys->emplace_back(k);
-    gpfloatValues->emplace_back(v);
-  }
-  gpdoubleKeys->clear();
-  gpdoubleValues->clear();
-  for (auto& [k, v] : doubleMap) {
-    gpdoubleKeys->emplace_back(k);
-    gpdoubleValues->emplace_back(v);
-  }
-  gpstringKeys->clear();
-  gpstringValues->clear();
-  for (auto& [k, v] : stringMap) {
-    gpstringKeys->emplace_back(k);
-    gpstringValues->emplace_back(v);
-  }
+  fillParams<int>(category, params);
+  fillParams<float>(category, params);
+  fillParams<double>(category, params);
+  fillParams<std::string>(category, params);
 
   m_writers[category]->Fill();
   m_categories.insert(category);

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -52,7 +52,6 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
   options.SetCompression(ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
 
   for (const auto& [name, coll] : collections) {
-    // coll->prepareForWrite();
     auto collBuffers = coll->getBuffers();
     if (collBuffers.vecPtr) {
       std::cout << "Capturing unsafe " << name << std::endl;

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -99,20 +99,21 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
       }
     }
 
-    // if (auto vmInfo = collBuffers.vectorMembers) {
-    //   int i = 0;
-    //   for (auto& [type, vec] : (*vmInfo)) {
-    //     const auto typeName = "vector<" + type + ">";
-    //     const auto brName = root_utils::vecBranch(name, i++);
-    //     std::cout << typeName << " " << brName << std::endl;
-    //     auto ptr = (std::vector<int>*)vec;
-    //     std::cout << "Size is " << ptr->size();
-    //     if (m_first) {
-    //       // m_entry->CaptureValueUnsafe(brName, (void*) vec);
-    //       m_first = false;
-    //     }
-    //   }
-    // }
+    if (auto vmInfo = collBuffers.vectorMembers) {
+      int i = 0;
+      for (auto& [type, vec] : (*vmInfo)) {
+        const auto typeName = "vector<" + type + ">";
+        const auto brName = root_utils::vecBranch(name, i++);
+        std::cout << typeName << " " << brName << std::endl;
+        auto ptr = *(std::vector<int>**)vec;
+        std::cout << "Vector: Size is " << ptr->size();
+        m_entry->CaptureValueUnsafe(brName, ptr);
+        // if (m_first) {
+        //   // m_entry->CaptureValueUnsafe(brName, (void*) vec);
+        //   m_first = false;
+        // }
+      }
+    }
 
     // Not supported
     // m_entry->CaptureValueUnsafe(root_utils::paramBranchName, &const_cast<podio::GenericParameters&>(frame.getParameters()));
@@ -149,7 +150,6 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
     gpintKeys->emplace_back(k);
     gpintValues->emplace_back(v);
   }
-  std::cout << "Size of gpfloatKeys before filling " << gpfloatKeys->size() << " " << gpfloatValues->size() << std::endl;
 
   gpfloatKeys->clear();
   gpfloatValues->clear();
@@ -203,16 +203,16 @@ std::unique_ptr<rnt::RNTupleModel> ROOTNTupleWriter::createModels(const std::vec
       }
     }
 
-    // if (auto vminfo = collBuffers.vectorMembers) {
-    //   int i = 0;
-    //   for (auto& [type, vec] : (*vminfo)) {
-    //     const auto typeName = "vector<" + type + ">";
-    //     const auto brName = root_utils::vecBranch(name, i);
-    //     auto field = rnt::Detail::RFieldBase::Create(brName, typeName).Unwrap();
-    //     model->AddField(std::move(field));
-    //     ++i;
-    //   }
-    // }
+    if (auto vminfo = collBuffers.vectorMembers) {
+      int i = 0;
+      for (auto& [type, vec] : (*vminfo)) {
+        const auto typeName = "vector<" + type + ">";
+        const auto brName = root_utils::vecBranch(name, i);
+        auto field = rnt::Detail::RFieldBase::Create(brName, typeName).Unwrap();
+        model->AddField(std::move(field));
+        ++i;
+      }
+    }
   }
   
   // gp = Generic Parameters
@@ -225,31 +225,6 @@ std::unique_ptr<rnt::RNTupleModel> ROOTNTupleWriter::createModels(const std::vec
   auto gpfloatValues = model->MakeField<std::vector<std::vector<float>>>("GP_float_values");
   auto gpdoubleValues = model->MakeField<std::vector<std::vector<double>>>("GP_double_values");
   auto gpstringValues = model->MakeField<std::vector<std::vector<std::string>>>("GP_string_values");
-
-  // auto intMap = params.getIntMap();
-  // auto floatMap = params.getFloatMap();
-  // auto doubleMap = params.getDoubleMap();
-  // auto stringMap = params.getStringMap();
-
-  // for (auto& [k, v] : intMap) {
-  //   gpintKeys->emplace_back(k);
-  //   gpintValues->emplace_back(v);
-  // }
-  // for (auto& [k, v] : floatMap) {
-  //   gpfloatKeys->emplace_back(k);
-  //   gpfloatValues->emplace_back(v);
-  //   for (auto& x : v) {
-  //     std::cout << "floatMap: " << x << std::endl;
-  //   }
-  // }
-  // for (auto& [k, v] : doubleMap) {
-  //   gpdoubleKeys->emplace_back(k);
-  //   gpdoubleValues->emplace_back(v);
-  // }
-  // for (auto& [k, v] : stringMap) {
-  //   gpstringKeys->emplace_back(k);
-  //   gpstringValues->emplace_back(v);
-  // }
 
   // Not supported by ROOT
   // model->MakeField<podio::GenericParameters>(root_utils::paramBranchName);

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -26,8 +26,7 @@ ROOTNTupleWriter::~ROOTNTupleWriter() {
 }
 
 template <typename T>
-std::pair<std::vector<std::string>&, std::vector<std::vector<T>>&>
-ROOTNTupleWriter::getKeyValueVectors() {
+std::pair<std::vector<std::string>&, std::vector<std::vector<T>>&> ROOTNTupleWriter::getKeyValueVectors() {
   if constexpr (std::is_same_v<T, int>) {
     return {m_intkeys, m_intvalues};
   } else if constexpr (std::is_same_v<T, float>) {
@@ -42,7 +41,7 @@ ROOTNTupleWriter::getKeyValueVectors() {
 }
 
 template <typename T>
-void ROOTNTupleWriter::fillParams(GenericParameters& params, ROOT::Experimental::REntry *entry) {
+void ROOTNTupleWriter::fillParams(GenericParameters& params, ROOT::Experimental::REntry* entry) {
   auto [key, value] = getKeyValueVectors<T>();
   entry->CaptureValueUnsafe(root_utils::getGPKeyName<T>(), &key);
   entry->CaptureValueUnsafe(root_utils::getGPValueName<T>(), &value);
@@ -56,7 +55,6 @@ void ROOTNTupleWriter::fillParams(GenericParameters& params, ROOT::Experimental:
     key.emplace_back(kk);
     value.emplace_back(vv);
   }
-
 }
 
 void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& category) {
@@ -171,15 +169,27 @@ ROOTNTupleWriter::createModels(const std::vector<StoreCollection>& collections) 
   // so we have to split them manually
   // model->MakeField<podio::GenericParameters>(root_utils::paramBranchName);
 
-  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::intKeyName, "std::vector<std::string>>").Unwrap());
-  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::floatKeyName, "std::vector<std::string>>").Unwrap());
-  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::doubleKeyName, "std::vector<std::string>>").Unwrap());
-  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::stringKeyName, "std::vector<std::string>>").Unwrap());
+  model->AddField(
+      ROOT::Experimental::Detail::RFieldBase::Create(root_utils::intKeyName, "std::vector<std::string>>").Unwrap());
+  model->AddField(
+      ROOT::Experimental::Detail::RFieldBase::Create(root_utils::floatKeyName, "std::vector<std::string>>").Unwrap());
+  model->AddField(
+      ROOT::Experimental::Detail::RFieldBase::Create(root_utils::doubleKeyName, "std::vector<std::string>>").Unwrap());
+  model->AddField(
+      ROOT::Experimental::Detail::RFieldBase::Create(root_utils::stringKeyName, "std::vector<std::string>>").Unwrap());
 
-  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::intValueName, "std::vector<std::vector<int>>").Unwrap());
-  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::floatValueName, "std::vector<std::vector<float>>").Unwrap());
-  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::doubleValueName, "std::vector<std::vector<double>>").Unwrap());
-  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::stringValueName, "std::vector<std::vector<std::string>>").Unwrap());
+  model->AddField(
+      ROOT::Experimental::Detail::RFieldBase::Create(root_utils::intValueName, "std::vector<std::vector<int>>")
+          .Unwrap());
+  model->AddField(
+      ROOT::Experimental::Detail::RFieldBase::Create(root_utils::floatValueName, "std::vector<std::vector<float>>")
+          .Unwrap());
+  model->AddField(
+      ROOT::Experimental::Detail::RFieldBase::Create(root_utils::doubleValueName, "std::vector<std::vector<double>>")
+          .Unwrap());
+  model->AddField(ROOT::Experimental::Detail::RFieldBase::Create(root_utils::stringValueName,
+                                                                 "std::vector<std::vector<std::string>>")
+                      .Unwrap());
 
   model->Freeze();
   return model;

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -60,7 +60,7 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
   for (const auto& [name, coll] : collections) {
     // coll->prepareForWrite();
     auto collBuffers = coll->getBuffers();
-    if (collBuffers.data) {
+    if (collBuffers.vecPtr) {
       std::cout << "Capturing unsafe " << name << std::endl;
 
       // auto v = (std::vector<ExampleMCData>*)collBuffers.data;
@@ -71,7 +71,7 @@ void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& 
       //   std::cout << x.energy << std::endl;
       // }
 
-      m_entry->CaptureValueUnsafe(name, (void*)collBuffers.data);
+      m_entry->CaptureValueUnsafe(name, (void*)collBuffers.vecPtr);
 
       // std::cout << "After capturing " << std::endl;
       // v = (std::vector<ExampleMCData>*)collBuffers.data;
@@ -183,7 +183,7 @@ std::unique_ptr<rnt::RNTupleModel> ROOTNTupleWriter::createModels(const std::vec
   for (auto& [name, coll] : collections) {
     const auto collBuffers = coll->getBuffers();
 
-    if (collBuffers.data) {
+    if (collBuffers.vecPtr) {
       auto collClassName = "std::vector<" + coll->getDataTypeName() +">";
       std::cout << name << " " << collClassName << std::endl;
       std::cout << "Making field with name = " << name << " and collClassName = " << collClassName << std::endl;

--- a/src/ROOTNTupleWriter.cc
+++ b/src/ROOTNTupleWriter.cc
@@ -1,0 +1,174 @@
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <algorithm>
+
+#include "rootUtils.h"
+
+#include "podio/CollectionBase.h"
+#include "podio/EventStore.h"
+#include "podio/ROOTWriter.h"
+#include "podio/podioVersion.h"
+
+// ROOT specifc includes
+#include "TFile.h"
+
+#include "podio/ROOTNTupleWriter.h"
+
+#include "datamodel/ExampleMCData.h"
+
+namespace podio {
+
+ROOTNTupleWriter::ROOTNTupleWriter(const std::string& filename) :
+    m_metadata(nullptr),
+    m_file(new TFile(filename.c_str(),"RECREATE","data file"))
+  {
+    m_metadata = rnt::RNTupleModel::Create();
+
+  }
+
+void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& category) {
+  writeFrame(frame, category, frame.getAvailableCollections());
+}
+
+void ROOTNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& category,
+                                  const std::vector<std::string>& collsToWrite) {
+
+  std::vector<StoreCollection> collections;
+  collections.reserve(collsToWrite.size());
+  for (const auto& name : collsToWrite) {
+    auto* coll = frame.getCollectionForWrite(name);
+    collections.emplace_back(name, const_cast<podio::CollectionBase*>(coll));
+  }
+
+  if (m_writers.find(category) == m_writers.end()) {
+    auto model = createModels(collections);
+    m_writers[category] = rnt::RNTupleWriter::Append(std::move(model), category, *m_file.get(), {});
+  }
+
+  m_entry = m_writers[category]->GetModel()->GetDefaultEntry();
+
+  rnt::RNTupleWriteOptions options;
+  options.SetCompression(ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
+
+  for (const auto& [name, coll] : collections) {
+    // coll->prepareForWrite();
+    auto collBuffers = coll->getBuffers();
+    if (collBuffers.data) {
+      std::cout << "Capturing unsafe " << name << std::endl;
+
+      // auto v = (std::vector<ExampleMCData>*)collBuffers.data;
+      // std::cout << "Size is " << v->size() << std::endl;
+      // std::cout << (*v)[0].energy << std::endl;
+      // for (auto& x : *v) {
+      //   std::cout << "Inside loop " << std::endl;
+      //   std::cout << x.energy << std::endl;
+      // }
+
+      m_entry->CaptureValueUnsafe(name, (void*)collBuffers.data);
+
+      // std::cout << "After capturing " << std::endl;
+      // v = (std::vector<ExampleMCData>*)collBuffers.data;
+      // std::cout << "Size is " << v->size() << std::endl;
+      // std::cout << (*v)[0].energy << std::endl;
+      // for (auto& x : *v) {
+      //   std::cout << "Inside loop " << std::endl;
+      //   std::cout << x.energy << std::endl;
+      // }
+
+      // auto ptr = (std::vector<ExampleMCData>*)collBuffers.data;
+      // auto start = (char*)ptr->data();
+      // for (int i = 0; i < 13; ++i) {
+      //     printf("%x ", start[i]);
+      // }
+      // std::cout << std::endl;
+
+    }
+
+    if (auto refColls = collBuffers.references) {
+      int i = 0;
+      for (auto& c : (*refColls)) {
+        const auto brName = root_utils::refBranch(name, i++);
+        m_entry->CaptureValueUnsafe(brName, c.get());
+      }
+    }
+
+    // if (auto vmInfo = collBuffers.vectorMembers) {
+    //   int i = 0;
+    //   for (auto& [type, vec] : (*vmInfo)) {
+    //     const auto typeName = "vector<" + type + ">";
+    //     const auto brName = root_utils::vecBranch(name, i++);
+    //     std::cout << typeName << " " << brName << std::endl;
+    //     auto ptr = (std::vector<int>*)vec;
+    //     std::cout << "Size is " << ptr->size();
+    //     if (m_first) {
+    //       // m_entry->CaptureValueUnsafe(brName, (void*) vec);
+    //       m_first = false;
+    //     }
+    //   }
+    // }
+  }
+  m_writers[category]->Fill();
+}
+
+std::unique_ptr<rnt::RNTupleModel> ROOTNTupleWriter::createModels(const std::vector<StoreCollection>& collections) {
+  auto model = rnt::RNTupleModel::Create();
+  for (auto& [name, coll] : collections) {
+    const auto collBuffers = coll->getBuffers();
+
+    if (collBuffers.data) {
+      auto collClassName = "std::vector<" + coll->getDataTypeName() +">";
+      std::cout << name << " " << collClassName << std::endl;
+      auto field = rnt::Detail::RFieldBase::Create(name, collClassName).Unwrap();
+      model->AddField(std::move(field));
+    }
+
+    if (auto refColls = collBuffers.references) {
+      int i = 0;
+      for (auto& c : (*refColls)) {
+        const auto brName = root_utils::refBranch(name, i);
+        auto collClassName = "vector<podio::ObjectID>";
+        auto field = rnt::Detail::RFieldBase::Create(brName, collClassName).Unwrap();
+        model->AddField(std::move(field));
+        ++i;
+      }
+    }
+
+    // if (auto vminfo = collBuffers.vectorMembers) {
+    //   int i = 0;
+    //   for (auto& [type, vec] : (*vminfo)) {
+    //     const auto typeName = "vector<" + type + ">";
+    //     const auto brName = root_utils::vecBranch(name, i);
+    //     auto field = rnt::Detail::RFieldBase::Create(brName, typeName).Unwrap();
+    //     model->AddField(std::move(field));
+    //     ++i;
+    //   }
+    // }
+  }
+  model->Freeze();
+  return model;
+}
+
+void ROOTNTupleWriter::finish() {
+
+  auto podioVersion = podio::version::build_version;
+  auto version_field = m_metadata->MakeField<std::vector<int>>(root_utils::versionBranchName);
+  *version_field = {podioVersion.major, podioVersion.minor, podioVersion.patch};
+
+  auto edmDefinitions = m_datamodelCollector.getDatamodelDefinitionsToWrite();
+  auto edm_field = m_metadata->MakeField<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
+  *edm_field = edmDefinitions;
+
+  m_metadata->Freeze();
+  m_metadata_writer = rnt::RNTupleWriter::Append(std::move(m_metadata), root_utils::metaTreeName, *m_file.get(), {});
+
+  m_metadata_writer->Fill();
+
+  m_file->Write();
+
+  // All the tuple writers have to be deleted before the file so that they flush
+  // unwritten output
+  m_writers.clear();
+  m_metadata_writer.reset();
+}
+
+} //namespace podio

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -47,6 +47,43 @@ constexpr static auto doubleValue = "GPDoubleValues";
 constexpr static auto stringValue = "GPStringValues";
 
 /**
+ * Get the name of the key depending on the type
+ */
+template <typename T>
+constexpr auto getGPKey() {
+  if constexpr (std::is_same<T, int>::value) {
+    return intKey;
+  } else if constexpr (std::is_same<T, float>::value) {
+    return floatKey;
+  } else if constexpr (std::is_same<T, double>::value) {
+    return doubleKey;
+  } else if constexpr (std::is_same<T, std::string>::value) {
+    return stringKey;
+  } else {
+    static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
+  }
+}
+
+/**
+ * Get the name of the value depending on the type
+ */
+template <typename T>
+constexpr auto getGPValue() {
+  if constexpr (std::is_same<T, int>::value) {
+    return intValue;
+  } else if constexpr (std::is_same<T, float>::value) {
+    return floatValue;
+  } else if constexpr (std::is_same<T, double>::value) {
+    return doubleValue;
+  } else if constexpr (std::is_same<T, std::string>::value) {
+    return stringValue;
+  } else {
+    static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
+  }
+}
+
+
+/**
  * Name of the field with the list of categories for RNTuples
  */
 constexpr static auto availableCategories = "availableCategories";

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -33,6 +33,41 @@ constexpr static auto metaTreeName = "podio_metadata";
 constexpr static auto paramBranchName = "PARAMETERS";
 
 /**
+ * Names of the fields with the keys and values of the generic parameters for
+ * the RNTuples until map types are supported
+ */
+constexpr static auto intKey = "GPIntKeys";
+constexpr static auto floatKey = "GPFloatKeys";
+constexpr static auto doubleKey = "GPDoubleKeys";
+constexpr static auto stringKey = "GPStringKeys";
+
+constexpr static auto intValue = "GPIntValues";
+constexpr static auto floatValue = "GPFloatValues";
+constexpr static auto doubleValue = "GPDoubleValues";
+constexpr static auto stringValue = "GPStringValues";
+
+/**
+ * Name of the field with the list of categories for RNTuples
+ */
+constexpr static auto availableCategories = "availableCategories";
+
+/**
+ * Name of the field with the names of the collections for RNTuples
+ */
+inline std::string collectionName(const std::string& category) {
+  return category + "_collectionNames";
+}
+
+/**
+ * Name of the field with the flag for subset collections for RNTuples
+ */
+inline std::string subsetCollection(const std::string& category) {
+  return category + "_isSubsetCollections";
+}
+
+
+
+/**
  * The name of the branch into which we store the build version of podio at the
  * time of writing the file
  */

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -82,7 +82,6 @@ constexpr auto getGPValueName() {
   }
 }
 
-
 /**
  * Name of the field with the list of categories for RNTuples
  */
@@ -101,8 +100,6 @@ inline std::string collectionName(const std::string& category) {
 inline std::string subsetCollection(const std::string& category) {
   return category + "_isSubsetCollections";
 }
-
-
 
 /**
  * The name of the branch into which we store the build version of podio at the

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -36,29 +36,29 @@ constexpr static auto paramBranchName = "PARAMETERS";
  * Names of the fields with the keys and values of the generic parameters for
  * the RNTuples until map types are supported
  */
-constexpr static auto intKey = "GPIntKeys";
-constexpr static auto floatKey = "GPFloatKeys";
-constexpr static auto doubleKey = "GPDoubleKeys";
-constexpr static auto stringKey = "GPStringKeys";
+constexpr static auto intKeyName = "GPIntKeys";
+constexpr static auto floatKeyName = "GPFloatKeys";
+constexpr static auto doubleKeyName = "GPDoubleKeys";
+constexpr static auto stringKeyName = "GPStringKeys";
 
-constexpr static auto intValue = "GPIntValues";
-constexpr static auto floatValue = "GPFloatValues";
-constexpr static auto doubleValue = "GPDoubleValues";
-constexpr static auto stringValue = "GPStringValues";
+constexpr static auto intValueName = "GPIntValues";
+constexpr static auto floatValueName = "GPFloatValues";
+constexpr static auto doubleValueName = "GPDoubleValues";
+constexpr static auto stringValueName = "GPStringValues";
 
 /**
  * Get the name of the key depending on the type
  */
 template <typename T>
-constexpr auto getGPKey() {
+constexpr auto getGPKeyName() {
   if constexpr (std::is_same<T, int>::value) {
-    return intKey;
+    return intKeyName;
   } else if constexpr (std::is_same<T, float>::value) {
-    return floatKey;
+    return floatKeyName;
   } else if constexpr (std::is_same<T, double>::value) {
-    return doubleKey;
+    return doubleKeyName;
   } else if constexpr (std::is_same<T, std::string>::value) {
-    return stringKey;
+    return stringKeyName;
   } else {
     static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
   }
@@ -68,15 +68,15 @@ constexpr auto getGPKey() {
  * Get the name of the value depending on the type
  */
 template <typename T>
-constexpr auto getGPValue() {
+constexpr auto getGPValueName() {
   if constexpr (std::is_same<T, int>::value) {
-    return intValue;
+    return intValueName;
   } else if constexpr (std::is_same<T, float>::value) {
-    return floatValue;
+    return floatValueName;
   } else if constexpr (std::is_same<T, double>::value) {
-    return doubleValue;
+    return doubleValueName;
   } else if constexpr (std::is_same<T, std::string>::value) {
-    return stringValue;
+    return stringValueName;
   } else {
     static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
   }

--- a/tests/root_io/CMakeLists.txt
+++ b/tests/root_io/CMakeLists.txt
@@ -12,6 +12,13 @@ set(root_dependent_tests
   read_frame_legacy_root.cpp
   read_frame_root_multiple.cpp
   )
+if(ENABLE_RNTUPLE)
+  set(root_dependent_tests
+      ${root_dependent_tests}
+      write_rntuple.cpp
+      read_rntuple.cpp
+     )
+endif()
 set(root_libs TestDataModelDict ExtensionDataModelDict podio::podioRootIO)
 foreach( sourcefile ${root_dependent_tests} )
   CREATE_PODIO_TEST(${sourcefile} "${root_libs}")
@@ -27,6 +34,9 @@ set_property(TEST read_frame_legacy_root PROPERTY DEPENDS write)
 set_property(TEST read_timed PROPERTY DEPENDS write_timed)
 set_property(TEST read_frame_root PROPERTY DEPENDS write_frame_root)
 set_property(TEST read_frame_root_multiple PROPERTY DEPENDS write_frame_root)
+if(ENABLE_RNTUPLE)
+  set_property(TEST read_rntuple PROPERTY DEPENDS write_rntuple)
+endif()
 
 add_test(NAME check_benchmark_outputs COMMAND check_benchmark_outputs write_benchmark_root.root read_benchmark_root.root)
 set_property(TEST check_benchmark_outputs PROPERTY DEPENDS read_timed write_timed)

--- a/tests/root_io/read_rntuple.cpp
+++ b/tests/root_io/read_rntuple.cpp
@@ -2,5 +2,5 @@
 #include "read_frame.h"
 
 int main() {
-   return read_frames<podio::ROOTNTupleReader>("example_rntuple.root");
+  return read_frames<podio::ROOTNTupleReader>("example_rntuple.root");
 }

--- a/tests/root_io/read_rntuple.cpp
+++ b/tests/root_io/read_rntuple.cpp
@@ -1,0 +1,6 @@
+#include "podio/ROOTNTupleReader.h"
+#include "read_frame.h"
+
+int main() {
+   return read_frames<podio::ROOTNTupleReader>("example_rntuple.root");
+}

--- a/tests/root_io/write_rntuple.cpp
+++ b/tests/root_io/write_rntuple.cpp
@@ -1,0 +1,6 @@
+#include "podio/ROOTNTupleWriter.h"
+#include "write_frame.h"
+
+int main(){
+  write_frames<podio::ROOTNTupleWriter>("example_rntuple.root");
+}

--- a/tests/root_io/write_rntuple.cpp
+++ b/tests/root_io/write_rntuple.cpp
@@ -1,6 +1,6 @@
 #include "podio/ROOTNTupleWriter.h"
 #include "write_frame.h"
 
-int main(){
+int main() {
   write_frames<podio::ROOTNTupleWriter>("example_rntuple.root");
 }


### PR DESCRIPTION
Add a writer and a reader using the podio Frame format. All tests pass and it doesn't break the other writes but the cost for that is a couple of ugly workarounds (see https://github.com/AIDASoft/podio/issues/393 for some of the issues that were found while doing this). My idea is that this is merged first and then we worry about the workarounds if fixes have not been found in time, otherwise this PR will get quite complicated.

For running with this a recent version of ROOT is needed, 6.28.00 or newer (I'm not sure 100% if it works with 6.28.00 since I have been running off master). There is a new option in the CMakeLists to enable support for this by asking cmake to find the relevant ROOT library. When this option is enabled (`-DENABLE_RNTUPLE`), the writer reader and tests will be compiled, otherwise nothing should have changed. 

The writer and reader have a very similar interface to the current TTree-based frame ones. The tests are the same for both. How the writer and reader work is a bit different, of course, from the TTree-based. For example, RNTuple doesn't support mapped types right now so for the generic parameters there is a 'disentangling' from the map types to simple vector types that are saved in the rntuple and then reconstructed in the reader (from vector to map types). I tried to make it as simple as possible by not using extra types and trying to pull few headers from podio.

It's still not fully ready for merging as cleanups need to be done and more comments are needed in several places. Also the support for reading from multiple files is not complete right now. It is a bit more tricky than the TTree case since there is no equivalent to a TChain as far as I know.

BEGINRELEASENOTES
- Add support for the new RNTuple format by adding a writer, reader and tests.

ENDRELEASENOTES

Supersedes https://github.com/AIDASoft/podio/pull/247