### PR TITLE
Fix the pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,14 +15,17 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_103/x86_64-centos7-clang12-opt
+        container: centos7
+        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           echo "::group::Setup pre-commit"
-          export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
-          export PATH=/root/.local/bin:$PATH
+          # export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
+          # export PATH=/root/.local/bin:$PATH
           pip install pre-commit
+          pip install pylint==2.12.2
+          pip install flake8
           # Use virtualenv from the LCG release
-          pip uninstall --yes virtualenv
+          # pip uninstall --yes virtualenv
           echo "::endgroup::"
           echo "::group::Run CMake"
           mkdir build

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: aidasoft/run-lcg-view@v4
       with:
-        release-platform: LCG_102/x86_64-centos7-clang12-opt
+        release-platform: LCG_103/x86_64-centos7-clang12-opt
         run: |
           echo "::group::Setup pre-commit"
           export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,13 +19,14 @@ jobs:
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           echo "::group::Setup pre-commit"
-          # export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
-          # export PATH=/root/.local/bin:$PATH
+          export PATH=/root/.local/bin:$PATH
+          # Newer versions of git are more cautious around the github runner
+          # environment and without this git rev-parse --show-cdup in pre-commit
+          # fails
+          git config --global --add safe.directory $(pwd)
           pip install pre-commit
           pip install pylint==2.12.2
           pip install flake8
-          # Use virtualenv from the LCG release
-          # pip uninstall --yes virtualenv
           echo "::endgroup::"
           echo "::group::Run CMake"
           mkdir build

--- a/src/EventStore.cc
+++ b/src/EventStore.cc
@@ -34,7 +34,7 @@ bool EventStore::get(uint32_t id, CollectionBase*& collection) const {
 }
 
 void EventStore::registerCollection(const std::string& name, podio::CollectionBase* coll) {
-  m_collections.push_back({name, coll});
+  m_collections.emplace_back(name, coll);
   auto id = m_table->add(name);
   coll->setID(id);
 }

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -133,7 +133,7 @@ CollectionBase* ROOTReader::readCollectionData(const root_utils::CollectionBranc
   collection->setID(id);
   collection->prepareAfterRead();
 
-  m_inputs.emplace_back(std::make_pair(collection, name));
+  m_inputs.emplace_back(collection, name);
   return collection;
 }
 

--- a/src/SIOBlockUserData.cc
+++ b/src/SIOBlockUserData.cc
@@ -1,7 +1,5 @@
 #include "podio/SIOBlockUserData.h"
 
-//#define PODIO_ADD_USER_TYPE_SIO(type) static UserDataSIOBlock<type>    _default##type##CollcetionSIOBlock ;
-
 namespace podio {
 
 static SIOBlockUserData<float> _defaultfloatCollcetionSIOBlock;
@@ -18,22 +16,3 @@ static SIOBlockUserData<uint32_t> _defaultuint32_tCollcetionSIOBlock;
 static SIOBlockUserData<uint64_t> _defaultuint64_tCollcetionSIOBlock;
 
 } // namespace podio
-
-// g++ -E ../src/SIOBlockUserData.cc
-// PODIO_ADD_USER_TYPE_SIO(int)
-// PODIO_ADD_USER_TYPE_SIO(long)
-// PODIO_ADD_USER_TYPE_SIO(float)
-// PODIO_ADD_USER_TYPE_SIO(double)
-// PODIO_ADD_USER_TYPE_SIO(unsigned)
-// PODIO_ADD_USER_TYPE_SIO(unsigned int)
-// PODIO_ADD_USER_TYPE_SIO(unsigned long)
-// PODIO_ADD_USER_TYPE_SIO(char)
-// PODIO_ADD_USER_TYPE_SIO(short)
-// PODIO_ADD_USER_TYPE_SIO(long long)
-// PODIO_ADD_USER_TYPE_SIO(unsigned long long)
-// PODIO_ADD_USER_TYPE_SIO(int16_t)
-// PODIO_ADD_USER_TYPE_SIO(int32_t)
-// PODIO_ADD_USER_TYPE_SIO(int64_t)
-// PODIO_ADD_USER_TYPE_SIO(uint16_t)
-// PODIO_ADD_USER_TYPE_SIO(uint32_t)
-// PODIO_ADD_USER_TYPE_SIO(uint64_t)

--- a/src/SchemaEvolution.cc
+++ b/src/SchemaEvolution.cc
@@ -50,7 +50,7 @@ void SchemaEvolution::registerEvolutionFunc(const std::string& collType, SchemaV
   // structure and update the index
   if (typeIt->second.index == MapIndex::NoEvolutionAvailable) {
     typeIt->second.index = m_evolutionFuncs.size();
-    m_evolutionFuncs.emplace_back(EvolFuncVersionMapT{});
+    m_evolutionFuncs.emplace_back();
   }
 
   // From here on out we don't need the mutabale any longer


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix the `pre-commit` workflow by making it run on top of the key4hep nightlies that come with a recent enough root version to be able to work with the RNTuple addition (#395)
- Fix a few minor complaints from newer versions of `clang-format` and `clang-tidy`

ENDRELEASENOTES