### PR TITLE
Make building SIO tests depend on ENABLE_SIO

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,7 +54,9 @@ add_executable(check_benchmark_outputs check_benchmark_outputs.cpp)
 target_link_libraries(check_benchmark_outputs PRIVATE ROOT::Tree)
 
 add_subdirectory(root_io)
-add_subdirectory(sio_io)
+if (ENABLE_SIO)
+  add_subdirectory(sio_io)
+endif()
 add_subdirectory(unittests)
 add_subdirectory(dumpmodel)
 

--- a/tests/sio_io/CMakeLists.txt
+++ b/tests/sio_io/CMakeLists.txt
@@ -1,32 +1,28 @@
-if (TARGET TestDataModelSioBlocks)
-  set(sio_dependent_tests
-    write_sio.cpp
-    read_sio.cpp
-    read_and_write_sio.cpp
-    write_timed_sio.cpp
-    read_timed_sio.cpp
-    read_frame_sio.cpp
-    write_frame_sio.cpp
-    read_frame_legacy_sio.cpp)
-  set(sio_libs podio::podioSioIO)
-  foreach( sourcefile ${sio_dependent_tests} )
-    CREATE_PODIO_TEST(${sourcefile} "${sio_libs}")
-  endforeach()
+set(sio_dependent_tests
+  write_sio.cpp
+  read_sio.cpp
+  read_and_write_sio.cpp
+  write_timed_sio.cpp
+  read_timed_sio.cpp
+  read_frame_sio.cpp
+  write_frame_sio.cpp
+  read_frame_legacy_sio.cpp)
+set(sio_libs podio::podioSioIO)
+foreach( sourcefile ${sio_dependent_tests} )
+  CREATE_PODIO_TEST(${sourcefile} "${sio_libs}")
+endforeach()
 
-  # These need to be linked against TTree explicitly, since it is not done
-  # through another library and the TimedReader/Writer decorators are
-  # header-only wrappers
-  target_link_libraries(write_timed_sio PRIVATE ROOT::Tree)
-  target_link_libraries(read_timed_sio PRIVATE ROOT::Tree)
-endif()
+# These need to be linked against TTree explicitly, since it is not done
+# through another library and the TimedReader/Writer decorators are
+# header-only wrappers
+target_link_libraries(write_timed_sio PRIVATE ROOT::Tree)
+target_link_libraries(read_timed_sio PRIVATE ROOT::Tree)
 
-if (TARGET read_sio)
-  set_property(TEST read_sio PROPERTY DEPENDS write_sio)
-  set_property(TEST read_and_write_sio PROPERTY DEPENDS write_sio)
-  set_property(TEST read_timed_sio PROPERTY DEPENDS write_timed_sio)
-  set_property(TEST read_frame_sio PROPERTY DEPENDS write_frame_sio)
-  set_property(TEST read_frame_legacy_sio PROPERTY DEPENDS write_sio)
+set_property(TEST read_sio PROPERTY DEPENDS write_sio)
+set_property(TEST read_and_write_sio PROPERTY DEPENDS write_sio)
+set_property(TEST read_timed_sio PROPERTY DEPENDS write_timed_sio)
+set_property(TEST read_frame_sio PROPERTY DEPENDS write_frame_sio)
+set_property(TEST read_frame_legacy_sio PROPERTY DEPENDS write_sio)
 
-  add_test(NAME check_benchmark_outputs_sio COMMAND check_benchmark_outputs write_benchmark_sio.root read_benchmark_sio.root)
-  set_property(TEST check_benchmark_outputs_sio PROPERTY DEPENDS read_timed_sio write_timed_sio)
-endif()
+add_test(NAME check_benchmark_outputs_sio COMMAND check_benchmark_outputs write_benchmark_sio.root read_benchmark_sio.root)
+set_property(TEST check_benchmark_outputs_sio PROPERTY DEPENDS read_timed_sio write_timed_sio)


### PR DESCRIPTION

BEGINRELEASENOTES
- Simplify the test setup for SIO in CMake and make it explicit on the `ENABLE_SIO` option rather than on the presence of targets.

ENDRELEASENOTES