### PR TITLE
Add an error message when there is a std::bad_function_call

### DIFF
--- a/python/podio/frame_iterator.py
+++ b/python/podio/frame_iterator.py
@@ -2,7 +2,7 @@
 """Module defining the Frame iterator used by the Reader interface"""
 
 # pylint: disable-next=import-error # gbl is a dynamic module from cppyy
-from cppyy.gbl import std
+from cppyy.gbl import std, bad_function_call
 from podio.frame import Frame
 
 
@@ -51,7 +51,14 @@ class FrameCategoryIterator:
       # If we are below 0 now, we do not have enough entries to serve the request
       raise IndexError
 
-    frame_data = self._reader.readEntry(self._category, entry)
+    try:
+      frame_data = self._reader.readEntry(self._category, entry)
+    except bad_function_call:
+      print('Error: Unable to read an entry of the input file. This can happen when the '
+            'ROOT model dictionaries are not in LD_LIBRARY_PATH. Make sure that LD_LIBRARY_PATH '
+            'points to the library folder of the installation of podio and also to the library '
+            'folder with your data model\n')
+      raise
     if frame_data:
       return Frame(std.move(frame_data))
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add an error message when there is an std::bad_function_call, which currently shows
  a stacktrace and is quite uninformative.

ENDRELEASENOTES

Depending on what is found and what isn't it is possible to trigger a `std::bad_function_call` that will show a very uninformative traceback:

``` python
Traceback (most recent call last):
  File "/podio/install/bin/podio-dump", line 175, in <module>
    main(clargs)
  File "/podio/install/bin/podio-dump", line 130, in main
    print_frame(frames[ient], args.category, ient, args.detailed)
                ~~~~~~^^^^^^
  File "/podio/install/python/podio/frame_iterator.py", line 55, in __getitem__
    frame_data = self._reader.readEntry(self._category, entry)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cppyy.gbl.bad_function_call: unique_ptr<podio::ROOTFrameData,default_delete<podio::ROOTFrameData> > podio::ROOTFrameReader::readEntry(const string& name, const unsigned int entry) =>
    bad_function_call: bad_function_call
```

where the only source of information is some warnings from before from ROOT (warnings if it's missing for example the .rootmap file, errors if the .so files are missing).