### PR TITLE
Add Python formatting targets (black, flake8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,3 +224,6 @@ if(BUILD_TESTING)
 endif()
 #--- add CMake infrastructure --------------------------------------------------
 include(cmake/podioCreateConfig.cmake)
+
+#--- code format targets -------------------------------------------------------
+include(cmake/pythonFormat.cmake)

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -7,15 +7,26 @@
 file(GLOB_RECURSE ALL_PYTHON_FILES ${PROJECT_SOURCE_DIR}/*.py)
 
 # Black is rather simple because there are no options...
-add_custom_target(
-        black
-        COMMAND black
-        ${ALL_PYTHON_FILES}
-)
+find_program(BLACK_EXECUTABLE black)
+if(BLACK_EXECUTABLE)
+    add_custom_target(
+            black
+            COMMAND black
+            ${ALL_PYTHON_FILES}
+    )
+else()
+    message(WARNING "Failed to find black executable - no target to run black can be set")
+endif()
 
-add_custom_target(
+find_program(FLAKE8_EXECUTABLE flake8)
+if(FLAKE8_EXECUTABLE)
+    add_custom_target(
         flake8
         COMMAND flake8
         --config=${CMAKE_CURRENT_SOURCE_DIR}/.flake8
         ${ALL_PYTHON_FILES}
-)
+    )
+else()
+    message(WARNING "Failed to find flake8 executable - no target to run flake8 can be set")
+endif()
+

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -1,0 +1,21 @@
+# Additional target to run python linters and formatters on python scripts
+#
+# Requires black/flake8 to be available in the environment
+
+
+# Get all our Python files (submodules are excluded!)
+file(GLOB_RECURSE ALL_PYTHON_FILES ${PROJECT_SOURCE_DIR}/*.py)
+
+# Black is rather simple because there are no options...
+add_custom_target(
+        black
+        COMMAND black
+        ${ALL_PYTHON_FILES}
+)
+
+add_custom_target(
+        flake8
+        COMMAND flake8
+        --config=${CMAKE_CURRENT_SOURCE_DIR}/.flake8
+        ${ALL_PYTHON_FILES}
+)

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -3,7 +3,7 @@
 # Requires black/flake8 to be available in the environment
 
 
-# Get all our Python files (submodules are excluded!)
+# Get all our Python files
 file(GLOB_RECURSE ALL_PYTHON_FILES ${PROJECT_SOURCE_DIR}/*.py)
 
 # Black is rather simple because there are no options...

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -4,7 +4,8 @@
 
 
 # Get all our Python files
-file(GLOB_RECURSE ALL_PYTHON_FILES ${PROJECT_SOURCE_DIR}/*.py)
+file(GLOB_RECURSE ALL_PYTHON_FILES ${PROJECT_SOURCE_DIR}/python/*.py)
+
 
 # Black is rather simple because there are no options...
 find_program(BLACK_EXECUTABLE black)
@@ -23,8 +24,9 @@ find_program(FLAKE8_EXECUTABLE flake8)
 if(FLAKE8_EXECUTABLE)
     add_custom_target(
         flake8
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMAND ${FLAKE8_EXECUTABLE}
-        --config=${CMAKE_CURRENT_SOURCE_DIR}/.flake8
+        --config=${PROJECT_SOURCE_DIR}/.flake8
         ${ALL_PYTHON_FILES}
     )
     set_target_properties(flake8 PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -11,7 +11,7 @@ find_program(BLACK_EXECUTABLE black)
 if(BLACK_EXECUTABLE)
     add_custom_target(
             black
-            COMMAND black
+            COMMAND ${BLACK_EXECUTABLE}
             ${ALL_PYTHON_FILES}
     )
     set_target_properties(black PROPERTIES EXCLUDE_FROM_ALL TRUE)
@@ -23,7 +23,7 @@ find_program(FLAKE8_EXECUTABLE flake8)
 if(FLAKE8_EXECUTABLE)
     add_custom_target(
         flake8
-        COMMAND flake8
+        COMMAND ${FLAKE8_EXECUTABLE}
         --config=${CMAKE_CURRENT_SOURCE_DIR}/.flake8
         ${ALL_PYTHON_FILES}
     )
@@ -31,4 +31,3 @@ if(FLAKE8_EXECUTABLE)
 else()
     message(STATUS "Failed to find flake8 executable - no target to run flake8 can be set")
 endif()
-

--- a/cmake/pythonFormat.cmake
+++ b/cmake/pythonFormat.cmake
@@ -14,8 +14,9 @@ if(BLACK_EXECUTABLE)
             COMMAND black
             ${ALL_PYTHON_FILES}
     )
+    set_target_properties(black PROPERTIES EXCLUDE_FROM_ALL TRUE)
 else()
-    message(WARNING "Failed to find black executable - no target to run black can be set")
+    message(STATUS "Failed to find black executable - no target to run black can be set")
 endif()
 
 find_program(FLAKE8_EXECUTABLE flake8)
@@ -26,7 +27,8 @@ if(FLAKE8_EXECUTABLE)
         --config=${CMAKE_CURRENT_SOURCE_DIR}/.flake8
         ${ALL_PYTHON_FILES}
     )
+    set_target_properties(flake8 PROPERTIES EXCLUDE_FROM_ALL TRUE)
 else()
-    message(WARNING "Failed to find flake8 executable - no target to run flake8 can be set")
+    message(STATUS "Failed to find flake8 executable - no target to run flake8 can be set")
 endif()
 


### PR DESCRIPTION
Add CMake targets for running  black and flake8 on Python source files

CMake will look to find the relevant binaries and setup the targets if they are there
If they are not found it's a warning (too severe?)
Note that current Key4hep nightlies don't have flake8 - if we use another linter that can be substituted

BEGINRELEASENOTES
Add CMake targets for running  black and flake8 on Python source files
ENDRELEASENOTES