### PR TITLE
Create a variant using clang format and set it to off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ option(CREATE_DOC        "Whether or not to create doxygen doc target." OFF)
 option(ENABLE_SIO        "Build SIO I/O support" OFF)
 option(PODIO_RELAX_PYVER "Do not require exact python version match with ROOT" OFF)
 option(ENABLE_RNTUPLE    "Build with support for the new ROOT NTtuple format" OFF)
+option(PODIO_USE_CLANG_FORMAT "Use clang-format to format the code" OFF)
 
 
 #--- Declare ROOT dependency ---------------------------------------------------


### PR DESCRIPTION
BEGINRELEASENOTES
- Create a variant using clang format and set it to off by default. It is significantly slower to run cmake with this option on.

ENDRELEASENOTES

I don't think most users care and we could run clang-format for the builds in the stacks, but if you are building I think you would rather get to whatever you want to do sooner.

I have some times for configure without downloading the test files. Rebuild means when for example you make a change in a CMakeLists.txt file so that configure has to run again when you try to build:

On my machine (all local): 

|                      | From scratch | Rebuild |
|----------------------|--------------|---------|
| With clang-format    | 16 s         | 14 s    |
| Without clang-format | 6 s          | 4 s     |

On a build node (Alma 9):

|                      | From scratch | Rebuild |
|----------------------|--------------|---------|
| With clang-format    | 27 s         | 20 s    |
| Without clang-format | 20 s         | 13 s    |