### PR TITLE
Fix a few easy to fix issues flagged by coverity

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -203,7 +203,7 @@ public:
    */
   template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
   inline void putParameter(const std::string& key, T value) {
-    m_self->parameters().setValue(key, value);
+    m_self->parameters().setValue(key, std::move(value));
   }
 
   /** Add a string value to the parameters of the Frame by copying it. Dedicated

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -242,7 +242,7 @@ void GenericParameters::setValue(const std::string& key, T value) {
     map.insert_or_assign(key, std::move(value));
   } else {
     // Wrap the value into a vector with exactly one entry and store that
-    std::vector<T> v = {value};
+    std::vector<T> v = {std::move(value)};
     std::lock_guard lock{mtx};
     map.insert_or_assign(key, std::move(v));
   }

--- a/include/podio/ROOTFrameData.h
+++ b/include/podio/ROOTFrameData.h
@@ -26,7 +26,7 @@ public:
   ROOTFrameData& operator=(const ROOTFrameData&) = delete;
 
   ROOTFrameData(BufferMap&& buffers, CollIDPtr&& idTable, podio::GenericParameters&& params) :
-      m_buffers(std::move(buffers)), m_idTable(idTable), m_parameters(std::move(params)) {
+      m_buffers(std::move(buffers)), m_idTable(std::move(idTable)), m_parameters(std::move(params)) {
   }
 
   std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name) {

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -116,8 +116,8 @@ public:
   void read(sio::read_device& device, sio::version_type version) override;
   void write(sio::write_device& device) override;
 
-  podio::CollectionIDTable* getTable() {
-    return new podio::CollectionIDTable(std::move(_ids), std::move(_names));
+  podio::CollectionIDTable getTable() {
+    return podio::CollectionIDTable(std::move(_ids), std::move(_names));
   }
   const std::vector<std::string>& getTypeNames() const {
     return _types;

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -22,7 +22,7 @@ Mutable{{ type }} {{ full_type }}::clone() const {
   return Mutable{{ type }}(podio::utils::MaybeSharedPtr(new {{ type }}Obj(*m_obj), podio::utils::MarkOwned));
 }
 
-{{ full_type }}::{{ full_type }}(podio::utils::MaybeSharedPtr<{{ type }}Obj> obj) : m_obj(obj) {}
+{{ full_type }}::{{ full_type }}(podio::utils::MaybeSharedPtr<{{ type }}Obj> obj) : m_obj(std::move(obj)) {}
 
 {%- endmacro %}
 

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -47,12 +47,15 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& values) {
 
 template <typename MapType>
 void printMap(const MapType& map, std::ostream& os) {
+  const auto osflags = os.flags();
   os << std::left << std::setw(30) << "Key "
      << "Value " << '\n';
   os << "--------------------------------------------------------------------------------\n";
   for (const auto& [key, value] : map) {
     os << std::left << std::setw(30) << key << value << '\n';
   }
+
+  os.flags(osflags);
 }
 
 void GenericParameters::print(std::ostream& os, bool flush) {

--- a/src/SIOFrameData.cc
+++ b/src/SIOFrameData.cc
@@ -95,7 +95,7 @@ void SIOFrameData::readIdTable() {
   sio::api::read_blocks(uncBuffer.span(), blocks);
 
   auto* idTableBlock = static_cast<SIOCollectionIDTableBlock*>(blocks[0].get());
-  m_idTable = std::move(*idTableBlock->getTable());
+  m_idTable = idTableBlock->getTable();
   m_typeNames = idTableBlock->getTypeNames();
   m_subsetCollectionBits = idTableBlock->getSubsetCollectionBits();
 }

--- a/tests/read_python_frame.h
+++ b/tests/read_python_frame.h
@@ -24,7 +24,7 @@ int checkHits(const ExampleHitCollection& hits) {
   auto hit2 = hits[1];
   if (hit2.cellID() != 0xcaffee || hit2.x() != 1.0 || hit2.y() != 0.0 || hit2.z() != 0.0 || hit2.energy() != 12.0) {
     std::cerr << "Could not retrieve the correct hit[1]: (expected: "
-              << MutableExampleHit(0xcaffee, 1.0, 0.0, 0.0, 12.0) << ", actual: " << hit1 << ")" << std::endl;
+              << MutableExampleHit(0xcaffee, 1.0, 0.0, 0.0, 12.0) << ", actual: " << hit2 << ")" << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Implement the suggestions from coverity to move in places where it is easily possible.
- Fix a small resource leak in SIO.
- Fix a small copy-paste error in test output (only triggered in case test fails)
- Restore ostream state after altering it for formatting.

ENDRELEASENOTES