### PR TITLE
Fix RNTuple writer after API break in ROOT

### DIFF
--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -15,6 +15,10 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RVersion.hxx>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
+  #include <ROOT/RNTupleReader.hxx>
+#endif
 
 namespace podio {
 

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -15,7 +15,7 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RVersion.hxx>
+#include <RVersion.h>
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
   #include <ROOT/RNTupleReader.hxx>
 #endif

--- a/include/podio/RNTupleWriter.h
+++ b/include/podio/RNTupleWriter.h
@@ -10,6 +10,10 @@
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RVersion.hxx>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
+  #include <ROOT/RNTupleWriter.hxx>
+#endif
 
 #include <string>
 #include <unordered_map>

--- a/include/podio/RNTupleWriter.h
+++ b/include/podio/RNTupleWriter.h
@@ -10,7 +10,7 @@
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RVersion.hxx>
+#include <RVersion.h>
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
   #include <ROOT/RNTupleWriter.hxx>
 #endif

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -8,7 +8,6 @@
 #include "rootUtils.h"
 
 #include <ROOT/RError.hxx>
-#include <ROOT/RVersion.hxx>
 
 #include <memory>
 

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -202,7 +202,7 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
     buffers.emplace(m_collectionInfo[category].name[i], std::move(collBuffers));
   }
 
-  m_readers[category][0]->LoadEntry(entNum);
+  m_readers[category][0]->LoadEntry(entNum, *dentry);
 
   auto parameters = readEventMetaData(category, entNum);
 

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -139,7 +139,11 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
 
   ROOTFrameData::BufferMap buffers;
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
-  auto dentry = m_readers[category][0]->GetModel().CreateBareEntry();
+  // We need to create a non-bare entry here, because the entries for the
+  // parameters are not explicitly (re)set and we need them default initialized.
+  // In principle we would only need a bare entry for the collection data, since
+  // we set all the fields there in any case.
+  auto dentry = m_readers[category][0]->GetModel().CreateEntry();
 #else
   auto dentry = m_readers[category][0]->GetModel()->GetDefaultEntry();
 #endif

--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -11,7 +11,6 @@
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RVersion.hxx>
 
 #include <algorithm>
 

--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -12,6 +12,7 @@
 #include <ROOT/RNTupleModel.hxx>
 
 #include <algorithm>
+#include <functional>
 
 namespace podio {
 
@@ -107,7 +108,10 @@ void RNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& cat
     }
   }
 
-  auto entry = m_categories[category].writer->GetModel()->CreateBareEntry();
+  // We use std::invoke here, because ROOT has slightly changed the semantics of
+  // this API in https://github.com/root-project/root/pull/14391
+  auto entry =
+      std::invoke(&ROOT::Experimental::RNTupleModel::CreateBareEntry, m_categories[category].writer->GetModel());
 
   ROOT::Experimental::RNTupleWriteOptions options;
   options.SetCompression(ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix the RNTupleWriter after ROOT has slightly changed the API for the RNTupleModel. Fixes #545 

ENDRELEASENOTES