### PR TITLE
Make SIOFrameData work properly with dropped collections

### DIFF
--- a/tests/read_frame.cpp
+++ b/tests/read_frame.cpp
@@ -1,7 +1,9 @@
+#include "read_frame.h"
+#include "read_frame_auxiliary.h"
+
 #include "podio/ROOTFrameReader.h"
 
-#include "read_frame.h"
-
 int main() {
-  return read_frames<podio::ROOTFrameReader>("example_frame.root");
+  return read_frames<podio::ROOTFrameReader>("example_frame.root") +
+      test_frame_aux_info<podio::ROOTFrameReader>("example_frame.root");
 }

--- a/tests/read_frame_auxiliary.h
+++ b/tests/read_frame_auxiliary.h
@@ -1,0 +1,65 @@
+#ifndef PODIO_TESTS_READ_FRAME_AUXILIARY_H // NOLINT(llvm-header-guard): folder structure not suitable
+#define PODIO_TESTS_READ_FRAME_AUXILIARY_H // NOLINT(llvm-header-guard): folder structure not suitable
+
+#include "write_frame.h"
+
+#include "podio/Frame.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+bool present(const std::string& elem, const std::vector<std::string>& vec) {
+  return std::find(vec.begin(), vec.end(), elem) != vec.end();
+}
+
+int testGetAvailableCollections(const podio::Frame& frame, const std::vector<std::string>& expected) {
+  const auto& collNames = frame.getAvailableCollections();
+  int result = 0;
+  for (const auto& name : expected) {
+    if (!present(name, collNames)) {
+      std::cerr << "Cannot find expected collection " << name << " in collections of Frame" << std::endl;
+      result = 1;
+    }
+  }
+
+  // Get a few collections and make sure that the resutls are unchanged (apart
+  // from ordering)
+  frame.get("hitRefs");
+  frame.get("mcparticles");
+
+  const auto& newCollNames = frame.getAvailableCollections();
+  for (const auto& name : newCollNames) {
+    if (!present(name, collNames)) {
+      std::cerr << "getAvailableCollections returns different collections after getting collections" << std::endl;
+      return 1;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Test function for testing some auxiliary functionality of the Frame.
+ * Encapsulates everything, such that a corresponding main function boils down
+ * to including the reader to test and defining a main that invokes and returns
+ * this function.
+ *
+ * @param fileName the name of the file to read from
+ * @tparam ReaderT a Frame based I/O capable reader
+ * @return 0 if all checks pass, non-zero otherwise
+ * */
+template <typename ReaderT>
+int test_frame_aux_info(const std::string& fileName) {
+  auto reader = ReaderT{};
+  reader.openFile(fileName);
+
+  // Test on the first event only here. Additionally, also only testing the
+  // "events" category, since that is the one where not all collections are
+  // written
+  auto event = podio::Frame(reader.readEntry("events", 0));
+
+  return testGetAvailableCollections(event, collsToWrite);
+}
+
+#endif // PODIO_TESTS_READ_FRAME_AUXILIARY_H

--- a/tests/read_frame_sio.cpp
+++ b/tests/read_frame_sio.cpp
@@ -1,7 +1,9 @@
+#include "read_frame.h"
+#include "read_frame_auxiliary.h"
+
 #include "podio/SIOFrameReader.h"
 
-#include "read_frame.h"
-
 int main() {
-  return read_frames<podio::SIOFrameReader>("example_frame.sio");
+  return read_frames<podio::SIOFrameReader>("example_frame.sio") +
+      test_frame_aux_info<podio::SIOFrameReader>("example_frame.sio");
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a bug in `SIOFrameData::getAvailableCollections` to also work with Frames where some of the collections have not been written and that could lead to a seg fault.
- Add a test for this in c++ (previously only covered in python unittests of Frame). 

ENDRELEASENOTES

Previously obtaining all collection names relied on the fact that the indices in the `m_blocks` block list aligned with the order of the collectionID table. It worked if the collectionIDs were contiguous (which is the case if no collections are dropped during writing). Since the order of the collIDs in the table coincides with the indices of the `m_blocks`, we use that to get the correct name.