### PR TITLE
Switch edm4hep workflows to newer LCG releases

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -13,8 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_102/x86_64-centos7-gcc11-opt",
-              "LCG_102/x86_64-ubuntu2004-gcc9-opt"]
+        LCG: ["LCG_104/x86_64-el9-gcc13-opt",
+              "LCG_104/x86_64-ubuntu2004-gcc9-opt",
+              "LCG_104/x86_64-el9-clang16-opt"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           repository: catchorg/Catch2
           path: catch2
+          ref: v3.4.0
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: aidasoft/run-lcg-view@v4
         with:

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -67,6 +67,7 @@ jobs:
             cmake -DCMAKE_CXX_STANDARD=17 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
               -DUSE_EXTERNAL_CATCH2=ON \
+              -DSKIP_CATCH_DISCOVERY=ON \
               -G Ninja ..
             ninja -k0
             ctest --output-on-failure

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         LCG: ["LCG_104/x86_64-el9-gcc13-opt",
-              "LCG_104/x86_64-ubuntu2004-gcc9-opt",
+              "dev4/x86_64-ubuntu2004-gcc9-opt",
               "LCG_104/x86_64-el9-clang16-opt"]
     steps:
       - uses: actions/checkout@v3
@@ -67,7 +67,6 @@ jobs:
             cmake -DCMAKE_CXX_STANDARD=17 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
               -DUSE_EXTERNAL_CATCH2=ON \
-              -DSKIP_CATCH_DISCOVERY=ON \
               -G Ninja ..
             ninja -k0
             ctest --output-on-failure


### PR DESCRIPTION

BEGINRELEASENOTES
- Switch the edm4hep workflows to an LCG stack with a recent enough version of CMake. Necessary after key4hep/EDM4hep#235

ENDRELEASENOTES