### PR TITLE
Make GenericParameters return optional instead of empty defaults on non-existant keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(podio)
 #--- Version -------------------------------------------------------------------
 SET( ${PROJECT_NAME}_VERSION_MAJOR 0 )
 SET( ${PROJECT_NAME}_VERSION_MINOR 99 )
-SET( ${PROJECT_NAME}_VERSION_PATCH 0 )
+SET( ${PROJECT_NAME}_VERSION_PATCH 99 )
 
 SET( ${PROJECT_NAME}_VERSION  "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -236,7 +236,7 @@ public:
   /// @param value The value of the parameter. A copy will be put into the Frame
   template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
   inline void putParameter(const std::string& key, T value) {
-    m_self->parameters().setValue(key, std::move(value));
+    m_self->parameters().set(key, std::move(value));
   }
 
   /// Add a string value to the parameters of the Frame.
@@ -286,8 +286,8 @@ public:
   ///
   /// @returns   The value of the parameter or an empty default value
   template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
-  inline podio::GenericDataReturnType<T> getParameter(const std::string& key) const {
-    return m_self->parameters().getValue<T>(key);
+  inline auto getParameter(const std::string& key) const {
+    return m_self->parameters().get<T>(key).value_or(T{});
   }
 
   /// Retrieve all parameters stored in this Frame.

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -284,10 +284,10 @@ public:
   /// @tparam T  The desired type of the parameter (can also be std::vector<T>)
   /// @param key The key under which the value is stored
   ///
-  /// @returns   The value of the parameter or an empty default value
+  /// @returns   An optional holding the value if it was present
   template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
   inline auto getParameter(const std::string& key) const {
-    return m_self->parameters().get<T>(key).value_or(T{});
+    return m_self->parameters().get<T>(key);
   }
 
   /// Retrieve all parameters stored in this Frame.

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -278,13 +278,10 @@ public:
 
   /// Retrieve parameters via key from the internal store.
   ///
-  /// The return type will either be a const reference or a value depending on
-  /// the desired type. See podio::GenericParameters for more details.
-  ///
   /// @tparam T  The desired type of the parameter (can also be std::vector<T>)
   /// @param key The key under which the value is stored
   ///
-  /// @returns   An optional holding the value if it was present
+  /// @returns   An optional holding the value if it is present
   template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
   inline auto getParameter(const std::string& key) const {
     return m_self->parameters().get<T>(key);
@@ -293,7 +290,7 @@ public:
   /// Retrieve all parameters stored in this Frame.
   ///
   /// This is mainly intended for I/O purposes and we encourage to use the Frame
-  /// functionality of getParameters or getParameterKeys in general.
+  /// functionality of getParameter or getParameterKeys in general.
   ///
   /// @returns The internally used GenericParameters
   inline const podio::GenericParameters& getParameters() const {

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -40,35 +40,6 @@ static constexpr bool isSupportedGenericDataType = detail::isAnyOrVectorOf<T, Su
 template <typename T>
 using EnableIfValidGenericDataType = typename std::enable_if_t<isSupportedGenericDataType<T>>;
 
-namespace detail {
-  /// Helper struct to determine how to return different types from the
-  /// GenericParameters to avoid unnecessary copies but also to make it possible
-  /// do distinguish between set and unset
-  template <typename T>
-  struct GenericDataReturnTypeHelper {
-    using type = T;
-  };
-
-  /// Specialization for std::string. Those will always be returned by const ref
-  template <>
-  struct GenericDataReturnTypeHelper<std::string> {
-    using type = const std::string&;
-  };
-
-  /// Specialization for std::vector. Those will always be returned by const ref
-  template <typename T>
-  struct GenericDataReturnTypeHelper<std::vector<T>> {
-    using type = const std::vector<T>&;
-  };
-} // namespace detail
-
-/// Alias template for determining the appropriate return type for the passed in
-/// type
-
-template <typename T>
-using GenericDataReturnType [[deprecated("GenericParameters will return by optional soon")]] =
-    typename detail::GenericDataReturnTypeHelper<T>::type;
-
 /// GenericParameters objects allow one to store generic named parameters of type
 ///  int, float and string or vectors of these types.
 ///  They can be used  to store (user) meta data that is

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -13,11 +13,13 @@
 #include <string>
 #include <vector>
 
+#if PODIO_ENABLE_SIO
 namespace sio {
 class read_device;
 class write_device;
 using version_type = uint32_t; // from sio/definitions
 } // namespace sio
+#endif
 
 #if PODIO_ENABLE_RNTUPLE
 namespace podio {
@@ -127,6 +129,21 @@ public:
   friend RNTupleWriter;
 #endif
 
+private:
+  /// Get a reference to the internal map for a given type
+  template <typename T>
+  MapType<detail::GetVectorType<T>>& getMap() {
+    if constexpr (std::is_same_v<detail::GetVectorType<T>, int>) {
+      return _intMap;
+    } else if constexpr (std::is_same_v<detail::GetVectorType<T>, float>) {
+      return _floatMap;
+    } else if constexpr (std::is_same_v<detail::GetVectorType<T>, double>) {
+      return _doubleMap;
+    } else {
+      return _stringMap;
+    }
+  }
+
   /// Get a reference to the internal map for a given type
   template <typename T>
   const MapType<detail::GetVectorType<T>>& getMap() const {
@@ -141,22 +158,6 @@ public:
     }
   }
 
-private:
-  /// Get a reference to the internal map for a given type (necessary for SIO)
-  template <typename T>
-  MapType<detail::GetVectorType<T>>& getMap() {
-    if constexpr (std::is_same_v<detail::GetVectorType<T>, int>) {
-      return _intMap;
-    } else if constexpr (std::is_same_v<detail::GetVectorType<T>, float>) {
-      return _floatMap;
-    } else if constexpr (std::is_same_v<detail::GetVectorType<T>, double>) {
-      return _doubleMap;
-    } else {
-      return _stringMap;
-    }
-  }
-
-private:
   /// Get the mutex that guards the map for the given type
   template <typename T>
   std::mutex& getMutex() const {

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -129,10 +129,9 @@ public:
   friend RNTupleWriter;
 #endif
 
-private:
   /// Get a reference to the internal map for a given type
   template <typename T>
-  MapType<detail::GetVectorType<T>>& getMap() {
+  const MapType<detail::GetVectorType<T>>& getMap() const {
     if constexpr (std::is_same_v<detail::GetVectorType<T>, int>) {
       return _intMap;
     } else if constexpr (std::is_same_v<detail::GetVectorType<T>, float>) {
@@ -144,9 +143,10 @@ private:
     }
   }
 
+private:
   /// Get a reference to the internal map for a given type
   template <typename T>
-  const MapType<detail::GetVectorType<T>>& getMap() const {
+  MapType<detail::GetVectorType<T>>& getMap() {
     if constexpr (std::is_same_v<detail::GetVectorType<T>, int>) {
       return _intMap;
     } else if constexpr (std::is_same_v<detail::GetVectorType<T>, float>) {

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Module for the python bindings of the podio::Frame"""
 
+from copy import deepcopy
+
 import cppyy
 
 import ROOT
@@ -193,7 +195,7 @@ class Frame:
             par_value = self._frame.getParameter[par_type](name)
             if len(par_value) == 1:
                 return par_value[0]
-            return list(par_value)
+            return list(deepcopy(par_value))
 
         # This access already raises the KeyError if there is no such parameter
         par_type = self._param_key_types[name]

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -192,7 +192,9 @@ class Frame:
         """
 
         def _get_param_value(par_type, name):
-            par_value = self._frame.getParameter[par_type](name)
+            # We can safely assume that getting the value here works, because
+            # only valid keys will end up here
+            par_value = self._frame.getParameter[par_type](name).value()
             if len(par_value) == 1:
                 return par_value[0]
             return list(deepcopy(par_value))

--- a/tests/read_python_frame.h
+++ b/tests/read_python_frame.h
@@ -56,34 +56,34 @@ std::ostream& operator<<(std::ostream& o, const std::vector<T>& vec) {
 }
 
 int checkParameters(const podio::Frame& frame) {
-  const auto iVal = frame.getParameter<int>("an_int");
+  const auto iVal = frame.getParameter<int>("an_int").value();
   if (iVal != 42) {
     std::cerr << "Parameter an_int was not stored correctly (expected 42, actual " << iVal << ")" << std::endl;
     return 1;
   }
 
-  const auto& dVal = frame.getParameter<std::vector<double>>("some_floats");
+  const auto dVal = frame.getParameter<std::vector<double>>("some_floats").value();
   if (dVal.size() != 3 || dVal[0] != 1.23 || dVal[1] != 7.89 || dVal[2] != 3.14) {
     std::cerr << "Parameter some_floats was not stored correctly (expected [1.23, 7.89, 3.14], actual " << dVal << ")"
               << std::endl;
     return 1;
   }
 
-  const auto& strVal = frame.getParameter<std::vector<std ::string>>("greetings");
+  const auto strVal = frame.getParameter<std::vector<std ::string>>("greetings").value();
   if (strVal.size() != 2 || strVal[0] != "from" || strVal[1] != "python") {
     std::cerr << "Parameter greetings was not stored correctly (expected [from, python], actual " << strVal << ")"
               << std::endl;
     return 1;
   }
 
-  const auto realFloat = frame.getParameter<float>("real_float");
+  const auto realFloat = frame.getParameter<float>("real_float").value_or(-1.f);
   if (realFloat != 3.14f) {
     std::cerr << "Parameter real_float was not stored correctly (expected 3.14, actual " << realFloat << ")"
               << std::endl;
     return 1;
   }
 
-  const auto& realFloats = frame.getParameter<std::vector<float>>("more_real_floats");
+  const auto realFloats = frame.getParameter<std::vector<float>>("more_real_floats").value();
   if (realFloats.size() != 3 || realFloats[0] != 1.23f || realFloats[1] != 4.56f || realFloats[2] != 7.89f) {
     std::cerr << "Parameter more_real_floats was not stored as correctly (expected [1.23, 4.56, 7.89], actual"
               << realFloats << ")" << std::endl;

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -39,7 +39,7 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 }
 
 void processEvent(const podio::Frame& event, int eventNum, podio::version::Version fileVersion) {
-  const float evtWeight = event.getParameter<float>("UserEventWeight");
+  const float evtWeight = event.getParameter<float>("UserEventWeight").value();
   if (evtWeight != (float)100. * eventNum) {
     std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << (float)100. * eventNum << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
@@ -47,7 +47,7 @@ void processEvent(const podio::Frame& event, int eventNum, podio::version::Versi
 
   std::stringstream ss;
   ss << " event_number_" << eventNum;
-  const auto& evtName = event.getParameter<std::string>("UserEventName");
+  const auto evtName = event.getParameter<std::string>("UserEventName").value();
 
   if (evtName != ss.str()) {
     std::cout << " read UserEventName: " << evtName << " - expected : " << ss.str() << std::endl;
@@ -55,7 +55,7 @@ void processEvent(const podio::Frame& event, int eventNum, podio::version::Versi
   }
 
   if (fileVersion > podio::version::Version{0, 14, 1}) {
-    const auto& someVectorData = event.getParameter<std::vector<int>>("SomeVectorData");
+    const auto someVectorData = event.getParameter<std::vector<int>>("SomeVectorData").value();
     if (someVectorData.size() != 4) {
       throw std::runtime_error("Couldn't read event meta data parameters: 'SomeVectorData'");
     }
@@ -67,7 +67,7 @@ void processEvent(const podio::Frame& event, int eventNum, podio::version::Versi
   }
 
   if (fileVersion > podio::version::Version{0, 16, 2}) {
-    const auto& doubleParams = event.getParameter<std::vector<double>>("SomeVectorData");
+    const auto doubleParams = event.getParameter<std::vector<double>>("SomeVectorData").value();
     if (doubleParams.size() != 2 || doubleParams[0] != eventNum * 1.1 || doubleParams[1] != eventNum * 2.2) {
       throw std::runtime_error("Could not read event parameter: 'SomeDoubleValues' correctly");
     }

--- a/tests/unittests/frame.cpp
+++ b/tests/unittests/frame.cpp
@@ -239,7 +239,7 @@ void checkFrame(const podio::Frame& frame) {
   REQUIRE(clusters[1].Clusters()[0] == clusters[0]);
 
   REQUIRE(frame.getParameter<int>("anInt") == 42);
-  auto& floats = frame.getParameter<std::vector<float>>("someFloats");
+  auto floats = frame.getParameter<std::vector<float>>("someFloats");
   REQUIRE(floats.size() == 3);
   REQUIRE(floats[0] == 1.23f);
   REQUIRE(floats[1] == 2.34f);

--- a/tests/unittests/frame.cpp
+++ b/tests/unittests/frame.cpp
@@ -33,13 +33,13 @@ TEST_CASE("Frame parameters", "[frame][basics]") {
   REQUIRE(event.getParameter<std::string>("aString") == "from a string literal");
 
   event.putParameter("someInts", {42, 123});
-  const auto& ints = event.getParameter<std::vector<int>>("someInts");
+  const auto ints = event.getParameter<std::vector<int>>("someInts").value();
   REQUIRE(ints.size() == 2);
   REQUIRE(ints[0] == 42);
   REQUIRE(ints[1] == 123);
 
   event.putParameter("someStrings", {"one", "two", "three"});
-  const auto& strings = event.getParameter<std::vector<std::string>>("someStrings");
+  const auto strings = event.getParameter<std::vector<std::string>>("someStrings").value();
   REQUIRE(strings.size() == 3);
   REQUIRE(strings[0] == "one");
   REQUIRE(strings[1] == "two");
@@ -239,7 +239,7 @@ void checkFrame(const podio::Frame& frame) {
   REQUIRE(clusters[1].Clusters()[0] == clusters[0]);
 
   REQUIRE(frame.getParameter<int>("anInt") == 42);
-  auto floats = frame.getParameter<std::vector<float>>("someFloats");
+  const auto floats = frame.getParameter<std::vector<float>>("someFloats").value();
   REQUIRE(floats.size() == 3);
   REQUIRE(floats[0] == 1.23f);
   REQUIRE(floats[1] == 2.34f);
@@ -339,7 +339,7 @@ TEST_CASE("Frame parameters multithread insert and read", "[frame][basics][multi
       frame.putParameter(makeName("string", i), std::to_string(i));
       CHECK_INCREASE(frame.getParameter<std::string>("string_par") == "some string", successes[i]);
 
-      const auto& floatPars = frame.getParameter<std::vector<float>>("float_pars");
+      const auto floatPars = frame.getParameter<std::vector<float>>("float_pars").value();
       CHECK_INCREASE(floatPars.size() == 3, successes[i]);
       CHECK_INCREASE(floatPars[0] == 1.23f, successes[i]);
       CHECK_INCREASE(floatPars[1] == 4.56f, successes[i]);

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1111,25 +1111,6 @@ TEST_CASE("GenericParameters constructors", "[generic-parameters]") {
   }
 }
 
-// Helper alias template "macro" to get the return type of calling
-// GenericParameters::getValue with the desired template type
-template <typename T>
-using GPGetValue = decltype(std::declval<podio::GenericParameters>().getValue<T>(std::declval<std::string>()));
-
-TEST_CASE("GenericParameters return types", "[generic-parameters][static-checks]") {
-  // Tests for checking that the getValue returns return by value resp. by const
-  // reference as expected
-  STATIC_REQUIRE(std::is_same_v<GPGetValue<int>, int>); // int and float are returned by value
-  STATIC_REQUIRE(std::is_same_v<GPGetValue<std::vector<int>>, const std::vector<int>&>); // vectors are const
-                                                                                         // references
-
-  STATIC_REQUIRE(std::is_same_v<GPGetValue<std::string>, const std::string&>); // std::strings are returned by const
-                                                                               // reference as well
-  STATIC_REQUIRE(std::is_same_v<GPGetValue<std::vector<std::string>>, const std::vector<std::string>&>); // as are
-                                                                                                         // vectors of
-                                                                                                         // strings
-}
-
 TEST_CASE("Missing files (ROOT readers)", "[basics]") {
   auto root_legacy_reader = podio::ROOTLegacyReader();
   REQUIRE_THROWS_AS(root_legacy_reader.openFile("NonExistentFile.root"), std::runtime_error);


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the `GenericParameters` return `std::optional` on non-existant keys instead of empty defaults. This allows to differentiate between empty (but set) and unset parameters, as the default value could actually be a valid parameter value for some types (e.g. integers or floats).
  - Rename the `setValue` and `getValue` functions to just `set` and `get`. This is also a breaking change, but as far as we are aware the `GenericParameters` are only used internally in podio.
- Make the `Frame::getParameter` also return this `std::optional`. **This is a breaking change that might require adaptation of existing code**

ENDRELEASENOTES

Fixes #576 

The following PRs make this introduction work transparently and need to be merged first to not break the nightlies
- [x] https://github.com/key4hep/EDM4hep/pull/305
- [x] https://github.com/AIDASoft/DD4hep/pull/1264
- [x] https://github.com/key4hep/k4FWCore/pull/195
- [x] https://github.com/key4hep/k4Clue/pull/59
- [x] https://github.com/key4hep/k4EDM4hep2LcioConv/pull/64