### PR TITLE
Make it possible to use interface types in STL containers relying on comparisons

### DIFF
--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -201,7 +201,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
     def _preprocess_for_class(self, datatype):
         """Do the preprocessing that is necessary for the classes and Mutable classes"""
         includes = set(datatype["includes_data"])
-        fwd_declarations = {}
+        fwd_declarations = defaultdict(list)
         includes_cc = set()
 
         for member in datatype["Members"]:
@@ -212,10 +212,8 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
             if self._is_interface(relation.full_type):
                 relation.interface_types = self.datamodel.interfaces[relation.full_type]["Types"]
             if self._needs_include(relation.full_type):
-                if relation.namespace not in fwd_declarations:
-                    fwd_declarations[relation.namespace] = []
                 fwd_declarations[relation.namespace].append(relation.bare_type)
-                fwd_declarations[relation.namespace].append("Mutable" + relation.bare_type)
+                fwd_declarations[relation.namespace].append(f"Mutable{relation.bare_type}")
                 includes_cc.add(self._build_include(relation))
 
         if datatype["VectorMembers"] or datatype["OneToManyRelations"]:

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -65,7 +65,7 @@ class {{ class.bare_type }} {
 
     void unlink() final { m_value.unlink(); }
     bool isAvailable() const final { return m_value.isAvailable(); }
-    podio::ObjectID getObjectID() const { return m_value.getObjectID(); }
+    podio::ObjectID getObjectID() const final { return m_value.getObjectID(); }
 
     const std::type_info& typeInfo() const final { return typeid(ValueT); }
 

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -48,6 +48,7 @@ class {{ class.bare_type }} {
 {{ macros.member_getters_concept(Members, use_get_syntax) }}
     virtual const std::type_info& typeInfo() const = 0;
     virtual bool equal(const Concept* rhs) const = 0;
+    virtual const void* objAddress() const = 0;
   };
 
   template<typename ValueT>
@@ -74,6 +75,10 @@ class {{ class.bare_type }} {
         return m_value == static_cast<const Model<ValueT>*>(rhs)->m_value;
       }
       return false;
+    }
+
+    const void* objAddress() const final {
+      return m_value.m_obj.get();
     }
 
 {{ macros.member_getters_model(Members, use_get_syntax) }}
@@ -142,6 +147,10 @@ public:
 
   friend bool operator!=(const {{ class.bare_type }}& lhs, const {{ class.bare_type }}& rhs) {
     return !(lhs == rhs);
+  }
+
+  friend bool operator<(const {{ class.bare_type }}& lhs, const {{ class.bare_type }}& rhs) {
+    return lhs.m_self->objAddress() < rhs.m_self->objAddress();
   }
 
 {{ macros.member_getters(Members, use_get_syntax) }}

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -34,6 +34,9 @@ class {{ class.bare_type }} {
   friend class {{ class.bare_type }}Collection;
   friend class {{ class.full_type }}CollectionData;
   friend class {{ class.bare_type }}CollectionIterator;
+{% for interface in using_interface_types %}
+  friend class {{ interface }};
+{% endfor %}
 
 public:
   using mutable_type = Mutable{{ class.bare_type }};

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -7,6 +7,8 @@
 #include "datamodel/ExampleClusterCollection.h"
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/TypeWithEnergy.h"
+
+#include <map>
 #include <stdexcept>
 
 TEST_CASE("InterfaceTypes basic functionality", "[interface-types][basics]") {
@@ -43,6 +45,25 @@ TEST_CASE("InterfaceTypes basic functionality", "[interface-types][basics]") {
   hitColl.setID(42);
   wrapper1 = hitColl.create();
   REQUIRE(wrapper1.id() == podio::ObjectID{0, 42});
+}
+
+TEST_CASE("InterfaceTypes STL usage", "[interface-types][basics]") {
+  // Make sure that interface types can be used with STL map and set
+  std::map<TypeWithEnergy, int> counterMap{};
+
+  auto empty = TypeWithEnergy::makeEmpty();
+  counterMap[empty]++;
+
+  ExampleHit hit{};
+  auto wrapper = TypeWithEnergy{hit};
+  counterMap[wrapper]++;
+
+  // No way this implicit conversion could ever lead to a subtle bug ;)
+  counterMap[hit]++;
+
+  REQUIRE(counterMap[empty] == 1);
+  REQUIRE(counterMap[hit] == 2);
+  REQUIRE(counterMap[wrapper] == 2);
 }
 
 TEST_CASE("InterfaceType from immutable", "[interface-types][basics]") {


### PR DESCRIPTION

BEGINRELEASENOTES
- Introduce an `operator<` to the interface types to make it possible to use them in STL containers that require that (e.g. `std::map` and `std::set`).

ENDRELEASENOTES