### PR TITLE
Use getAvailableCollections() instead of the deprecated .collections

### DIFF
--- a/python/podio/base_writer.py
+++ b/python/podio/base_writer.py
@@ -22,4 +22,4 @@ class BaseWriterMixin:
            write. If None, all collections are written
     """
     # pylint: disable-next=protected-access
-    self._writer.writeFrame(frame._frame, category, collections or frame.collections)
+    self._writer.writeFrame(frame._frame, category, collections or frame.getAvailableCollections())


### PR DESCRIPTION
BEGINRELEASENOTES
- Use getAvailableCollections() instead of the deprecated .collections

ENDRELEASENOTES

I don't know how I missed this one when I searched for ".collections"