### PR TITLE
Introduce warnings about upcoming signature change

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -62,7 +62,7 @@ jobs:
             cd $STARTDIR/edm4hep
             mkdir build && cd build
             cmake -DCMAKE_CXX_STANDARD=17 \
-              -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
+              -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
               -DUSE_EXTERNAL_CATCH2=ON \
               -G Ninja ..
             ninja -k0

--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#define DEPR_SIGNATURE [[deprecated("The return type of this function will become string_view soon")]]
+
 namespace podio {
 // forward declarations
 class ICollectionProvider;
@@ -63,11 +65,11 @@ public:
   virtual size_t size() const = 0;
 
   /// fully qualified type name
-  virtual std::string getTypeName() const = 0;
+  DEPR_SIGNATURE virtual std::string getTypeName() const = 0;
   /// fully qualified type name of elements - with namespace
-  virtual std::string getValueTypeName() const = 0;
+  DEPR_SIGNATURE virtual std::string getValueTypeName() const = 0;
   /// fully qualified type name of stored POD elements - with namespace
-  virtual std::string getDataTypeName() const = 0;
+  DEPR_SIGNATURE virtual std::string getDataTypeName() const = 0;
   /// schema version of the collection
   virtual SchemaVersionT getSchemaVersion() const = 0;
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a deprecation warning for podio::CollectionBase::getTypeName` and friends to warn about the upcoming (#402) change in return type. 

ENDRELEASENOTES

As discussed during the meeting on Apr 11 in order to give a heads up to users.