### PR TITLE
Initialize all branches index based for v00-16 series

### DIFF
--- a/src/ROOTFrameReader.cc
+++ b/src/ROOTFrameReader.cc
@@ -155,7 +155,7 @@ void ROOTFrameReader::initCategory(CategoryInfo& catInfo, const std::string& cat
 
   // For backwards compatibility make it possible to read the index based files
   // from older versions
-  if (m_fileVersion <= podio::version::Version{0, 16, 6}) {
+  if (m_fileVersion < podio::version::Version{0, 16, 99}) {
     std::tie(catInfo.branches, catInfo.storedClasses) =
         createCollectionBranchesIndexBased(catInfo.chain.get(), *catInfo.table, *collInfo);
   } else {


### PR DESCRIPTION
BEGINRELEASENOTES
- Initialize the branch names to be index based for reading (i.e. legacy behavior) for all releases of the v00-16 series.

ENDRELEASENOTES

Together with #461 this makes sure that we can also read files produced with the upcoming v00-16-07 tag (see #470) properly without crashing. This also means that #405 will not be able to land in any v00-16 series release.