### PR TITLE
python/templates: add references between Objects and Collection types

### DIFF
--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -48,6 +48,7 @@ A Collection is identified by an ID.
 */
 class {{ class.bare_type }}Collection : public podio::CollectionBase {
 public:
+  using value_type = {{ class.bare_type }};
   using const_iterator = {{ class.bare_type }}CollectionIterator;
   using iterator = {{ class.bare_type }}MutableCollectionIterator;
 

--- a/python/templates/MutableObject.h.jinja2
+++ b/python/templates/MutableObject.h.jinja2
@@ -32,6 +32,8 @@ class Mutable{{ class.bare_type }} {
   friend class {{ class.bare_type }};
 
 public:
+  using object_type = {{ class.bare_type }};
+  using collection_type = {{ class.bare_type }}Collection;
 
 {{ macros.constructors_destructors(class.bare_type, Members, prefix='Mutable') }}
   /// conversion to const object

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -22,6 +22,7 @@
 
 {{ utils.namespace_open(class.namespace) }}
 class Mutable{{ class.bare_type }};
+class {{ class.bare_type }}Collection;
 
 {{ macros.class_description(class.bare_type, Description, Author) }}
 class {{ class.bare_type }} {
@@ -31,6 +32,9 @@ class {{ class.bare_type }} {
   friend class {{ class.bare_type }}CollectionIterator;
 
 public:
+  using mutable_type = Mutable{{ class.bare_type }};
+  using collection_type = {{ class.bare_type }}Collection;
+
 {{ macros.constructors_destructors(class.bare_type, Members) }}
 
 public:


### PR DESCRIPTION

BEGINRELEASENOTES
- Object's collection type can now be referenced as `Object::collection`. Conversely, the object type is reachable as `ObjectCollection::object`.

ENDRELEASENOTES

This should allow to remove some codegen hack from EICrecon https://github.com/eic/EICrecon/blob/1f6727948696b70fc29b1fe582f23f2e37c476b2/src/services/io/podio/make_datamodel_glue.py#L76-L84

cc @wdconinc @nathanwbrei 