### PR TITLE
Improve error message for push_back when using an immutable type

### DIFF
--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -158,7 +158,7 @@ void {{ collection_type }}::push_back(Mutable{{ class.bare_type }} object) {
 
 void {{ collection_type }}::push_back({{ class.bare_type }} object) {
   if (!m_isSubsetColl) {
-    throw std::invalid_argument("Can only add immutable objects to subset collections");
+    throw std::invalid_argument("Immutable objects can only be added to subset collections");
   }
   auto obj = object.m_obj;
   if (obj->id.index < 0) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve error message for push_back when using an immutable type

ENDRELEASENOTES

Possible (wrong) meaning that can be inferred from the current one: this is a subset collection and you are trying to push a mutable object so "Can only add immutable objects to subset collections", therefore you should change your mutable object to immutable object (wrong conclusion).

With the new one I don't think the wrong meaning can be inferred; it means you are pushing an immutable object but "Immutable objects can only be added to subset collections", which means it's not a subset collection, and the answer here is to change from immutable to mutable.