### PR TITLE
Fix legacy tests

### DIFF
--- a/tests/root_io/CMakeLists.txt
+++ b/tests/root_io/CMakeLists.txt
@@ -59,8 +59,7 @@ target_link_libraries(read-legacy-files-root PRIVATE TestDataModel TestDataModel
 macro(ADD_PODIO_LEGACY_TEST version base_test input_file)
   ExternalData_Add_Test(legacy_test_cases
     NAME ${base_test}_${version}
-    COMMAND ${base_test} ${CMAKE_CURRENT_BINARY_DIR}/../input_files/${input_file}
-    DATA{${PROJECT_SOURCE_DIR}/tests/input_files/${input_file}}
+    COMMAND ${base_test} DATA{${PROJECT_SOURCE_DIR}/tests/input_files/${input_file}}
   )
   set_property(TEST ${base_test}_${version} PROPERTY ENVIRONMENT
     LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/tests:${PROJECT_BINARY_DIR}/src:$ENV{LD_LIBRARY_PATH}

--- a/tests/root_io/read_frame_root.cpp
+++ b/tests/root_io/read_frame_root.cpp
@@ -13,6 +13,11 @@ int main(int argc, char* argv[]) {
     inputFile = argv[1];
     assertBuildVersion = false;
   }
+  else if (argc > 2) {
+    std::cout << "Wrong number of arguments" << std::endl;
+    std::cout << "Usage: " << argv[0] << " FILE" << std::endl;
+    return 1;
+  }
 
   return read_frames<podio::ROOTFrameReader>(inputFile, assertBuildVersion) +
       test_frame_aux_info<podio::ROOTFrameReader>(inputFile);

--- a/tests/root_io/read_frame_root.cpp
+++ b/tests/root_io/read_frame_root.cpp
@@ -12,8 +12,7 @@ int main(int argc, char* argv[]) {
   if (argc == 2) {
     inputFile = argv[1];
     assertBuildVersion = false;
-  }
-  else if (argc > 2) {
+  } else if (argc > 2) {
     std::cout << "Wrong number of arguments" << std::endl;
     std::cout << "Usage: " << argv[0] << " FILE" << std::endl;
     return 1;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix legacy tests; an extra argument was being passed and default in the .cpp file `example_frame.root` was being used which (almost) always exists (because there is a another test creating it) so it was hard to notice.
ENDRELEASENOTES

Maybe this default should be changed so as to be more explicit so this can't happen but it would make the implementation in the CMakeLists in root_io a bit less clean.