### PR TITLE
Cache podio_PYTHON_DIR

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ foreach( _conf ${CMAKE_CONFIGURATION_TYPES} )
 endforeach()
 
 # Set the podio_PYTHON_DIR manually here because the macros below expect it
-SET(podio_PYTHON_DIR ${PROJECT_SOURCE_DIR}/python)
+SET(podio_PYTHON_DIR ${PROJECT_SOURCE_DIR}/python CACHE PATH "Path to the podio python directory")
 
 PODIO_GENERATE_DATAMODEL(datamodel datalayout.yaml headers sources
   IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS}


### PR DESCRIPTION
BEGINRELEASENOTES
- Cache podio_PYTHON_DIR

ENDRELEASENOTES

Under some conditions this variable can be needed to generate the datamodels but won't be found. If it's cached it will always be found, without any downsides since this variable isn't supposed to change often.