### PR TITLE
Fix I/O issues of subset collections with vector members

### DIFF
--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -18,7 +18,7 @@ EXPECTED_COLL_NAMES = {
     'emptyCollection', 'emptySubsetColl'
     }
 # The expected collections from the extension (only present in the other_events category)
-EXPECTED_EXTENSION_COLL_NAMES = {"extension_Contained", "extension_ExternalComponent", "extension_ExternalRelation"}
+EXPECTED_EXTENSION_COLL_NAMES = {"extension_Contained", "extension_ExternalComponent", "extension_ExternalRelation", "VectorMemberSubsetColl"}
 
 # The expected parameter names in each frame
 EXPECTED_PARAM_NAMES = {'anInt', 'UserEventWeight', 'UserEventName', 'SomeVectorData', 'SomeValue'}

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -18,7 +18,10 @@ EXPECTED_COLL_NAMES = {
     'emptyCollection', 'emptySubsetColl'
     }
 # The expected collections from the extension (only present in the other_events category)
-EXPECTED_EXTENSION_COLL_NAMES = {"extension_Contained", "extension_ExternalComponent", "extension_ExternalRelation", "VectorMemberSubsetColl"}
+EXPECTED_EXTENSION_COLL_NAMES = {
+    "extension_Contained", "extension_ExternalComponent", "extension_ExternalRelation",
+    "VectorMemberSubsetColl"
+    }
 
 # The expected parameter names in each frame
 EXPECTED_PARAM_NAMES = {'anInt', 'UserEventWeight', 'UserEventName', 'SomeVectorData', 'SomeValue'}

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -198,14 +198,15 @@ podio::CollectionReadBuffers createBuffers(bool isSubset) {
   };
 
   readBuffers.recast = [](podio::CollectionReadBuffers& buffers) {
+    // We only have any of these buffers if this is not a subset collection
     if (buffers.data) {
       buffers.data = podio::CollectionWriteBuffers::asVector<{{ class.full_type }}Data>(buffers.data);
-    }
 {% if VectorMembers %}
 {% for member in VectorMembers %}
     (*buffers.vectorMembers)[{{ loop.index0 }}].second = podio::CollectionWriteBuffers::asVector<{{ member.full_type }}>((*buffers.vectorMembers)[{{ loop.index0 }}].second);
 {% endfor %}
 {% endif %}
+    }
   };
 
   return readBuffers;

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -83,11 +83,13 @@ void {{ class_type }}::clear(bool isSubsetColl) {
 
 podio::CollectionWriteBuffers {{ class_type }}::getCollectionBuffers(bool isSubsetColl) {
 {% if VectorMembers %}
-  // Make sure these point to the right place, even if a collection has been
-  // moved since it has been created
+  if (!isSubsetColl) {
+    // Make sure these point to the right place, even if a collection has been
+    // moved since it has been created
 {% for member in VectorMembers %}
-  m_vecmem_info[{{ loop.index0 }}].second = &m_vec_{{ member.name }};
+    m_vecmem_info[{{ loop.index0 }}].second = &m_vec_{{ member.name }};
 {% endfor %}
+  }
 {% endif -%}
 
   return {

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -40,18 +40,18 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type version
   }
 
 {% if VectorMembers %}
+  if (not m_subsetColl) {
 {% for member in VectorMembers %}
-  // auto {{ member.name }}Buffers = new std::vector<{{ member.full_type }}>();
-  // m_buffers.vectorMembers->emplace_back("{{ member.full_type }}", &{{ member.name }}Buffers);
-  m_buffers.vectorMembers->emplace_back("{{ member.full_type }}", new std::vector<{{ member.full_type }}>());
+    m_buffers.vectorMembers->emplace_back("{{ member.full_type }}", new std::vector<{{ member.full_type }}>());
 {% endfor %}
-  //---- read vector members
-  auto* vecMemInfo = m_buffers.vectorMembers;
-  unsigned size{0};
+    //---- read vector members
+    auto* vecMemInfo = m_buffers.vectorMembers;
+    unsigned size{0};
 
 {% for member in VectorMembers %}
 {{ macros.vector_member_read(member, loop.index0) }}
 {% endfor %}
+  }
 {% endif %}
 }
 
@@ -72,13 +72,15 @@ void {{ block_class }}::write(sio::write_device& device) {
   }
 
 {% if VectorMembers %}
-  //---- write vector members
-  auto* vecMemInfo = m_buffers.vectorMembers;
-  unsigned size{0};
+  if (not m_subsetColl) {
+    //---- write vector members
+    auto* vecMemInfo = m_buffers.vectorMembers;
+    unsigned size{0};
 
 {% for member in VectorMembers %}
 {{ macros.vector_member_write(member, loop.index0) }}
 {% endfor %}
+  }
 {% endif %}
 }
 

--- a/python/templates/macros/sioblocks.jinja2
+++ b/python/templates/macros/sioblocks.jinja2
@@ -1,16 +1,16 @@
 {% macro vector_member_write(member, index) %}
-  auto* vec{{ index }} = *reinterpret_cast<std::vector<{{ member.full_type }}>**>(vecMemInfo->at({{ index }}).second);
-  size = vec{{ index }}->size();
-  device.data(size);
-  podio::handlePODDataSIO(device, &(*vec{{ index }})[0], size);
+    auto* vec{{ index }} = *reinterpret_cast<std::vector<{{ member.full_type }}>**>(vecMemInfo->at({{ index }}).second);
+    size = vec{{ index }}->size();
+    device.data(size);
+    podio::handlePODDataSIO(device, &(*vec{{ index }})[0], size);
 
 {% endmacro %}
 
 
 {% macro vector_member_read(member, index) %}
-  auto* vec{{ index }} = reinterpret_cast<std::vector<{{ member.full_type }}>*>(vecMemInfo->at({{ index }}).second);
-  size = 0u;
-  device.data(size);
-  vec{{ index }}->resize(size);
-  podio::handlePODDataSIO(device, vec{{ index }}->data(), size);
+    auto* vec{{ index }} = reinterpret_cast<std::vector<{{ member.full_type }}>*>(vecMemInfo->at({{ index }}).second);
+    size = 0u;
+    device.data(size);
+    vec{{ index }}->resize(size);
+    podio::handlePODDataSIO(device, vec{{ index }}->data(), size);
 {% endmacro %}

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -24,6 +24,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     read_frame_root_multiple
     write_python_frame_root
     read_python_frame_root
+    read_and_write_frame_root
 
     write_frame_root
     read_frame_root
@@ -39,6 +40,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     read_frame_legacy_sio
     write_python_frame_sio
     read_python_frame_sio
+    read_and_write_frame_sio
 
     write_ascii
 

--- a/tests/read_and_write_frame.h
+++ b/tests/read_and_write_frame.h
@@ -1,0 +1,38 @@
+#ifndef PODIO_TESTS_READ_AND_WRITE_FRAME_H // NOLINT(llvm-header-guard): folder structure not suitable
+#define PODIO_TESTS_READ_AND_WRITE_FRAME_H // NOLINT(llvm-header-guard): folder structure not suitable
+
+#include "read_frame.h"
+
+#include <string>
+
+template <typename ReaderT, typename WriterT>
+int rewrite_frames(const std::string& inputFile, const std::string& newOutput) {
+  auto reader = ReaderT();
+  reader.openFile(inputFile);
+
+  auto writer = WriterT(newOutput);
+
+  const auto frame = podio::Frame(reader.readEntry(podio::Category::Event, 0));
+  writer.writeFrame(frame, podio::Category::Event);
+
+  const auto otherFrame = podio::Frame(reader.readEntry("other_events", 0));
+  writer.writeFrame(otherFrame, "other_events");
+
+  return 0;
+}
+
+template <typename ReaderT>
+int read_rewritten_frames(const std::string& inputName) {
+  auto reader = ReaderT();
+  reader.openFile(inputName);
+
+  const auto frame = podio::Frame(reader.readEntry(podio::Category::Event, 0));
+  processEvent(frame, 0, reader.currentFileVersion());
+
+  const auto otherFrame = podio::Frame(reader.readEntry("other_events", 0));
+  processEvent(otherFrame, 100, reader.currentFileVersion());
+
+  return 0;
+}
+
+#endif // PODIO_TESTS_READ_AND_WRITE_FRAME_H

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -1,6 +1,7 @@
 #ifndef PODIO_TESTS_READ_FRAME_H // NOLINT(llvm-header-guard): folder structure not suitable
 #define PODIO_TESTS_READ_FRAME_H // NOLINT(llvm-header-guard): folder structure not suitable
 
+#include "datamodel/ExampleWithVectorMemberCollection.h"
 #include "read_test.h"
 
 #include "extension_model/ContainedTypeCollection.h"
@@ -60,6 +61,14 @@ void processExtensions(const podio::Frame& event, int iEvent, podio::version::Ve
   ASSERT(structs[2].y == 2 * iEvent, "struct value not as expected");
 }
 
+void checkVecMemSubsetColl(const podio::Frame& event) {
+  const auto& subsetColl = event.get<ExampleWithVectorMemberCollection>("VectorMemberSubsetColl");
+  const auto& origColl = event.get<ExampleWithVectorMemberCollection>("WithVectorMember");
+  ASSERT(subsetColl.isSubsetCollection(), "subset collection not read back as a sbuset collection");
+  ASSERT(subsetColl.size() == 1, "subset collection should have size 1");
+  ASSERT(subsetColl[0] == origColl[0], "subset coll does not have the right contents");
+}
+
 template <typename ReaderT>
 int read_frames(const std::string& filename, bool assertBuildVersion = true) {
   auto reader = ReaderT();
@@ -111,6 +120,10 @@ int read_frames(const std::string& filename, bool assertBuildVersion = true) {
     // The other_events category also holds external collections
     if (reader.currentFileVersion() > podio::version::Version{0, 16, 2}) {
       processExtensions(otherFrame, i + 100, reader.currentFileVersion());
+    }
+    // As well as a test for the vector members subset category
+    if (reader.currentFileVersion() >= podio::version::Version{0, 16, 99}) {
+      checkVecMemSubsetColl(otherFrame);
     }
   }
 

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -64,7 +64,7 @@ void processExtensions(const podio::Frame& event, int iEvent, podio::version::Ve
 void checkVecMemSubsetColl(const podio::Frame& event) {
   const auto& subsetColl = event.get<ExampleWithVectorMemberCollection>("VectorMemberSubsetColl");
   const auto& origColl = event.get<ExampleWithVectorMemberCollection>("WithVectorMember");
-  ASSERT(subsetColl.isSubsetCollection(), "subset collection not read back as a sbuset collection");
+  ASSERT(subsetColl.isSubsetCollection(), "subset collection not read back as a subset collection");
   ASSERT(subsetColl.size() == 1, "subset collection should have size 1");
   ASSERT(subsetColl[0] == origColl[0], "subset coll does not have the right contents");
 }

--- a/tests/root_io/CMakeLists.txt
+++ b/tests/root_io/CMakeLists.txt
@@ -12,6 +12,7 @@ set(root_dependent_tests
   read_frame_legacy_root.cpp
   read_frame_root_multiple.cpp
   read_python_frame_root.cpp
+  read_and_write_frame_root.cpp
   )
 if(ENABLE_RNTUPLE)
   set(root_dependent_tests
@@ -33,8 +34,16 @@ set_property(TEST read-multiple PROPERTY DEPENDS write)
 set_property(TEST read_and_write PROPERTY DEPENDS write)
 set_property(TEST read_frame_legacy_root PROPERTY DEPENDS write)
 set_property(TEST read_timed PROPERTY DEPENDS write_timed)
-set_property(TEST read_frame_root PROPERTY DEPENDS write_frame_root)
-set_property(TEST read_frame_root_multiple PROPERTY DEPENDS write_frame_root)
+
+set_tests_properties(
+  read_frame_root
+  read_frame_root_multiple
+  read_and_write_frame_root
+
+  PROPERTIES
+    DEPENDS write_frame_root
+)
+
 if(ENABLE_RNTUPLE)
   set_property(TEST read_rntuple PROPERTY DEPENDS write_rntuple)
 endif()

--- a/tests/root_io/read_and_write_frame_root.cpp
+++ b/tests/root_io/read_and_write_frame_root.cpp
@@ -1,0 +1,9 @@
+#include "read_and_write_frame.h"
+
+#include "podio/ROOTFrameReader.h"
+#include "podio/ROOTFrameWriter.h"
+
+int main() {
+  return rewrite_frames<podio::ROOTFrameReader, podio::ROOTFrameWriter>("example_frame.root", "rewritten_frame.root") +
+      read_rewritten_frames<podio::ROOTFrameReader>("rewritten_frame.root");
+}

--- a/tests/sio_io/CMakeLists.txt
+++ b/tests/sio_io/CMakeLists.txt
@@ -6,7 +6,9 @@ set(sio_dependent_tests
   read_timed_sio.cpp
   read_frame_sio.cpp
   write_frame_sio.cpp
-  read_frame_legacy_sio.cpp)
+  read_frame_legacy_sio.cpp
+  read_and_write_frame_sio.cpp
+)
 set(sio_libs podio::podioSioIO)
 foreach( sourcefile ${sio_dependent_tests} )
   CREATE_PODIO_TEST(${sourcefile} "${sio_libs}")
@@ -21,8 +23,16 @@ target_link_libraries(read_timed_sio PRIVATE ROOT::Tree)
 set_property(TEST read_sio PROPERTY DEPENDS write_sio)
 set_property(TEST read_and_write_sio PROPERTY DEPENDS write_sio)
 set_property(TEST read_timed_sio PROPERTY DEPENDS write_timed_sio)
-set_property(TEST read_frame_sio PROPERTY DEPENDS write_frame_sio)
 set_property(TEST read_frame_legacy_sio PROPERTY DEPENDS write_sio)
+
+set_tests_properties(
+  read_frame_sio
+  read_and_write_frame_sio
+
+  PROPERTIES
+    DEPENDS
+    write_frame_sio
+)
 
 add_test(NAME check_benchmark_outputs_sio COMMAND check_benchmark_outputs write_benchmark_sio.root read_benchmark_sio.root)
 set_property(TEST check_benchmark_outputs_sio PROPERTY DEPENDS read_timed_sio write_timed_sio)

--- a/tests/sio_io/read_and_write_frame_sio.cpp
+++ b/tests/sio_io/read_and_write_frame_sio.cpp
@@ -1,0 +1,9 @@
+#include "read_and_write_frame.h"
+
+#include "podio/SIOFrameReader.h"
+#include "podio/SIOFrameWriter.h"
+
+int main() {
+  return rewrite_frames<podio::SIOFrameReader, podio::SIOFrameWriter>("example_frame.sio", "rewritten_frame.sio") +
+      read_rewritten_frames<podio::SIOFrameReader>("rewritten_frame.sio");
+}

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -773,20 +773,6 @@ TEST_CASE("Move-only collections", "[collections][move-semantics]") {
     auto newClusters = std::move(clusterColl);
 
     vecMemColl.prepareForWrite();
-    auto buffers = vecMemColl.getBuffers();
-    auto vecBuffers = buffers.vectorMembers;
-    auto thisVec = (*vecBuffers)[0].second;
-
-    const auto floatVec = podio::CollectionWriteBuffers::asVector<float>(thisVec);
-    const auto floatVec2 = podio::CollectionReadBuffers::asVector<float>(thisVec);
-
-    std::cout << floatVec->size() << '\n';
-    std::cout << floatVec2->size() << '\n';
-
-    // auto vecBuffers = buffers.vectorMembers;
-    // const auto vecBuffer = podio::CollectionWriteBuffers::asVector<float>((*vecBuffers)[0].second);
-    // TD<decltype(vecBuffer)> td;
-    // REQUIRE(vecBuffer->size() == 2);
     auto newVecMems = std::move(vecMemColl);
 
     userDataColl.prepareForWrite();

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -782,6 +782,19 @@ TEST_CASE("Move-only collections", "[collections][move-semantics]") {
   }
 
   SECTION("Moved collections can be prepared") {
+    auto newHits = std::move(hitColl);
+    newHits.prepareForWrite();
+
+    auto newClusters = std::move(clusterColl);
+    newClusters.prepareForWrite();
+
+    auto newVecMems = std::move(vecMemColl);
+    newVecMems.prepareForWrite();
+
+    auto newUserData = std::move(userDataColl);
+    newUserData.prepareForWrite();
+
+    checkCollections(newHits, newClusters, newVecMems, newUserData);
   }
 
   SECTION("Prepared collections can be move assigned") {

--- a/tests/write_frame.h
+++ b/tests/write_frame.h
@@ -215,6 +215,15 @@ auto createVectorMemberCollection(int i) {
   return vecs;
 }
 
+auto createVectorMemberSubsetCollection(const ExampleWithVectorMemberCollection& coll) {
+  ExampleWithVectorMemberCollection refs;
+  refs.setSubsetCollection();
+
+  refs.push_back(coll[0]);
+
+  return refs;
+}
+
 auto createInfoCollection(int i) {
   EventInfoCollection info;
 
@@ -361,7 +370,8 @@ podio::Frame makeFrame(int iFrame) {
   podio::Frame frame{};
 
   frame.put(createArrayCollection(iFrame), "arrays");
-  frame.put(createVectorMemberCollection(iFrame), "WithVectorMember");
+  const auto& vecMemColl = frame.put(createVectorMemberCollection(iFrame), "WithVectorMember");
+  frame.put(createVectorMemberSubsetCollection(vecMemColl), "VectorMemberSubsetColl");
   frame.put(createInfoCollection(iFrame), "info");
   frame.put(createFixedWidthCollection(), "fixedWidthInts");
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure to only access vector member buffers of collections of datatypes with `VectorMembers` if they actually exist. This is necessary to make subset collections of such datatypes work in I/O. Fixes [#462](https://github.com/AIDASoft/podio/issues/462)
- Add a test that reproduces the original issue and is fixed by this.

ENDRELEASENOTES