### PR TITLE
Add a schema_version for the extension datamodel

### DIFF
--- a/tests/datalayout_extension.yaml
+++ b/tests/datalayout_extension.yaml
@@ -1,4 +1,5 @@
 ---
+schema_version: 1
 options:
   getSyntax: True
   exposePODMembers: False


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a schema_version for the extension datamodel, this fixes a warning at configure time

ENDRELEASENOTES

``` python
/podio/python/podio_gen/generator_base.py:119: FutureWarning: Please provide a schema_version entry. It will become mandatory. Setting it to 1 as default
  self.datamodel = PodioConfigReader.read(yamlfile, package_name, upstream_edm)
```

When going through the paths in the errors this is the first one when configuring which is annoying