### PR TITLE
Make it possible to read only a subset of available collections in readers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,13 +82,15 @@ option(ENABLE_JULIA      "Enable Julia support. When enabled, Julia datamodels w
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(root_components_needed RIO Tree)
+set(root_min_version 6.28.04)
 if(ENABLE_RNTUPLE)
   list(APPEND root_components_needed ROOTNTuple)
+  set(root_min_version 6.32)
 endif()
 if(ENABLE_DATASOURCE)
   list(APPEND root_components_needed ROOTDataFrame)
 endif()
-find_package(ROOT 6.28.04 REQUIRED COMPONENTS ${root_components_needed})
+find_package(ROOT ${root_min_version} REQUIRED COMPONENTS ${root_components_needed})
 
 # ROOT_CXX_STANDARD was introduced in https://github.com/root-project/root/pull/6466
 # before that it's an empty variable so we check if it's any number > 0

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ use a recent LCG or Key4hep stack release.
 
 On Mac OS or Ubuntu, you need to install the following software.
 
-### ROOT 6.28.04
+### ROOT 6.28.04 (6.32 for RNTuple support)
 
 Install ROOT 6.28.04 (or later) built with c++20 support and set up your ROOT environment:
 
     source <root_path>/bin/thisroot.sh
+
+If you want to build with RNTuple support, you will need 6.32 at least.
 
 ### Catch2 v3 (optional)
 

--- a/include/podio/DataSource.h
+++ b/include/podio/DataSource.h
@@ -23,12 +23,25 @@ public:
   ///
   /// @brief Construct the podio::DataSource from the provided file.
   ///
-  explicit DataSource(const std::string& filePath, int nEvents = -1);
+  /// @param filePath Path to the file that should be read
+  /// @param nEvents Number of events to process (optional, defaults to -1 for
+  ///                all events)
+  /// @param collsToRead The collections that should be made available (optional,
+  ///                    defaults to empty vector for all collections)
+  ///
+  explicit DataSource(const std::string& filePath, int nEvents = -1, const std::vector<std::string>& collsToRead = {});
 
   ///
   /// @brief Construct the podio::DataSource from the provided file list.
   ///
-  explicit DataSource(const std::vector<std::string>& filePathList, int nEvents = -1);
+  /// @param filePathList Paths to the files that should be read
+  /// @param nEvents Number of events to process (optional, defaults to -1 for
+  ///                all events)
+  /// @param collsToRead The collections that should be made available (optional,
+  ///                    defaults to empty vector for all collections)
+  ///
+  explicit DataSource(const std::vector<std::string>& filePathList, int nEvents = -1,
+                      const std::vector<std::string>& collsToRead = {});
 
   ///
   /// @brief Inform the podio::DataSource of the desired level of parallelism.
@@ -139,7 +152,7 @@ private:
   ///
   /// @param[in] nEvents Number of events.
   ///
-  void SetupInput(int nEvents);
+  void SetupInput(int nEvents, const std::vector<std::string>& collsToRead);
 };
 
 ///
@@ -147,18 +160,25 @@ private:
 ///
 /// @param[in] filePathList  List of file paths from which the RDataFrame
 ///                          will be created.
+/// @param[in] collsToRead   List of collection names that should be made
+///                          available
+///
 /// @return                  RDataFrame created from input file list.
 ///
-ROOT::RDataFrame CreateDataFrame(const std::vector<std::string>& filePathList);
+ROOT::RDataFrame CreateDataFrame(const std::vector<std::string>& filePathList,
+                                 const std::vector<std::string>& collsToRead = {});
 
 ///
 /// @brief Create RDataFrame from a Podio file or glob pattern matching multiple Podio files.
 ///
 /// @param[in] filePath  File path from which the RDataFrame will be created.
 ///                      The file path can include glob patterns to match multiple files.
+/// @param[in] collsToRead   List of collection names that should be made
+///                          available
+///
 /// @return              RDataFrame created from input file list.
 ///
-ROOT::RDataFrame CreateDataFrame(const std::string& filePath);
+ROOT::RDataFrame CreateDataFrame(const std::string& filePath, const std::vector<std::string>& collsToRead = {});
 } // namespace podio
 
 #endif /* PODIO_DATASOURCE_H */

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -12,10 +12,8 @@
 #include <vector>
 
 #include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleReader.hxx>
 #include <RVersion.h>
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
-  #include <ROOT/RNTupleReader.hxx>
-#endif
 
 namespace podio {
 

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -19,10 +19,6 @@
 
 namespace podio {
 
-/**
-This class has the function to read available data from disk
-and to prepare collections and buffers.
-**/
 /// The RNTupleReader can be used to read files that have been written with the
 /// RNTuple backend.
 ///
@@ -61,20 +57,26 @@ public:
   /// Read the next data entry for a given category.
   ///
   /// @param name The category name for which to read the next entry
+  /// @param collsToRead (optional) the collection names that should be read. If
+  ///             not provided (or empty) all collections will be read
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category exists and if there are still entries left to read.
   ///          Otherwise a nullptr
-  std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string& name);
+  std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string& name,
+                                                      const std::vector<std::string>& collsToRead = {});
 
   /// Read the desired data entry for a given category.
   ///
   /// @param name  The category name for which to read the next entry
   /// @param entry The entry number to read
+  /// @param collsToRead (optional) the collection names that should be read. If
+  ///             not provided (or empty) all collections will be read
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category and the desired entry exist. Otherwise a nullptr
-  std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string& name, const unsigned entry);
+  std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string& name, const unsigned entry,
+                                                  const std::vector<std::string>& collsToRead = {});
 
   /// Get the names of all the available Frame categories in the current file(s).
   ///

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -63,6 +63,9 @@ public:
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category exists and if there are still entries left to read.
   ///          Otherwise a nullptr
+  ///
+  /// @throws std::invalid_argument in case collsToRead contains collection
+  /// names that are not available
   std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string& name,
                                                       const std::vector<std::string>& collsToRead = {});
 
@@ -75,6 +78,9 @@ public:
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category and the desired entry exist. Otherwise a nullptr
+  ///
+  /// @throws std::invalid_argument in case collsToRead contains collection
+  /// names that are not available
   std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string& name, const unsigned entry,
                                                   const std::vector<std::string>& collsToRead = {});
 

--- a/include/podio/RNTupleWriter.h
+++ b/include/podio/RNTupleWriter.h
@@ -9,9 +9,7 @@
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
-  #include <ROOT/RNTupleWriter.hxx>
-#endif
+#include <ROOT/RNTupleWriter.hxx>
 
 #include <string>
 #include <unordered_map>

--- a/include/podio/ROOTLegacyReader.h
+++ b/include/podio/ROOTLegacyReader.h
@@ -75,20 +75,23 @@ public:
   /// Read the next data entry from which a Frame can be constructed.
   ///
   /// @note the category name has to be "events" in this case, as only that
-  /// category is available for legacy files.
+  /// category is available for legacy files. Also the collections to read
+  /// argument will be ignored.
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if there
   ///          are still entries left to read. Otherwise a nullptr
-  std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string&);
+  std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string&, const std::vector<std::string>& = {});
 
   /// Read the desired data entry from which a Frame can be constructed.
   ///
   /// @note the category name has to be "events" in this case, as only that
-  /// category is available for legacy files.
+  /// category is available for legacy files. Also the collections to read
+  /// argument will be ignored.
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          desired entry exists. Otherwise a nullptr
-  std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string&, const unsigned entry);
+  std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string&, const unsigned entry,
+                                                  const std::vector<std::string>& = {});
 
   /// Get the number of entries for the given name
   ///

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -74,20 +74,26 @@ public:
   /// Read the next data entry for a given category.
   ///
   /// @param name The category name for which to read the next entry
+  /// @param collsToRead (optional) the collection names that should be read. If
+  ///             not provided (or empty) all collections will be read
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category exists and if there are still entries left to read.
   ///          Otherwise a nullptr
-  std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string& name);
+  std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string& name,
+                                                      const std::vector<std::string>& collsToRead = {});
 
   /// Read the desired data entry for a given category.
   ///
   /// @param name  The category name for which to read the next entry
   /// @param entry The entry number to read
+  /// @param collsToRead (optional) the collection names that should be read. If
+  ///              not provided (or empty) all collections will be read
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category and the desired entry exist. Otherwise a nullptr
-  std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string& name, const unsigned entry);
+  std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string& name, const unsigned entry,
+                                                  const std::vector<std::string>& collsToRead = {});
 
   /// Get the number of entries for the given name
   ///
@@ -174,7 +180,8 @@ private:
   /// Read the data entry specified in the passed CategoryInfo, and increase the
   /// counter afterwards. In case the requested entry is larger than the
   /// available number of entries, return a nullptr.
-  std::unique_ptr<podio::ROOTFrameData> readEntry(ROOTReader::CategoryInfo& catInfo);
+  std::unique_ptr<podio::ROOTFrameData> readEntry(ROOTReader::CategoryInfo& catInfo,
+                                                  const std::vector<std::string>& collsToRead);
 
   /// Get / read the buffers at index iColl in the passed category information
   podio::CollectionReadBuffers getCollectionBuffers(CategoryInfo& catInfo, size_t iColl, bool reloadBranches,

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -28,6 +28,10 @@ namespace detail {
   // vector
   using CollectionInfo = std::tuple<std::string, bool, SchemaVersionT, size_t>;
 
+  struct NamedCollInfo {
+    std::string name{};
+    CollectionInfo info{};
+  };
 } // namespace detail
 
 class CollectionBase;
@@ -152,12 +156,12 @@ private:
     /// constructor from chain for more convenient map insertion
     CategoryInfo(std::unique_ptr<TChain>&& c) : chain(std::move(c)) {
     }
-    std::unique_ptr<TChain> chain{nullptr};                                      ///< The TChain with the data
-    unsigned entry{0};                                                           ///< The next entry to read
-    std::vector<std::pair<std::string, detail::CollectionInfo>> storedClasses{}; ///< The stored collections in this
-                                                                                 ///< category
-    std::vector<root_utils::CollectionBranches> branches{};                      ///< The branches for this category
-    std::shared_ptr<CollectionIDTable> table{nullptr}; ///< The collection ID table for this category
+    std::unique_ptr<TChain> chain{nullptr};                 ///< The TChain with the data
+    unsigned entry{0};                                      ///< The next entry to read
+    std::vector<detail::NamedCollInfo> storedClasses{};     ///< The stored collections in this
+                                                            ///< category
+    std::vector<root_utils::CollectionBranches> branches{}; ///< The branches for this category
+    std::shared_ptr<CollectionIDTable> table{nullptr};      ///< The collection ID table for this category
   };
 
   /// Initialize the passed CategoryInfo by setting up the necessary branches,

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -84,6 +84,9 @@ public:
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category exists and if there are still entries left to read.
   ///          Otherwise a nullptr
+  ///
+  /// @throws std::invalid_argument in case collsToRead contains collection
+  /// names that are not available
   std::unique_ptr<podio::ROOTFrameData> readNextEntry(const std::string& name,
                                                       const std::vector<std::string>& collsToRead = {});
 
@@ -96,6 +99,9 @@ public:
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category and the desired entry exist. Otherwise a nullptr
+  ///
+  /// @throws std::invalid_argument in case collsToRead contains collection
+  /// names that are not available
   std::unique_ptr<podio::ROOTFrameData> readEntry(const std::string& name, const unsigned entry,
                                                   const std::vector<std::string>& collsToRead = {});
 

--- a/include/podio/SIOFrameData.h
+++ b/include/podio/SIOFrameData.h
@@ -4,13 +4,10 @@
 #include "podio/CollectionBuffers.h"
 #include "podio/CollectionIDTable.h"
 #include "podio/GenericParameters.h"
-#include "podio/SIOBlock.h"
 
 #include <sio/buffer.h>
 #include <sio/definitions.h>
 
-#include <memory>
-#include <numeric>
 #include <optional>
 #include <string>
 #include <vector>
@@ -36,13 +33,7 @@ public:
   /// collections. The two size parameters denote the uncompressed size of the
   /// respective buffers.
   SIOFrameData(sio::buffer&& collBuffers, std::size_t dataSize, sio::buffer&& tableBuffer, std::size_t tableSize,
-               std::vector<std::string> limitColls = {}) :
-      m_recBuffer(std::move(collBuffers)),
-      m_tableBuffer(std::move(tableBuffer)),
-      m_dataSize(dataSize),
-      m_tableSize(tableSize),
-      m_limitColls(std::move(limitColls)) {
-  }
+               std::vector<std::string> limitColls = {});
 
   std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
 

--- a/include/podio/SIOFrameData.h
+++ b/include/podio/SIOFrameData.h
@@ -32,15 +32,15 @@ public:
   /// tableBuffer containing the necessary information for unpacking the
   /// collections. The two size parameters denote the uncompressed size of the
   /// respective buffers.
+  ///
+  /// In case the limitColls contain a collection name that is not available
+  /// from the idTable names this throws an exception
   SIOFrameData(sio::buffer&& collBuffers, std::size_t dataSize, sio::buffer&& tableBuffer, std::size_t tableSize,
                std::vector<std::string> limitColls = {});
 
   std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
 
   podio::CollectionIDTable getIDTable() {
-    if (m_idTable.empty()) {
-      readIdTable();
-    }
     return {m_idTable.ids(), m_idTable.names()};
   }
 

--- a/include/podio/SIOFrameData.h
+++ b/include/podio/SIOFrameData.h
@@ -35,11 +35,13 @@ public:
   /// tableBuffer containing the necessary information for unpacking the
   /// collections. The two size parameters denote the uncompressed size of the
   /// respective buffers.
-  SIOFrameData(sio::buffer&& collBuffers, std::size_t dataSize, sio::buffer&& tableBuffer, std::size_t tableSize) :
+  SIOFrameData(sio::buffer&& collBuffers, std::size_t dataSize, sio::buffer&& tableBuffer, std::size_t tableSize,
+               std::vector<std::string> limitColls = {}) :
       m_recBuffer(std::move(collBuffers)),
       m_tableBuffer(std::move(tableBuffer)),
       m_dataSize(dataSize),
-      m_tableSize(tableSize) {
+      m_tableSize(tableSize),
+      m_limitColls(std::move(limitColls)) {
   }
 
   std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
@@ -79,6 +81,10 @@ private:
   std::vector<short> m_subsetCollectionBits{};
 
   podio::GenericParameters m_parameters{};
+
+  /// The collections that should be made available for a Frame constructed from
+  /// this (if non-empty)
+  std::vector<std::string> m_limitColls{};
 };
 } // namespace podio
 

--- a/include/podio/SIOLegacyReader.h
+++ b/include/podio/SIOLegacyReader.h
@@ -40,20 +40,23 @@ public:
   /// there are no more entries left, this returns a nullptr.
   ///
   /// @note the category name has to be "events" in this case, as only that
-  /// category is available for legacy files.
+  /// category is available for legacy files. Also the collections to read
+  /// argument will be ignored.
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if there
   ///          are still entries left to read. Otherwise a nullptr
-  std::unique_ptr<podio::SIOFrameData> readNextEntry(const std::string&);
+  std::unique_ptr<podio::SIOFrameData> readNextEntry(const std::string&, const std::vector<std::string>& = {});
 
   /// Read the desired data entry from which a Frame can be constructed.
   ///
   /// @note the category name has to be "events" in this case, as only that
-  /// category is available for legacy files.
+  /// category is available for legacy files. Also the collections to read
+  /// argument will be ignored.
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          desired entry exists. Otherwise a nullptr
-  std::unique_ptr<podio::SIOFrameData> readEntry(const std::string&, const unsigned entry);
+  std::unique_ptr<podio::SIOFrameData> readEntry(const std::string&, const unsigned entry,
+                                                 const std::vector<std::string>& = {});
 
   /// Get the number of entries for the given name
   ///

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -37,21 +37,39 @@ public:
 
   /// Read the next data entry for a given category.
   ///
+  /// @note Given how the SIO files are currently layed out it is in fact not
+  /// possible to only read a subset of a Frame. Rather the subset of
+  /// collections to read will be an artificial limit on the returned
+  /// SIOFrameData. Limiting the collections to read will not improve I/O
+  /// performance.
+  ///
   /// @param name The category name for which to read the next entry
+  /// @param collsToRead (optional) the collection names that should be read. If
+  ///             not provided (or empty) all collections will be read
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category exists and if there are still entries left to read.
   ///          Otherwise a nullptr
-  std::unique_ptr<podio::SIOFrameData> readNextEntry(const std::string& name);
+  std::unique_ptr<podio::SIOFrameData> readNextEntry(const std::string& name,
+                                                     const std::vector<std::string>& collsToRead = {});
 
   /// Read the desired data entry for a given category.
   ///
+  /// @note Given how the SIO files are currently layed out it is in fact not
+  /// possible to only read a subset of a Frame. Rather the subset of
+  /// collections to read will be an artificial limit on the returned
+  /// SIOFrameData. Limiting the collections to read will not improve I/O
+  /// performance.
+  ///
   /// @param name  The category name for which to read the next entry
   /// @param entry The entry number to read
+  /// @param collsToRead (optional) the collection names that should be read. If
+  ///             not provided (or empty) all collections will be read
   ///
   /// @returns FrameData from which a podio::Frame can be constructed if the
   ///          category and the desired entry exist. Otherwise a nullptr
-  std::unique_ptr<podio::SIOFrameData> readEntry(const std::string& name, const unsigned entry);
+  std::unique_ptr<podio::SIOFrameData> readEntry(const std::string& name, const unsigned entry,
+                                                 const std::vector<std::string>& collsToRead = {});
 
   /// Get the number of entries for the given name
   ///

--- a/python/podio/base_reader.py
+++ b/python/podio/base_reader.py
@@ -35,17 +35,21 @@ class BaseReaderMixin:
         """
         return self._categories
 
-    def get(self, category):
+    def get(self, category, coll_names=None):
         """Get an iterator with access functionality for a given category.
 
         Args:
             category (str): The name of the desired category
+            coll_names (list[str]): The list of collections to read (optional,
+                all available collections will by default)
 
         Returns:
             FrameCategoryIterator: The iterator granting access to all Frames of the
                 desired category
         """
-        return FrameCategoryIterator(self._reader, category)
+        if self.is_legacy and coll_names:
+            raise ValueError("Legacy readers do not support selective reading")
+        return FrameCategoryIterator(self._reader, category, coll_names)
 
     @property
     def is_legacy(self):

--- a/python/podio/test_Reader.py
+++ b/python/podio/test_Reader.py
@@ -89,6 +89,24 @@ class ReaderTestCaseMixin:
         with self.assertRaises(KeyError):
             self.reader.current_file_version("non-existant-model")
 
+    def test_limited_collections(self):
+        """Make sure only reading a subset of collections works"""
+        # We only do bare checks here as more extensive tests are already done
+        # on the c++ side
+        event = self.reader.get("events", ["hits", "info", "links"])[0]
+        self.assertEqual(set(event.getAvailableCollections()), {"hits", "info", "links"})
+
+    def test_invalid_limited_collections(self):
+        """Ensure that requesting non existant collections raises a value error"""
+        with self.assertRaises(ValueError):
+            events = self.reader.get("events", ["non-existent-collection"])
+            _ = events[0]
+
+        with self.assertRaises(ValueError):
+            events = self.reader.get("events", ["non-existent-collection"])
+            for _ in events:
+                pass
+
 
 class LegacyReaderTestCaseMixin:
     """Common test cases for the legacy readers python bindings.

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -138,11 +138,13 @@ std::vector<std::string_view> RNTupleReader::getAvailableCategories() const {
   return cats;
 }
 
-std::unique_ptr<ROOTFrameData> RNTupleReader::readNextEntry(const std::string& name) {
-  return readEntry(name, m_entries[name]);
+std::unique_ptr<ROOTFrameData> RNTupleReader::readNextEntry(const std::string& name,
+                                                            const std::vector<std::string>& collsToRead) {
+  return readEntry(name, m_entries[name], collsToRead);
 }
 
-std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& category, const unsigned entNum) {
+std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& category, const unsigned entNum,
+                                                        const std::vector<std::string>& collsToRead) {
   if (m_totalEntries.find(category) == m_totalEntries.end()) {
     getEntries(category);
   }
@@ -179,6 +181,9 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
   const auto& collInfo = m_collectionInfo[category];
 
   for (size_t i = 0; i < collInfo.id.size(); ++i) {
+    if (!collsToRead.empty() && std::ranges::find(collsToRead, collInfo.name[i]) == collsToRead.end()) {
+      continue;
+    }
     const auto& collType = collInfo.type[i];
     const auto& bufferFactory = podio::CollectionBufferFactory::instance();
     auto maybeBuffers =

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -178,15 +178,11 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
   auto readerIndex = upper - 1 - m_readerEntries[category].begin();
 
   ROOTFrameData::BufferMap buffers;
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
   // We need to create a non-bare entry here, because the entries for the
   // parameters are not explicitly (re)set and we need them default initialized.
   // In principle we would only need a bare entry for the collection data, since
   // we set all the fields there in any case.
   auto dentry = m_readers[category][readerIndex]->GetModel().CreateEntry();
-#else
-  auto dentry = m_readers[category][readerIndex]->GetModel()->GetDefaultEntry();
-#endif
 
   for (size_t i = 0; i < collInfo.id.size(); ++i) {
     if (!collsToRead.empty() && std::ranges::find(collsToRead, collInfo.name[i]) == collsToRead.end()) {
@@ -207,40 +203,24 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
     if (collInfo.isSubsetCollection[i]) {
       auto brName = root_utils::subsetBranch(collInfo.name[i]);
       auto vec = new std::vector<podio::ObjectID>;
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
       dentry->BindRawPtr(brName, vec);
-#else
-      dentry->CaptureValueUnsafe(brName, vec);
-#endif
       collBuffers.references->at(0) = std::unique_ptr<std::vector<podio::ObjectID>>(vec);
     } else {
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
       dentry->BindRawPtr(collInfo.name[i], collBuffers.data);
-#else
-      dentry->CaptureValueUnsafe(collInfo.name[i], collBuffers.data);
-#endif
 
       const auto relVecNames = podio::DatamodelRegistry::instance().getRelationNames(collType);
       for (size_t j = 0; j < relVecNames.relations.size(); ++j) {
         const auto relName = relVecNames.relations[j];
         auto vec = new std::vector<podio::ObjectID>;
         const auto brName = root_utils::refBranch(collInfo.name[i], relName);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
         dentry->BindRawPtr(brName, vec);
-#else
-        dentry->CaptureValueUnsafe(brName, vec);
-#endif
         collBuffers.references->at(j) = std::unique_ptr<std::vector<podio::ObjectID>>(vec);
       }
 
       for (size_t j = 0; j < relVecNames.vectorMembers.size(); ++j) {
         const auto vecName = relVecNames.vectorMembers[j];
         const auto brName = root_utils::vecBranch(collInfo.name[i], vecName);
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
         dentry->BindRawPtr(brName, collBuffers.vectorMembers->at(j).second);
-#else
-        dentry->CaptureValueUnsafe(brName, collBuffers.vectorMembers->at(j).second);
-#endif
       }
     }
 

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -158,6 +158,16 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
     }
   }
 
+  const auto& collInfo = m_collectionInfo[category];
+  // Make sure to not silently ignore non-existant but requested collections
+  if (!collsToRead.empty()) {
+    for (const auto& name : collsToRead) {
+      if (std::ranges::find(collInfo.name, name) == collInfo.name.end()) {
+        throw std::invalid_argument(name + " is not available from Frame");
+      }
+    }
+  }
+
   m_entries[category] = entNum + 1;
 
   // m_readerEntries contains the accumulated entries for all the readers
@@ -177,8 +187,6 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
 #else
   auto dentry = m_readers[category][readerIndex]->GetModel()->GetDefaultEntry();
 #endif
-
-  const auto& collInfo = m_collectionInfo[category];
 
   for (size_t i = 0; i < collInfo.id.size(); ++i) {
     if (!collsToRead.empty() && std::ranges::find(collsToRead, collInfo.name[i]) == collsToRead.end()) {

--- a/src/ROOTLegacyReader.cc
+++ b/src/ROOTLegacyReader.cc
@@ -17,14 +17,16 @@
 
 namespace podio {
 
-std::unique_ptr<ROOTFrameData> ROOTLegacyReader::readNextEntry(const std::string& name) {
+std::unique_ptr<ROOTFrameData> ROOTLegacyReader::readNextEntry(const std::string& name,
+                                                               const std::vector<std::string>&) {
   if (name != m_categoryName) {
     return nullptr;
   }
   return readEntry();
 }
 
-std::unique_ptr<podio::ROOTFrameData> ROOTLegacyReader::readEntry(const std::string& name, unsigned entry) {
+std::unique_ptr<podio::ROOTFrameData> ROOTLegacyReader::readEntry(const std::string& name, unsigned entry,
+                                                                  const std::vector<std::string>&) {
   if (name != m_categoryName) {
     return nullptr;
   }

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -101,6 +101,15 @@ std::unique_ptr<ROOTFrameData> ROOTReader::readEntry(ROOTReader::CategoryInfo& c
     return nullptr;
   }
 
+  // Make sure to not silently ignore non-existant but requested collections
+  if (!collsToRead.empty()) {
+    for (const auto& name : collsToRead) {
+      if (std::ranges::find(catInfo.storedClasses, name, &detail::NamedCollInfo::name) == catInfo.storedClasses.end()) {
+        throw std::invalid_argument(name + " is not available from Frame");
+      }
+    }
+  }
+
   // After switching trees in the chain, branch pointers get invalidated so
   // they need to be reassigned.
   // NOTE: root 6.22/06 requires that we get completely new branches here,

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -18,11 +18,11 @@
 
 namespace podio {
 
-std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<std::pair<std::string, detail::CollectionInfo>>>
+std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>
 createCollectionBranches(TChain* chain, const podio::CollectionIDTable& idTable,
                          const std::vector<root_utils::CollectionWriteInfoT>& collInfo);
 
-std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<std::pair<std::string, detail::CollectionInfo>>>
+std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>
 createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable& idTable,
                                    const std::vector<root_utils::CollectionWriteInfoT>& collInfo);
 
@@ -113,10 +113,10 @@ std::unique_ptr<ROOTFrameData> ROOTReader::readEntry(ROOTReader::CategoryInfo& c
 
   ROOTFrameData::BufferMap buffers;
   for (size_t i = 0; i < catInfo.storedClasses.size(); ++i) {
-    if (!collsToRead.empty() && std::ranges::find(collsToRead, catInfo.storedClasses[i].first) == collsToRead.end()) {
+    if (!collsToRead.empty() && std::ranges::find(collsToRead, catInfo.storedClasses[i].name) == collsToRead.end()) {
       continue;
     }
-    buffers.emplace(catInfo.storedClasses[i].first, getCollectionBuffers(catInfo, i, reloadBranches, localEntry));
+    buffers.emplace(catInfo.storedClasses[i].name, getCollectionBuffers(catInfo, i, reloadBranches, localEntry));
   }
 
   auto parameters = readEntryParameters(catInfo, reloadBranches, localEntry);
@@ -127,8 +127,8 @@ std::unique_ptr<ROOTFrameData> ROOTReader::readEntry(ROOTReader::CategoryInfo& c
 
 podio::CollectionReadBuffers ROOTReader::getCollectionBuffers(ROOTReader::CategoryInfo& catInfo, size_t iColl,
                                                               bool reloadBranches, unsigned int localEntry) {
-  const auto& name = catInfo.storedClasses[iColl].first;
-  const auto& [collType, isSubsetColl, schemaVersion, index] = catInfo.storedClasses[iColl].second;
+  const auto& name = catInfo.storedClasses[iColl].name;
+  const auto& [collType, isSubsetColl, schemaVersion, index] = catInfo.storedClasses[iColl].info;
   auto& branches = catInfo.branches[index];
 
   const auto& bufferFactory = podio::CollectionBufferFactory::instance();
@@ -314,14 +314,14 @@ std::vector<std::string_view> ROOTReader::getAvailableCategories() const {
   return cats;
 }
 
-std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<std::pair<std::string, detail::CollectionInfo>>>
+std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>
 createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable& idTable,
                                    const std::vector<root_utils::CollectionWriteInfoT>& collInfo) {
 
   size_t collectionIndex{0};
   std::vector<root_utils::CollectionBranches> collBranches;
   collBranches.reserve(collInfo.size() + 1);
-  std::vector<std::pair<std::string, detail::CollectionInfo>> storedClasses;
+  std::vector<detail::NamedCollInfo> storedClasses;
   storedClasses.reserve(collInfo.size());
 
   for (const auto& [collID, collType, isSubsetColl, collSchemaVersion] : collInfo) {
@@ -366,14 +366,14 @@ createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable
   return {std::move(collBranches), storedClasses};
 }
 
-std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<std::pair<std::string, detail::CollectionInfo>>>
+std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>
 createCollectionBranches(TChain* chain, const podio::CollectionIDTable& idTable,
                          const std::vector<root_utils::CollectionWriteInfoT>& collInfo) {
 
   size_t collectionIndex{0};
   std::vector<root_utils::CollectionBranches> collBranches;
   collBranches.reserve(collInfo.size() + 1);
-  std::vector<std::pair<std::string, detail::CollectionInfo>> storedClasses;
+  std::vector<detail::NamedCollInfo> storedClasses;
   storedClasses.reserve(collInfo.size());
 
   for (const auto& [collID, collType, isSubsetColl, collSchemaVersion] : collInfo) {

--- a/src/SIOFrameData.cc
+++ b/src/SIOFrameData.cc
@@ -78,10 +78,6 @@ void SIOFrameData::unpackBuffers() {
     return;
   }
 
-  if (m_idTable.empty()) {
-    readIdTable();
-  }
-
   createBlocks();
 
   sio::zlib_compression compressor;

--- a/src/SIOFrameData.cc
+++ b/src/SIOFrameData.cc
@@ -7,6 +7,26 @@
 #include <iterator>
 
 namespace podio {
+
+SIOFrameData::SIOFrameData(sio::buffer&& collBuffers, std::size_t dataSize, sio::buffer&& tableBuffer,
+                           std::size_t tableSize, std::vector<std::string> limitColls) :
+    m_recBuffer(std::move(collBuffers)),
+    m_tableBuffer(std::move(tableBuffer)),
+    m_dataSize(dataSize),
+    m_tableSize(tableSize),
+    m_limitColls(std::move(limitColls)) {
+  readIdTable();
+  // Assuming here that the idTable only contains the collections that are
+  // also available
+  if (!m_limitColls.empty()) {
+    for (const auto& name : m_limitColls) {
+      if (std::ranges::find(m_idTable.names(), name) == m_idTable.names().end()) {
+        throw std::invalid_argument(name + " is not available from Frame");
+      }
+    }
+  }
+}
+
 std::optional<podio::CollectionReadBuffers> SIOFrameData::getCollectionBuffers(const std::string& name) {
   unpackBuffers();
 

--- a/src/SIOLegacyReader.cc
+++ b/src/SIOLegacyReader.cc
@@ -23,7 +23,7 @@ void SIOLegacyReader::openFile(const std::string& filename) {
   readCollectionIDTable();
 }
 
-std::unique_ptr<SIOFrameData> SIOLegacyReader::readNextEntry(const std::string& name) {
+std::unique_ptr<SIOFrameData> SIOLegacyReader::readNextEntry(const std::string& name, const std::vector<std::string>&) {
   if (name != m_categoryName) {
     return nullptr;
   }
@@ -47,7 +47,8 @@ std::unique_ptr<SIOFrameData> SIOLegacyReader::readNextEntry(const std::string& 
                                         m_tableUncLength);
 }
 
-std::unique_ptr<podio::SIOFrameData> SIOLegacyReader::readEntry(const std::string& name, const unsigned entry) {
+std::unique_ptr<podio::SIOFrameData> SIOLegacyReader::readEntry(const std::string& name, const unsigned entry,
+                                                                const std::vector<std::string>&) {
   if (name != m_categoryName) {
     return nullptr;
   }

--- a/src/SIOReader.cc
+++ b/src/SIOReader.cc
@@ -26,7 +26,8 @@ void SIOReader::openFile(const std::string& filename) {
   readEDMDefinitions(); // Potentially could do this lazily
 }
 
-std::unique_ptr<SIOFrameData> SIOReader::readNextEntry(const std::string& name) {
+std::unique_ptr<SIOFrameData> SIOReader::readNextEntry(const std::string& name,
+                                                       const std::vector<std::string>& collsToRead) {
   // Skip to where the next record of this name starts in the file, based on
   // how many times we have already read this name
   //
@@ -44,14 +45,15 @@ std::unique_ptr<SIOFrameData> SIOReader::readNextEntry(const std::string& name) 
   m_nameCtr[name]++;
 
   return std::make_unique<SIOFrameData>(std::move(dataBuffer), dataInfo._uncompressed_length, std::move(tableBuffer),
-                                        tableInfo._uncompressed_length);
+                                        tableInfo._uncompressed_length, collsToRead);
 }
 
-std::unique_ptr<SIOFrameData> SIOReader::readEntry(const std::string& name, const unsigned entry) {
+std::unique_ptr<SIOFrameData> SIOReader::readEntry(const std::string& name, const unsigned entry,
+                                                   const std::vector<std::string>& collsToRead) {
   // NOTE: Will create or overwrite the entry counter
   //       All checks are done in the following function
   m_nameCtr[name] = entry;
-  return readNextEntry(name);
+  return readNextEntry(name, collsToRead);
 }
 
 std::vector<std::string_view> SIOReader::getAvailableCategories() const {

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -25,6 +25,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     read_frame_root
     read_glob
     read_python_multiple
+    selected_colls_roundtrip_root
 
     write_interface_root
     read_interface_root
@@ -98,6 +99,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
 
       read_rntuple
       read_interface_rntuple
+      selected_colls_roundtrip_rntuple
     )
   endif()
 
@@ -109,6 +111,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
       read_rntuple
       write_interface_rntuple
       read_interface_rntuple
+      selected_colls_roundtrip_rntuple
     )
 
   endif()

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -320,6 +320,22 @@ int test_read_frame_limited(ReaderT& reader) {
     return 1;
   }
 
+  // Check that nothing breaks if we pass in an unavailable collection name
+  const auto emptyEvent = [&]() {
+    if constexpr (std::is_same_v<ReaderT, podio::Reader>) {
+      return podio::Frame(reader.readFrame("events", 1, {"no-collection-with-this-name", "orThisOne"}));
+    } else {
+      return podio::Frame(reader.readEntry("events", 1, {"no-collection-with-this-name", "orThisOne"}));
+    }
+  }();
+
+  if (!emptyEvent.getAvailableCollections().empty()) {
+    std::cerr << "Trying to read collection names that are unavailable should not break, but should also not give a "
+                 "meaningful event"
+              << std::endl;
+    return 1;
+  }
+
   return 0;
 }
 

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -285,6 +285,16 @@ int test_read_frame_limited(const std::string& inputFile) {
 
   if (validColls) {
     std::cerr << "The available collections are not as expected" << std::endl;
+    std::cerr << "expected: ";
+    for (const auto& c : std::set(collsToRead.begin(), collsToRead.end())) {
+      std::cerr << c << " ";
+    }
+    std::cerr << "\nactual: ";
+    for (const auto& c : std::set(availColls.begin(), availColls.end())) {
+      std::cerr << c << " ";
+    }
+    std::cerr << std::endl;
+
     return 1;
   }
 

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -183,13 +183,13 @@ int read_frames(const std::string& filename, bool assertBuildVersion = true) {
   }
 
   if (reader.getEntries(podio::Category::Event) != 10) {
-    std::cerr << "Could not read back the number of events correctly. " << "(expected:" << 10
+    std::cerr << "Could not read back the number of events correctly. (expected: " << 10
               << ", actual: " << reader.getEntries(podio::Category::Event) << ")" << std::endl;
     return 1;
   }
 
   if (reader.getEntries(podio::Category::Event) != reader.getEntries("other_events")) {
-    std::cerr << "Could not read back the number of events correctly. " << "(expected:" << 10
+    std::cerr << "Could not read back the number of events correctly. (expected: " << 10
               << ", actual: " << reader.getEntries("other_events") << ")" << std::endl;
     return 1;
   }

--- a/tests/root_io/CMakeLists.txt
+++ b/tests/root_io/CMakeLists.txt
@@ -9,6 +9,7 @@ set(root_dependent_tests
   write_interface_root.cpp
   read_interface_root.cpp
   read_glob.cpp
+  selected_colls_roundtrip_root.cpp
   )
 if(ENABLE_RNTUPLE)
   set(root_dependent_tests
@@ -18,6 +19,7 @@ if(ENABLE_RNTUPLE)
       read_python_frame_rntuple.cpp
       write_interface_rntuple.cpp
       read_interface_rntuple.cpp
+      selected_colls_roundtrip_rntuple.cpp
      )
 endif()
 if(ENABLE_DATASOURCE)
@@ -41,6 +43,7 @@ set_tests_properties(
   read_frame_root_multiple
   read_and_write_frame_root
   read_glob
+  selected_colls_roundtrip_root
 
   PROPERTIES
     DEPENDS write_frame_root
@@ -51,7 +54,13 @@ PODIO_SET_TEST_ENV(read_python_multiple)
 set_property(TEST read_python_multiple PROPERTY DEPENDS write_frame_root)
 
 if(ENABLE_RNTUPLE)
-  set_property(TEST read_rntuple PROPERTY DEPENDS write_rntuple)
+  set_tests_properties(
+    read_rntuple
+    selected_colls_roundtrip_rntuple
+
+    PROPERTIES
+      DEPENDS write_rntuple
+  )
   set_property(TEST read_interface_rntuple PROPERTY DEPENDS write_interface_rntuple)
 endif()
 

--- a/tests/root_io/read_frame_root.cpp
+++ b/tests/root_io/read_frame_root.cpp
@@ -1,10 +1,51 @@
 #include "read_frame.h"
 #include "read_frame_auxiliary.h"
 
+#include "podio/Frame.h"
 #include "podio/ROOTReader.h"
 
 #include <iostream>
+#include <set>
 #include <string>
+#include <vector>
+
+int test_read_frame_limited(const std::string& inputFile) {
+  auto reader = podio::ROOTReader();
+  reader.openFile(inputFile);
+  const std::vector<std::string> collsToRead = {"mcparticles", "clusters"};
+
+  const auto event = podio::Frame(reader.readNextEntry("events", collsToRead));
+
+  const auto& availColls = event.getAvailableCollections();
+
+  const bool validColls =
+      std::set(availColls.begin(), availColls.end()) != std::set(collsToRead.begin(), collsToRead.end());
+
+  if (validColls) {
+    std::cerr << "The available collections are not as expected" << std::endl;
+    return 1;
+  }
+
+  if (!event.get("mcparticles")) {
+    std::cerr << "Collection 'mcparticles' should be available" << std::endl;
+    return 1;
+  }
+
+  if (event.get("hits")) {
+    std::cerr << "Collection 'hits' is available, but should not be" << std::endl;
+    return 1;
+  }
+
+  const auto& clusters = event.get<ExampleClusterCollection>("clusters");
+  const auto clu0 = clusters[0];
+  const auto hits = clu0.Hits();
+  if (hits.size() != 1 || hits[0].isAvailable()) {
+    std::cerr << "Hit in clusters are available but shouldn't be" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
 
 int main(int argc, char* argv[]) {
   std::string inputFile = "example_frame.root";
@@ -19,5 +60,5 @@ int main(int argc, char* argv[]) {
   }
 
   return read_frames<podio::ROOTReader>(inputFile, assertBuildVersion) +
-      test_frame_aux_info<podio::ROOTReader>(inputFile);
+      test_frame_aux_info<podio::ROOTReader>(inputFile) + test_read_frame_limited(inputFile);
 }

--- a/tests/root_io/read_frame_root.cpp
+++ b/tests/root_io/read_frame_root.cpp
@@ -1,51 +1,10 @@
 #include "read_frame.h"
 #include "read_frame_auxiliary.h"
 
-#include "podio/Frame.h"
 #include "podio/ROOTReader.h"
 
 #include <iostream>
-#include <set>
 #include <string>
-#include <vector>
-
-int test_read_frame_limited(const std::string& inputFile) {
-  auto reader = podio::ROOTReader();
-  reader.openFile(inputFile);
-  const std::vector<std::string> collsToRead = {"mcparticles", "clusters"};
-
-  const auto event = podio::Frame(reader.readNextEntry("events", collsToRead));
-
-  const auto& availColls = event.getAvailableCollections();
-
-  const bool validColls =
-      std::set(availColls.begin(), availColls.end()) != std::set(collsToRead.begin(), collsToRead.end());
-
-  if (validColls) {
-    std::cerr << "The available collections are not as expected" << std::endl;
-    return 1;
-  }
-
-  if (!event.get("mcparticles")) {
-    std::cerr << "Collection 'mcparticles' should be available" << std::endl;
-    return 1;
-  }
-
-  if (event.get("hits")) {
-    std::cerr << "Collection 'hits' is available, but should not be" << std::endl;
-    return 1;
-  }
-
-  const auto& clusters = event.get<ExampleClusterCollection>("clusters");
-  const auto clu0 = clusters[0];
-  const auto hits = clu0.Hits();
-  if (hits.size() != 1 || hits[0].isAvailable()) {
-    std::cerr << "Hit in clusters are available but shouldn't be" << std::endl;
-    return 1;
-  }
-
-  return 0;
-}
 
 int main(int argc, char* argv[]) {
   std::string inputFile = "example_frame.root";
@@ -60,5 +19,5 @@ int main(int argc, char* argv[]) {
   }
 
   return read_frames<podio::ROOTReader>(inputFile, assertBuildVersion) +
-      test_frame_aux_info<podio::ROOTReader>(inputFile) + test_read_frame_limited(inputFile);
+      test_frame_aux_info<podio::ROOTReader>(inputFile) + test_read_frame_limited<podio::ROOTReader>(inputFile);
 }

--- a/tests/root_io/read_interface_rntuple.cpp
+++ b/tests/root_io/read_interface_rntuple.cpp
@@ -4,6 +4,4 @@
 int main(int, char**) {
   auto reader = podio::makeReader("example_from_rntuple_interface.root");
   return read_frames(reader) + test_read_frame_limited(reader);
-
-  return 0;
 }

--- a/tests/root_io/read_interface_rntuple.cpp
+++ b/tests/root_io/read_interface_rntuple.cpp
@@ -1,10 +1,9 @@
+#include "read_frame.h"
 #include "read_interface.h"
 
 int main(int, char**) {
   auto reader = podio::makeReader("example_from_rntuple_interface.root");
-  if (read_frames(reader)) {
-    return 1;
-  }
+  return read_frames(reader) + test_read_frame_limited(reader);
 
   return 0;
 }

--- a/tests/root_io/read_interface_root.cpp
+++ b/tests/root_io/read_interface_root.cpp
@@ -1,11 +1,9 @@
+#include "read_frame.h"
 #include "read_interface.h"
 
+#include "podio/Reader.h"
+
 int main(int, char**) {
-
   auto reader = podio::makeReader("example_frame_interface.root");
-  if (read_frames(reader)) {
-    return 1;
-  }
-
-  return 0;
+  return read_frames(reader) + test_read_frame_limited(reader);
 }

--- a/tests/root_io/read_rntuple.cpp
+++ b/tests/root_io/read_rntuple.cpp
@@ -1,6 +1,10 @@
-#include "podio/RNTupleReader.h"
 #include "read_frame.h"
+#include "read_frame_auxiliary.h"
+
+#include "podio/RNTupleReader.h"
 
 int main() {
-  return read_frames<podio::RNTupleReader>("example_rntuple.root");
+  const std::string inputFile = "example_rntuple.root";
+
+  return read_frames<podio::RNTupleReader>(inputFile) + test_frame_aux_info<podio::RNTupleReader>(inputFile);
 }

--- a/tests/root_io/read_rntuple.cpp
+++ b/tests/root_io/read_rntuple.cpp
@@ -6,5 +6,6 @@
 int main() {
   const std::string inputFile = "example_rntuple.root";
 
-  return read_frames<podio::RNTupleReader>(inputFile) + test_frame_aux_info<podio::RNTupleReader>(inputFile);
+  return read_frames<podio::RNTupleReader>(inputFile) + test_frame_aux_info<podio::RNTupleReader>(inputFile) +
+      test_read_frame_limited<podio::RNTupleReader>(inputFile);
 }

--- a/tests/root_io/read_with_rdatasource_root.cpp
+++ b/tests/root_io/read_with_rdatasource_root.cpp
@@ -1,6 +1,8 @@
 #include "datamodel/ExampleClusterCollection.h"
 #include "podio/DataSource.h"
+#include "podio/Reader.h"
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 
@@ -28,8 +30,40 @@ int main(int argc, const char* argv[]) {
   dframe.Describe().Print();
   std::cout << std::endl;
 
+  const auto expectedCollNames = [&inputFile]() {
+    auto reader = podio::makeReader(inputFile);
+    auto cols = reader.readNextEvent().getAvailableCollections();
+    std::ranges::sort(cols);
+    return cols;
+  }();
+  const auto allColNames = [&dframe]() {
+    auto cols = dframe.GetColumnNames();
+    std::ranges::sort(cols);
+    return cols;
+  }();
+
+  if (!std::ranges::equal(expectedCollNames, allColNames)) {
+    std::cerr << "Column names are note as expected\n  expected: [";
+    for (const auto& name : expectedCollNames) {
+      std::cerr << name << " ";
+    }
+    std::cerr << "]\n    actual: [";
+    for (const auto& name : allColNames) {
+      std::cerr << name << " ";
+    }
+    std::cerr << "]" << std::endl;
+
+    return EXIT_FAILURE;
+  }
+
   auto cluterEnergy = dframe.Define("cluster_energy", getEnergy, {"clusters"}).Histo1D("cluster_energy");
   cluterEnergy->Print();
+
+  dframe = podio::CreateDataFrame(inputFile, {"hits"});
+  if (dframe.GetColumnNames()[0] != "hits") {
+    std::cerr << "Limiting to only one collection didn't work as expected" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/tests/root_io/selected_colls_roundtrip_rntuple.cpp
+++ b/tests/root_io/selected_colls_roundtrip_rntuple.cpp
@@ -1,0 +1,9 @@
+#include "selected_colls_roundtrip.h"
+
+#include "podio/RNTupleReader.h"
+#include "podio/RNTupleWriter.h"
+
+int main() {
+  return do_roundtrip<podio::RNTupleReader, podio::RNTupleWriter>("example_rntuple.root",
+                                                                  "selected_example_rntuple.root");
+}

--- a/tests/root_io/selected_colls_roundtrip_root.cpp
+++ b/tests/root_io/selected_colls_roundtrip_root.cpp
@@ -1,0 +1,8 @@
+#include "selected_colls_roundtrip.h"
+
+#include "podio/ROOTReader.h"
+#include "podio/ROOTWriter.h"
+
+int main() {
+  return do_roundtrip<podio::ROOTReader, podio::ROOTWriter>("example_frame.root", "selected_example_frame.root");
+}

--- a/tests/selected_colls_roundtrip.h
+++ b/tests/selected_colls_roundtrip.h
@@ -1,3 +1,6 @@
+#ifndef PODIO_TESTS_SELECTED_COLLS_ROUNDTRIP_H // NOLINT(llvm-header-guard): folder structure not suitable
+#define PODIO_TESTS_SELECTED_COLLS_ROUNDTRIP_H // NOLINT(llvm-header-guard): folder structure not suitable
+
 #include "read_test.h"
 
 #include <podio/Frame.h>
@@ -123,3 +126,5 @@ int do_roundtrip(const std::string& originalFile, const std::string& outputFile)
 
   return readSelectedFileFull<ReaderT>(outputFile) + readSelectedFilePartial<ReaderT>(outputFile);
 }
+
+#endif // PODIO_TESTS_SELECTED_COLLS_ROUNDTRIP_H

--- a/tests/selected_colls_roundtrip.h
+++ b/tests/selected_colls_roundtrip.h
@@ -1,0 +1,101 @@
+#include <podio/Frame.h>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+/// Roundtrip test for ensuring that files that have been written with Frames
+/// that have been read from file selecting only a few collections to be read
+/// are still properly usable when read again.
+///
+/// The flow is
+///
+/// - Open the original file (using one that has been produced by other I/O
+///   tests)
+/// - Read a Frame selecting only a few of the available collections
+/// - Write this frame into the outputFile without doing any further checks
+///   (that is done by other tests)
+/// - Read back that file and check that it can still be used
+///   - Reading full frames
+///   - and frames with a selection of collections
+///
+/// do_roundrip ties everything together and is the only function that needs to
+/// be called by backend specific tests
+
+/// The collection names that will be written into the new file
+const std::vector<std::string> collectionSelection = {"mcparticles", "links", "userInts", "hits"};
+
+/// The collections to select in the second round
+const std::vector<std::string> roundTripSelection = {"hits", "userInts"};
+
+/// Write a new file containing only a few selected collections and only one
+/// event
+template <typename ReaderT, typename WriterT>
+void writeSelectedFile(const std::string& originalFile, const std::string& outputFile) {
+  auto reader = ReaderT();
+  reader.openFile(originalFile);
+  const auto event = podio::Frame(reader.readEntry("events", 0, collectionSelection));
+
+  auto writer = WriterT(outputFile);
+  writer.writeFrame(event, "events");
+}
+
+bool compareUnordered(std::vector<std::string> lhs, std::vector<std::string> rhs) {
+  std::ranges::sort(lhs);
+  std::ranges::sort(rhs);
+  return std::ranges::equal(lhs, rhs);
+}
+
+std::ostream& operator<<(std::ostream& os, const std::vector<std::string>& vec) {
+  os << "[";
+  std::string delim = "";
+  for (const auto& v : vec) {
+    os << std::exchange(delim, ", ") << v;
+  }
+  return os << "]";
+}
+
+/// Read the file that has been created and check all available collections
+template <typename ReaderT>
+int readSelectedFileFull(const std::string& filename) {
+  auto reader = ReaderT();
+  reader.openFile(filename);
+
+  const auto event = podio::Frame(reader.readEntry("events", 0));
+
+  if (!compareUnordered(event.getAvailableCollections(), collectionSelection)) {
+    std::cerr
+        << "Collection names that are available from the selected collections file are not as expected (expected: "
+        << collectionSelection << ", actual " << event.getAvailableCollections() << ")" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+/// Read the file that has been created and check whether selecting on that file
+/// again also works
+template <typename ReaderT>
+int readSelectedFilePartial(const std::string& filename) {
+  auto reader = ReaderT();
+  reader.openFile(filename);
+
+  const auto event = podio::Frame(reader.readEntry("events", 0, roundTripSelection));
+
+  if (!compareUnordered(event.getAvailableCollections(), roundTripSelection)) {
+    std::cerr
+        << "Collection names that are available from the selected collections file are not as expected (expected: "
+        << roundTripSelection << ", actual " << event.getAvailableCollections() << ")" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+
+template <typename ReaderT, typename WriterT>
+int do_roundtrip(const std::string& originalFile, const std::string& outputFile) {
+  writeSelectedFile<ReaderT, WriterT>(originalFile, outputFile);
+
+  return readSelectedFileFull<ReaderT>(outputFile) + readSelectedFilePartial<ReaderT>(outputFile);
+}

--- a/tests/sio_io/CMakeLists.txt
+++ b/tests/sio_io/CMakeLists.txt
@@ -5,6 +5,7 @@ set(sio_dependent_tests
   read_python_frame_sio.cpp
   write_interface_sio.cpp
   read_interface_sio.cpp
+  selected_colls_roundtrip_sio.cpp
 )
 set(sio_libs podio::podioSioIO podio::podioIO)
 foreach( sourcefile ${sio_dependent_tests} )
@@ -14,6 +15,7 @@ endforeach()
 set_tests_properties(
   read_frame_sio
   read_and_write_frame_sio
+  selected_colls_roundtrip_sio
 
   PROPERTIES
     DEPENDS

--- a/tests/sio_io/read_frame_sio.cpp
+++ b/tests/sio_io/read_frame_sio.cpp
@@ -12,5 +12,5 @@ int main(int argc, char* argv[]) {
   }
 
   return read_frames<podio::SIOReader>(inputFile, assertBuildVersion) +
-      test_frame_aux_info<podio::SIOReader>(inputFile);
+      test_frame_aux_info<podio::SIOReader>(inputFile) + test_read_frame_limited<podio::SIOReader>(inputFile);
 }

--- a/tests/sio_io/read_interface_sio.cpp
+++ b/tests/sio_io/read_interface_sio.cpp
@@ -1,11 +1,9 @@
+#include "read_frame.h"
 #include "read_interface.h"
 
 int main(int, char**) {
-
   auto readerSIO = podio::makeReader("example_frame_sio_interface.sio");
-  if (read_frames(readerSIO)) {
-    return 1;
-  }
+  return read_frames(readerSIO) + test_read_frame_limited(readerSIO);
 
   return 0;
 }

--- a/tests/sio_io/selected_colls_roundtrip_sio.cpp
+++ b/tests/sio_io/selected_colls_roundtrip_sio.cpp
@@ -1,0 +1,8 @@
+#include "selected_colls_roundtrip.h"
+
+#include "podio/SIOReader.h"
+#include "podio/SIOWriter.h"
+
+int main() {
+  return do_roundtrip<podio::SIOReader, podio::SIOWriter>("example_frame.sio", "selected_example_frame.sio");
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `collsToRead` argument to `readEntry` and `readNextEntry` for the `ROOTFrameReader` to allow limiting the collections that are actually read.
- **This requires a bump in the minimum version of ROOT for RNTuple support to 6.32** as the previous RNTuple implementation apparently cannot handle switching between reading different sets of fields.

ENDRELEASENOTES

This is an (early) proposal for introducing this functionality which would in the end address #499 

- [x] Interface design: Do we want to have the possibility to change this frame-by-frame?
  - Alternatively would have to introduce a configuration method that takes a category name and a list of collections.
- [x] Should we only pass on the limited collection id table?
  - Interplay with Frame and assumptions there
- [x] Add tests and checks to avoid breaking things when collection names are passed that are not even available from the data
  - The way the check is implemented only names that exist in the frame will be checked. Non-existent names in `collsToRead` will be **silently** ignored.
- [x] Same capabilities for RNTuple reader
- [x] Documentation (once the rest has settled)
- [x] Ensure that files that have been read with a limited set of collections and are then written again, can be read without issues.
- [x] Needs #698 as it also starts using `std::ranges`.
- [x] Needs #719 to pass on `dev3` stacks
- [x] Needs #724 
- [x] Includes #730 
- [x] Check whether this can be used to ignore collections with unsupported schema evolutions.
- [x] python bindings
- [x] Includes #732 