### PR TITLE
Make sure that the `as_type` argument is respected for `Frame.put_parameters` for lists of values as well

### DIFF
--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -249,7 +249,7 @@ class Frame:
                 raise ValueError(f"Cannot put a parameter of type {type_name} into a Frame")
 
             par_type = vec_types[0]
-            if isinstance(value[0], float):
+            if as_type is None and isinstance(value[0], float):
                 # Always store floats as doubles from the python side
                 par_type = par_type.replace("float", "double")
 

--- a/tests/read_python_frame.h
+++ b/tests/read_python_frame.h
@@ -87,6 +87,7 @@ int checkParameters(const podio::Frame& frame) {
   if (realFloats.size() != 3 || realFloats[0] != 1.23f || realFloats[1] != 4.56f || realFloats[2] != 7.89f) {
     std::cerr << "Parameter more_real_floats was not stored as correctly (expected [1.23, 4.56, 7.89], actual"
               << realFloats << ")" << std::endl;
+    return 1;
   }
 
   return 0;


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that the `as_type` argument is respected in `Frame.put_parameter` also for lists of doubles / floats.
- Fix test to actually check for this.

ENDRELEASENOTES