### PR TITLE
Allow not calling `finish()` when using the writers

### DIFF
--- a/include/podio/ROOTFrameWriter.h
+++ b/include/podio/ROOTFrameWriter.h
@@ -24,7 +24,7 @@ class GenericParameters;
 class ROOTFrameWriter {
 public:
   ROOTFrameWriter(const std::string& filename);
-  ~ROOTFrameWriter() = default;
+  ~ROOTFrameWriter();
 
   ROOTFrameWriter(const ROOTFrameWriter&) = delete;
   ROOTFrameWriter& operator=(const ROOTFrameWriter&) = delete;
@@ -83,6 +83,8 @@ private:
   std::unordered_map<std::string, CategoryInfo> m_categories{}; ///< All categories
 
   DatamodelDefinitionCollector m_datamodelCollector{};
+
+  bool m_finished{false}; ///< Whether writing has been actually done
 };
 
 } // namespace podio

--- a/include/podio/SIOWriter.h
+++ b/include/podio/SIOWriter.h
@@ -20,7 +20,7 @@ class DEPR_EVTSTORE SIOWriter {
 
 public:
   SIOWriter(const std::string& filename, EventStore* store);
-  ~SIOWriter() = default;
+  ~SIOWriter();
 
   // non-copyable
   SIOWriter(const SIOWriter&) = delete;
@@ -46,6 +46,8 @@ private:
   std::shared_ptr<SIONumberedMetaDataBlock> m_collectionMetaData;
   SIOFileTOCRecord m_tocRecord{};
   std::vector<std::string> m_collectionsToWrite{};
+
+  bool m_finished{false};
 };
 
 } // namespace podio

--- a/src/ROOTFrameWriter.cc
+++ b/src/ROOTFrameWriter.cc
@@ -15,6 +15,12 @@ ROOTFrameWriter::ROOTFrameWriter(const std::string& filename) {
   m_file = std::make_unique<TFile>(filename.c_str(), "recreate");
 }
 
+ROOTFrameWriter::~ROOTFrameWriter() {
+  if (!m_finished) {
+    finish();
+  }
+}
+
 void ROOTFrameWriter::writeFrame(const podio::Frame& frame, const std::string& category) {
   writeFrame(frame, category, frame.getAvailableCollections());
 }
@@ -143,6 +149,8 @@ void ROOTFrameWriter::finish() {
 
   m_file->Write();
   m_file->Close();
+
+  m_finished = true;
 }
 
 } // namespace podio

--- a/src/SIOWriter.cc
+++ b/src/SIOWriter.cc
@@ -34,6 +34,12 @@ SIOWriter::SIOWriter(const std::string& filename, EventStore* store) :
   auto& libLoader [[maybe_unused]] = SIOBlockLibraryLoader::instance();
 }
 
+SIOWriter::~SIOWriter() {
+  if (!m_finished) {
+    finish();
+  }
+}
+
 void SIOWriter::writeEvent() {
   if (m_firstEvent) {
     // Write the collectionIDs as a separate record at the beginning of the
@@ -86,6 +92,8 @@ void SIOWriter::finish() {
   m_stream.write(reinterpret_cast<char*>(&finalWords), sizeof(finalWords));
 
   m_stream.close();
+
+  m_finished = true;
 }
 
 void SIOWriter::registerForWrite(const std::string& name) {


### PR DESCRIPTION
Forgetting `finish()` is likely a mistake and by the time the writer is destroyed what the user probably wanted to is to write. The RNTuple ROOT writer works like that and writes when the object is destroyed. For the RNTuple writer in podio this is already done.

BEGINRELEASENOTES
- Allow not calling `finish()` when using the writers

ENDRELEASENOTES