### PR TITLE
Fix python imports when built without SIO support

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
     DESTINATION ${podio_PYTHON_INSTALLDIR}
     REGEX test_.*\\.py$ EXCLUDE  # Do not install test files
     PATTERN __pycache__ EXCLUDE  # Or pythons caches
-    REGEX .*sio.*\\.py$ EXCLUDE  # All things sio related
+    REGEX .*sio_.*\\.py$ EXCLUDE  # All things sio related
     )
 endif()
 

--- a/python/podio/__init__.py
+++ b/python/podio/__init__.py
@@ -22,7 +22,15 @@ if ROOT.gSystem.DynamicPathName("libpodioDict.so", True):
 
 if _DYNAMIC_LIBS_LOADED:
   from .frame import Frame
-  from . import root_io, sio_io, reading
+  from . import root_io, reading
+
+  try:
+    # We try to import the sio bindings which may fail if ROOT is not able to
+    # load the dictionary in this case they have most likely not been built and
+    # we just move on
+    from . import sio_io
+  except ImportError:
+    pass
 
   from . import EventStore
 

--- a/python/podio/test_utils.py
+++ b/python/podio/test_utils.py
@@ -4,7 +4,8 @@
 import os
 import ROOT
 
-ROOT.gSystem.Load("libTestDataModelDict.so")  # noqa: E402
+if ROOT.gSystem.DynamicPathName("libTestDataModelDict.so", True):  # noqa: E402
+  ROOT.gSystem.Load("libTestDataModelDict.so")  # noqa: E402
 from ROOT import ExampleHitCollection, ExampleClusterCollection  # noqa: E402 # pylint: disable=wrong-import-position
 
 from podio import Frame  # pylint: disable=wrong-import-position


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix bugs in python imports when podio is built without SIO support. Fixes #489 

ENDRELEASENOTES

@kjvbrt do you want to give this a go?