### PR TITLE
Add support for interface types

### DIFF
--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -203,8 +203,11 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     ${YAML_FILE}
     ${PODIO_TEMPLATES}
     ${podio_PYTHON_DIR}/podio_class_generator.py
-    ${podio_PYTHON_DIR}/podio/generator_utils.py
-    ${podio_PYTHON_DIR}/podio/podio_config_reader.py
+    ${podio_PYTHON_DIR}/podio_gen/generator_utils.py
+    ${podio_PYTHON_DIR}/podio_gen/podio_config_reader.py
+    ${podio_PYTHON_DIR}/podio_gen/generator_base.py
+    ${podio_PYTHON_DIR}/podio_gen/cpp_generator.py
+    ${podio_PYTHON_DIR}/podio_gen/julia_generator.py
   )
 
   message(STATUS "Creating '${datamodel}' datamodel")

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -8,46 +8,46 @@
 #include <unordered_map>
 #include <vector>
 
+namespace podio {
 #if __has_include("experimental/type_traits.h")
   #include <experimental/type_traits>
 namespace det {
-using namespace std::experimental;
+  using namespace std::experimental;
 } // namespace det
 #else
 // Implement the minimal feature set we need
 namespace det {
-namespace detail {
-  template <typename DefT, typename AlwaysVoidT, template <typename...> typename Op, typename... Args>
-  struct detector {
-    using value_t = std::false_type;
-    using type = DefT;
+  namespace detail {
+    template <typename DefT, typename AlwaysVoidT, template <typename...> typename Op, typename... Args>
+    struct detector {
+      using value_t = std::false_type;
+      using type = DefT;
+    };
+
+    template <typename DefT, template <typename...> typename Op, typename... Args>
+    struct detector<DefT, std::void_t<Op<Args...>>, Op, Args...> {
+      using value_t = std::true_type;
+      using type = Op<Args...>;
+    };
+  } // namespace detail
+
+  struct nonesuch {
+    ~nonesuch() = delete;
+    nonesuch(const nonesuch&) = delete;
+    void operator=(const nonesuch&) = delete;
   };
+
+  template <template <typename...> typename Op, typename... Args>
+  using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+
+  template <template <typename...> typename Op, typename... Args>
+  static constexpr bool is_detected_v = is_detected<Op, Args...>::value;
 
   template <typename DefT, template <typename...> typename Op, typename... Args>
-  struct detector<DefT, std::void_t<Op<Args...>>, Op, Args...> {
-    using value_t = std::true_type;
-    using type = Op<Args...>;
-  };
-} // namespace detail
-
-struct nonesuch {
-  ~nonesuch() = delete;
-  nonesuch(const nonesuch&) = delete;
-  void operator=(const nonesuch&) = delete;
-};
-
-template <template <typename...> typename Op, typename... Args>
-using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
-
-template <template <typename...> typename Op, typename... Args>
-static constexpr bool is_detected_v = is_detected<Op, Args...>::value;
-
-template <typename DefT, template <typename...> typename Op, typename... Args>
-using detected_or = detail::detector<DefT, void, Op, Args...>;
+  using detected_or = detail::detector<DefT, void, Op, Args...>;
 } // namespace det
 #endif
 
-namespace podio {
 namespace detail {
 
   /**

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -8,6 +8,45 @@
 #include <unordered_map>
 #include <vector>
 
+#if __has_include("experimental/type_traits.h")
+  #include <experimental/type_traits>
+namespace det {
+using namespace std::experimental;
+} // namespace det
+#else
+// Implement the minimal feature set we need
+namespace det {
+namespace detail {
+  template <typename DefT, typename AlwaysVoidT, template <typename...> typename Op, typename... Args>
+  struct detector {
+    using value_t = std::false_type;
+    using type = DefT;
+  };
+
+  template <typename DefT, template <typename...> typename Op, typename... Args>
+  struct detector<DefT, std::void_t<Op<Args...>>, Op, Args...> {
+    using value_t = std::true_type;
+    using type = Op<Args...>;
+  };
+} // namespace detail
+
+struct nonesuch {
+  ~nonesuch() = delete;
+  nonesuch(const nonesuch&) = delete;
+  void operator=(const nonesuch&) = delete;
+};
+
+template <template <typename...> typename Op, typename... Args>
+using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+
+template <template <typename...> typename Op, typename... Args>
+static constexpr bool is_detected_v = is_detected<Op, Args...>::value;
+
+template <typename DefT, template <typename...> typename Op, typename... Args>
+using detected_or = detail::detector<DefT, void, Op, Args...>;
+} // namespace det
+#endif
+
 namespace podio {
 namespace detail {
 
@@ -158,6 +197,42 @@ namespace detail {
   template <typename T>
   using GetMappedType = typename MapLikeTypeHelper<T>::mapped_type;
 
+  /**
+   * Detector for checking the existence of a mutable_type type member. Used to
+   * determine whether T is (or could be) a podio generated default (immutable)
+   * handle.
+   */
+  template <typename T>
+  using hasMutable_t = typename T::mutable_type;
+
+  /**
+   * Detector for checking the existance of an object_type type member. Used ot
+   * determine whether T is (or could be) a podio generated mutable handle.
+   */
+  template <typename T>
+  using hasObject_t = typename T::object_type;
+
+  /**
+   * Variable template for determining whether type T is a podio generated
+   * handle class.
+   *
+   * NOTE: this basically just checks the existance of the mutable_type and
+   * object_type type members, so it is rather easy to fool this check if one
+   * wanted to. However, for our purposes we mainly need it for a static_assert
+   * to have more understandable compilation error message.
+   */
+  template <typename T>
+  constexpr static bool isPodioType = det::is_detected_v<hasObject_t, T> || det::is_detected_v<hasMutable_t, T>;
+
+  /**
+   * Variable template for obtaining the default handle type from any podio
+   * generated handle type.
+   *
+   * If T is already a default handle, this will return T, if T is a mutable
+   * handle it will return T::object_type.
+   */
+  template <typename T>
+  using GetDefaultHandleType = typename det::detected_or<T, hasObject_t, T>::type;
 } // namespace detail
 
 // forward declaration to be able to use it below

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -233,6 +233,24 @@ namespace detail {
    */
   template <typename T>
   using GetDefaultHandleType = typename det::detected_or<T, hasObject_t, T>::type;
+
+  /**
+   * Variable template for obtaining the mutable handle type from any podio
+   * generated handle type.
+   *
+   * If T is alrady a mutable handle, this will return T, if T is a default
+   * handle it will return T::mutable_type.
+   */
+  template <typename T>
+  using GetMutableHandleType = typename det::detected_or<T, hasMutable_t, T>::type;
+
+  /**
+   * Helper type alias to transform a tuple of handle types to a tuple of
+   * mutable handle types.
+   */
+  template <typename Tuple>
+  using TupleOfMutableTypes = typename ToTupleOfTemplateHelper<GetMutableHandleType, Tuple>::type;
+
 } // namespace detail
 
 // forward declaration to be able to use it below

--- a/python/podio_gen/generator_base.py
+++ b/python/podio_gen/generator_base.py
@@ -209,6 +209,7 @@ class ClassGeneratorBaseMixin:
     endings = {
         'Data': ('h',),
         'PrintInfo': ('h',),
+        'Interface': ('h',),
         'MutableStruct': ('jl',),
         'ParentModule': ('jl',),
         }.get(template_base, ('h', 'cc'))

--- a/python/podio_gen/generator_utils.py
+++ b/python/podio_gen/generator_utils.py
@@ -120,6 +120,7 @@ class DataType:
     """Return a string representation that can be parsed again"""
     return self.full_type
 
+
 class MemberVariable:
   """Simple class to hold information about a member variable"""
   def __init__(self, name, **kwargs):

--- a/python/podio_gen/generator_utils.py
+++ b/python/podio_gen/generator_utils.py
@@ -116,6 +116,9 @@ class DataType:
 
     return scoped_type
 
+  def _to_json(self):
+    """Return a string representation that can be parsed again"""
+    return self.full_type
 
 class MemberVariable:
   """Simple class to hold information about a member variable"""
@@ -138,6 +141,7 @@ class MemberVariable:
 
     self.includes = set()
     self.jl_imports = set()
+    self.interface_types = []  # populated in the generator script if necessary
 
     if kwargs:
       raise ValueError(f"Unused kwargs in MemberVariable: {list(kwargs.keys())}")
@@ -258,7 +262,7 @@ class MemberVariable:
 
 class DataModel:  # pylint: disable=too-few-public-methods
   """A class for holding a complete datamodel read from a configuration file"""
-  def __init__(self, datatypes=None, components=None, options=None, schema_version=None):
+  def __init__(self, datatypes=None, components=None, interfaces=None, options=None, schema_version=None):
     self.options = options or {
         # should getters / setters be prefixed with get / set?
         "getSyntax": False,
@@ -270,6 +274,7 @@ class DataModel:  # pylint: disable=too-few-public-methods
     self.schema_version = schema_version
     self.components = components or {}
     self.datatypes = datatypes or {}
+    self.interfaces = interfaces or {}
 
   def _to_json(self):
     """Return the dictionary, so that we can easily hook this into the pythons

--- a/python/podio_gen/julia_generator.py
+++ b/python/podio_gen/julia_generator.py
@@ -46,13 +46,25 @@ class JuliaClassGenerator(ClassGeneratorBaseMixin):
     component['upstream_edm'] = self.upstream_edm
     component['upstream_edm_name'] = self.get_upstream_name()
     self._fill_templates("MutableStruct", component)
+    return component
 
   def do_process_datatype(self, _, datatype):
     """Do the julia specific processing for a datatype"""
+    if any(self._is_interface(r.full_type) for r in datatype["OneToOneRelations"] + datatype["OneToManyRelations"]):
+      # Julia doesn't support any interfaces yet, so we have to also sort out
+      # all the datatypes that use them
+      return None
+
     datatype["params_jl"] = sorted(self._get_julia_params(datatype), key=lambda x: x[0])
     datatype["upstream_edm"] = self.upstream_edm
     datatype["upstream_edm_name"] = self.get_upstream_name()
+
     self._fill_templates("MutableStruct", datatype)
+    return datatype
+
+  def do_process_interface(self, _, __):
+    """Julia does not support interface types yet, so this does nothing"""
+    return None
 
   def get_upstream_name(self):
     """Get the name of the upstream datamodel if any"""

--- a/python/podio_gen/test_ClassDefinitionValidator.py
+++ b/python/podio_gen/test_ClassDefinitionValidator.py
@@ -446,16 +446,16 @@ class ClassDefinitionValidatorTest(unittest.TestCase):  # pylint: disable=too-ma
                               self.validate, make_dm({}, datatype, self.valid_interface), False)
 
   def test_interface_valid_upstream(self):
-   """Make sure that we can use interface definitions from upstream models"""
-   # Create an upstream datamodel that contains the interface type
-   upstream_dm = make_dm({}, self.valid_datatype, self.valid_interface)
+    """Make sure that we can use interface definitions from upstream models"""
+    # Create an upstream datamodel that contains the interface type
+    upstream_dm = make_dm({}, self.valid_datatype, self.valid_interface)
 
-   # Make a downstream model datatype that uses the interface from the upstream
-   # but doesn't bring along its own interface definitions
-   datatype = {'DownstreamType': deepcopy(self.valid_datatype['DataType'])}
-   datatype['DownstreamType']['OneToOneRelations'] = [MemberVariable(type='InterfaceType', name='interfaceRelation')]
-   self._assert_no_exception(DefinitionError, '{} should allow to use interface types from an upstream datamodel',
-                             self.validate, make_dm({}, datatype), upstream_dm)
+    # Make a downstream model datatype that uses the interface from the upstream
+    # but doesn't bring along its own interface definitions
+    datatype = {'DownstreamType': deepcopy(self.valid_datatype['DataType'])}
+    datatype['DownstreamType']['OneToOneRelations'] = [MemberVariable(type='InterfaceType', name='interfaceRelation')]
+    self._assert_no_exception(DefinitionError, '{} should allow to use interface types from an upstream datamodel',
+                              self.validate, make_dm({}, datatype), upstream_dm)
 
 
 if __name__ == '__main__':

--- a/python/templates/CMakeLists.txt
+++ b/python/templates/CMakeLists.txt
@@ -10,6 +10,7 @@ set(PODIO_TEMPLATES
   ${CMAKE_CURRENT_LIST_DIR}/Obj.cc.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/Object.cc.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/Object.h.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/Interface.h.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/MutableObject.cc.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/MutableObject.h.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/selection.xml.jinja2
@@ -22,6 +23,7 @@ set(PODIO_TEMPLATES
   ${CMAKE_CURRENT_LIST_DIR}/macros/iterator.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/macros/sioblocks.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/macros/utils.jinja2
+  ${CMAKE_CURRENT_LIST_DIR}/macros/interface.jinja2
 
   ${CMAKE_CURRENT_LIST_DIR}/MutableStruct.jl.jinja2
   ${CMAKE_CURRENT_LIST_DIR}/ParentModule.jl.jinja2

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -119,11 +119,12 @@ public:
     return static_cast<Model<T>*>(m_self.get())->m_value;
   }
 
-  bool operator==(const {{ class.bare_type }}& other) const {
-    return m_self->equal(other.m_self.get());
+  friend bool operator==(const {{ class.bare_type }}& lhs, const {{ class.bare_type }}& rhs) {
+    return lhs.m_self->equal(rhs.m_self.get());
   }
-  bool operator!=(const {{ class.bare_type }}& other) const {
-    return !(*this == other);
+
+  friend bool operator!=(const {{ class.bare_type }}& lhs, const {{ class.bare_type }}& rhs) {
+    return !(lhs == rhs);
   }
 
 {{ macros.member_getters(Members, use_get_syntax) }}

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -10,6 +10,7 @@
 {{ include_types[0] }}
 
 #include "podio/ObjectID.h"
+#include "podio/utilities/TypeHelpers.h"
 
 #include <memory>
 #include <ostream>
@@ -69,7 +70,9 @@ class {{ class.bare_type }} {
 public:
   template<typename ValueT>
   {{ class.bare_type }}(ValueT value) :
-    m_self(std::make_unique<Model<ValueT>>(value)) {}
+    m_self(std::make_unique<Model<podio::detail::GetDefaultHandleType<ValueT>>>(value)) {
+    static_assert(podio::detail::isPodioType<ValueT>, "{{ class.bare_type }} can only be initialized with a podio type");
+  }
 
   {{ class.bare_type }}(const {{ class.bare_type }}& other) :
     m_self(other.m_self->clone()) {}

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -1,0 +1,136 @@
+{% import "macros/declarations.jinja2" as common_macros %}
+{% import "macros/utils.jinja2" as utils %}
+{% import "macros/interface.jinja2" as macros %}
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+
+#ifndef {{ package_name.upper() }}_{{ class.bare_type }}_H
+#define {{ package_name.upper() }}_{{ class.bare_type }}_H
+
+{# We only need one concrete type below for the makeEmpty static initialization. #}
+{{ include_types[0] }}
+
+#include "podio/ObjectID.h"
+
+#include <memory>
+#include <ostream>
+#include <stdexcept>
+
+{{ utils.namespace_open(class.namespace) }}
+
+{{ common_macros.class_description(class.bare_type, Description, Author) }}
+class {{ class.bare_type }} {
+
+  struct Concept {
+    virtual ~Concept() = default;
+    virtual std::unique_ptr<Concept> clone() const = 0;
+    virtual void print(std::ostream&) const = 0;
+
+    virtual podio::ObjectID getObjectID() const = 0;
+    virtual bool isAvailable() const = 0;
+    virtual void unlink() = 0;
+{{ macros.member_getters_concept(Members, use_get_syntax) }}
+    virtual const std::type_info& typeInfo() const = 0;
+    virtual bool equal(const Concept* rhs) const = 0;
+  };
+
+  template<typename ValueT>
+  struct Model final : Concept {
+    ~Model() = default;
+    Model(ValueT value) : m_value(value) {}
+
+    std::unique_ptr<Concept> clone() const final {
+      return std::make_unique<Model<ValueT>>(m_value);
+    }
+
+    void print(std::ostream& os) const final {
+      os << m_value;
+    }
+
+    void unlink() final { m_value.unlink(); }
+    bool isAvailable() const final { return m_value.isAvailable(); }
+    podio::ObjectID getObjectID() const { return m_value.getObjectID(); }
+
+    const std::type_info& typeInfo() const final { return typeid(ValueT); }
+
+    bool equal(const Concept* rhs) const final {
+      if (typeInfo() == rhs->typeInfo()) {
+        return m_value == static_cast<const Model<ValueT>*>(rhs)->m_value;
+      }
+      return false;
+    }
+
+{{ macros.member_getters_model(Members, use_get_syntax) }}
+
+    ValueT m_value{};
+  };
+
+  std::unique_ptr<Concept> m_self{nullptr};
+
+public:
+  template<typename ValueT>
+  {{ class.bare_type }}(ValueT value) :
+    m_self(std::make_unique<Model<ValueT>>(value)) {}
+
+  {{ class.bare_type }}(const {{ class.bare_type }}& other) :
+    m_self(other.m_self->clone()) {}
+  {{ class.bare_type }}& operator=(const {{ class.bare_type }}& other) {
+    {{ class.bare_type }} tmp{other};
+    std::swap(tmp.m_self, this->m_self);
+    return *this;
+  }
+
+  ~{{ class.bare_type }}() = default;
+  {{ class.bare_type }}({{ class.bare_type }}&&) = default;
+  {{ class.bare_type }}& operator=({{ class.bare_type }}&&) = default;
+
+  /// Create an empty handle
+  static {{ class.bare_type }} makeEmpty() {
+    // We simply chose the first type of the interfaced types here to initialize
+    // an empty handle
+    return {{ Types[0] }}::makeEmpty();
+  }
+
+  /// check whether the object is actually available
+  bool isAvailable() const { return m_self->isAvailable(); }
+  /// disconnect from the underlying value
+  void unlink() { m_self->unlink(); }
+
+  podio::ObjectID id() const { return getObjectID(); }
+  podio::ObjectID getObjectID() const { return m_self->getObjectID(); }
+
+  /// Check if the object currently holds a value of the requested type
+  template<typename T>
+  bool holds() const {
+    return typeid(T) == m_self->typeInfo();
+  }
+
+  /// Get the contained value as the concrete type it was put in. This will
+  /// throw a std::runtime_error if T is not the type of the currently held
+  /// value. Use holds to check beforehand if necessary  template<typename T>
+  template<typename T>
+  T getValue() const {
+    if (!holds<T>()) {
+      throw std::runtime_error("Cannot get value as object currently holds anotyer type");
+    }
+    // We can safely cast here since we check types before
+    return static_cast<Model<T>*>(m_self.get())->m_value;
+  }
+
+  bool operator==(const {{ class.bare_type }}& other) const {
+    return m_self->equal(other.m_self.get());
+  }
+  bool operator!=(const {{ class.bare_type }}& other) const {
+    return !(*this == other);
+  }
+
+{{ macros.member_getters(Members, use_get_syntax) }}
+
+  friend std::ostream& operator<<(std::ostream& os, const {{ class.bare_type }}& value) {
+    value.m_self->print(os);
+    return os;
+  }
+};
+
+{{ utils.namespace_close(class.namespace) }}
+
+#endif

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -103,7 +103,7 @@ public:
 
   /// Check if the object currently holds a value of the requested type
   template<typename T>
-  bool holds() const {
+  bool isA() const {
     return typeid(T) == m_self->typeInfo();
   }
 
@@ -112,7 +112,7 @@ public:
   /// value. Use holds to check beforehand if necessary  template<typename T>
   template<typename T>
   T getValue() const {
-    if (!holds<T>()) {
+    if (!isA<T>()) {
       throw std::runtime_error("Cannot get value as object currently holds anotyer type");
     }
     // We can safely cast here since we check types before

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -6,8 +6,9 @@
 #ifndef {{ package_name.upper() }}_{{ class.bare_type }}_H
 #define {{ package_name.upper() }}_{{ class.bare_type }}_H
 
-{# We only need one concrete type below for the makeEmpty static initialization. #}
-{{ include_types[0] }}
+{% for include in include_types %}
+{{ include }}
+{% endfor %}
 
 #include "podio/ObjectID.h"
 #include "podio/utilities/TypeHelpers.h"
@@ -20,6 +21,21 @@
 
 {{ common_macros.class_description(class.bare_type, Description, Author) }}
 class {{ class.bare_type }} {
+
+  /// type alias containing all the types this interface should work for.
+  using InterfacedTypes = std::tuple<{{ Types | join(", ")}}>;
+  /// type alias containing all the mutable types that can be used to initalize
+  /// this interface
+  using InterfacedMutableTypes = podio::detail::TupleOfMutableTypes<InterfacedTypes>;
+
+  /// template variable for determining whether type T is a valid interface type
+  template<typename T>
+  constexpr static bool isInterfacedType = podio::detail::isInTuple<T, InterfacedTypes>;
+
+  /// template variable for determining whether type T can be used to initialize
+  /// this interface
+  template<typename T>
+  constexpr static bool isInitializableFrom = isInterfacedType<T> || podio::detail::isInTuple<T, InterfacedMutableTypes>;
 
   struct Concept {
     virtual ~Concept() = default;
@@ -65,13 +81,13 @@ class {{ class.bare_type }} {
     ValueT m_value{};
   };
 
-  std::unique_ptr<Concept> m_self{nullptr};
+ std::unique_ptr<Concept> m_self{nullptr};
 
 public:
   template<typename ValueT>
   {{ class.bare_type }}(ValueT value) :
     m_self(std::make_unique<Model<podio::detail::GetDefaultHandleType<ValueT>>>(value)) {
-    static_assert(podio::detail::isPodioType<ValueT>, "{{ class.bare_type }} can only be initialized with a podio type");
+    static_assert(isInitializableFrom<ValueT>, "{{ class.bare_type }} can only be initialized with one of the following types (and their Mutable counter parts): {{ Types | join(", ") }}");
   }
 
   {{ class.bare_type }}(const {{ class.bare_type }}& other) :
@@ -104,6 +120,7 @@ public:
   /// Check if the object currently holds a value of the requested type
   template<typename T>
   bool isA() const {
+    static_assert(isInterfacedType<T>, "{{ class.bare_type }} can only ever be one of the following types: {{ Types | join (", ") }}");
     return typeid(T) == m_self->typeInfo();
   }
 

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -73,9 +73,10 @@ std::vector<{{ member.full_type }}> {{ class.bare_type }}Collection::{{ member.n
       }
 {% if relation.interface_types %}
       // We need the concrete collection type to assign it to an InferenceWrapper
+{% set else = joiner("else") %}
 {% for int_type in relation.interface_types %}
-      if (auto concreteColl = dynamic_cast<{{ int_type.full_type }}Collection*>(coll)) {
-        const auto tmp = (*concreteColl)[id.index];
+      {{ else() }} if (auto {{ int_type.bare_type }}Coll = dynamic_cast<{{ int_type.full_type }}Collection*>(coll)) {
+        const auto tmp = (*{{ int_type.bare_type }}Coll)[id.index];
         m_rel_{{ relation.name }}->emplace_back(tmp);
       }
 {% endfor %}
@@ -102,9 +103,10 @@ std::vector<{{ member.full_type }}> {{ class.bare_type }}Collection::{{ member.n
         continue;
       }
 {% if relation.interface_types %}
+{% set else = joiner("else") %}
 {% for int_type in relation.interface_types %}
-      if (auto concreteColl = dynamic_cast<{{ int_type.full_type }}Collection*>(coll)) {
-        entries[i]->m_{{ relation.name }} = new {{ relation.full_type }}((*concreteColl)[id.index]);
+      {{ else() }} if (auto {{ int_type.bare_type }}Coll = dynamic_cast<{{ int_type.full_type }}Collection*>(coll)) {
+        entries[i]->m_{{ relation.name }} = new {{ relation.full_type }}((*{{ int_type.bare_type }}Coll)[id.index]);
       }
 {% endfor %}
 {% else %}

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -71,9 +71,19 @@ std::vector<{{ member.full_type }}> {{ class.bare_type }}Collection::{{ member.n
         m_rel_{{ relation.name }}->emplace_back({{ relation.full_type }}::makeEmpty());
         continue;
       }
+{% if relation.interface_types %}
+      // We need the concrete collection type to assign it to an InferenceWrapper
+{% for int_type in relation.interface_types %}
+      if (auto concreteColl = dynamic_cast<{{ int_type.full_type }}Collection*>(coll)) {
+        const auto tmp = (*concreteColl)[id.index];
+        m_rel_{{ relation.name }}->emplace_back(tmp);
+      }
+{% endfor %}
+{% else %}
       {{ relation.full_type }}Collection* tmp_coll = static_cast<{{ relation.full_type }}Collection*>(coll);
       const auto tmp = (*tmp_coll)[id.index];
       m_rel_{{ relation.name }}->emplace_back(tmp);
+{% endif %}
     } else {
       m_rel_{{ relation.name }}->emplace_back({{ relation.full_type }}::makeEmpty());
     }
@@ -91,8 +101,16 @@ std::vector<{{ member.full_type }}> {{ class.bare_type }}Collection::{{ member.n
         entries[i]->m_{{ relation.name }} = nullptr;
         continue;
       }
+{% if relation.interface_types %}
+{% for int_type in relation.interface_types %}
+      if (auto concreteColl = dynamic_cast<{{ int_type.full_type }}Collection*>(coll)) {
+        entries[i]->m_{{ relation.name }} = new {{ relation.full_type }}((*concreteColl)[id.index]);
+      }
+{% endfor %}
+{% else %}
       {{ relation.full_type }}Collection* tmp_coll = static_cast<{{ relation.full_type }}Collection*>(coll);
       entries[i]->m_{{ relation.name }} = new {{ relation.full_type }}((*tmp_coll)[id.index]);
+{% endif %}
     } else {
       entries[i]->m_{{ relation.name }} = nullptr;
     }

--- a/python/templates/macros/interface.jinja2
+++ b/python/templates/macros/interface.jinja2
@@ -1,0 +1,48 @@
+{% macro member_getters_concept(members, get_syntax) %}
+{%for member in members %}
+    virtual const {{ member.full_type }}& {{ member.getter_name(get_syntax) }}() const = 0;
+{% if member.is_array %}
+    virtual const {{ member.array_type }}& {{ member.getter_name(get_syntax) }}(size_t i) const = 0;
+{%- endif %}
+{% if member.sub_members %}
+{% for sub_member in member.sub_members %}
+    virtual const {{ sub_member.full_type }}& {{ sub_member.getter_name(get_sytnax) }}() const = 0;
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+{% endmacro %}
+
+
+{% macro member_getters_model(members, get_syntax) %}
+{%for member in members %}
+    const {{ member.full_type }}& {{ member.getter_name(get_syntax) }}() const final { return m_value.{{ member.getter_name(get_syntax) }}(); }
+{% if member.is_array %}
+    const {{ member.array_type }}& {{ member.getter_name(get_syntax) }}(size_t i) const final { return m_value.{{ member.getter_name(get_syntax) }}(i); }
+{%- endif %}
+{% if member.sub_members %}
+{% for sub_member in member.sub_members %}
+    const {{ sub_member.full_type }}& {{ sub_member.getter_name(get_sytnax) }}() const final { return m_value.{{ sub_member.getter_name(get_syntax) }}(); }
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+{% endmacro %}
+
+{% macro member_getters(members, get_syntax) %}
+{%for member in members %}
+  /// Access the {{ member.docstring }}
+  const {{ member.full_type }}& {{ member.getter_name(get_syntax) }}() const { return m_self->{{ member.getter_name(get_syntax) }}(); }
+{% if member.is_array %}
+  /// Access item i of the {{ member.docstring }}
+  const {{ member.array_type }}& {{ member.getter_name(get_syntax) }}(size_t i) const { return m_self->{{ member.getter_name(get_syntax) }}(i); }
+{%- endif %}
+{% if member.sub_members %}
+{% for sub_member in member.sub_members %}
+  /// Access the member of {{ member.docstring }}
+  const {{ sub_member.full_type }}& {{ sub_member.getter_name(get_sytnax) }}() const { return m_self->{{ sub_member.getter_name(get_syntax) }}(); }
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+{% endmacro %}

--- a/python/templates/macros/interface.jinja2
+++ b/python/templates/macros/interface.jinja2
@@ -1,12 +1,12 @@
 {% macro member_getters_concept(members, get_syntax) %}
 {%for member in members %}
-    virtual const {{ member.full_type }}& {{ member.getter_name(get_syntax) }}() const = 0;
+    virtual {{ member.getter_return_type() }} {{ member.getter_name(get_syntax) }}() const = 0;
 {% if member.is_array %}
-    virtual const {{ member.array_type }}& {{ member.getter_name(get_syntax) }}(size_t i) const = 0;
+    virtual {{ member.getter_return_type(True) }} {{ member.getter_name(get_syntax) }}(size_t i) const = 0;
 {%- endif %}
 {% if member.sub_members %}
 {% for sub_member in member.sub_members %}
-    virtual const {{ sub_member.full_type }}& {{ sub_member.getter_name(get_sytnax) }}() const = 0;
+    virtual {{ sub_member.getter_return_type() }} {{ sub_member.getter_name(get_sytnax) }}() const = 0;
 {% endfor %}
 {% endif %}
 
@@ -16,13 +16,13 @@
 
 {% macro member_getters_model(members, get_syntax) %}
 {%for member in members %}
-    const {{ member.full_type }}& {{ member.getter_name(get_syntax) }}() const final { return m_value.{{ member.getter_name(get_syntax) }}(); }
+    {{ member.getter_return_type() }} {{ member.getter_name(get_syntax) }}() const final { return m_value.{{ member.getter_name(get_syntax) }}(); }
 {% if member.is_array %}
-    const {{ member.array_type }}& {{ member.getter_name(get_syntax) }}(size_t i) const final { return m_value.{{ member.getter_name(get_syntax) }}(i); }
+    {{ member.getter_return_type(True) }} {{ member.getter_name(get_syntax) }}(size_t i) const final { return m_value.{{ member.getter_name(get_syntax) }}(i); }
 {%- endif %}
 {% if member.sub_members %}
 {% for sub_member in member.sub_members %}
-    const {{ sub_member.full_type }}& {{ sub_member.getter_name(get_sytnax) }}() const final { return m_value.{{ sub_member.getter_name(get_syntax) }}(); }
+    {{ sub_member.getter_return_type() }} {{ sub_member.getter_name(get_sytnax) }}() const final { return m_value.{{ sub_member.getter_name(get_syntax) }}(); }
 {% endfor %}
 {% endif %}
 
@@ -32,15 +32,15 @@
 {% macro member_getters(members, get_syntax) %}
 {%for member in members %}
   /// Access the {{ member.docstring }}
-  const {{ member.full_type }}& {{ member.getter_name(get_syntax) }}() const { return m_self->{{ member.getter_name(get_syntax) }}(); }
+  {{ member.getter_return_type() }} {{ member.getter_name(get_syntax) }}() const { return m_self->{{ member.getter_name(get_syntax) }}(); }
 {% if member.is_array %}
   /// Access item i of the {{ member.docstring }}
-  const {{ member.array_type }}& {{ member.getter_name(get_syntax) }}(size_t i) const { return m_self->{{ member.getter_name(get_syntax) }}(i); }
+  {{ member.getter_return_type(True) }} {{ member.getter_name(get_syntax) }}(size_t i) const { return m_self->{{ member.getter_name(get_syntax) }}(i); }
 {%- endif %}
 {% if member.sub_members %}
 {% for sub_member in member.sub_members %}
   /// Access the member of {{ member.docstring }}
-  const {{ sub_member.full_type }}& {{ sub_member.getter_name(get_sytnax) }}() const { return m_self->{{ sub_member.getter_name(get_syntax) }}(); }
+  {{ sub_member.getter_return_type() }} {{ sub_member.getter_name(get_sytnax) }}() const { return m_self->{{ sub_member.getter_name(get_syntax) }}(); }
 {% endfor %}
 {% endif %}
 

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -198,3 +198,39 @@ datatypes :
       - ex2::NamespaceStruct s{10, 11} // one that we happen to know works
       - double d{9.876e5} // double val
       - CompWithInit comp // To make sure that the default initializer of the component does what it should
+
+  ExampleWithInterfaceRelation:
+    Description: "Datatype that uses an interface type as one of its relations"
+    Author: "Thomas Madlener"
+    OneToOneRelations:
+      - TypeWithEnergy aSingleEnergyType // single relation
+      - ex42::AnotherTypeWithEnergy energyRelation // another single relation
+    OneToManyRelations:
+      - TypeWithEnergy manyEnergies // multiple relations
+      - ex42::AnotherTypeWithEnergy moreEnergies // multiple namespace relations
+
+  nsp::EnergyInNamespace:
+    Description: "A type with energy in a namespace"
+    Author: "Thomas Madlener"
+    Members:
+      - double energy // energy
+
+interfaces:
+  TypeWithEnergy:
+    Description: "Generic interface for all types with an energy member"
+    Author: "Thomas Madlener"
+    Types:
+      - ExampleMC
+      - ExampleCluster
+      - ExampleHit
+    Members:
+      - double energy // the energy
+
+  ex42::AnotherTypeWithEnergy:
+    Description: "Another interface type for making sure they also work in namespaces"
+    Author: "Thomas Madlener"
+    Types:
+      - ExampleHit
+      - nsp::EnergyInNamespace
+    Members:
+      - double energy // the energy

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -214,6 +214,9 @@ datatypes :
     Author: "Thomas Madlener"
     Members:
       - double energy // energy
+    ExtraCode:
+      declaration:
+        "int PDG() const { return 42; }"
 
 interfaces:
   TypeWithEnergy:
@@ -230,7 +233,8 @@ interfaces:
     Description: "Another interface type for making sure they also work in namespaces"
     Author: "Thomas Madlener"
     Types:
-      - ExampleHit
+      - ExampleMC
       - nsp::EnergyInNamespace
     Members:
       - double energy // the energy
+      - int PDG // a pdg

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -223,9 +223,9 @@ interfaces:
     Description: "Generic interface for all types with an energy member"
     Author: "Thomas Madlener"
     Types:
+      - ExampleHit
       - ExampleMC
       - ExampleCluster
-      - ExampleHit
     Members:
       - double energy // the energy
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -40,7 +40,7 @@ if(NOT Catch2_FOUND)
 endif()
 
 find_package(Threads REQUIRED)
-add_executable(unittest_podio unittest.cpp frame.cpp buffer_factory.cpp)
+add_executable(unittest_podio unittest.cpp frame.cpp buffer_factory.cpp interface_types.cpp)
 target_link_libraries(unittest_podio PUBLIC TestDataModel PRIVATE Catch2::Catch2WithMain Threads::Threads podio::podioRootIO)
 if (ENABLE_SIO)
   target_link_libraries(unittest_podio PRIVATE podio::podioSioIO)

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -14,7 +14,7 @@ TEST_CASE("InterfaceTypes basic functionality", "[interface-types][basics]") {
 
   auto emptyWrapper = WrapperT::makeEmpty();
   REQUIRE_FALSE(emptyWrapper.isAvailable());
-  REQUIRE(emptyWrapper.holds<ExampleHit>());
+  REQUIRE(emptyWrapper.isA<ExampleHit>());
 
   ExampleHit hit{};
   WrapperT wrapper1 = hit;
@@ -50,14 +50,14 @@ TEST_CASE("InterfaceType from immutable", "[interface-types][basics]") {
 
   ExampleHit hit{};
   WrapperT wrapper{hit};
-  REQUIRE(wrapper.holds<ExampleHit>());
-  REQUIRE_FALSE(wrapper.holds<ExampleCluster>());
+  REQUIRE(wrapper.isA<ExampleHit>());
+  REQUIRE_FALSE(wrapper.isA<ExampleCluster>());
   REQUIRE(wrapper.getValue<ExampleHit>() == hit);
   REQUIRE(wrapper == hit);
 
   ExampleCluster cluster{};
   wrapper = cluster;
-  REQUIRE(wrapper.holds<ExampleCluster>());
+  REQUIRE(wrapper.isA<ExampleCluster>());
   REQUIRE(wrapper.getValue<ExampleCluster>() == cluster);
   REQUIRE_THROWS_AS(wrapper.getValue<ExampleHit>(), std::runtime_error);
   REQUIRE(wrapper != hit);
@@ -68,8 +68,8 @@ TEST_CASE("InterfaceType from mutable", "[interface-types][basics]") {
 
   ExampleHit hit{};
   WrapperT wrapper{hit};
-  REQUIRE(wrapper.holds<ExampleHit>());
-  REQUIRE_FALSE(wrapper.holds<ExampleCluster>());
+  REQUIRE(wrapper.isA<ExampleHit>());
+  REQUIRE_FALSE(wrapper.isA<ExampleCluster>());
   REQUIRE(wrapper.getValue<ExampleHit>() == hit);
   REQUIRE(wrapper == hit);
   // Comparison also work against the immutable classes
@@ -78,7 +78,7 @@ TEST_CASE("InterfaceType from mutable", "[interface-types][basics]") {
 
   MutableExampleCluster cluster{};
   wrapper = cluster;
-  REQUIRE(wrapper.holds<ExampleCluster>());
+  REQUIRE(wrapper.isA<ExampleCluster>());
   REQUIRE(wrapper.getValue<ExampleCluster>() == cluster);
   REQUIRE_THROWS_AS(wrapper.getValue<ExampleHit>(), std::runtime_error);
   REQUIRE(wrapper != hit);

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -1,0 +1,85 @@
+#include "catch2/catch_test_macros.hpp"
+
+#include "podio/ObjectID.h"
+
+#include "datamodel/AnotherTypeWithEnergy.h"
+#include "datamodel/EnergyInNamespaceCollection.h"
+#include "datamodel/ExampleClusterCollection.h"
+#include "datamodel/ExampleHitCollection.h"
+#include "datamodel/TypeWithEnergy.h"
+#include <stdexcept>
+
+TEST_CASE("InterfaceTypes basic functionality", "[interface-types][basics]") {
+  using WrapperT = TypeWithEnergy;
+
+  auto emptyWrapper = WrapperT::makeEmpty();
+  REQUIRE_FALSE(emptyWrapper.isAvailable());
+  REQUIRE(emptyWrapper.holds<ExampleHit>());
+
+  ExampleHit hit{};
+  WrapperT wrapper1 = hit;
+  WrapperT wrapper2 = hit;
+
+  // The operator== compares the underlying pointers
+  REQUIRE(wrapper1 == wrapper2);
+  // Reassgning to a different entity should make comparisons fail
+  wrapper2 = ExampleHit{};
+  REQUIRE(wrapper1 != wrapper2);
+
+  // Make sure that the object id functionality work as expected. The wrapped
+  // object is in no collection, so it should be the default id.
+  REQUIRE(wrapper1.id() == podio::ObjectID{});
+
+  // Create an element in a collection to get one with a non-default object id
+  ExampleHitCollection hitColl{};
+  hitColl.setID(42);
+  wrapper1 = hitColl.create();
+  REQUIRE(wrapper1.id() == podio::ObjectID{0, 42});
+}
+
+TEST_CASE("InterfaceType from immutable", "[interface-types][basics]") {
+  using WrapperT = TypeWithEnergy;
+
+  ExampleHit hit{};
+  WrapperT wrapper{hit};
+  REQUIRE(wrapper.holds<ExampleHit>());
+  REQUIRE_FALSE(wrapper.holds<ExampleCluster>());
+  REQUIRE(wrapper.getValue<ExampleHit>() == hit);
+  REQUIRE(wrapper == hit);
+
+  ExampleCluster cluster{};
+  wrapper = cluster;
+  REQUIRE(wrapper.holds<ExampleCluster>());
+  REQUIRE(wrapper.getValue<ExampleCluster>() == cluster);
+  REQUIRE_THROWS_AS(wrapper.getValue<ExampleHit>(), std::runtime_error);
+  REQUIRE(wrapper != hit);
+}
+
+TEST_CASE("InterfaceType from mutable", "[interface-types][basics]") {
+  using WrapperT = TypeWithEnergy;
+
+  ExampleHit hit{};
+  WrapperT wrapper{hit};
+  REQUIRE(wrapper.holds<ExampleHit>());
+  REQUIRE_FALSE(wrapper.holds<ExampleCluster>());
+  REQUIRE(wrapper.getValue<ExampleHit>() == hit);
+  REQUIRE(wrapper == hit);
+  // Comparison also work against the immutable classes
+  ExampleHit immutableHit = hit;
+  REQUIRE(wrapper == immutableHit);
+
+  MutableExampleCluster cluster{};
+  wrapper = cluster;
+  REQUIRE(wrapper.holds<ExampleCluster>());
+  REQUIRE(wrapper.getValue<ExampleCluster>() == cluster);
+  REQUIRE_THROWS_AS(wrapper.getValue<ExampleHit>(), std::runtime_error);
+  REQUIRE(wrapper != hit);
+}
+
+TEST_CASE("InterfaceType getters", "[basics][interface-types][code-gen]") {
+  MutableExampleCluster cluster{};
+  cluster.energy(3.14f);
+
+  TypeWithEnergy interfaceType = cluster;
+  REQUIRE(interfaceType.energy() == 3.14f);
+}

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -22,9 +22,17 @@ TEST_CASE("InterfaceTypes basic functionality", "[interface-types][basics]") {
 
   // The operator== compares the underlying pointers
   REQUIRE(wrapper1 == wrapper2);
+  // The comparison operator is symmetric
+  REQUIRE(hit == wrapper1);
   // Reassgning to a different entity should make comparisons fail
   wrapper2 = ExampleHit{};
   REQUIRE(wrapper1 != wrapper2);
+
+  // Comparisons also work with Mutable types
+  MutableExampleHit mutHit{};
+  wrapper2 = mutHit;
+  REQUIRE(mutHit != wrapper1);
+  REQUIRE(wrapper2 == mutHit);
 
   // Make sure that the object id functionality work as expected. The wrapped
   // object is in no collection, so it should be the default id.


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a new category of types that can be generated by podio: `interfaces`. These can be used to provide a type that can be initialized from several other datatypes and offers some common functionality. These interface types can be used in `OneToOneRelation`s and in `OneToManyRelation`s.
  - `interfaces` need to provide a list of types which they interface. Other types cannot be used with them.

ENDRELEASENOTES

Draft resurrection of #215 with the major difference that this no longer uses a `std::variant` of the `Obj*` types, but rather relies on a type-erased wrapping of the default handle types. Additionally, this also no longer supports mutable interface types, as I don't think we really have a use case for them.

- [x] Release notes
- [x] Needs #514 (builds directly on top of that)
- [x] Documentation