### PR TITLE
Reduce unnecessary template instantiations

### DIFF
--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -209,7 +209,6 @@ have resolvable schema evolution incompatibilities:")
 
     endings = {
         'Data': ('h',),
-        'Component': ('h',),
         'PrintInfo': ('h',)
         }.get(template_base, ('h', 'cc'))
 

--- a/python/templates/CMakeLists.txt
+++ b/python/templates/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PODIO_TEMPLATES
   ${CMAKE_CURRENT_LIST_DIR}/CollectionData.cc.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/CollectionData.h.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/Component.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Component.cc.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/Data.h.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/Obj.h.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/Obj.cc.jinja2

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -13,6 +13,10 @@
 {{ include }}
 {% endfor %}
 
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
+#include "nlohmann/json.hpp"
+#endif
+
 // standard includes
 #include <stdexcept>
 #include <iomanip>

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -19,7 +19,7 @@
 #include "podio/CollectionIDTable.h"
 
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
-#include "nlohmann/json.hpp"
+#include "nlohmann/json_fwd.hpp"
 #endif
 
 #include <string>

--- a/python/templates/Component.cc.jinja2
+++ b/python/templates/Component.cc.jinja2
@@ -1,0 +1,39 @@
+{% import "macros/utils.jinja2" as utils %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#include "{{ incfolder }}{{ class.bare_type }}.h"
+
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
+#include "nlohmann/json.hpp"
+#endif
+
+{{ utils.namespace_open(class.namespace) }}
+
+std::ostream& operator<<(std::ostream& o, const {{class.full_type}}& value) {
+{% for member in Members %}
+{% if member.is_array %}
+  for (int i = 0; i < {{ member.array_size }}; ++i) {
+    o << value.{{ member.name }}[i] << "|";
+  }
+  o << " ";
+{% else %}
+  o << value.{{ member.name }} << " ";
+{% endif %}
+{% endfor %}
+
+  return o;
+}
+
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
+void to_json(nlohmann::json& j, const {{ class.bare_type }}& value) {
+  j = nlohmann::json{
+{% set comma = joiner(",") %}
+{% for member in Members %}
+  {{ comma() }}{"{{ member.name }}", value.{{ member.name }}}
+{% endfor %}
+  };
+}
+#endif
+
+{{ utils.namespace_close(class.namespace) }}
+

--- a/python/templates/Component.h.jinja2
+++ b/python/templates/Component.h.jinja2
@@ -11,7 +11,7 @@
 #include <ostream>
 
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
-#include "nlohmann/json.hpp"
+#include "nlohmann/json_fwd.hpp"
 #endif
 
 {{ utils.namespace_open(class.namespace) }}
@@ -25,30 +25,10 @@ public:
 {{ utils.if_present(ExtraCode, "declaration") }}
 };
 
-inline std::ostream& operator<<(std::ostream& o, const {{class.full_type}}& value) {
-{% for member in Members %}
-{% if member.is_array %}
-  for (int i = 0; i < {{ member.array_size }}; ++i) {
-    o << value.{{ member.name }}[i] << "|";
-  }
-  o << " ";
-{% else %}
-  o << value.{{ member.name }} << " ";
-{% endif %}
-{% endfor %}
-
-  return o;
-}
+std::ostream& operator<<(std::ostream& o, const {{class.full_type}}& value);
 
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
-inline void to_json(nlohmann::json& j, const {{ class.bare_type }}& value) {
-  j = nlohmann::json{
-{% set comma = joiner(",") %}
-{% for member in Members %}
-  {{ comma() }}{"{{ member.name }}", value.{{ member.name }}}
-{% endfor %}
-  };
-}
+void to_json(nlohmann::json& j, const {{ class.bare_type }}& value);
 #endif
 
 {{ utils.namespace_close(class.namespace) }}

--- a/python/templates/MutableObject.cc.jinja2
+++ b/python/templates/MutableObject.cc.jinja2
@@ -8,6 +8,10 @@
 {{ include }}
 {% endfor %}
 
+#ifdef PODIO_JSON_OUTPUT && !defined(__CLING__)
+#include "nlohmann/json.hpp"
+#endif
+
 #include <ostream>
 
 {{ utils.namespace_open(class.namespace) }}

--- a/python/templates/MutableObject.cc.jinja2
+++ b/python/templates/MutableObject.cc.jinja2
@@ -8,7 +8,7 @@
 {{ include }}
 {% endfor %}
 
-#ifdef PODIO_JSON_OUTPUT && !defined(__CLING__)
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json.hpp"
 #endif
 

--- a/python/templates/MutableObject.h.jinja2
+++ b/python/templates/MutableObject.h.jinja2
@@ -16,7 +16,7 @@
 #include <ostream>
 #include <cstddef>
 
-#ifdef PODIO_JSON_OUTPUT
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json_fwd.hpp"
 #endif
 

--- a/python/templates/MutableObject.h.jinja2
+++ b/python/templates/MutableObject.h.jinja2
@@ -17,7 +17,7 @@
 #include <cstddef>
 
 #ifdef PODIO_JSON_OUTPUT
-#include "nlohmann/json.hpp"
+#include "nlohmann/json_fwd.hpp"
 #endif
 
 {{ utils.forward_decls(forward_declarations) }}

--- a/python/templates/Object.cc.jinja2
+++ b/python/templates/Object.cc.jinja2
@@ -8,6 +8,10 @@
 {{ include }}
 {% endfor %}
 
+#ifdef PODIO_JSON_OUTPUT && !defined(__CLING__)
+#include "nlohmann/json.hpp"
+#endif
+
 #include <ostream>
 
 {{ utils.namespace_open(class.namespace) }}

--- a/python/templates/Object.cc.jinja2
+++ b/python/templates/Object.cc.jinja2
@@ -8,7 +8,7 @@
 {{ include }}
 {% endfor %}
 
-#ifdef PODIO_JSON_OUTPUT && !defined(__CLING__)
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json.hpp"
 #endif
 

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -14,7 +14,7 @@
 #include <ostream>
 #include <cstddef>
 
-#ifdef PODIO_JSON_OUTPUT && !defined(__CLING__)
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json_fwd.hpp"
 #endif
 

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -14,8 +14,8 @@
 #include <ostream>
 #include <cstddef>
 
-#ifdef PODIO_JSON_OUTPUT
-#include "nlohmann/json.hpp"
+#ifdef PODIO_JSON_OUTPUT && !defined(__CLING__)
+#include "nlohmann/json_fwd.hpp"
 #endif
 
 {{ utils.forward_decls(forward_declarations) }}

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -134,7 +134,7 @@
 {%- endmacro %}
 
 {% macro json_output(type, prefix='') %}
-#ifdef PODIO_JSON_OUTPUT
+#ifdef PODIO_JSON_OUTPUT && !defined(__CLING__)
 void to_json(nlohmann::json& j, const {{ prefix }}{{ type }}& value);
 #endif
 {% endmacro %}

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -134,7 +134,7 @@
 {%- endmacro %}
 
 {% macro json_output(type, prefix='') %}
-#ifdef PODIO_JSON_OUTPUT && !defined(__CLING__)
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 void to_json(nlohmann::json& j, const {{ prefix }}{{ type }}& value);
 #endif
 {% endmacro %}

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -210,7 +210,7 @@ std::ostream& operator<<(std::ostream& o, const {{ type }}& value) {
 {%- endmacro %}
 
 {% macro json_output(class, members, single_relations, multi_relations, vector_members, get_syntax, prefix='') %}
-#ifdef PODIO_JSON_OUTPUT
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 void to_json(nlohmann::json& j, const {{ prefix }}{{ class.bare_type }}& value) {
   j = nlohmann::json{
 {% set comma = joiner(",") %}


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `nlohmann/json_fwd.hpp` in headers to reduce unnecessary template instantiations. Fixes #475 

ENDRELEASENOTES

@wdconinc could you give this a try and see if this solves things already? ~Currently there are only the components left with the original include. That is mainly because they do not have a `.cc` file yet, but if necessary we can also introduce that.~ 