### PR TITLE
Set the right path for `PODIO_SIOBLOCK_PATH` and add an error message

### DIFF
--- a/src/SIOBlock.cc
+++ b/src/SIOBlock.cc
@@ -165,6 +165,11 @@ std::vector<std::tuple<std::string, std::string>> SIOBlockLibraryLoader::getLibN
         libs.emplace_back(std::move(filename), dir);
       }
     }
+    if (std::getenv("PODIO_SIOBLOCK_PATH") && libs.empty()) {
+      throw std::runtime_error(
+          "No SIOBlocks libraries found in PODIO_SIOBLOCK_PATH. Please set PODIO_SIOBLOCK_PATH to the directory "
+          "containing the SIOBlocks libraries or unset it to fallback to LD_LIBRARY_PATH.");
+    }
   }
 
   return libs;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -61,21 +61,11 @@ if (NOT FORCE_RUN_ALL_TESTS)
   endif()
 endif()
 
-option(SKIP_CATCH_DISCOVERY "Skip the Catch2 test discovery" OFF)
-
-# To work around https://github.com/catchorg/Catch2/issues/2424 we need the
-# DL_PATH argument for catch_discoer_tests which requires CMake 3.22 at least
-# The whole issue can be avoided if we skip the catch test discovery and set the
-# environment on our own
-if (CMAKE_VERSION VERSION_LESS 3.22)
-  set(SKIP_CATCH_DISCOVERY ON)
-endif()
-
-if (USE_SANITIZER MATCHES "Memory(WithOrigin)?" OR SKIP_CATCH_DISCOVERY)
+if (USE_SANITIZER MATCHES "Memory(WithOrigin)?")
   # Automatic test discovery fails with Memory sanitizers due to some issues in
   # Catch2. So in that case we skip the discovery step and simply run the thing
   # directly in the tests.
-  if (FORCE_RUN_ALL_TESTS OR SKIP_CATCH_DISCOVERY)
+  if (FORCE_RUN_ALL_TESTS)
     # Unfortunately Memory sanitizer seems to be really unhappy with Catch2 and
     # it fails to successfully launch the executable and execute any test. Here
     # we just include them in order to have them show up as failing

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -90,7 +90,8 @@ else()
       TEST_SPEC ${filter_tests} # discover only tests that are known to not fail
       PROPERTIES
         ENVIRONMENT
+        PODIO_SIOBLOCK_PATH=${PROJECT_BINARY_DIR}/tests
+        ENVIRONMENT
         LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$<TARGET_FILE_DIR:ROOT::Tree>:$<$<TARGET_EXISTS:SIO::sio>:$<TARGET_FILE_DIR:SIO::sio>>:$ENV{LD_LIBRARY_PATH}
-        PODIO_SIOBLOCK_PATH=${CMAKE_CURRENT_BINARY_DIR}
   )
 endif()

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -88,9 +88,9 @@ else()
       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
       TEST_PREFIX "UT_" # make it possible to filter easily with -R ^UT
       TEST_SPEC ${filter_tests} # discover only tests that are known to not fail
-      DL_PATHS ${CMAKE_CURRENT_BINARY_DIR}:${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$<TARGET_FILE_DIR:ROOT::Tree>:$<$<TARGET_EXISTS:SIO::sio>:$<TARGET_FILE_DIR:SIO::sio>>:$ENV{LD_LIBRARY_PATH}
       PROPERTIES
         ENVIRONMENT
+        LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}:${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$<TARGET_FILE_DIR:ROOT::Tree>:$<$<TARGET_EXISTS:SIO::sio>:$<TARGET_FILE_DIR:SIO::sio>>:$ENV{LD_LIBRARY_PATH}
         PODIO_SIOBLOCK_PATH=${CMAKE_CURRENT_BINARY_DIR}
   )
 endif()


### PR DESCRIPTION
BEGINRELEASENOTES
- Set the right path for `PODIO_SIOBLOCK_PATH`, fixing unit tests that read and write SIO files (there aren't any at the moment)
- Add an error message when `PODIO_SIOBLOCK_PATH` is set but none of the SioBlock libraries are found.

ENDRELEASENOTES

Adding a simple test that writes a frame to a SIO file won't work when ran with `ctest`. It looks like the environment is not correctly set because when running the test manually it will work fine. I don't know why but using `LD_LIBRARY_PATH` instead of `DL_PATHS` fixes this. This is the test

``` c++
+#if PODIO_ENABLE_SIO
+
+TEST_CASE("SIO writing a frame", "[relations]") {
+  auto frame = podio::Frame();
+  auto emptyColl = ExampleClusterCollection();
+  frame.put(std::move(emptyColl), "emptyClusters");
+  auto writer = podio::SIOWriter("unittests_frame_sio.sio");
+  writer.writeFrame(frame, podio::Category::Event);
+  writer.finish();
+}
+
+#endif
```

Here I don't think we need a unittest to simply test the environment, but for running with sanitizers, since all the ROOT ones fail then it's useful to have the SIO ones run from the unit tests.