### PR TITLE
Hide the JSON output functionality from CLING

### DIFF
--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -227,7 +227,7 @@ const auto registeredCollection = registerCollection();
 } // namespace
 
 
-#ifdef PODIO_JSON_OUTPUT
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 void to_json(nlohmann::json& j, const {{ collection_type }}& collection) {
   j = nlohmann::json::array();
   for (auto&& elem : collection) {

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -18,7 +18,7 @@
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
 
-#ifdef PODIO_JSON_OUTPUT
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json.hpp"
 #endif
 
@@ -193,7 +193,7 @@ Mutable{{ class.bare_type }} {{ class.bare_type }}Collection::create(Args&&... a
   return Mutable{{ class.bare_type }}(obj);
 }
 
-#ifdef PODIO_JSON_OUTPUT
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 void to_json(nlohmann::json& j, const {{ class.bare_type }}Collection& collection);
 #endif
 

--- a/python/templates/Component.h.jinja2
+++ b/python/templates/Component.h.jinja2
@@ -9,7 +9,7 @@
 {% endfor %}
 #include <ostream>
 
-#ifdef PODIO_JSON_OUTPUT
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json.hpp"
 #endif
 
@@ -39,7 +39,7 @@ inline std::ostream& operator<<(std::ostream& o, const {{class.full_type}}& valu
   return o;
 }
 
-#ifdef PODIO_JSON_OUTPUT
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 inline void to_json(nlohmann::json& j, const {{ class.bare_type }}& value) {
   j = nlohmann::json{
 {% set comma = joiner(",") %}


### PR DESCRIPTION

BEGINRELEASENOTES
- Extend the pre-processor condition for the `to_json` functionality to not be visible in `rootcling` or the root interpreter. Fixes #435 

ENDRELEASENOTES

@wdconinc thanks for the hint with `__CLING__`, wouldn't have thought of that. Could you check if this is indeed enough to fix the issue. The example in #435 works for me, but that might not be the end of the story.