### PR TITLE
Define PODIO_ENABLE_SIO for targets depending on podioSioIO

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,10 +125,10 @@ if(ENABLE_SIO)
 
   PODIO_ADD_LIB_AND_DICT(podioSioIO "${sio_headers}" "${sio_sources}" sio_selection.xml)
   target_link_libraries(podioSioIO PUBLIC podio::podio SIO::sio ${CMAKE_DL_LIBS} ${PODIO_FS_LIBS})
+  target_compile_definitions(podioSioIO PUBLIC PODIO_ENABLE_SIO=1)
 
   # Make sure the legacy python bindings know about the SIO backend
   target_link_libraries(podioPythonStore PRIVATE podioSioIO)
-  target_compile_definitions(podioPythonStore PRIVATE PODIO_ENABLE_SIO=1)
 
   LIST(APPEND INSTALL_LIBRARIES podioSioIO podioSioIODict)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ function(CREATE_PODIO_TEST sourcefile additional_libs)
   add_executable( ${name} ${sourcefile} )
   add_test(NAME ${name} COMMAND ${name})
 
-  target_link_libraries(${name} TestDataModel ExtensionDataModel ${additional_libs})
+  target_link_libraries(${name} PRIVATE TestDataModel ExtensionDataModel ${additional_libs})
   set_property(TEST ${name} PROPERTY ENVIRONMENT
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH}
       # Clear the ROOT_INCLUDE_PATH for the tests, to avoid potential conflicts
@@ -96,7 +96,7 @@ endif()
 if (DEFINED CACHE{PODIO_TEST_INPUT_DATA_DIR})
   message(STATUS "Using test inputs stored in: "  ${PODIO_TEST_INPUT_DATA_DIR})
   add_executable(read-legacy-files read-legacy-files.cpp)
-  target_link_libraries(read-legacy-files TestDataModel TestDataModelDict podio::podioRootIO)
+  target_link_libraries(read-legacy-files PRIVATE TestDataModel TestDataModelDict podio::podioRootIO)
   add_test(NAME read-legacy-files COMMAND read-legacy-files ${PODIO_TEST_INPUT_DATA_DIR}/example.root)
 
   set_property(TEST read-legacy-files PROPERTY ENVIRONMENT
@@ -157,8 +157,8 @@ if (TARGET TestDataModelSioBlocks)
   # These need to be linked against TTree explicitly, since it is not done
   # through another library and the TimedReader/Writer decorators are
   # header-only wrappers
-  target_link_libraries(write_timed_sio ROOT::Tree)
-  target_link_libraries(read_timed_sio ROOT::Tree)
+  target_link_libraries(write_timed_sio PRIVATE ROOT::Tree)
+  target_link_libraries(read_timed_sio PRIVATE ROOT::Tree)
 endif()
 
 #--- set some dependencies between the different tests to ensure input generating ones are run first
@@ -170,7 +170,7 @@ set_property(TEST read_timed PROPERTY DEPENDS write_timed)
 set_property(TEST read_frame PROPERTY DEPENDS write_frame_root)
 
 add_executable(check_benchmark_outputs check_benchmark_outputs.cpp)
-target_link_libraries(check_benchmark_outputs ROOT::Tree)
+target_link_libraries(check_benchmark_outputs PRIVATE ROOT::Tree)
 
 add_test(NAME check_benchmark_outputs COMMAND check_benchmark_outputs write_benchmark_root.root read_benchmark_root.root)
 set_property(TEST check_benchmark_outputs PROPERTY DEPENDS read_timed write_timed)
@@ -207,7 +207,6 @@ add_executable(unittest unittest.cpp frame.cpp)
 target_link_libraries(unittest PUBLIC TestDataModel PRIVATE Catch2::Catch2WithMain Threads::Threads podio::podioRootIO)
 if (ENABLE_SIO)
   target_link_libraries(unittest PRIVATE podio::podioSioIO)
-  target_compile_definitions(unittest PRIVATE PODIO_WITH_SIO)
 endif()
 
 # The unittests are a bit better and they are labelled so we can put together a

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -15,7 +15,11 @@
 #include "podio/ROOTLegacyReader.h"
 #include "podio/ROOTReader.h"
 #include "podio/podioVersion.h"
-#ifdef PODIO_ENABLE_SIO
+
+#ifndef PODIO_ENABLE_SIO
+  #define PODIO_ENABLE_SIO 0
+#endif
+#if PODIO_ENABLE_SIO
   #include "podio/SIOFrameReader.h"
   #include "podio/SIOLegacyReader.h"
   #include "podio/SIOReader.h"
@@ -1061,7 +1065,7 @@ TEST_CASE("Missing files (ROOT readers)", "[basics]") {
   REQUIRE_THROWS_AS(root_frame_reader.openFile("NonExistentFile.root"), std::runtime_error);
 }
 
-#ifdef PODIO_ENABLE_SIO
+#if PODIO_ENABLE_SIO
 TEST_CASE("Missing files (SIO readers)", "[basics]") {
   auto sio_reader = podio::SIOReader();
   REQUIRE_THROWS_AS(sio_reader.openFile("NonExistentFile.sio"), std::runtime_error);

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -15,7 +15,7 @@
 #include "podio/ROOTLegacyReader.h"
 #include "podio/ROOTReader.h"
 #include "podio/podioVersion.h"
-#ifdef PODIO_WITH_SIO
+#ifdef PODIO_ENABLE_SIO
   #include "podio/SIOFrameReader.h"
   #include "podio/SIOLegacyReader.h"
   #include "podio/SIOReader.h"
@@ -1061,7 +1061,7 @@ TEST_CASE("Missing files (ROOT readers)", "[basics]") {
   REQUIRE_THROWS_AS(root_frame_reader.openFile("NonExistentFile.root"), std::runtime_error);
 }
 
-#ifdef PODIO_WITH_SIO
+#ifdef PODIO_ENABLE_SIO
 TEST_CASE("Missing files (SIO readers)", "[basics]") {
   auto sio_reader = podio::SIOReader();
   REQUIRE_THROWS_AS(sio_reader.openFile("NonExistentFile.sio"), std::runtime_error);


### PR DESCRIPTION

BEGINRELEASENOTES
- Add `PODIO_ENABLE_SIO=1` to the public `target_compile_definitions` for `podioSioIO` so that all dependent targets automatically get it as well. This should make it easier to use SIO dependent features in dependencies. 
- Consistently use a scope for `target_link_libraries` in tests.

ENDRELEASENOTES


 Since `podioSioIO` is the main target from podio that will always be necessary to link against when using SIO features this should cover all possible cases (as long as CMake is used to build dependencies).