### PR TITLE
Fix a version check inside the ROOTReader to avoid seg faults

### DIFF
--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -177,7 +177,7 @@ void ROOTReader::openFiles(const std::vector<std::string>& filenames) {
     const auto collectionInfo = root_utils::reconstructCollectionInfo(m_chain, *m_table);
     createCollectionBranches(collectionInfo);
 
-  } else if (m_fileVersion < podio::version::Version{0, 17, 0}) {
+  } else if (m_fileVersion < podio::version::Version{0, 16, 4}) {
 
     auto* collInfoBranch = root_utils::getBranch(metadatatree, "CollectionTypeInfo");
     auto collectionInfoWithoutSchema = new std::vector<root_utils::CollectionInfoTWithoutSchema>;


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a version check inside the `ROOTReader` to avoid segmentation violations

ENDRELEASENOTES

Caused by the manual changes of the CMake version variables in #341 . Now using an actual tag, and going back to the automatic changes in the tagging script.