### PR TITLE
Change FCC stack to Key4hep in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## Prerequisites
 
 If you are on lxplus, all the necessary software is preinstalled if you
-use a recent LCG or FCC stack release.
+use a recent LCG or Key4hep stack release.
 
 On Mac OS or Ubuntu, you need to install the following software.
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Change FCC stack to Key4hep in the README

ENDRELEASENOTES

Let's try to be more precise to reduce the amount of people that are confused with "FCC
software"