### PR TITLE
CI: use clang16 nightly builds

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -13,8 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ["sw.hsf.org/key4hep",
-                  "sw-nightlies.hsf.org/key4hep"]
+        include:
+          - release: "sw.hsf.org/key4hep"
+            RNTUPLE: OFF
+          - release: "sw-nightlies.hsf.org/key4hep"
+            RNTUPLE: ON
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -31,7 +34,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DUSE_EXTERNAL_CATCH2=ON \
-            -DENABLE_RNTUPLE=ON \
+            -DENABLE_RNTUPLE=${{ matrix.RNTUPLE }} \
             -G Ninja ..
           echo "::endgroup::"
           echo "::group::Build"

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - release: "sw.hsf.org/key4hep"
-            RNTUPLE: OFF
           - release: "sw-nightlies.hsf.org/key4hep"
             RNTUPLE: ON
     steps:

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -33,7 +33,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
-            -DUSE_EXTERNAL_CATCH2=ON \
+            -DUSE_EXTERNAL_CATCH2=AUTO \
             -DENABLE_RNTUPLE=${{ matrix.RNTUPLE }} \
             -G Ninja ..
           echo "::endgroup::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CXX_STANDARD: [20]
-        RNTUPLE: [ON]
         LCG: ["dev3/x86_64-el9-clang16-opt",
               "dev4/x86_64-el9-clang16-opt"]
+        CXX_STANDARD: [20]
+        RNTUPLE: [ON]
         include:
           - LCG: "dev4/x86_64-centos7-gcc11-opt"
             CXX_STANDARD: 17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        CXX_STANDARD: [20]
         RNTUPLE: [ON]
         LCG: ["dev3/x86_64-el9-clang16-opt",
-              "dev4/x86_64-centos7-gcc11-opt",
               "dev4/x86_64-el9-clang16-opt"]
         include:
+          - LCG: "dev4/x86_64-centos7-gcc11-opt"
+            CXX_STANDARD: 17
           - LCG: "LCG_102/x86_64-centos7-clang12-opt"
             RNTUPLE: OFF
+            CXX_STANDARD: 17
           - LCG: "LCG_102/x86_64-centos8-gcc11-opt"
             RNTUPLE: OFF
+            CXX_STANDARD: 17
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -35,7 +39,7 @@ jobs:
           cmake -DENABLE_SIO=ON \
             -DENABLE_RNTUPLE=${{ matrix.RNTUPLE }} \
             -DCMAKE_INSTALL_PREFIX=../install \
-            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja ..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         RNTUPLE: [ON]
-        LCG: ["dev3/x86_64-centos7-clang12-opt",
+        LCG: ["dev3/x86_64-el9-clang16-opt",
               "dev4/x86_64-centos7-gcc11-opt",
-              "dev4/x86_64-centos7-clang12-opt"]
+              "dev4/x86_64-el9-clang16-opt"]
         include:
           - LCG: "LCG_102/x86_64-centos7-clang12-opt"
             RNTUPLE: OFF

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,8 +1,13 @@
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+  set(CATCH2_MIN_VERSION 3.4)
+else()
+  set(CATCH2_MIN_VERSION 3.1)
+endif()
 if(USE_EXTERNAL_CATCH2)
   if (USE_EXTERNAL_CATCH2 STREQUAL AUTO)
-    find_package(Catch2 3.1)
+    find_package(Catch2 ${CATCH2_MIN_VERSION})
   else()
-    find_package(Catch2 3.1 REQUIRED)
+    find_package(Catch2 ${CATCH2_MIN_VERSION} REQUIRED)
   endif()
 endif()
 
@@ -16,7 +21,7 @@ if(NOT Catch2_FOUND)
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.1.0
+    GIT_TAG        v3.4.0
     )
   FetchContent_MakeAvailable(Catch2)
   set(CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
BEGINRELEASENOTES
- Tests: update required catch2 version to 3.4 for builds with c++20
- CI: use clang16 on el9 (alma9), instead of clang12 on cs7, using c++20
- CI: disable key4hep-release-based tests (`tabulate` available)

ENDRELEASENOTES

Hmm: these nightly builds are with c++20...