### PR TITLE
fix rootUtils for macOS 12 / 13

### DIFF
--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <iterator>
 #include <string>
+#include <sstream>
 #include <string_view>
 #include <tuple>
 #include <vector>

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -15,8 +15,8 @@
 #include <cctype>
 #include <iostream>
 #include <iterator>
-#include <string>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <tuple>
 #include <vector>


### PR DESCRIPTION
Needed on macOS12 clang14, macOS13 clang15

BEGINRELEASENOTES
- rootUtils: include sstream, fixes build on macOS 12 / 13

ENDRELEASENOTES

```
[ 67%] Building CXX object src/CMakeFiles/podioSioIO.dir/SIOLegacyReader.cc.o
In file included from /Users/sftnight/build/workspace/lcg_mr_pipeline/build/frameworks/podio-00.17.04/src/podio/00.17.04/src/ROOTLegacyReader.cc:4:
/Users/sftnight/build/workspace/lcg_mr_pipeline/build/frameworks/podio-00.17.04/src/podio/00.17.04/src/rootUtils.h:334:21: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
  std::stringstream sstr;
                    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/iosfwd:134:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_stringstream;
                               ^
1 error generated.
```