### PR TITLE
Silence when SIO is missing and exit if the podio dictionary is not found

### DIFF
--- a/python/podio/__init__.py
+++ b/python/podio/__init__.py
@@ -5,28 +5,19 @@ from .__version__ import __version__
 
 from .podio_config_reader import *  # noqa: F403, F401
 
-import ROOT  # pylint: disable=wrong-import-order
-
-# Track whether we were able to dynamially load the library that is built by
-# podio and enable certain features of the bindings only if they are actually
-# available.
-_DYNAMIC_LIBS_LOADED = False
-
-# Check if we can locate the dictionary wthout loading it as this allows us to
-# silence any ouptput. If we can find it, we can also safely load it
-if ROOT.gSystem.DynamicPathName("libpodioDict.so", True):
-  ROOT.gSystem.Load("libpodioDict.so")
+# Try to load podio, this is equivalent to trying to load libpodio.so and will
+# error if libpodio.so is not found but work if it's found
+try:
   from ROOT import podio
-
-  _DYNAMIC_LIBS_LOADED = True
-
-if _DYNAMIC_LIBS_LOADED:
+except ImportError:
+  print('Unable to load podio, make sure that libpodio.so is in LD_LIBRARY_PATH')
+else:
   from .frame import Frame
   from . import root_io, reading
 
   try:
     # We try to import the sio bindings which may fail if ROOT is not able to
-    # load the dictionary in this case they have most likely not been built and
+    # load the dictionary. In this case they have most likely not been built and
     # we just move on
     from . import sio_io
   except ImportError:

--- a/python/podio/__init__.py
+++ b/python/podio/__init__.py
@@ -11,6 +11,7 @@ try:
   from ROOT import podio
 except ImportError:
   print('Unable to load podio, make sure that libpodio.so is in LD_LIBRARY_PATH')
+  raise
 else:
   from .frame import Frame
   from . import root_io, reading

--- a/python/podio/__init__.py
+++ b/python/podio/__init__.py
@@ -12,37 +12,37 @@ try:
 except ImportError:
   print('Unable to load podio, make sure that libpodio.so is in LD_LIBRARY_PATH')
   raise
-else:
-  from .frame import Frame
-  from . import root_io, reading
 
-  try:
-    # We try to import the sio bindings which may fail if ROOT is not able to
-    # load the dictionary. In this case they have most likely not been built and
-    # we just move on
-    from . import sio_io
-  except ImportError:
-    pass
+from .frame import Frame
+from . import root_io, reading
 
-  from . import EventStore
+try:
+  # We try to import the sio bindings which may fail if ROOT is not able to
+  # load the dictionary. In this case they have most likely not been built and
+  # we just move on
+  from . import sio_io
+except ImportError:
+  pass
 
-  try:
-    # For some reason the test_utils only work at (test) runtime if they are
-    # imported with the rest of podio. Otherwise they produce a weird c++ error.
-    # This happens even if we import the *exact* same file.
-    from . import test_utils  # noqa: F401
-  except ImportError:
-    pass
+from . import EventStore
 
-  # Make sure that this module is actually usable as podio even though most of
-  # it is dynamically populated by cppyy
-  sys.modules["podio"] = podio
+try:
+  # For some reason the test_utils only work at (test) runtime if they are
+  # imported with the rest of podio. Otherwise they produce a weird c++ error.
+  # This happens even if we import the *exact* same file.
+  from . import test_utils  # noqa: F401
+except ImportError:
+  pass
 
-  __all__ = [
-      "__version__",
-      "Frame",
-      "root_io",
-      "sio_io",
-      "reading",
-      "EventStore"
-      ]
+# Make sure that this module is actually usable as podio even though most of
+# it is dynamically populated by cppyy
+sys.modules["podio"] = podio
+
+__all__ = [
+    "__version__",
+    "Frame",
+    "root_io",
+    "sio_io",
+    "reading",
+    "EventStore"
+    ]

--- a/python/podio/sio_io.py
+++ b/python/podio/sio_io.py
@@ -2,9 +2,9 @@
 """Python module for reading sio files containing podio Frames"""
 
 from ROOT import gSystem
-ret = gSystem.Load('libpodioSioIO')  # noqa: 402
-# Return values: -1 when it doesn't exist and -2 when there is a version mismatch
-if ret < 0:
+if gSystem.DynamicPathName("libpodioSioIO.so", True):
+  gSystem.Load('libpodioSioIO')  # noqa: 402
+else:
   raise ImportError('Error when importing libpodioSioIO')
 from ROOT import podio  # noqa: 402 # pylint: disable=wrong-import-position
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Silence when SIO is missing so that the messages are not shown every time a datamodel is generated when a podio installation already exists
- Simplify `__init__.py`, remove an unneeded `import ROOT`

ENDRELEASENOTES