### PR TITLE
Generate mutable reference getters for all members

### DIFF
--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -32,8 +32,11 @@
 {% if member.is_array %}
   void {{ member.setter_name(get_syntax) }}(size_t i, {{ member.array_type }} value);
 {% endif %}
-{% if not member.is_builtin %}
+  /// Get mutable reference to {{ member.docstring }}
+  {{ member.full_type }}& {{ member.getter_name(get_syntax) }}();
+{% if get_syntax %}
   /// Get reference to {{ member.docstring }}
+  [[deprecated("use {{ member.getter_name(get_syntax) }} instead")]]
   {{ member.full_type }}& {{ member.name }}();
 {% endif %}
 {% if member.sub_members %}

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -50,8 +50,9 @@ void {{ class_type }}::{{ member.setter_name(get_syntax) }}({{ member.full_type 
 {% if member.is_array %}
 void {{ class_type }}::{{ member.setter_name(get_syntax) }}(size_t i, {{ member.array_type }} value) { m_obj->data.{{ member.name }}.at(i) = value; }
 {% endif %}
-{% if not member.is_builtin %}
-{{ member.full_type }}& {{ class_type }}::{{ member.name }}() { return m_obj->data.{{ member.name }}; }
+{{ member.full_type }}& {{ class_type }}::{{ member.getter_name(get_syntax) }}() { return m_obj->data.{{ member.name }}; }
+{% if get_syntax %}
+{{ member.full_type }}& {{ class_type }}::{{ member.name }}() {  return m_obj->data.{{ member.name }}; }
 {% endif %}
 {% if member.sub_members %}
 {% for sub_member in member.sub_members %}

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -44,6 +44,8 @@
 #include "datamodel/ExampleWithOneRelationCollection.h"
 #include "datamodel/ExampleWithUserInitCollection.h"
 #include "datamodel/ExampleWithVectorMemberCollection.h"
+#include "datamodel/MutableExampleCluster.h"
+#include "datamodel/MutableExampleWithArray.h"
 #include "datamodel/MutableExampleWithComponent.h"
 #include "podio/UserDataCollection.h"
 
@@ -356,7 +358,7 @@ TEST_CASE("Arrays") {
 }
 */
 
-TEST_CASE("member getter return types", "[basics][code-gen]") {
+TEST_CASE("member getter return types", "[basics][code-gen][const-correctness]") {
   // Check that the return types of the getter functions are as expected
   // Builtin member types are returned by value, including fixed width integers
   STATIC_REQUIRE(std::is_same_v<decltype(std::declval<ExampleHit>().energy()), double>);
@@ -372,6 +374,13 @@ TEST_CASE("member getter return types", "[basics][code-gen]") {
   STATIC_REQUIRE(std::is_same_v<decltype(std::declval<ExampleWithArrayComponent>().x()), int>);
   STATIC_REQUIRE(std::is_same_v<decltype(std::declval<ExampleWithArrayComponent>().p()), const std::array<int, 4>&>);
   STATIC_REQUIRE(std::is_same_v<decltype(std::declval<ExampleWithArray>().data()), const SimpleStruct&>);
+
+  // Mutable types also give access to mutable references
+  STATIC_REQUIRE(std::is_same_v<decltype(std::declval<MutableExampleCluster>().energy()), double&>);
+  STATIC_REQUIRE(std::is_same_v<decltype(std::declval<MutableExampleWithArray>().data()), SimpleStruct&>);
+  // However if they are const the usual rules apply
+  STATIC_REQUIRE(std::is_same_v<decltype(std::declval<const MutableExampleCluster>().energy()), double>);
+  STATIC_REQUIRE(std::is_same_v<decltype(std::declval<const MutableExampleWithArray>().data()), const SimpleStruct&>);
 }
 
 TEST_CASE("Extracode", "[basics][code-gen]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Generate mutable reference getters for all members on the `Mutable` types
  - Previously this was only generated for non-builtin (i.e. non-trivial) members. 
  - Additionally, deprecate the API that does not respect the `getSyntax` option.
  - Fixes https://github.com/AIDASoft/podio/issues/551

ENDRELEASENOTES

- [x] tests

@paulgessinger this should be more or less what we discussed today. A minor drawback that I just realized is that for the `const` versions of these getters we return by value for builtin types rather than by `const&` (mainly premature optimization I would say). In any case, it shouldn't really matter for you, and I think I am OK with that small inconsistency. 