### PR TITLE
Backports for v00-16-07 patch release

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ["sw.hsf.org/key4hep",
-                  "sw-nightlies.hsf.org/key4hep"]
+        include:
+          - release: "sw-nightlies.hsf.org/key4hep"
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -30,7 +30,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
-            -DUSE_EXTERNAL_CATCH2=ON \
+            -DUSE_EXTERNAL_CATCH2=AUTO \
+            -DUSE_EXTERNAL_CATCH2=AUTO \
             -G Ninja ..
           echo "::endgroup::"
           echo "::group::Build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sio: [ON]
-        LCG: ["LCG_102/x86_64-centos7-clang12-opt",
-              "LCG_102/x86_64-centos8-gcc11-opt",
-              "dev3/x86_64-centos7-clang12-opt",
-              "dev4/x86_64-centos7-gcc11-opt",
-              "dev4/x86_64-centos7-clang12-opt"]
+        LCG: ["dev3/x86_64-el9-clang16-opt",
+              "dev4/x86_64-el9-clang16-opt"]
+        CXX_STANDARD: [20]
+        include:
+          - LCG: "dev4/x86_64-centos7-gcc11-opt"
+            CXX_STANDARD: 17
+          - LCG: "LCG_102/x86_64-centos7-clang12-opt"
+            CXX_STANDARD: 17
+          - LCG: "LCG_102/x86_64-centos8-gcc11-opt"
+            CXX_STANDARD: 17
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -29,9 +33,9 @@ jobs:
           echo "::group::Run CMake"
           mkdir build install
           cd build
-          cmake -DENABLE_SIO=${{ matrix.sio }} \
+          cmake -DENABLE_SIO=ON \
             -DCMAKE_INSTALL_PREFIX=../install \
-            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -G Ninja ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,9 @@ endif()
 
 #--- enable unit testing capabilities ------------------------------------------
 include(CTest)
-option(USE_EXTERNAL_CATCH2 "Link against an external Catch2 v3 static library, otherwise build it locally" ON)
+
+set(USE_EXTERNAL_CATCH2 AUTO CACHE STRING "Link against an external Catch2 v3 static library, otherwise build it locally")
+set_property(CACHE USE_EXTERNAL_CATCH2 PROPERTY STRINGS AUTO ON OFF)
 
 #--- enable CPack --------------------------------------------------------------
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -3,6 +3,7 @@
 
 #include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
+#include "podio/FrameCategories.h" // mainly for convenience
 #include "podio/GenericParameters.h"
 #include "podio/ICollectionProvider.h"
 #include "podio/utilities/TypeHelpers.h"

--- a/include/podio/FrameCategories.h
+++ b/include/podio/FrameCategories.h
@@ -1,0 +1,43 @@
+#ifndef PODIO_FRAMECATEGORIES_H
+#define PODIO_FRAMECATEGORIES_H
+
+#include <string>
+
+namespace podio {
+
+/**
+ * Create a parameterName that encodes the collection name and the parameter
+ * Name into one string.
+ *
+ * This codifies a convention that was decided on to store collection level
+ * parameters. These are parameters / metadata that are valid for all
+ * collections of a given name in a file, e.g. CellID encoding strings. These
+ * parameters are usually stored in a dedicated metadata Frame inside a file,
+ * see the predefined category names in the Cateogry namespace.
+ *
+ * @param collName the name of the collection
+ * @param paramName the name of the parameter
+ *
+ * @returns A single key string that combines the collection and parameter name
+ */
+inline std::string collMetadataParamName(const std::string& collName, const std::string& paramName) {
+  return collName + "__" + paramName;
+}
+
+/**
+ * This namespace mimics an enum (at least in its usage) and simply defines
+ * either commonly used category names, or category names that form a
+ * convention.
+ */
+namespace Category {
+  /// The event category
+  constexpr const auto Event = "events";
+  /// The run category
+  constexpr const auto Run = "runs";
+  /// The metadata cateogry that is used to store a single Frame that holds data
+  /// that is valid for a whole file, e.g. collection level parameters
+  constexpr const auto Metadata = "metadata";
+} // namespace Category
+} // namespace podio
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,9 +110,20 @@ endif()
 CREATE_PODIO_TEST(ostream_operator.cpp "")
 CREATE_PODIO_TEST(write_ascii.cpp "")
 
-if(USE_EXTERNAL_CATCH2)
-  find_package(Catch2 3 REQUIRED)
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+  set(CATCH2_MIN_VERSION 3.4)
 else()
+  set(CATCH2_MIN_VERSION 3.1)
+endif()
+if(USE_EXTERNAL_CATCH2)
+  if (USE_EXTERNAL_CATCH2 STREQUAL AUTO)
+    find_package(Catch2 ${CATCH2_MIN_VERSION})
+  else()
+    find_package(Catch2 ${CATCH2_MIN_VERSION} REQUIRED)
+  endif()
+endif()
+
+if(NOT Catch2_FOUND)
   message(STATUS "Fetching local copy of Catch2 library for unit-tests...")
   # Build Catch2 with the default flags, to avoid generating warnings when we
   # build it
@@ -122,7 +133,7 @@ else()
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.0.1
+    GIT_TAG        v3.4.0
     )
   FetchContent_MakeAvailable(Catch2)
   set(CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras ${CMAKE_MODULE_PATH})

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -77,13 +77,13 @@ int read_frames(const std::string& filename) {
     return 1;
   }
 
-  if (reader.getEntries("events") != 10) {
+  if (reader.getEntries(podio::Category::Event) != 10) {
     std::cerr << "Could not read back the number of events correctly. "
-              << "(expected:" << 10 << ", actual: " << reader.getEntries("events") << ")" << std::endl;
+              << "(expected:" << 10 << ", actual: " << reader.getEntries(podio::Category::Event) << ")" << std::endl;
     return 1;
   }
 
-  if (reader.getEntries("events") != reader.getEntries("other_events")) {
+  if (reader.getEntries(podio::Category::Event) != reader.getEntries("other_events")) {
     std::cerr << "Could not read back the number of events correctly. "
               << "(expected:" << 10 << ", actual: " << reader.getEntries("other_events") << ")" << std::endl;
     return 1;
@@ -91,8 +91,8 @@ int read_frames(const std::string& filename) {
 
   // Read the frames in a different order than when writing them here to make
   // sure that the writing/reading order does not impose any usage requirements
-  for (size_t i = 0; i < reader.getEntries("events"); ++i) {
-    auto frame = podio::Frame(reader.readNextEntry("events"));
+  for (size_t i = 0; i < reader.getEntries(podio::Category::Event); ++i) {
+    auto frame = podio::Frame(reader.readNextEntry(podio::Category::Event));
     if (reader.currentFileVersion() > podio::version::Version{0, 16, 2}) {
       if (frame.get("emptySubsetColl") == nullptr) {
         std::cerr << "Could not retrieve an empty subset collection" << std::endl;
@@ -114,7 +114,7 @@ int read_frames(const std::string& filename) {
     }
   }
 
-  if (reader.readNextEntry("events")) {
+  if (reader.readNextEntry(podio::Category::Event)) {
     std::cerr << "Trying to read more frame data than is present should return a nullptr" << std::endl;
     return 1;
   }
@@ -127,10 +127,10 @@ int read_frames(const std::string& filename) {
 
   // Reading specific (jumping to) entry
   {
-    auto frame = podio::Frame(reader.readEntry("events", 4));
+    auto frame = podio::Frame(reader.readEntry(podio::Category::Event, 4));
     processEvent(frame, 4, reader.currentFileVersion());
     // Reading the next entry after jump, continues from after the jump
-    auto nextFrame = podio::Frame(reader.readNextEntry("events"));
+    auto nextFrame = podio::Frame(reader.readNextEntry(podio::Category::Event));
     processEvent(nextFrame, 5, reader.currentFileVersion());
 
     auto otherFrame = podio::Frame(reader.readEntry("other_events", 4));
@@ -147,7 +147,7 @@ int read_frames(const std::string& filename) {
     }
 
     // Trying to read a Frame that is not present returns a nullptr
-    if (reader.readEntry("events", 10)) {
+    if (reader.readEntry(podio::Category::Event, 10)) {
       std::cerr << "Trying to read a specific entry that does not exist should return a nullptr" << std::endl;
       return 1;
     }

--- a/tests/read_frame_auxiliary.h
+++ b/tests/read_frame_auxiliary.h
@@ -56,9 +56,9 @@ int test_frame_aux_info(const std::string& fileName) {
   reader.openFile(fileName);
 
   // Test on the first event only here. Additionally, also only testing the
-  // "events" category, since that is the one where not all collections are
+  // events category, since that is the one where not all collections are
   // written
-  auto event = podio::Frame(reader.readEntry("events", 0));
+  auto event = podio::Frame(reader.readEntry(podio::Category::Event, 0));
 
   auto collsToRead = collsToWrite;
   if (reader.currentFileVersion() < podio::version::Version{0, 16, 3}) {

--- a/tests/write_frame.h
+++ b/tests/write_frame.h
@@ -444,7 +444,7 @@ void write_frames(const std::string& filename) {
 
   for (int i = 0; i < 10; ++i) {
     auto frame = makeFrame(i);
-    writer.writeFrame(frame, "events", collsToWrite);
+    writer.writeFrame(frame, podio::Category::Event, collsToWrite);
   }
 
   for (int i = 100; i < 110; ++i) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Backport of #439
- (Partial) backport of #469 to fix CI for this branch. Removed the RNTuple setup since that is not available here yet.
- Backport the `AUTO` configuration option for the cmake `USE_EXTERNAL_CATCH2` config parameter

ENDRELEASENOTES