### PR TITLE
feat: podio-vis --upstream-edm and some tests

### DIFF
--- a/python/podio/__init__.py
+++ b/python/podio/__init__.py
@@ -1,4 +1,5 @@
 """Python module for the podio EDM toolkit and its utilities"""
+
 from .__version__ import __version__
 
 # Try to load podio, this is equivalent to trying to load libpodio.so and will

--- a/python/podio_gen/generator_base.py
+++ b/python/podio_gen/generator_base.py
@@ -247,7 +247,7 @@ class ClassGeneratorBaseMixin:
         if not self.dryrun:
             self.generated_files.append(fullname)
             if self.formatter_func is not None:
-                content = self.formatter_func(content, fullname)
+                content = self.formatter_func(content, fullname)  # pylint: disable=not-callable
 
             changed = write_file_if_changed(fullname, content)
             self.any_changes = changed or self.any_changes

--- a/python/podio_gen/podio_config_reader.py
+++ b/python/podio_gen/podio_config_reader.py
@@ -1,6 +1,5 @@
 """Datamodel yaml configuration file reading and validation utilities."""
 
-
 import copy
 import re
 import yaml

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,6 +4,36 @@ if(ENABLE_RNTUPLE)
   install(PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/podio-ttree-to-rntuple DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
+# Add a very basic test of podio-vis
+if(BUILD_TESTING)
+  # Helper function for easily creating "tests" that simply execute podio-vis
+  # with different arguments. Not crashing is considered success.
+  #
+  # Args:
+  #     name        the name of the test
+  #     depends_on  the target name of the test that produces the required input file
+  function(CREATE_VIS_TEST name depends_on)
+    add_test(NAME ${name} COMMAND ./podio-vis ${ARGN})
+    PODIO_SET_TEST_ENV(${name})
+
+    set_tests_properties(${name} PROPERTIES
+       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+       )
+    if (depends_on)
+      set_tests_properties(${name} PROPERTIES
+        DEPENDS ${depends_on}
+        )
+    endif()
+  endfunction()
+
+  CREATE_VIS_TEST(podio-vis-help _dummy_target_
+    --help)
+  CREATE_VIS_TEST(podio-vis-datamodel datamodel
+    --dot ${PROJECT_SOURCE_DIR}/tests/datalayout.yaml)
+  CREATE_VIS_TEST(podio-vis-datamodel-extension extension_model
+    --dot --upstream-edm datamodel:${PROJECT_SOURCE_DIR}/tests/datalayout.yaml ${PROJECT_SOURCE_DIR}/tests/datalayout_extension.yaml)
+endif()
+
 # Add a very basic tests here to make sure that podio-dump at least runs
 if(BUILD_TESTING)
   # Helper function for easily creating "tests" that simply execute podio-dump

--- a/tools/podio-vis
+++ b/tools/podio-vis
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 """Tool to transform data model descriptions in YAML to a graph that can be visualized"""
 
-import os
 import sys
 import argparse
 import yaml
 from podio_class_generator import read_upstream_edm
-from podio_gen.generator_utils import DefinitionError
 from podio_gen.podio_config_reader import PodioConfigReader
 
 try:

--- a/tools/podio-vis
+++ b/tools/podio-vis
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tool to transform data model descriptions in YAML to a graph that can be visualized"""
 
+import os
 import sys
 import argparse
 import yaml
@@ -12,14 +13,33 @@ except ImportError:
     print("graphviz is not installed. please run pip install graphviz")
     sys.exit(1)
 
+def read_upstream_edm(name_path):
+    """Read an upstream EDM yaml definition file to make the types that are defined
+    in that available to the current EDM"""
+    if name_path is None:
+        return None
+
+    try:
+        name, path = name_path.split(':')
+    except ValueError as err:
+        raise argparse.ArgumentTypeError('upstream-edm argument needs to be the upstream package '
+                                         'name and the upstream edm yaml file separated by a colon') from err
+
+    if not os.path.isfile(path):
+        raise argparse.ArgumentTypeError(f'{path} needs to be an EDM yaml file')
+
+    try:
+        return PodioConfigReader.read(path, name)
+    except DefinitionError as err:
+        raise argparse.ArgumentTypeError(f'{path} does not contain a valid datamodel definition') from err
 
 class ModelToGraphviz:
     """Class to transform a data model description into a graphical representation"""
 
-    def __init__(self, yamlfile, dot, fmt, filename, graph_conf):
+    def __init__(self, yamlfile, name, dot, fmt, filename, graph_conf, upstream_edm=None):
         self.yamlfile = yamlfile
         self.use_dot = dot
-        self.datamodel = PodioConfigReader.read(yamlfile, "podio")
+        self.datamodel = PodioConfigReader.read(yamlfile, name, upstream_edm)
         self.graph = Digraph(node_attr={"shape": "box"})
         self.graph.attr(rankdir="RL", size="8,5")
         self.fmt = fmt
@@ -105,6 +125,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("description", help="yaml file describing the datamodel")
+    parser.add_argument("-n", "--name", default="edm4hep", help="datamodel name")
     parser.add_argument(
         "-d",
         "--dot",
@@ -115,14 +136,19 @@ if __name__ == "__main__":
     parser.add_argument("--fmt", default="svg", help="Which format to use for saving the file")
     parser.add_argument("--filename", default="gv", help="Which filename to use for the output")
     parser.add_argument("--graph-conf", help="Configuration file for defining groups")
+    parser.add_argument("--upstream-edm", default=None, type=read_upstream_edm,
+                        help="Make datatypes of this upstream EDM available to the current"
+                        " EDM. Format is '<upstream-name>:<upstream.yaml>'. ")
 
     args = parser.parse_args()
 
     vis = ModelToGraphviz(
         args.description,
+        args.name,
         args.dot,
         fmt=args.fmt,
         filename=args.filename,
         graph_conf=args.graph_conf,
+        upstream_edm=args.upstream_edm,
     )
     vis.make_viz()

--- a/tools/podio-vis
+++ b/tools/podio-vis
@@ -5,6 +5,7 @@ import os
 import sys
 import argparse
 import yaml
+from podio_class_generator import read_upstream_edm
 from podio_gen.generator_utils import DefinitionError
 from podio_gen.podio_config_reader import PodioConfigReader
 
@@ -13,31 +14,6 @@ try:
 except ImportError:
     print("graphviz is not installed. please run pip install graphviz")
     sys.exit(1)
-
-
-def read_upstream_edm(name_path):
-    """Read an upstream EDM yaml definition file to make the types that are defined
-    in that available to the current EDM"""
-    if name_path is None:
-        return None
-
-    try:
-        name, path = name_path.split(":")
-    except ValueError as err:
-        raise argparse.ArgumentTypeError(
-            "upstream-edm argument needs to be the upstream package "
-            "name and the upstream edm yaml file separated by a colon"
-        ) from err
-
-    if not os.path.isfile(path):
-        raise argparse.ArgumentTypeError(f"{path} needs to be an EDM yaml file")
-
-    try:
-        return PodioConfigReader.read(path, name)
-    except DefinitionError as err:
-        raise argparse.ArgumentTypeError(
-            f"{path} does not contain a valid datamodel definition"
-        ) from err
 
 
 class ModelToGraphviz:

--- a/tools/podio-vis
+++ b/tools/podio-vis
@@ -5,6 +5,7 @@ import os
 import sys
 import argparse
 import yaml
+from podio_gen.generator_utils import DefinitionError
 from podio_gen.podio_config_reader import PodioConfigReader
 
 try:
@@ -13,6 +14,7 @@ except ImportError:
     print("graphviz is not installed. please run pip install graphviz")
     sys.exit(1)
 
+
 def read_upstream_edm(name_path):
     """Read an upstream EDM yaml definition file to make the types that are defined
     in that available to the current EDM"""
@@ -20,18 +22,23 @@ def read_upstream_edm(name_path):
         return None
 
     try:
-        name, path = name_path.split(':')
+        name, path = name_path.split(":")
     except ValueError as err:
-        raise argparse.ArgumentTypeError('upstream-edm argument needs to be the upstream package '
-                                         'name and the upstream edm yaml file separated by a colon') from err
+        raise argparse.ArgumentTypeError(
+            "upstream-edm argument needs to be the upstream package "
+            "name and the upstream edm yaml file separated by a colon"
+        ) from err
 
     if not os.path.isfile(path):
-        raise argparse.ArgumentTypeError(f'{path} needs to be an EDM yaml file')
+        raise argparse.ArgumentTypeError(f"{path} needs to be an EDM yaml file")
 
     try:
         return PodioConfigReader.read(path, name)
     except DefinitionError as err:
-        raise argparse.ArgumentTypeError(f'{path} does not contain a valid datamodel definition') from err
+        raise argparse.ArgumentTypeError(
+            f"{path} does not contain a valid datamodel definition"
+        ) from err
+
 
 class ModelToGraphviz:
     """Class to transform a data model description into a graphical representation"""
@@ -136,9 +143,13 @@ if __name__ == "__main__":
     parser.add_argument("--fmt", default="svg", help="Which format to use for saving the file")
     parser.add_argument("--filename", default="gv", help="Which filename to use for the output")
     parser.add_argument("--graph-conf", help="Configuration file for defining groups")
-    parser.add_argument("--upstream-edm", default=None, type=read_upstream_edm,
-                        help="Make datatypes of this upstream EDM available to the current"
-                        " EDM. Format is '<upstream-name>:<upstream.yaml>'. ")
+    parser.add_argument(
+        "--upstream-edm",
+        default=None,
+        type=read_upstream_edm,
+        help="Make datatypes of this upstream EDM available to the current"
+        " EDM. Format is '<upstream-name>:<upstream.yaml>'. ",
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This adds some basic support for extension data models into podio-vis.

Also adds three tests for podio-vis to make sure it doesn't fail. May require graphviz python to be installed in the CI environment.

BEGINRELEASENOTES
- support podio-vis for extension data models

ENDRELEASENOTES