### PR TITLE
Add a getAvailableCollections method in python

### DIFF
--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Module for the python bindings of the podio::Frame"""
 
-# pylint: disable-next=import-error # gbl is a dynamic module from cppyy
-import cppyy
 import sys
+import cppyy
 
 import ROOT
 

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -125,7 +125,7 @@ class Frame:
     Returns:
         tuple(str): The names of the available collections from this Frame.
     """
-    warnings.warn('WARNING: collections is deprecated use getAvailableCollections()'
+    warnings.warn('WARNING: collections is deprecated, use getAvailableCollections()'
                   ' (like in C++) instead', FutureWarning)
     return self.getAvailableCollections()
 

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Module for the python bindings of the podio::Frame"""
 
-import sys
+import warnings
 import cppyy
 
 import ROOT
@@ -125,8 +125,8 @@ class Frame:
     Returns:
         tuple(str): The names of the available collections from this Frame.
     """
-    print('WARNING: collections is deprecated, use getAvailableCollections() (like in C++) instead',
-          file=sys.stderr)
+    warnings.warn('WARNING: collections is deprecated use getAvailableCollections()'
+                  ' (like in C++) instead', FutureWarning)
     return self.getAvailableCollections()
 
   def get(self, name):

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -3,6 +3,7 @@
 
 # pylint: disable-next=import-error # gbl is a dynamic module from cppyy
 import cppyy
+import sys
 
 import ROOT
 
@@ -125,6 +126,8 @@ class Frame:
     Returns:
         tuple(str): The names of the available collections from this Frame.
     """
+    print('WARNING: collections is deprecated, use getAvailableCollections() (like in C++) instead',
+          file=sys.stderr)
     return self.getAvailableCollections()
 
   def get(self, name):

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -110,6 +110,14 @@ class Frame:
 
     self._param_key_types = self._get_param_keys_types()
 
+  def getAvailableCollections(self):
+    """Get the currently available collection (names) from this Frame.
+
+    Returns:
+        tuple(str): The names of the available collections from this Frame.
+    """
+    return tuple(str(s) for s in self._frame.getAvailableCollections())
+
   @property
   def collections(self):
     """Get the currently available collection (names) from this Frame.
@@ -117,7 +125,7 @@ class Frame:
     Returns:
         tuple(str): The names of the available collections from this Frame.
     """
-    return tuple(str(s) for s in self._frame.getAvailableCollections())
+    return self.getAvailableCollections()
 
   def get(self, name):
     """Get a collection from the Frame by name.

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -117,7 +117,8 @@ class FrameReadTest(unittest.TestCase):
   def test_frame_collections(self):
     """Check that all expected collections are available."""
     self.assertEqual(set(self.event.getAvailableCollections()), EXPECTED_COLL_NAMES)
-    self.assertEqual(set(self.other_event.getAvailableCollections()), EXPECTED_COLL_NAMES.union(EXPECTED_EXTENSION_COLL_NAMES))
+    self.assertEqual(set(self.other_event.getAvailableCollections()),
+                     EXPECTED_COLL_NAMES.union(EXPECTED_EXTENSION_COLL_NAMES))
 
     # Not going over all collections here, as that should all be covered by the
     # c++ test cases; Simply picking a few and doing some basic tests

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -48,12 +48,12 @@ class FrameTest(unittest.TestCase):
   def test_frame_put_collection(self):
     """Check that putting a collection works as expected"""
     frame = Frame()
-    self.assertEqual(frame.collections, tuple())
+    self.assertEqual(frame.getAvailableCollections(), tuple())
 
     hits = ExampleHitCollection()
     hits.create()
     hits2 = frame.put(hits, "hits_from_python")
-    self.assertEqual(frame.collections, tuple(["hits_from_python"]))
+    self.assertEqual(frame.getAvailableCollections(), tuple(["hits_from_python"]))
     # The original collection is gone at this point, and ideally just leaves an
     # empty shell
     self.assertEqual(len(hits), 0)
@@ -116,8 +116,8 @@ class FrameReadTest(unittest.TestCase):
 
   def test_frame_collections(self):
     """Check that all expected collections are available."""
-    self.assertEqual(set(self.event.collections), EXPECTED_COLL_NAMES)
-    self.assertEqual(set(self.other_event.collections), EXPECTED_COLL_NAMES.union(EXPECTED_EXTENSION_COLL_NAMES))
+    self.assertEqual(set(self.event.getAvailableCollections()), EXPECTED_COLL_NAMES)
+    self.assertEqual(set(self.other_event.getAvailableCollections()), EXPECTED_COLL_NAMES.union(EXPECTED_EXTENSION_COLL_NAMES))
 
     # Not going over all collections here, as that should all be covered by the
     # c++ test cases; Simply picking a few and doing some basic tests

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -38,7 +38,7 @@ def print_frame_detailed(frame):
       frame (podio.Frame): The frame to print
   """
   print('Collections:')
-  for name in sorted(frame.collections, key=str.casefold):
+  for name in sorted(frame.getAvailableCollections(), key=str.casefold):
     coll = frame.get(name)
     print(name, flush=True)
     coll.print()
@@ -56,7 +56,7 @@ def print_frame_overview(frame):
       frame (podio.Frame): The frame to print
   """
   rows = []
-  for name in sorted(frame.collections, key=str.casefold):
+  for name in sorted(frame.getAvailableCollections(), key=str.casefold):
     coll = frame.get(name)
     rows.append(
         (name, coll.getValueTypeName().data(), len(coll), f'{coll.getID():0>8x}')


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `getAvailableCollections` method in python that does the same thing as in C++

ENDRELEASENOTES

Currently `frame.collections` is the way of getting the collections. I'd prefer the C++ method and the python one to have the same name so it's easier to remember.

I'm also in favor of removing the current `.collections` which is probably only used in podio (in podio-dump).