### PR TITLE
fix: upgrade github-action-cvmfs@v3 to github-action-cvmfs@v4

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'AIDASoft/podio'
     steps:
     - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         coverity-cmake-command: 'cmake -DCMAKE_CXX_STANDARD=17  -DENABLE_SIO=ON -DENABLE_JULIA=ON -DUSE_EXTERNAL_CATCH2=OFF ..'

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -29,7 +29,7 @@ jobs:
           repository: catchorg/Catch2
           path: catch2
           ref: v3.4.0
-      - uses: cvmfs-contrib/github-action-cvmfs@v3
+      - uses: cvmfs-contrib/github-action-cvmfs@v4
       - uses: aidasoft/run-lcg-view@v4
         with:
           release-platform: ${{ matrix.LCG }}

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -18,7 +18,7 @@ jobs:
             RNTUPLE: ON
     steps:
     - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         container: centos7

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         container: centos7

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         container: el9

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -29,7 +29,7 @@ jobs:
         #     sanitizer: MemoryWithOrigin
     steps:
       - uses: actions/checkout@v3
-      - uses: cvmfs-contrib/github-action-cvmfs@v3
+      - uses: cvmfs-contrib/github-action-cvmfs@v4
       - uses: aidasoft/run-lcg-view@v4
         with:
           release-platform: LCG_102/x86_64-centos7-${{ matrix.compiler }}-opt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
             CXX_STANDARD: 17
     steps:
     - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         release-platform: ${{ matrix.LCG }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
               "dev4/x86_64-ubuntu2004-gcc9-opt"]
     steps:
     - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
         release-platform: ${{ matrix.LCG }}


### PR DESCRIPTION
Avoid some CI warnings about node-16 in actions/cache@v3 by upgrading github-action-cvmfs@v3 to github-action-cvmfs@v4.

BEGINRELEASENOTES
- upgrade github-action-cvmfs@v3 to github-action-cvmfs@v4

ENDRELEASENOTES