### PR TITLE
add description and author to components

### DIFF
--- a/python/podio/podio_config_reader.py
+++ b/python/podio/podio_config_reader.py
@@ -162,7 +162,7 @@ class ClassDefinitionValidator:
     """Check the components."""
     for name, component in datamodel.components.items():
       for field in component:
-        if field not in ['Members', 'ExtraCode']:
+        if field not in ['Members', 'ExtraCode', 'Description', 'Author']:
           raise DefinitionError(f"{name} defines a '{field}' field which is not allowed for a component")
 
       if 'ExtraCode' in component:

--- a/python/podio/test_ClassDefinitionValidator.py
+++ b/python/podio/test_ClassDefinitionValidator.py
@@ -109,11 +109,6 @@ class ClassDefinitionValidatorTest(unittest.TestCase):
     self._assert_no_exception(DefinitionError, '{} should allow for component members in components',
                               self.validate, make_dm(components, {}), False)
 
-  def test_component_invalid_field(self):
-    self.valid_component['Component']['Author'] = 'An invalid field for a component'
-    with self.assertRaises(DefinitionError):
-      self.validate(make_dm(self.valid_component, {}), False)
-
   def test_datatype_valid_members(self):
     self._assert_no_exception(DefinitionError, '{} should not raise for a valid datatype',
                               self.validate, make_dm({}, self.valid_datatype, self.def_opts))

--- a/python/templates/Component.h.jinja2
+++ b/python/templates/Component.h.jinja2
@@ -1,3 +1,4 @@
+{% import "macros/declarations.jinja2" as macros %}
 {% import "macros/utils.jinja2" as utils %}
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
@@ -14,7 +15,7 @@
 #endif
 
 {{ utils.namespace_open(class.namespace) }}
-
+{{ macros.class_description(class.bare_type, Description, Author) }}
 class {{ class.bare_type }} {
 public:
 {% for member in Members %}

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -23,6 +23,8 @@ components :
       "
 
   NotSoSimpleStruct:
+    Description : "A not so simple struct"
+    Author : "Someone"
     Members:
       - SimpleStruct data // component members can have descriptions
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Add optional description and author fields to component definition
ENDRELEASENOTES

addressing #371