### PR TITLE
Make sure that v00-16-06 files can be read with the master branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(podio)
 #--- Version -------------------------------------------------------------------
 SET( ${PROJECT_NAME}_VERSION_MAJOR 0 )
 SET( ${PROJECT_NAME}_VERSION_MINOR 16 )
-SET( ${PROJECT_NAME}_VERSION_PATCH 6 )
+SET( ${PROJECT_NAME}_VERSION_PATCH 99 )
 
 SET( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
 

--- a/src/ROOTFrameReader.cc
+++ b/src/ROOTFrameReader.cc
@@ -155,7 +155,7 @@ void ROOTFrameReader::initCategory(CategoryInfo& catInfo, const std::string& cat
 
   // For backwards compatibility make it possible to read the index based files
   // from older versions
-  if (m_fileVersion <= podio::version::Version{0, 16, 5}) {
+  if (m_fileVersion <= podio::version::Version{0, 16, 6}) {
     std::tie(catInfo.branches, catInfo.storedClasses) =
         createCollectionBranchesIndexBased(catInfo.chain.get(), *catInfo.table, *collInfo);
   } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(legacy_test_versions
   v00-16
   v00-16-02
   v00-16-05
+  v00-16-06
 )
 
 ### Define the actual tests


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure the `ROOTFrameReader` on the master branch can read `v00-16-06` files
- Add `v00-16-06` to the legacy versions that are tested

ENDRELEASENOTES