### PR TITLE
Make the SIOFrameWriter call to finish non-mandatory

### DIFF
--- a/include/podio/SIOFrameWriter.h
+++ b/include/podio/SIOFrameWriter.h
@@ -17,7 +17,7 @@ class Frame;
 class SIOFrameWriter {
 public:
   SIOFrameWriter(const std::string& filename);
-  ~SIOFrameWriter() = default;
+  ~SIOFrameWriter();
 
   SIOFrameWriter(const SIOFrameWriter&) = delete;
   SIOFrameWriter& operator=(const SIOFrameWriter&) = delete;
@@ -37,6 +37,7 @@ private:
   sio::ofstream m_stream{};       ///< The output file stream
   SIOFileTOCRecord m_tocRecord{}; ///< The "table of contents" of the written file
   DatamodelDefinitionCollector m_datamodelCollector{};
+  bool m_finished{false}; ///< Has finish been called already?
 };
 } // namespace podio
 

--- a/src/SIOFrameWriter.cc
+++ b/src/SIOFrameWriter.cc
@@ -26,6 +26,12 @@ SIOFrameWriter::SIOFrameWriter(const std::string& filename) {
   sio_utils::writeRecord(blocks, "podio_header_info", m_stream, sizeof(podio::version::Version), false);
 }
 
+SIOFrameWriter::~SIOFrameWriter() {
+  if (!m_finished) {
+    finish();
+  }
+}
+
 void SIOFrameWriter::writeFrame(const podio::Frame& frame, const std::string& category) {
   writeFrame(frame, category, frame.getAvailableCollections());
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- Make calling `finish` for the `SIOFrameWriter` non-mandatory. See #442 for other related changes.

ENDRELEASENOTES