### PR TITLE
Move podio_PYTHON_DIR to the top level CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,11 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/NOTICE
 
 #--- project specific subdirectories -------------------------------------------
 add_subdirectory(src)
+
+# Set the podio_PYTHON_DIR manually here because the macros in tests expect it
+# If testing is not build this helps when building together with other packages
+SET(podio_PYTHON_DIR ${PROJECT_SOURCE_DIR}/python CACHE PATH "Path to the podio python directory")
+
 if(BUILD_TESTING)
   include(cmake/podioTest.cmake)
   add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,9 +5,6 @@ foreach( _conf ${CMAKE_CONFIGURATION_TYPES} )
   set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${_conf} ${CMAKE_CURRENT_BINARY_DIR} )
 endforeach()
 
-# Set the podio_PYTHON_DIR manually here because the macros below expect it
-SET(podio_PYTHON_DIR ${PROJECT_SOURCE_DIR}/python CACHE PATH "Path to the podio python directory")
-
 PODIO_GENERATE_DATAMODEL(datamodel datalayout.yaml headers sources
   IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS}
   )


### PR DESCRIPTION
BEGINRELEASENOTES
- Move podio_PYTHON_DIR to the top level CMakeLists so that it is set even when BUILD_TESTING is off

ENDRELEASENOTES

This is useful when building other packages at the same time and having BUILD_TESTING=OFF. Alternatively, to reduce the number of lines in the top level CMakeLists the `if(BUILD_TESTING)` could be moved inside the `tests/CMakeLists.txt` and this variable could be always be set there