### PR TITLE
Fix crash when a writer is in the global namespace

### DIFF
--- a/python/podio/base_writer.py
+++ b/python/podio/base_writer.py
@@ -2,6 +2,31 @@
 """Python module for defining the basic writer interface that is used by the
 backend specific bindings"""
 
+import atexit
+
+
+class AllWriters:
+  """Class to manage all writers in the program
+     so that they can be properly finished at the end of the program
+  """
+  writers = []
+
+  def add(self, writer):
+    """Add a writer to the list of managed writers"""
+    self.writers.append(writer)
+
+  def finish(self):
+    """Finish all managed writers"""
+    for writer in self.writers:
+      try:
+        writer._writer.finish()  # pylint: disable=protected-access
+      except AttributeError:
+        pass
+
+
+_all_writers = AllWriters()
+atexit.register(_all_writers.finish)
+
 
 class BaseWriterMixin:
   """Mixin class that defines the base interface of the writers.
@@ -10,6 +35,10 @@ class BaseWriterMixin:
   following members:
     - _writer: The actual writer that is able to write frames
   """
+
+  def __init__(self):
+    """Initialize the writer"""
+    _all_writers.add(self)
 
   def write_frame(self, frame, category, collections=None):
     """Write the given frame under the passed category, optionally limiting the

--- a/python/podio/root_io.py
+++ b/python/podio/root_io.py
@@ -9,6 +9,7 @@ from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
 from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
 from podio.base_writer import BaseWriterMixin  # pylint: disable=wrong-import-position
 
+
 class AllWriters:
   """Class to manage all writers in the program
      so that they can be properly finished at the end of the program
@@ -23,12 +24,14 @@ class AllWriters:
     """Finish all managed writers"""
     for writer in self.writers:
       try:
-        writer._writer.finish()
+        writer._writer.finish() # pylint: disable=protected-access
       except AttributeError:
         pass
 
+
 _all_writers = AllWriters()
 atexit.register(_all_writers.finish)
+
 
 class Reader(BaseReaderMixin):
   """Reader class for reading podio root files."""

--- a/python/podio/root_io.py
+++ b/python/podio/root_io.py
@@ -1,36 +1,12 @@
 #!/usr/bin/env python3
 """Python module for reading root files containing podio Frames"""
 
-import atexit
 from ROOT import gSystem
 gSystem.Load('libpodioRootIO')  # noqa: E402
 from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
 
 from podio.base_reader import BaseReaderMixin  # pylint: disable=wrong-import-position
 from podio.base_writer import BaseWriterMixin  # pylint: disable=wrong-import-position
-
-
-class AllWriters:
-  """Class to manage all writers in the program
-     so that they can be properly finished at the end of the program
-  """
-  writers = []
-
-  def add(self, writer):
-    """Add a writer to the list of managed writers"""
-    self.writers.append(writer)
-
-  def finish(self):
-    """Finish all managed writers"""
-    for writer in self.writers:
-      try:
-        writer._writer.finish()  # pylint: disable=protected-access
-      except AttributeError:
-        pass
-
-
-_all_writers = AllWriters()
-atexit.register(_all_writers.finish)
 
 
 class Reader(BaseReaderMixin):
@@ -101,7 +77,7 @@ class Writer(BaseWriterMixin):
         filename (str): The name of the output file
     """
     self._writer = podio.ROOTFrameWriter(filename)
-    _all_writers.add(self)
+    super().__init__()
 
 
 class RNTupleWriter(BaseWriterMixin):
@@ -113,4 +89,4 @@ class RNTupleWriter(BaseWriterMixin):
         filename (str): The name of the output file
     """
     self._writer = podio.ROOTNTupleWriter(filename)
-    _all_writers.add(self)
+    super().__init__()

--- a/python/podio/root_io.py
+++ b/python/podio/root_io.py
@@ -24,7 +24,7 @@ class AllWriters:
     """Finish all managed writers"""
     for writer in self.writers:
       try:
-        writer._writer.finish() # pylint: disable=protected-access
+        writer._writer.finish()  # pylint: disable=protected-access
       except AttributeError:
         pass
 

--- a/python/podio/root_io.py
+++ b/python/podio/root_io.py
@@ -22,7 +22,10 @@ class AllWriters:
   def finish(self):
     """Finish all managed writers"""
     for writer in self.writers:
-      writer._writer.finish()
+      try:
+        writer._writer.finish()
+      except AttributeError:
+        pass
 
 _all_writers = AllWriters()
 atexit.register(_all_writers.finish)

--- a/python/podio/sio_io.py
+++ b/python/podio/sio_io.py
@@ -56,3 +56,4 @@ class Writer(BaseWriterMixin):
         filename (str): The name of the output file
     """
     self._writer = podio.SIOFrameWriter(filename)
+    super().__init__()


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix crash when a writer is in the global namespace by adding a class that will manage all the writers and finish them before exiting

ENDRELEASENOTES

The following code crashes (either `Writer` or `RNTupleWriter`):

``` python
import podio
writer = podio.root_io.RNTupleWriter('rntuple.root')
```

The workaround is to add a `del writer` at the end. This happens because the writers do something when they are destructed but podio and/or ROOT may get destructed before. Error message:

``` c++
Error in <TKey::Create>: Cannot allocate 658 bytes for ID =  Title =
SysError in <TFile::Seek>: cannot seek to position 0 in file rntuple.root, retpos=-1 Bad file descriptor
Fatal: !rv violated at line 1152 of `/root/tree/ntuple/v7/src/RMiniFile.cxx'
aborting
```