### PR TITLE
Switch to more recent OS and compilers for sanitizer workflows

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc11, clang12]
+        compiler: [gcc13, clang16]
         # Since Leak is usually part of Address, we do not run it separately in
         # CI. Keeping Address and Undefined separate for easier debugging
         sanitizer: [Thread,
@@ -32,7 +32,7 @@ jobs:
       - uses: cvmfs-contrib/github-action-cvmfs@v4
       - uses: aidasoft/run-lcg-view@v4
         with:
-          release-platform: LCG_102/x86_64-centos7-${{ matrix.compiler }}-opt
+          release-platform: LCG_105/x86_64-el9-${{ matrix.compiler }}-opt
           run: |
             echo "::group::Run CMake"
             mkdir build

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -39,7 +39,7 @@ jobs:
             cd build
             cmake -DCMAKE_BUILD_TYPE=Debug \
               -DUSE_SANITIZER=${{ matrix.sanitizer }} \
-              -DCMAKE_CXX_STANDARD=17 \
+              -DCMAKE_CXX_STANDARD=20 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
               -DUSE_EXTERNAL_CATCH2=OFF \
               -DENABLE_SIO=ON \


### PR DESCRIPTION

BEGINRELEASENOTES
- Switch to gcc13 and clang16 for sanitizer workflows. Also switch to EL9 as OS to run on.

ENDRELEASENOTES