### PR TITLE
Improve the collection interface

### DIFF
--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -55,6 +55,9 @@ public:
   /// number of elements in the collection
   virtual size_t size() const = 0;
 
+  /// Is the collection empty
+  virtual bool empty() const = 0;
+
   /// fully qualified type name
   virtual const std::string_view getTypeName() const = 0;
   /// fully qualified type name of elements - with namespace

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -136,6 +136,11 @@ public:
     return _vec.size();
   }
 
+  /// Is the collection empty
+  bool empty() const override {
+    return _vec.empty();
+  }
+
   /// fully qualified type name
   const std::string_view getTypeName() const override {
     return typeName;

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -51,6 +51,10 @@ std::size_t {{ collection_type }}::size() const {
   return m_storage.entries.size();
 }
 
+bool {{ collection_type }}::empty() const {
+  return m_storage.entries.empty();
+}
+
 void {{ collection_type }}::setSubsetCollection(bool setSubset) {
   if (m_isSubsetColl != setSubset && !m_storage.entries.empty()) {
     throw std::logic_error("Cannot change the character of a collection that already contains elements");

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -85,6 +85,9 @@ public:
   /// number of elements in the collection
   std::size_t size() const final;
 
+  /// Is the collection empty
+  bool empty() const final;
+
   /// fully qualified type name
   const std::string_view getTypeName() const final { return typeName; }
   /// fully qualified type name of elements - with namespace

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -11,6 +11,10 @@ public:
     return m_index != x.m_index; // TODO: may not be complete
   }
 
+  bool operator==(const {{ iterator_type }}& x) const {
+    return m_index ==  x.m_index; // TODO: may not be complete
+  }
+
   {{ prefix }}{{ class.bare_type }} operator*();
   {{ prefix }}{{ class.bare_type }}* operator->();
   {{ iterator_type }}& operator++();

--- a/tests/unittests/frame.cpp
+++ b/tests/unittests/frame.cpp
@@ -220,7 +220,7 @@ void checkFrame(const podio::Frame& frame) {
   REQUIRE(hits[1].energy() == 1);
   REQUIRE(hits[1].cellID() == 0x123ULL);
 
-  REQUIRE(frame.get<ExampleClusterCollection>("emptyClusters").size() == 0);
+  REQUIRE(frame.get<ExampleClusterCollection>("emptyClusters").empty());
 
   auto& clusters = frame.get<ExampleClusterCollection>("clusters");
   REQUIRE(clusters.size() == 2);

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -80,7 +80,6 @@ TEST_CASE("Assignment-operator ref count", "[basics][memory-management]") {
 }
 
 TEST_CASE("Clearing", "[UBSAN-FAIL][ASAN-FAIL][THREAD-FAIL][basics][memory-management]") {
-  bool success = true;
   auto store = podio::EventStore();
   auto& hits = store.create<ExampleHitCollection>("hits");
   auto& clusters = store.create<ExampleClusterCollection>("clusters");
@@ -102,10 +101,7 @@ TEST_CASE("Clearing", "[UBSAN-FAIL][ASAN-FAIL][THREAD-FAIL][basics][memory-manag
     oneRels.push_back(oneRel);
   }
   hits.clear();
-  if (hits.size() != 0) {
-    success = false;
-  }
-  REQUIRE(success);
+  REQUIRE(hits.empty());
 }
 
 TEST_CASE("Cloning", "[basics][memory-management]") {
@@ -438,6 +434,15 @@ TEST_CASE("UserInitialization", "[basics][code-gen]") {
 TEST_CASE("NonPresentCollection", "[basics][event-store]") {
   auto store = podio::EventStore();
   REQUIRE_THROWS_AS(store.get<ExampleHitCollection>("NonPresentCollection"), std::runtime_error);
+}
+
+TEST_CASE("Collection size and empty", "[basics][collections]") {
+  ExampleClusterCollection coll{};
+  REQUIRE(coll.empty());
+
+  coll.create();
+  coll.create();
+  REQUIRE(coll.size() == 2u);
 }
 
 TEST_CASE("const correct indexed access to const collections", "[const-correctness]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `empty` method to `CollectionBase`
- Add `operator==` to the collection iterators

ENDRELEASENOTES

Fixes #476 