### PR TITLE
Add python bindings for writing Frames

### DIFF
--- a/python/podio/base_writer.py
+++ b/python/podio/base_writer.py
@@ -21,4 +21,4 @@ class BaseWriterMixin:
         collections (optional, default=None): The subset of collections to
            write. If None, all collections are written
     """
-    self._writer.writeFrame(frame._frame, category, collections or list())
+    self._writer.writeFrame(frame._frame, category, collections or frame.collections)

--- a/python/podio/base_writer.py
+++ b/python/podio/base_writer.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Python module for defining the basic writer interface that is used by the
+backend specific bindings"""
+
+
+class BaseWriterMixin:
+  """Mixin class that defines the base interface of the writers.
+
+  The backend specific writers inherit from here and have to initialize the
+  following members:
+    - _writer: The actual writer that is able to write frames
+  """
+
+  def write_frame(self, frame, category, collections=None):
+    """Write the given frame under the passed category, optionally limiting the
+    collections that are written.
+
+    Args:
+        frame (podio.frame.Frame): The Frame to write
+        category (str): The category name
+        collections (optional, default=None): The subset of collections to
+           write. If None, all collections are written
+    """
+    self._writer.writeFrame(frame._frame, category, collections or list())

--- a/python/podio/base_writer.py
+++ b/python/podio/base_writer.py
@@ -21,4 +21,5 @@ class BaseWriterMixin:
         collections (optional, default=None): The subset of collections to
            write. If None, all collections are written
     """
+    # pylint: disable-next=protected-access
     self._writer.writeFrame(frame._frame, category, collections or frame.collections)

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -236,7 +236,6 @@ class Frame:
 
     self._param_key_types = self._get_param_keys_types()  # refresh the cache
 
-
   def get_parameters(self):
     """Get the complete podio::GenericParameters object stored in this Frame.
 

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -82,7 +82,6 @@ class Frame:
   # with the correct type that we can compare against
   _coll_nullptr = cppyy.bind_object(cppyy.nullptr, 'podio::CollectionBase')
 
-
   def __init__(self, data=None):
     """Create a Frame.
 

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -131,13 +131,18 @@ class Frame:
   def put(self, collection, name):
     """Put the collection into the frame
 
+    The passed collectoin is "moved" into the Frame, i.e. it cannot be used any
+    longer after a call to this function. This also means that only objects that
+    were in the collection at the time of calling this function will be
+    available afterwards.
+
     Args:
         collection (podio.CollectionBase): The collection to put into the Frame
         name (str): The name of the collection
 
     Returns:
         podio.CollectionBase: The reference to the collection that has been put
-           into the Frame
+            into the Frame. NOTE: That mutating this collection is not allowed.
 
     Raises:
         ValueError: If collection is not actually a podio.CollectionBase

--- a/python/podio/root_io.py
+++ b/python/podio/root_io.py
@@ -8,6 +8,7 @@ from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
 from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
 from podio.base_writer import BaseWriterMixin  # pylint: disable=wrong-import-position
 
+
 class Reader(BaseReaderMixin):
   """Reader class for reading podio root files."""
 

--- a/python/podio/root_io.py
+++ b/python/podio/root_io.py
@@ -6,8 +6,7 @@ gSystem.Load('libpodioRootIO')  # noqa: E402
 from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
 
 from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
-
-Writer = podio.ROOTFrameWriter
+from podio.base_writer import BaseWriterMixin  # pylint: disable=wrong-import-position
 
 
 class Reader(BaseReaderMixin):
@@ -49,3 +48,14 @@ class LegacyReader(BaseReaderMixin):
     self._is_legacy = True
 
     super().__init__()
+
+
+class Writer(BaseWriterMixin):
+  """Writer class for writing podio root files"""
+  def __init__(self, filename):
+    """Create a writer for writing files
+
+    Args:
+        filename (str): The name of the output file
+    """
+    self._writer = podio.ROOTFrameWriter(filename)

--- a/python/podio/root_io.py
+++ b/python/podio/root_io.py
@@ -8,7 +8,6 @@ from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
 from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
 from podio.base_writer import BaseWriterMixin  # pylint: disable=wrong-import-position
 
-
 class Reader(BaseReaderMixin):
   """Reader class for reading podio root files."""
 

--- a/python/podio/sio_io.py
+++ b/python/podio/sio_io.py
@@ -9,8 +9,7 @@ if ret < 0:
 from ROOT import podio  # noqa: 402 # pylint: disable=wrong-import-position
 
 from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
-
-Writer = podio.SIOFrameWriter
+from podio.base_writer import BaseWriterMixin  # pylint: disable=wrong-import-position
 
 
 class Reader(BaseReaderMixin):
@@ -46,3 +45,14 @@ class LegacyReader(BaseReaderMixin):
     self._is_legacy = True
 
     super().__init__()
+
+
+class Writer(BaseWriterMixin):
+  """Writer class for writing podio root files"""
+  def __init__(self, filename):
+    """Create a writer for writing files
+
+    Args:
+        filename (str): The name of the output file
+    """
+    self._writer = podio.SIOFrameWriter(filename)

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -7,7 +7,7 @@ from podio.frame import Frame
 # using root_io as that should always be present regardless of which backends are built
 from podio.root_io import Reader
 
-from test_utils import ExampleClusterCollection, ExampleHitCollection
+from test_utils import ExampleHitCollection
 
 # The expected collections in each frame
 EXPECTED_COLL_NAMES = {

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -7,6 +7,8 @@ from podio.frame import Frame
 # using root_io as that should always be present regardless of which backends are built
 from podio.root_io import Reader
 
+from test_utils import ExampleClusterCollection, ExampleHitCollection
+
 # The expected collections in each frame
 EXPECTED_COLL_NAMES = {
     'arrays', 'WithVectorMember', 'info', 'fixedWidthInts', 'mcparticles',
@@ -33,6 +35,23 @@ class FrameTest(unittest.TestCase):
 
     with self.assertRaises(KeyError):
       _ = frame.get_parameter('NonExistantParameter')
+
+    with self.assertRaises(ValueError):
+      _ = frame.put(list(), "invalid_collection_type")
+
+  def test_frame_put_collection(self):
+    frame = Frame()
+    self.assertEqual(frame.collections, tuple())
+
+    hits = ExampleHitCollection()
+    hits.create()
+    hits2 = frame.put(hits, "hits_from_python")
+    self.assertEqual(frame.collections, tuple(["hits_from_python"]))
+    # The original collection is gone at this point, and ideally just leaves an
+    # empty shell
+    self.assertEqual(len(hits), 0)
+    # On the other hand the return value of put has the original content
+    self.assertEqual(len(hits2), 1)
 
 
 class FrameReadTest(unittest.TestCase):

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -84,6 +84,14 @@ class FrameTest(unittest.TestCase):
     self.assertEqual(len(vec), 3)
     self.assertEqual(vec, [1.23, 4.56, 7.89])
 
+    frame.put_parameter("real_float_vec", [1.23, 4.56, 7.89], as_type="float")
+    f_vec = frame.get_parameter("real_float_vec", as_type="float")
+    self.assertEqual(len(f_vec), 3)
+    self.assertEqual(vec, [1.23, 4.56, 7.89])
+
+    frame.put_parameter("float_as_float", 3.14, as_type="float")
+    self.assertAlmostEqual(frame.get_parameter("float_as_float"), 3.14, places=5)
+
 
 class FrameReadTest(unittest.TestCase):
   """Unit tests for the Frame python bindings for Frames read from file.

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -40,6 +40,7 @@ class FrameTest(unittest.TestCase):
       _ = frame.put(list(), "invalid_collection_type")
 
   def test_frame_put_collection(self):
+    """Check that putting a collection works as expected"""
     frame = Frame()
     self.assertEqual(frame.collections, tuple())
 
@@ -52,6 +53,36 @@ class FrameTest(unittest.TestCase):
     self.assertEqual(len(hits), 0)
     # On the other hand the return value of put has the original content
     self.assertEqual(len(hits2), 1)
+
+  def test_frame_put_parameters(self):
+    """Check that putting a parameter works as expected"""
+    frame = Frame()
+    self.assertEqual(frame.parameters, tuple())
+
+    frame.put_parameter("a_string_param", "a string")
+    self.assertEqual(frame.parameters, tuple(["a_string_param"]))
+    self.assertEqual(frame.get_parameter("a_string_param"), "a string")
+
+    frame.put_parameter("float_param", 3.14)
+    self.assertEqual(frame.get_parameter("float_param"), 3.14)
+
+    frame.put_parameter("int", 42)
+    self.assertEqual(frame.get_parameter("int"), 42)
+
+    frame.put_parameter("string_vec", ["a", "b", "cd"])
+    str_vec = frame.get_parameter("string_vec")
+    self.assertEqual(len(str_vec), 3)
+    self.assertEqual(str_vec, ["a", "b", "cd"])
+
+    frame.put_parameter("more_ints", [1, 2345])
+    int_vec = frame.get_parameter("more_ints")
+    self.assertEqual(len(int_vec), 2)
+    self.assertEqual(int_vec, [1, 2345])
+
+    frame.put_parameter("float_vec", [1.23, 4.56, 7.89])
+    vec = frame.get_parameter("float_vec", as_type="double")
+    self.assertEqual(len(vec), 3)
+    self.assertEqual(vec, [1.23, 4.56, 7.89])
 
 
 class FrameReadTest(unittest.TestCase):

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -37,7 +37,8 @@ class FrameTest(unittest.TestCase):
       _ = frame.get_parameter('NonExistantParameter')
 
     with self.assertRaises(ValueError):
-      _ = frame.put(list(), "invalid_collection_type")
+      collection = [1, 2, 4]
+      _ = frame.put(collection, "invalid_collection_type")
 
   def test_frame_put_collection(self):
     """Check that putting a collection works as expected"""

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -7,7 +7,7 @@ from podio.frame import Frame
 # using root_io as that should always be present regardless of which backends are built
 from podio.root_io import Reader
 
-from test_utils import ExampleHitCollection
+from podio.test_utils import ExampleHitCollection
 
 # The expected collections in each frame
 EXPECTED_COLL_NAMES = {

--- a/python/podio/test_utils.py
+++ b/python/podio/test_utils.py
@@ -15,7 +15,7 @@ from podio.frame import Frame
 def create_hit_collection():
   """Create a simple hit collection with two hits for testing"""
   hits = ExampleHitCollection()
-  hits.create(0xBAD, 0.0, 0.0, 23.0)
+  hits.create(0xBAD, 0.0, 0.0, 0.0, 23.0)
   hits.create(0xCAFFEE, 1.0, 0.0, 0.0, 12.0)
 
   return hits
@@ -35,8 +35,10 @@ def create_cluster_collection():
 def create_frame():
   """Create a frame with an ExampleHit and an ExampleCluster collection"""
   frame = Frame()
-  frame.put(create_hit_collection(), "hits_from_python")
-  frame.put(create_cluster_collection(), "cluster_from_python")
+  hits = create_hit_collection()
+  frame.put(hits, "hits_from_python")
+  clusters = create_cluster_collection()
+  frame.put(clusters, "clusters_from_python")
 
   return frame
 

--- a/python/podio/test_utils.py
+++ b/python/podio/test_utils.py
@@ -40,6 +40,10 @@ def create_frame():
   clusters = create_cluster_collection()
   frame.put(clusters, "clusters_from_python")
 
+  frame.put_parameter("an_int", 42)
+  frame.put_parameter("some_floats", [1.23, 7.89, 3.14])
+  frame.put_parameter("greetings", ["from", "python"])
+
   return frame
 
 

--- a/python/podio/test_utils.py
+++ b/python/podio/test_utils.py
@@ -8,3 +8,43 @@ SKIP_SIO_TESTS = os.environ.get("SKIP_SIO_TESTS", "1") == "1"
 import ROOT
 ROOT.gSystem.Load("libTestDataModelDict.so")
 from ROOT import ExampleHitCollection, ExampleClusterCollection
+
+from podio.frame import Frame
+
+
+def create_hit_collection():
+  """Create a simple hit collection with two hits for testing"""
+  hits = ExampleHitCollection()
+  hits.create(0xBAD, 0.0, 0.0, 23.0)
+  hits.create(0xCAFFEE, 1.0, 0.0, 0.0, 12.0)
+
+  return hits
+
+
+def create_cluster_collection():
+  """Create a simple cluster collection with two clusters"""
+  clusters = ExampleClusterCollection()
+  clu0 = clusters.create()
+  clu0.energy(3.14)
+  clu1 = clusters.create()
+  clu1.energy(1.23)
+
+  return clusters
+
+
+def create_frame():
+  """Create a frame with an ExampleHit and an ExampleCluster collection"""
+  frame = Frame()
+  frame.put(create_hit_collection(), "hits_from_python")
+  frame.put(create_cluster_collection(), "cluster_from_python")
+
+  return frame
+
+
+def write_file(WriterT, filename):
+  """Write a file using the given Writer type and put one Frame into it under
+  the events category
+  """
+  writer = WriterT(filename)
+  event = create_frame()
+  writer.write_frame(event, "events")

--- a/python/podio/test_utils.py
+++ b/python/podio/test_utils.py
@@ -43,6 +43,8 @@ def create_frame():
   frame.put_parameter("an_int", 42)
   frame.put_parameter("some_floats", [1.23, 7.89, 3.14])
   frame.put_parameter("greetings", ["from", "python"])
+  frame.put_parameter("real_float", 3.14, as_type="float")
+  frame.put_parameter("more_real_floats", [1.23, 4.56, 7.89], as_type="float")
 
   return frame
 

--- a/python/podio/test_utils.py
+++ b/python/podio/test_utils.py
@@ -2,14 +2,14 @@
 """Utilities for python unittests"""
 
 import os
+import ROOT
+ROOT.gSystem.Load("libTestDataModelDict.so")  # noqa: E402
+from ROOT import ExampleHitCollection, ExampleClusterCollection  # noqa: E402 # pylint: disable=wrong-import-position
+
+from podio.frame import Frame  # pylint: disable=wrong-import-position
+
 
 SKIP_SIO_TESTS = os.environ.get("SKIP_SIO_TESTS", "1") == "1"
-
-import ROOT
-ROOT.gSystem.Load("libTestDataModelDict.so")
-from ROOT import ExampleHitCollection, ExampleClusterCollection
-
-from podio.frame import Frame
 
 
 def create_hit_collection():
@@ -47,10 +47,10 @@ def create_frame():
   return frame
 
 
-def write_file(WriterT, filename):
+def write_file(writer_type, filename):
   """Write a file using the given Writer type and put one Frame into it under
   the events category
   """
-  writer = WriterT(filename)
+  writer = writer_type(filename)
   event = create_frame()
   writer.write_frame(event, "events")

--- a/python/podio/test_utils.py
+++ b/python/podio/test_utils.py
@@ -3,4 +3,8 @@
 
 import os
 
-SKIP_SIO_TESTS = os.environ.get('SKIP_SIO_TESTS', '1') == '1'
+SKIP_SIO_TESTS = os.environ.get("SKIP_SIO_TESTS", "1") == "1"
+
+import ROOT
+ROOT.gSystem.Load("libTestDataModelDict.so")
+from ROOT import ExampleHitCollection, ExampleClusterCollection

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -22,6 +22,8 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     read-legacy-files-root_v00-13
     read_frame_legacy_root
     read_frame_root_multiple
+    write_python_frame_root
+    read_python_frame_root
 
     write_frame_root
     read_frame_root
@@ -35,6 +37,8 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     write_frame_sio
     read_frame_sio
     read_frame_legacy_sio
+    write_python_frame_sio
+    read_python_frame_sio
 
     write_ascii
 

--- a/tests/read_python_frame.h
+++ b/tests/read_python_frame.h
@@ -1,0 +1,60 @@
+#ifndef PODIO_TESTS_READ_PYTHON_FRAME_H // NOLINT(llvm-header-guard): folder structure not suitable
+#define PODIO_TESTS_READ_PYTHON_FRAME_H // NOLINT(llvm-header-guard): folder structure not suitable
+
+#include "datamodel/ExampleClusterCollection.h"
+#include "datamodel/ExampleHitCollection.h"
+
+#include "podio/Frame.h"
+
+#include <iostream>
+
+int checkHits(const ExampleHitCollection& hits) {
+  if (hits.size() != 2) {
+    std::cerr << "There should be two hits in the collection (actual size: " << hits.size() << ")" << std::endl;
+    return 1;
+  }
+
+  auto hit1 = hits[0];
+  if (hit1.cellID() != 0xbad || hit1.x() != 0.0 || hit1.y() != 0.0 || hit1.z() != 0.0 || hit1.energy() != 23.0) {
+    std::cerr << "Could not retrieve the correct hit[0]: (expected: " << ExampleHit(0xbad, 0.0, 0.0, 0.0, 23.0)
+              << ", actual: " << hit1 << ")" << std::endl;
+    return 1;
+  }
+
+  auto hit2 = hits[1];
+  if (hit2.cellID() != 0xcaffee || hit2.x() != 1.0 || hit2.y() != 0.0 || hit2.z() != 0.0 || hit2.energy() != 12.0) {
+    std::cerr << "Could not retrieve the correct hit[1]: (expected: " << ExampleHit(0xcaffee, 1.0, 0.0, 0.0, 12.0)
+              << ", actual: " << hit1 << ")" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+int checkClusters(const ExampleClusterCollection& clusters) {
+  if (clusters.size() != 2) {
+    std::cerr << "There should be two clusters in the collection (actual size: " << clusters.size() << ")" << std::endl;
+    return 1;
+  }
+
+  if (clusters[0].energy() != 3.14 || clusters[1].energy() != 1.23) {
+    std::cerr << "Energies of the clusters is wrong: (expected: 3.14 and 1.23, actual " << clusters[0].energy()
+              << " and " << clusters[1].energy() << ")" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+template <typename ReaderT>
+int read_frame(const std::string& filename) {
+  auto reader = ReaderT();
+  reader.openFile(filename);
+
+  auto event = podio::Frame(reader.readEntry("events", 0));
+
+  return checkHits(event.get<ExampleHitCollection>("hits_from_python")) +
+      checkClusters(event.get<ExampleClusterCollection>("clusters_from_python"));
+}
+
+#endif // PODIO_TESTS_READ_PYTHON_FRAME_H

--- a/tests/read_python_frame.h
+++ b/tests/read_python_frame.h
@@ -76,6 +76,19 @@ int checkParameters(const podio::Frame& frame) {
     return 1;
   }
 
+  const auto realFloat = frame.getParameter<float>("real_float");
+  if (realFloat != 3.14f) {
+    std::cerr << "Parameter real_float was not stored correctly (expected 3.14, actual " << realFloat << ")"
+              << std::endl;
+    return 1;
+  }
+
+  const auto& realFloats = frame.getParameter<std::vector<float>>("more_real_floats");
+  if (realFloats.size() != 3 || realFloats[0] != 1.23f || realFloats[1] != 4.56f || realFloats[2] != 7.89f) {
+    std::cerr << "Parameter more_real_floats was not stored as correctly (expected [1.23, 4.56, 7.89], actual"
+              << realFloats << ")" << std::endl;
+  }
+
   return 0;
 }
 

--- a/tests/read_python_frame.h
+++ b/tests/read_python_frame.h
@@ -46,6 +46,39 @@ int checkClusters(const ExampleClusterCollection& clusters) {
   return 0;
 }
 
+template <typename T>
+std::ostream& operator<<(std::ostream& o, const std::vector<T>& vec) {
+  auto delim = "[";
+  for (const auto& v : vec) {
+    o << std::exchange(delim, ", ") << v;
+  }
+  return o << "]";
+}
+
+int checkParameters(const podio::Frame& frame) {
+  const auto iVal = frame.getParameter<int>("an_int");
+  if (iVal != 42) {
+    std::cerr << "Parameter an_int was not stored correctly (expected 42, actual " << iVal << ")" << std::endl;
+    return 1;
+  }
+
+  const auto& dVal = frame.getParameter<std::vector<double>>("some_floats");
+  if (dVal.size() != 3 || dVal[0] != 1.23 || dVal[1] != 7.89 || dVal[2] != 3.14) {
+    std::cerr << "Parameter some_floats was not stored correctly (expected [1.23, 7.89, 3.14], actual " << dVal << ")"
+              << std::endl;
+    return 1;
+  }
+
+  const auto& strVal = frame.getParameter<std::vector<std ::string>>("greetings");
+  if (strVal.size() != 2 || strVal[0] != "from" || strVal[1] != "python") {
+    std::cerr << "Parameter greetings was not stored correctly (expected [from, python], actual " << strVal << ")"
+              << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
 template <typename ReaderT>
 int read_frame(const std::string& filename) {
   auto reader = ReaderT();
@@ -54,7 +87,7 @@ int read_frame(const std::string& filename) {
   auto event = podio::Frame(reader.readEntry("events", 0));
 
   return checkHits(event.get<ExampleHitCollection>("hits_from_python")) +
-      checkClusters(event.get<ExampleClusterCollection>("clusters_from_python"));
+      checkClusters(event.get<ExampleClusterCollection>("clusters_from_python")) + checkParameters(event);
 }
 
 #endif // PODIO_TESTS_READ_PYTHON_FRAME_H

--- a/tests/root_io/CMakeLists.txt
+++ b/tests/root_io/CMakeLists.txt
@@ -69,3 +69,8 @@ if (DEFINED CACHE{PODIO_TEST_INPUT_DATA_DIR})
     ADD_PODIO_LEGACY_TEST(${version} read_frame_legacy_root example.root legacy_test_cases)
   endforeach()
 endif()
+
+#--- Write via python and the ROOT backend and see if we can read it back in in
+#--- c++
+add_test(NAME write_frame_root_python COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/write_frame_root.py)
+PODIO_SET_TEST_ENV(write_frame_root_python)

--- a/tests/root_io/CMakeLists.txt
+++ b/tests/root_io/CMakeLists.txt
@@ -11,6 +11,7 @@ set(root_dependent_tests
   write_frame_root.cpp
   read_frame_legacy_root.cpp
   read_frame_root_multiple.cpp
+  read_python_frame_root.cpp
   )
 if(ENABLE_RNTUPLE)
   set(root_dependent_tests
@@ -72,5 +73,6 @@ endif()
 
 #--- Write via python and the ROOT backend and see if we can read it back in in
 #--- c++
-add_test(NAME write_frame_root_python COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/write_frame_root.py)
-PODIO_SET_TEST_ENV(write_frame_root_python)
+add_test(NAME write_python_frame_root COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/write_frame_root.py)
+PODIO_SET_TEST_ENV(write_python_frame_root)
+set_property(TEST read_python_frame_root PROPERTY DEPENDS write_python_frame_root)

--- a/tests/root_io/read_python_frame_root.cpp
+++ b/tests/root_io/read_python_frame_root.cpp
@@ -1,0 +1,7 @@
+#include "read_python_frame.h"
+
+#include "podio/ROOTFrameReader.h"
+
+int main() {
+  return read_frame<podio::ROOTFrameReader>("example_frame_with_py.root");
+}

--- a/tests/root_io/write_frame_root.py
+++ b/tests/root_io/write_frame_root.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Script to write a Frame in ROOT format"""
 
 from podio import test_utils
 from podio.root_io import Writer

--- a/tests/root_io/write_frame_root.py
+++ b/tests/root_io/write_frame_root.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from podio import test_utils
+from podio.root_io import Writer
+
+test_utils.write_file(Writer, "example_frame_with_py.root")

--- a/tests/sio_io/read_python_frame_sio.cpp
+++ b/tests/sio_io/read_python_frame_sio.cpp
@@ -1,0 +1,7 @@
+#include "read_python_frame.h"
+
+#include "podio/SIOFrameReader.h"
+
+int main() {
+  return read_frame<podio::SIOFrameReader>("example_frame_with_py.sio");
+}

--- a/tests/sio_io/write_frame_sio.py
+++ b/tests/sio_io/write_frame_sio.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from podio import test_utils
+from podio.sio_io import Writer
+
+test_utils.write_file(Writer, "example_frame_with_py.sio")

--- a/tests/sio_io/write_frame_sio.py
+++ b/tests/sio_io/write_frame_sio.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Script to write a Frame in SIO format"""
 
 from podio import test_utils
 from podio.sio_io import Writer


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a python wrapper around the different available Frame writers.
- Add a `put` method to the `Frame` wrapper that allows to add collections to the Frame without having to explicitly use `cppyy.gbl.std.move`. Fixes #432 
- Add test cases that write via python bindings and read via c++.

ENDRELEASENOTES

- [x] Needs #446 
- [x] Also add `put_parameters` (+ tests)
- [x] rebase this onto #449
- [x] Needs #457 