### PR TITLE
Improve error messages when opening a bad file

### DIFF
--- a/src/ROOTLegacyReader.cc
+++ b/src/ROOTLegacyReader.cc
@@ -113,7 +113,7 @@ void ROOTLegacyReader::openFiles(const std::vector<std::string>& filenames) {
     //-1 forces the headers to be read so that
     // the validity of the files can be checked
     if (!m_chain->Add(filename.c_str(), -1)) {
-      throw std::runtime_error("File " + filename + " couldn't be found");
+      throw std::runtime_error("File " + filename + " couldn't be found or the \"events\" tree couldn't be read.");
     }
   }
 

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -201,7 +201,8 @@ void ROOTReader::openFiles(const std::vector<std::string>& filenames) {
   // Reading all files is done to check that all file exists
   for (const auto& filename : filenames) {
     if (!m_metaChain->Add(filename.c_str(), -1)) {
-      throw std::runtime_error("File " + filename + " couldn't be found");
+      throw std::runtime_error("File " + filename + " couldn't be found or the \"" + root_utils::metaTreeName +
+                               "\" tree couldn't be read.");
     }
   }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve error messages when opening a bad file; instead of saying that the file couldn't be found say also that the tree that podio looks for couldn't be read

ENDRELEASENOTES

A bit more precise since the current error messages will always say that the file couldn't be found when it's possible that the file exists but it's a bad file.