### PR TITLE
Make `Object::id()` return an ObjectID since unsigned has become useless

### DIFF
--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -2,6 +2,8 @@
 #define PODIO_OBJECTID_H
 
 #include <cstdint>
+#include <iomanip>
+#include <ostream>
 
 namespace podio {
 
@@ -24,6 +26,13 @@ public:
     return index == other.index && collectionID == other.collectionID;
   }
 };
+
+inline std::ostream& operator<<(std::ostream& os, const podio::ObjectID& id) {
+  const auto oldFlags = os.flags();
+  os << std::hex << std::setw(8) << id.collectionID;
+  os.flags(oldFlags);
+  return os << id.index;
+}
 
 } // namespace podio
 

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -93,7 +93,7 @@
   // less comparison operator, so that objects can be e.g. stored in sets.
   bool operator<(const {{ full_type }}& other) const { return m_obj < other.m_obj; }
 
-  unsigned int id() const { return getObjectID().collectionID * 10000000 + getObjectID().index; }
+  podio::ObjectID id() const { return getObjectID(); }
 
   const podio::ObjectID getObjectID() const;
 

--- a/tests/write_frame.h
+++ b/tests/write_frame.h
@@ -98,13 +98,13 @@ auto createMCRefCollection(const ExampleMCCollection& mcps, const ExampleMCColle
   mcpsRefs.setSubsetCollection();
   // ----------------- add all "odd" mc particles into a subset collection
   for (auto p : mcps) {
-    if (p.id() % 2) {
+    if (p.id().index % 2) {
       mcpsRefs.push_back(p);
     }
   }
   // ----------------- add the "even" counterparts from a different collection
   for (auto p : moreMCs) {
-    if (p.id() % 2 == 0) {
+    if (p.id().index % 2 == 0) {
       mcpsRefs.push_back(p);
     }
   }

--- a/tests/write_test.h
+++ b/tests/write_test.h
@@ -189,13 +189,13 @@ void write(podio::EventStore& store, WriterT& writer) {
 
     // ----------------- add all "odd" mc particles into a subset collection
     for (auto p : mcps) {
-      if (p.id() % 2) {
+      if (p.id().index % 2) {
         mcpsRefs.push_back(p);
       }
     }
     // ----------------- add the "even" counterparts from a different collection
     for (auto p : moreMCs) {
-      if (p.id() % 2 == 0) {
+      if (p.id().index % 2 == 0) {
         mcpsRefs.push_back(p);
       }
     }


### PR DESCRIPTION
BEGINRELEASENOTES
- Make `[Mutable]Object::id()` return a `podio::ObjectID` instead of `unsigned`, since the latter has become useless with #412. Fixes #438 
- Add an `operator<<(std::ostream&)` for `podio::ObjectID`

ENDRELEASENOTES