### PR TITLE
Check if the data passed to the frame model is not a nullptr

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -391,11 +391,13 @@ const CollT& Frame::put(CollT&& coll, const std::string& name) {
 
 template <typename FrameDataT>
 Frame::FrameModel<FrameDataT>::FrameModel(std::unique_ptr<FrameDataT> data) :
-    m_mapMtx(std::make_unique<std::mutex>()),
-    m_data(std::move(data)),
-    m_dataMtx(std::make_unique<std::mutex>()),
-    m_idTable(std::move(m_data->getIDTable())),
-    m_parameters(std::move(m_data->getParameters())) {
+    m_mapMtx(std::make_unique<std::mutex>()), m_dataMtx(std::make_unique<std::mutex>()) {
+  if (!data) {
+    throw std::invalid_argument("Building a Frame failed; if you are reading from a file it may be corrupted");
+  }
+  m_data = std::move(data);
+  m_idTable = std::move(m_data->getIDTable());
+  m_parameters = std::move(m_data->getParameters());
 }
 
 template <typename FrameDataT>

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -151,7 +151,9 @@ public:
   /// @tparam FrameDataT Arbitrary data container that provides access to the
   ///                    collection buffers as well as the metadata, when
   ///                    requested by the Frame. The unique_ptr has to be checked
-  ///                    for validity or this constructor will throw an std::invalid_argument
+  ///                    for validity before calling this construtor.
+  ///
+  /// @throws std::invalid_argument if the passed pointer is a nullptr.
   template <typename FrameDataT>
   Frame(std::unique_ptr<FrameDataT>);
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -150,7 +150,8 @@ public:
   ///
   /// @tparam FrameDataT Arbitrary data container that provides access to the
   ///                    collection buffers as well as the metadata, when
-  ///                    requested by the Frame.
+  ///                    requested by the Frame. The unique_ptr has to be checked
+  ///                    for validity or this constructor will throw an std::invalid_argument
   template <typename FrameDataT>
   Frame(std::unique_ptr<FrameDataT>);
 
@@ -393,7 +394,9 @@ template <typename FrameDataT>
 Frame::FrameModel<FrameDataT>::FrameModel(std::unique_ptr<FrameDataT> data) :
     m_mapMtx(std::make_unique<std::mutex>()), m_dataMtx(std::make_unique<std::mutex>()) {
   if (!data) {
-    throw std::invalid_argument("Building a Frame failed; if you are reading from a file it may be corrupted");
+    throw std::invalid_argument(
+        "FrameData is a nullptr. If you are reading from a file it may be corrupted or you may reading beyond the end "
+        "of the file, please check the validity of the data before creating a Frame.");
   }
   m_data = std::move(data);
   m_idTable = std::move(m_data->getIDTable());


### PR DESCRIPTION
BEGINRELEASENOTES
- Check if the data passed to the frame model is not a nullptr before doing anything with it.

ENDRELEASENOTES

It looks like a good idea to check if the pointer is null or not regardless. This makes opening corrupted or wrong files throw

```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Building a Frame failed; if you are reading from a file it may be corrupted
```

instead of crashing.