### PR TITLE
Improve podio dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ In order for the `yaml` module to be working it might also be necessary to insta
 
 Check that you can now import the `yaml` and `jinja2` modules in python.
 
-Optionally, `graphviz` is also required for the visualization tool `podio-vis`.
+Some tools have additional dependencies that are not required for code generation or library use
+- `graphviz` is required for `podio-vis`
+- `tabulate` is required for `podio-dump`
 
 ## Preparing the environment
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # From pypi
 pyyaml
 jinja2
+tabulate

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -5,8 +5,10 @@ import sys
 import json
 import yaml
 
-from podio import __version__
 from tabulate import tabulate
+
+from podio import __version__
+
 
 def print_general_info(reader, filename):
   """Print an overview of the file contents at the very beginning.
@@ -57,17 +59,15 @@ def print_frame_overview(frame):
   for name in sorted(frame.collections, key=str.casefold):
     coll = frame.get(name)
     rows.append(
-      (name, coll.getValueTypeName().data(), len(coll), f'{coll.getID():0>8x}')
-    )
+        (name, coll.getValueTypeName().data(), len(coll), f'{coll.getID():0>8x}')
+        )
   print('Collections:')
   print(tabulate(rows, headers=["Name", "ValueType", "Size", "ID"]))
 
   rows = []
   for name in sorted(frame.parameters, key=str.casefold):
     for par_type, n_pars in frame.get_param_info(name).items():
-      rows.append(
-        [name, par_type, n_pars]
-      )
+      rows.append([name, par_type, n_pars])
   print('\nParameters:')
   print(tabulate(rows, headers=["Name", "Type", "Elements"]))
 
@@ -106,7 +106,7 @@ def dump_model(reader, model_name):
 
 def main(args):
   """Main"""
-  from podio.reading import get_reader
+  from podio.reading import get_reader  # pylint: disable=import-outside-toplevel
   try:
     reader = get_reader(args.inputfile)
   except ValueError as err:

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -45,7 +45,7 @@ def print_frame(frame, cat_name, ientry, detailed):
     print('-' * 82)
 
   # Print collections
-  for name in frame.collections:
+  for name in sorted(frame.collections, key=str.casefold):
     coll = frame.get(name)
     if detailed:
       print(name, flush=True)

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -5,8 +5,6 @@ import sys
 import json
 import yaml
 
-from podio.reading import get_reader
-
 
 def print_general_info(reader, filename):
   """Print an overview of the file contents at the very beginning.
@@ -86,6 +84,7 @@ def dump_model(reader, model_name):
 
 def main(args):
   """Main"""
+  from podio.reading import get_reader
   try:
     reader = get_reader(args.inputfile)
   except ValueError as err:

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -5,6 +5,7 @@ import sys
 import json
 import yaml
 
+from podio import __version__
 
 def print_general_info(reader, filename):
   """Print an overview of the file contents at the very beginning.
@@ -144,6 +145,7 @@ if __name__ == '__main__':
   parser.add_argument('--dump-edm',
                       help='Dump the specified EDM definition from the file in yaml format',
                       type=str, default=None)
+  parser.add_argument('--version', action='version', version=f'podio {__version__}')
 
   clargs = parser.parse_args()
   main(clargs)

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -6,6 +6,7 @@ import json
 import yaml
 
 from podio import __version__
+from tabulate import tabulate
 
 def print_general_info(reader, filename):
   """Print an overview of the file contents at the very beginning.
@@ -28,8 +29,51 @@ def print_general_info(reader, filename):
   print()
 
 
+def print_frame_detailed(frame):
+  """Print the Frame in all its glory, dumping every collection via print
+
+  Args:
+      frame (podio.Frame): The frame to print
+  """
+  print('Collections:')
+  for name in sorted(frame.collections, key=str.casefold):
+    coll = frame.get(name)
+    print(name, flush=True)
+    coll.print()
+    print(flush=True)
+
+  print('\nParameters:', flush=True)
+  frame.get_parameters().print()
+  print(flush=True)
+
+
+def print_frame_overview(frame):
+  """Print a Frame overview, dumping just collection names, types and sizes
+
+  Args:
+      frame (podio.Frame): The frame to print
+  """
+  rows = []
+  for name in sorted(frame.collections, key=str.casefold):
+    coll = frame.get(name)
+    rows.append(
+      (name, coll.getValueTypeName().data(), len(coll), f'{coll.getID():0>8x}')
+    )
+  print('Collections:')
+  print(tabulate(rows, headers=["Name", "ValueType", "Size", "ID"]))
+
+  rows = []
+  for name in sorted(frame.parameters, key=str.casefold):
+    for par_type, n_pars in frame.get_param_info(name).items():
+      rows.append(
+        [name, par_type, n_pars]
+      )
+  print('\nParameters:')
+  print(tabulate(rows, headers=["Name", "Type", "Elements"]))
+
+
 def print_frame(frame, cat_name, ientry, detailed):
-  """Print a Frame overview.
+  """Print a Frame.
 
   Args:
       frame (podio.Frame): The frame to print
@@ -38,34 +82,11 @@ def print_frame(frame, cat_name, ientry, detailed):
       detailed (bool): Print just an overview or dump the whole contents
   """
   print('{:#^82}'.format(f' {cat_name} {ientry} '))  # pylint: disable=consider-using-f-string
-  print('Collections:')
 
-  if not detailed:
-    print(f'{"Name":<38} {"ID":<4} {"Type":<32} {"Size":<10}')
-    print('-' * 82)
-
-  # Print collections
-  for name in sorted(frame.collections, key=str.casefold):
-    coll = frame.get(name)
-    if detailed:
-      print(name, flush=True)
-      coll.print()
-      print(flush=True)
-    else:
-      print(f'{name:<38} {coll.getID():<4} {coll.getValueTypeName().data():<32} {len(coll):<10}')
-
-  # And then parameters
-  print('\nParameters:', flush=True)
   if detailed:
-    frame.get_parameters().print()
-    print(flush=True)
+    print_frame_detailed(frame)
   else:
-    print(f'{"Name":<30} {"Type":<12} {"Elements":<10}')
-    print('-' * 54)
-    for name in frame.parameters:
-      par_infos = frame.get_param_info(name)
-      for par_type, n_pars in par_infos.items():
-        print(f'{name:<30} {par_type:<12} {n_pars:<10}')
+    print_frame_overview(frame)
 
   # Additional new line before the next entry
   print('\n', flush=True)


### PR DESCRIPTION

BEGINRELEASENOTES
- Delay library loading as long as possible, mainly for quicker responses for `--help`
- Add a `--version` flag for dumping the podio version
- Display collections and parameters in alphabetical order and automatically adjust column widths to fit contents (using the `tabulate` package).

ENDRELEASENOTES

Fixes #352 

