### PR TITLE
Copy .clang-format to the dumpmodel test directory

### DIFF
--- a/tests/dumpmodel/CMakeLists.txt
+++ b/tests/dumpmodel/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copy the main .clang-format to here so that the tests can always find it
+configure_file(${PROJECT_SOURCE_DIR}/.clang-format ${CMAKE_CURRENT_BINARY_DIR}/.clang-format COPYONLY)
+
 # Add tests for storing and retrieving the EDM definitions into the produced
 # files
 add_test(NAME datamodel_def_store_roundtrip_root COMMAND ${PROJECT_SOURCE_DIR}/tests/scripts/dumpModelRoundTrip.sh


### PR DESCRIPTION
BEGINRELEASENOTES
- Copy .clang-format to the dumpmodel test directory and fix some tests when the build directory is not a subdirectory of the main directory. In some tests `clang-format` will try to find a `.clang-format` looking in the directories above and if it doesn't exist it will format files differently and some tests will fail.

ENDRELEASENOTES