### PR TITLE
Make it possible to get the name from a collectionID

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -318,6 +318,26 @@ public:
     return m_self->availableCollections();
   }
 
+  /// Get the name of the passed collection
+  ///
+  /// @param coll The collection for which the name should be obtained
+  ///
+  /// @returns The name of the collection or an empty optional if this
+  ///          collection is not known to the Frame
+  inline std::optional<std::string> getName(const podio::CollectionBase& coll) const {
+    return getName(coll.getID());
+  }
+
+  /// Get the name for the passed collectionID
+  ///
+  /// @param collectionID The collection ID of the collection for which the name
+  ///                     should be obtained
+  /// @returns The name of the collection or an empty optional if this
+  ///          collectionID is not known to the Frame
+  inline std::optional<std::string> getName(const uint32_t collectionID) const {
+    return m_self->getIDTable().name(collectionID);
+  }
+
   // Interfaces for writing below
 
   /// Get a collection for writing.

--- a/tests/unittests/frame.cpp
+++ b/tests/unittests/frame.cpp
@@ -413,6 +413,15 @@ TEST_CASE("Frame destructor ASanFail") {
   }
 }
 
+TEST_CASE("Frame getName", "[frame][basics]") {
+  const auto frame = createFrame();
+
+  const auto& hits = frame.get<ExampleHitCollection>("hits");
+  REQUIRE(frame.getName(hits).value() == "hits");
+
+  REQUIRE_FALSE(frame.getName(0xfffffff).has_value());
+}
+
 TEST_CASE("EIC-Jana2 cleanup use case", "[memory-management][492][174]") {
   // Test case that only triggers in ASan builds if memory-management / cleanup
   // has a bug


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a `Frame::getName` method to retrieve the name of a collection via it's collectionID (if the collection is known to the Frame).

ENDRELEASENOTES