### PR TITLE
Remove selection rules for classes that don't exist anymore

### DIFF
--- a/src/selection.xml
+++ b/src/selection.xml
@@ -6,9 +6,6 @@
         <field name="m_doubleMtx" transient="true"/>
         <field name="m_stringMtx" transient="true"/>
     </class>
-    <class name="podio::IntVec"/>
-    <class name="podio::FloatVec"/>
-    <class name="podio::StringVec"/>
     <class name="podio::GenericParameters::MapType<int>"/>
     <class name="podio::GenericParameters::MapType<float>"/>
     <class name="podio::GenericParameters::MapType<double>"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove selection rules for classes that don't exist anymore

ENDRELEASENOTES

Forgotten in #415. There are a few small warnings but it's very hard to see them between all the warnings about deprecated stuff. I think that should be all, I only found a reference in a [comment](https://github.com/AIDASoft/podio/blob/master/lcio/datalayout.yaml#L93) 