### PR TITLE
Add pythonizations for collection subscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
  - [Data Model Syntax](./doc/datamodel_syntax.md)
  - [Examples](./doc/examples.md)
  - [Advanced Topics](./doc/advanced_topics.md)
+ - [Python Interface](./doc/python.md)
  - [Contributing](./doc/contributing.md)
 
 <!-- Browse the API documentation created with Doxygen at -->

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,5 +17,6 @@ Welcome to PODIO's documentation!
    userdata.md
    advanced_topics.md
    templates.md
+   python.md
    cpp_api/api
    py_api/modules

--- a/doc/python.md
+++ b/doc/python.md
@@ -1,0 +1,56 @@
+# Python interface for data models
+
+Podio provides support for a Python interface for the generated data models. The [design choice](design.md) to create Python interface resembling the C++ interface is achieved by generating Python bindings from the C++ interface using
+[cppyy](https://cppyy.readthedocs.io/en/latest/index.html).
+
+It's important to note that cppyy loads the bindings and presents them lazily at runtime to the Python interpreter, rather than writing Python interface files. Consequently, the Python bindings have a runtime dependency on both cppyy and the data model's C++ interface.
+
+To load the Python bindings from a generated C++ model dictionary, first make sure the model's library and headers can be found in `LD_LIBRARY_PATH` and `ROOT_INCLUDE_HEADERS` respectively, then:
+
+```python
+import ROOT
+
+res = ROOT.gSystem.Load('libGeneratedModelDict.so')
+if res < 0:
+    raise RuntimeError('Failed to load libGeneratedModelDict.so')
+```
+
+For reference usage, see [Python module of EDM4HEP](https://github.com/key4hep/EDM4hep/blob/main/python/edm4hep/__init__.py) data model.
+
+## Pythonizations
+
+Python as a language uses different constructions and conventions than C++, perfectly fine C++ code translated one to one to Python could be clunky by Python's standard. cppyy offers a mechanism called [pythonizations](https://cppyy.readthedocs.io/en/latest/pythonizations.html) to make the resulting bindings more pythonic. Some basic pythonizations are included automatically (for instance `operator[]` is translated to `__getitem__`) but others can be specified by a user.
+
+Podio comes with its own set pythonizations useful for the data models generated with it. To apply all the provided pythonizations to a `model_namespace` namespace:
+
+```python
+from podio.pythonizations import load_pythonizations
+
+load_pythonizations("model_namespace")
+```
+
+If only specific pythonizations should be applied:
+
+```python
+from  podio.pythonizations import collection_subscript # specific pythonization
+
+collection_subscript.CollectionSubscriptPythonizer.register("model_namespace")
+```
+
+### Developing new pythonizations
+
+To be discovered by `load_pythonizations`, any new pythonization should be placed in `podio.pythonizations` and be derived from the abstract class `podio.pythonizations.utils.pythonizer.Pythonizer`.
+
+A pythonization class should implement the following three class methods:
+
+- `priority`: The `load_pythonizations` function applies the pythonizations in increasing order of their `priority`
+- `filter`: A predicate to filter out classes to which given pythonization should be applied. See the [cppyy documentation](https://cppyy.readthedocs.io/en/latest/pythonizations.html#python-callbacks).
+- `modify`: Applying the modifications to the pythonized classes.
+
+### Considerations
+
+The cppyy pythonizations come with some considerations:
+
+- The general cppyy idea to lazily load only things that are needed applies only partially to the pythonizations. For instance, a pythonization modifying the `collection[]` will be applied the first time a class of `collection` is used, regardless if `collection[]` is actually used.
+- Each pythonization is applied to all the entities in a namespace and relies on a conditional mechanism (`filter` method) inside the pythonizations to select entities they modify. With a large number of pythonizations, the overheads will add up and slow down the usage of any class from a pythonized namespace.
+- The cppyy bindings hooking to the C++ routines are characterized by high performance compared to ordinary Python code. The pythonizations are written in Python and are executed at ordinary Python code speed.

--- a/doc/python.md
+++ b/doc/python.md
@@ -1,9 +1,9 @@
 # Python interface for data models
 
 Podio provides support for a Python interface for the generated data models. The [design choice](design.md) to create Python interface resembling the C++ interface is achieved by generating Python bindings from the C++ interface using
-[cppyy](https://cppyy.readthedocs.io/en/latest/index.html).
+[cppyy](https://cppyy.readthedocs.io/en/latest/index.html). To make pyROOT aware of the bindings, the cppyy functionality bundled with ROOT can be used.
 
-It's important to note that cppyy loads the bindings and presents them lazily at runtime to the Python interpreter, rather than writing Python interface files. Consequently, the Python bindings have a runtime dependency on both cppyy and the data model's C++ interface.
+It's important to note that cppyy loads the bindings and presents them lazily at runtime to the Python interpreter, rather than writing Python interface files. Consequently, the Python bindings have a runtime dependencies on ROOT, cppyy and the data model's C++ interface.
 
 To load the Python bindings from a generated C++ model dictionary, first make sure the model's library and headers can be found in `LD_LIBRARY_PATH` and `ROOT_INCLUDE_HEADERS` respectively, then:
 
@@ -15,13 +15,13 @@ if res < 0:
     raise RuntimeError('Failed to load libGeneratedModelDict.so')
 ```
 
-For reference usage, see [Python module of EDM4HEP](https://github.com/key4hep/EDM4hep/blob/main/python/edm4hep/__init__.py) data model.
+For reference usage, see the [Python module of EDM4hep](https://github.com/key4hep/EDM4hep/blob/main/python/edm4hep/__init__.py).
 
 ## Pythonizations
 
 Python as a language uses different constructions and conventions than C++, perfectly fine C++ code translated one to one to Python could be clunky by Python's standard. cppyy offers a mechanism called [pythonizations](https://cppyy.readthedocs.io/en/latest/pythonizations.html) to make the resulting bindings more pythonic. Some basic pythonizations are included automatically (for instance `operator[]` is translated to `__getitem__`) but others can be specified by a user.
 
-Podio comes with its own set pythonizations useful for the data models generated with it. To apply all the provided pythonizations to a `model_namespace` namespace:
+Podio comes with its own set of pythonizations useful for the data models generated with it. To apply all the provided pythonizations to a `model_namespace` namespace:
 
 ```python
 from podio.pythonizations import load_pythonizations

--- a/python/podio/pythonizations/__init__.py
+++ b/python/podio/pythonizations/__init__.py
@@ -1,0 +1,16 @@
+"""cppyy pythonizations for podio"""
+
+from importlib import import_module
+from pkgutil import walk_packages
+from .utils.pythonizer import Pythonizer
+
+
+def load_pythonizations(namespace):
+    """Register all available pythonizations for a given namespace"""
+    module_names = [name for _, name, _ in walk_packages(__path__)]
+    module_names = filter(lambda x: not x.startswith("test_"), module_names)
+    for module_name in module_names:
+        import_module(__name__ + "." + module_name)
+    pythonizers = sorted(Pythonizer.__subclasses__(), key=lambda x: x.priority())
+    for i in pythonizers:
+        i.register(namespace)

--- a/python/podio/pythonizations/__init__.py
+++ b/python/podio/pythonizations/__init__.py
@@ -7,8 +7,7 @@ from .utils.pythonizer import Pythonizer
 
 def load_pythonizations(namespace):
     """Register all available pythonizations for a given namespace"""
-    module_names = [name for _, name, _ in walk_packages(__path__)]
-    module_names = filter(lambda x: not x.startswith("test_"), module_names)
+    module_names = [name for _, name, _ in walk_packages(__path__) if not name.startswith("test_")]
     for module_name in module_names:
         import_module(__name__ + "." + module_name)
     pythonizers = sorted(Pythonizer.__subclasses__(), key=lambda x: x.priority())

--- a/python/podio/pythonizations/collection_subscript.py
+++ b/python/podio/pythonizations/collection_subscript.py
@@ -1,0 +1,27 @@
+"""Pythonize subscript operation for collections"""
+
+import cppyy
+from .utils.pythonizer import Pythonizer
+
+
+class CollectionSubscriptPythonizer(Pythonizer):
+    """Bound-check __getitem__ for classes derived from podio::CollectionBase"""
+
+    @classmethod
+    def priority(cls):
+        return 50
+
+    @classmethod
+    def callback(cls, class_, name):
+        def get_item(self, i):
+            if i >= len(self):
+                raise IndexError("collection index out of range")
+            return getitem_raw(self, i)
+
+        if (
+            issubclass(class_, cppyy.gbl.podio.CollectionBase)
+            and hasattr(class_, "__getitem__")
+            and hasattr(class_, "__len__")
+        ):
+            getitem_raw = class_.__getitem__
+            class_.__getitem__ = get_item

--- a/python/podio/pythonizations/collection_subscript.py
+++ b/python/podio/pythonizations/collection_subscript.py
@@ -16,8 +16,8 @@ class CollectionSubscriptPythonizer(Pythonizer):
         def get_item(self, i):
             try:
                 return self.at(i)
-            except cppyy.gbl.std.out_of_range as exc:
-                raise IndexError("collection index out of range") from exc
+            except cppyy.gbl.std.out_of_range:
+                raise IndexError("collection index out of range") from None
 
         if issubclass(class_, cppyy.gbl.podio.CollectionBase) and hasattr(class_, "at"):
             class_.__getitem__ = get_item

--- a/python/podio/pythonizations/collection_subscript.py
+++ b/python/podio/pythonizations/collection_subscript.py
@@ -12,12 +12,15 @@ class CollectionSubscriptPythonizer(Pythonizer):
         return 50
 
     @classmethod
-    def callback(cls, class_, name):
+    def filter(cls, class_, name):
+        return issubclass(class_, cppyy.gbl.podio.CollectionBase)
+
+    @classmethod
+    def modify(cls, class_, name):
         def get_item(self, i):
             try:
                 return self.at(i)
             except cppyy.gbl.std.out_of_range:
                 raise IndexError("collection index out of range") from None
 
-        if issubclass(class_, cppyy.gbl.podio.CollectionBase):
-            class_.__getitem__ = get_item
+        class_.__getitem__ = get_item

--- a/python/podio/pythonizations/collection_subscript.py
+++ b/python/podio/pythonizations/collection_subscript.py
@@ -14,14 +14,10 @@ class CollectionSubscriptPythonizer(Pythonizer):
     @classmethod
     def callback(cls, class_, name):
         def get_item(self, i):
-            if i >= len(self):
-                raise IndexError("collection index out of range")
-            return getitem_raw(self, i)
+            try:
+                return self.at(i)
+            except cppyy.gbl.std.out_of_range as exc:
+                raise IndexError("collection index out of range") from exc
 
-        if (
-            issubclass(class_, cppyy.gbl.podio.CollectionBase)
-            and hasattr(class_, "__getitem__")
-            and hasattr(class_, "__len__")
-        ):
-            getitem_raw = class_.__getitem__
+        if issubclass(class_, cppyy.gbl.podio.CollectionBase) and hasattr(class_, "at"):
             class_.__getitem__ = get_item

--- a/python/podio/pythonizations/collection_subscript.py
+++ b/python/podio/pythonizations/collection_subscript.py
@@ -19,5 +19,5 @@ class CollectionSubscriptPythonizer(Pythonizer):
             except cppyy.gbl.std.out_of_range:
                 raise IndexError("collection index out of range") from None
 
-        if issubclass(class_, cppyy.gbl.podio.CollectionBase) and hasattr(class_, "at"):
+        if issubclass(class_, cppyy.gbl.podio.CollectionBase):
             class_.__getitem__ = get_item

--- a/python/podio/pythonizations/utils/pythonizer.py
+++ b/python/podio/pythonizations/utils/pythonizer.py
@@ -12,14 +12,46 @@ class Pythonizer(metaclass=ABCMeta):
     @classmethod
     @abstractmethod
     def priority(cls):
-        """Order in which the pythonizations are applied"""
+        """Order in which the pythonizations are applied
+
+        Returns:
+            int: Priority
+        """
 
     @classmethod
     @abstractmethod
-    def callback(cls, class_, name):
-        """Pythonization callback"""
+    def filter(cls, class_, name):
+        """
+        Abstract classmethod to filter classes to which the pythonizations should be applied
+
+        Args:
+            class_ (type): Class object.
+            name (str): Name of the class.
+
+        Returns:
+            bool: True if class should be pythonized.
+        """
+
+    @classmethod
+    @abstractmethod
+    def modify(cls, class_, name):
+        """Abstract classmethod modifying classes to be pythonized
+
+        Args:
+            class_ (type): Class object.
+            name (str): Name of the class.
+        """
 
     @classmethod
     def register(cls, namespace):
-        """Helper method to apply the pythonization to the given namespace"""
-        cppyy.py.add_pythonization(cls.callback, namespace)
+        """Helper method to apply the pythonization to the given namespace
+
+        Args:
+            namespace (str): Namespace to by pythonized
+        """
+
+        def pythonization_callback(class_, name):
+            if cls.filter(class_, name):
+                cls.modify(class_, name)
+
+        cppyy.py.add_pythonization(pythonization_callback, namespace)

--- a/python/podio/pythonizations/utils/pythonizer.py
+++ b/python/podio/pythonizations/utils/pythonizer.py
@@ -1,0 +1,25 @@
+"""cppyy pythonizations for podio"""
+
+from abc import ABCMeta, abstractmethod
+import cppyy
+
+
+class Pythonizer(metaclass=ABCMeta):
+    """
+    Base class to define cppyy pythonization for podio
+    """
+
+    @classmethod
+    @abstractmethod
+    def priority(cls):
+        """Order in which the pythonizations are applied"""
+
+    @classmethod
+    @abstractmethod
+    def callback(cls, class_, name):
+        """Pythonization callback"""
+
+    @classmethod
+    def register(cls, namespace):
+        """Helper method to apply the pythonization to the given namespace"""
+        cppyy.py.add_pythonization(cls.callback, namespace)

--- a/python/podio/test_CodeGen.py
+++ b/python/podio/test_CodeGen.py
@@ -4,6 +4,12 @@
 import unittest
 import ROOT
 from ROOT import ExampleMCCollection, MutableExampleMC
+from ROOT import nsp
+from pythonizations import load_pythonizations  # pylint: disable=import-error
+
+# load all available pythonizations to the classes in a namespace
+# loading pythonizations changes the state of cppyy backend shared by all the tests in a process
+load_pythonizations("nsp")
 
 
 class ObjectConversionsTest(unittest.TestCase):
@@ -31,3 +37,6 @@ class OneToManyRelationsTest(unittest.TestCase):
         self.assertEqual(len(daughter_particle.parents()), 0)
         daughter_particle.addparents(parent_particle)
         self.assertEqual(len(daughter_particle.parents()), 1)
+
+
+

--- a/python/podio/test_CodeGen.py
+++ b/python/podio/test_CodeGen.py
@@ -39,4 +39,13 @@ class OneToManyRelationsTest(unittest.TestCase):
         self.assertEqual(len(daughter_particle.parents()), 1)
 
 
+class CollectionSubscriptTest(unittest.TestCase):
+    """Collection subscript test"""
 
+    def test_bound_check(self):
+        collection = nsp.EnergyInNamespaceCollection()
+        _ = collection.create()
+        self.assertEqual(len(collection), 1)
+        with self.assertRaises(IndexError):
+            _ = collection[20]
+        _ = collection[0]


### PR DESCRIPTION

BEGINRELEASENOTES
- Added mechanism to load cppyy pythonizations
- Added pythonization for bound-check subscript operation in collections

ENDRELEASENOTES

#458 and key4hep/EDM4hep#288 show there is some interest in tuning the cppyy generated bindings. The cppyy  has a feature for this called [pythonization](https://cppyy.readthedocs.io/en/latest/pythonizations.html) -> a callback can be registered for all the classes that fulfill some predicate (e.g. derived from `podio::CollectionBase`).

This PR contains:
- an abstraction for adding pythonizations (each pythonization implemented in a class derived from `podio.pythonizations.utils.Pythonizer`)
-  pythonization adding bound check `__getitem__` for classes derived from `podio::CollectionBase`

The mechanism of loading the pythonizations is inspired by [ROOT pythonizations](https://github.com/root-project/root/blob/master/bindings/pyroot/pythonizations/python/ROOT/_pythonization/__init__.py) with a change that de order of loading of the pythonizations is defined.

To load the pythonizations in a downstream projects, for instance for project utilizing a "edm4hep" namespace
```python
from podio.pythonizations import load_pythonizations

load_pythonizations("edm4hep")
```
alternatively a selection of pythonizations can be loaded by importing and applying them one by one

The alternative mechanism I tough about:
- [c++ callback pythonization](https://cppyy.readthedocs.io/en/latest/pythonizations.html#c-callbacks) - instead of in python the callback to cppyy could be defined in C++ using the Python API. The downsides are extra dependency for C++ code (`Python::Module`) and knowing the Python C API is required
- generating python wrappers with jinja2 - it would be rather cumbersome to add another set jinja2 templates for tuning the python bindings

