### PR TITLE
Add an operator != in podio::ObjectID

### DIFF
--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -25,6 +25,9 @@ public:
   bool operator==(const ObjectID& other) const {
     return index == other.index && collectionID == other.collectionID;
   }
+  bool operator!=(const ObjectID& other) const {
+    return !(*this == other);
+  }
 };
 
 inline std::ostream& operator<<(std::ostream& os, const podio::ObjectID& id) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Add an operator != to fix negative comparisons since after https://github.com/AIDASoft/podio/pull/493 now `id()` returns a `podioObjectID`

ENDRELEASENOTES

Fixes https://github.com/AIDASoft/podio/issues/495

The nightlies are currently not compiling because there are a few cases of these negative comparisons