### PR TITLE
Do not mark generated files as GENERATED

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -464,7 +464,6 @@ have resolvable schema evolution incompatibilities:")
         list_cont.append(f'  {os.path.join(target_folder, fname)}')
 
       list_cont.append(')')
-      list_cont.append(f'SET_PROPERTY(SOURCE ${{{name}}} PROPERTY GENERATED TRUE)\n')
 
       return '\n'.join(list_cont)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the `GENERATED` property from generated files in CMake to avoid inconsistent removal of headers and source files with the `clean` target. Fixes #396 

ENDRELEASENOTES

@andresailer do you have any better idea for this? There was quite some discussion already in #143 but nothing too specific about the `GENERATED` property.

@DraTeots could you give this a go and check whether this indeed solves your issue?