### PR TITLE
Remove deprecated Frame functionality for v1.0

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -259,14 +259,6 @@ public:
 
   // Interfaces for writing below
   // TODO: Hide this from the public interface somehow?
-
-  /**
-   * Get the GenericParameters for writing
-   */
-  [[deprecated("use getParameters instead")]] const podio::GenericParameters& getGenericParametersForWrite() const {
-    return m_self->parameters();
-  }
-
   /**
    * Get a collection for writing (in a prepared and "ready-to-write" state)
    */

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Module for the python bindings of the podio::Frame"""
 
-import warnings
 import cppyy
 
 import ROOT

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -119,20 +119,6 @@ class Frame:
         """
         return tuple(str(s) for s in self._frame.getAvailableCollections())
 
-    @property
-    def collections(self):
-        """Get the currently available collection (names) from this Frame.
-
-        Returns:
-            tuple(str): The names of the available collections from this Frame.
-        """
-        warnings.warn(
-            "WARNING: collections is deprecated, use getAvailableCollections()"
-            " (like in C++) instead",
-            FutureWarning,
-        )
-        return self.getAvailableCollections()
-
     def get(self, name):
         """Get a collection from the Frame by name.
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove deprecated `collections` property from Frame python bindings
- Remove deprecated `getParametersForWrite` method from Frame interface

ENDRELEASENOTES