### PR TITLE
Pass arguments by const reference to avoid making copies

### DIFF
--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -133,7 +133,7 @@ bool {{ collection_type }}::setReferences(const podio::ICollectionProvider* coll
   return m_storage.setReferences(collectionProvider, m_isSubsetColl);
 }
 
-void {{ collection_type }}::push_back(Mutable{{ class.bare_type }} object) {
+void {{ collection_type }}::push_back(const Mutable{{ class.bare_type }}& object) {
   // We have to do different things here depending on whether this is a
   // subset collection or not. A normal collection cannot collect objects
   // that are already part of another collection, while a subset collection
@@ -156,7 +156,7 @@ void {{ collection_type }}::push_back(Mutable{{ class.bare_type }} object) {
   }
 }
 
-void {{ collection_type }}::push_back({{ class.bare_type }} object) {
+void {{ collection_type }}::push_back(const {{ class.bare_type }}& object) {
   if (!m_isSubsetColl) {
     throw std::invalid_argument("Immutable objects can only be added to subset collections");
   }

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -115,9 +115,9 @@ public:
 
 
   /// Append object to the collection
-  void push_back(Mutable{{class.bare_type}} object);
+  void push_back(const Mutable{{class.bare_type}}& object);
   /// Append an object to the (subset) collection
-  void push_back({{ class.bare_type }} object);
+  void push_back(const {{ class.bare_type }}& object);
 
   void prepareForWrite() const final;
   void prepareAfterRead() final;

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -206,7 +206,7 @@ podio::CollectionReadBuffers createBuffersV{{ schemaVersion }}(bool isSubset) {
 {% endfor %}
   }
 
-  readBuffers.createCollection = [](podio::CollectionReadBuffers buffers, bool isSubsetColl) {
+  readBuffers.createCollection = [](const podio::CollectionReadBuffers& buffers, bool isSubsetColl) {
     {{ collection_type }}Data data(buffers, isSubsetColl);
     return std::make_unique<{{ collection_type }}>(std::move(data), isSubsetColl);
   };

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -128,7 +128,7 @@
 {% macro multi_relation_handling(relations, get_syntax, with_adder=False) %}
 {% for relation in relations %}
 {% if with_adder %}
-  void {{ relation.setter_name(get_syntax, is_relation=True) }}({{ relation.full_type }});
+  void {{ relation.setter_name(get_syntax, is_relation=True) }}(const {{ relation.full_type }}&);
 {% endif %}
   std::size_t {{ relation.name }}_size() const;
   {{ relation.full_type }} {{ relation.getter_name(get_syntax) }}(std::size_t) const;

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -98,7 +98,7 @@ void {{ class_type }}::{{ relation.setter_name(get_syntax) }}({{ relation.full_t
 {% set class_type = prefix + class.bare_type %}
 {% for relation in relations %}
 {% if with_adder %}
-void {{ class_type }}::{{ relation.setter_name(get_syntax, is_relation=True) }}({{ relation.full_type }} component) {
+void {{ class_type }}::{{ relation.setter_name(get_syntax, is_relation=True) }}(const {{ relation.full_type }}& component) {
   m_obj->m_{{ relation.name }}->push_back(component);
   m_obj->data.{{ relation.name }}_end++;
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- Pass arguments by const reference to avoid making copies in a few places where passing by value was used

ENDRELEASENOTES

I think copies are not needed in these places