### PR TITLE
Fix leak in the buffer vectorMembers when reading SIO frames

### DIFF
--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -42,7 +42,16 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type version
 {% if VectorMembers %}
   if (not m_subsetColl) {
 {% for member in VectorMembers %}
-    m_buffers.vectorMembers->emplace_back("{{ member.full_type }}", new std::vector<{{ member.full_type }}>());
+    bool found = false;
+    for (const auto& [first, second] : *m_buffers.vectorMembers) {
+      if (first == "{{ member.full_type }}") {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      m_buffers.vectorMembers->emplace_back("{{ member.full_type }}", new std::vector<{{ member.full_type }}>());
+    }
 {% endfor %}
     //---- read vector members
     auto* vecMemInfo = m_buffers.vectorMembers;

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -41,8 +41,9 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type version
 
 {% if VectorMembers %}
   if (not m_subsetColl) {
+    bool found;
 {% for member in VectorMembers %}
-    bool found = false;
+    found = false;
     for (const auto& [first, second] : *m_buffers.vectorMembers) {
       if (first == "{{ member.full_type }}") {
         found = true;

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -41,19 +41,6 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type version
 
 {% if VectorMembers %}
   if (not m_subsetColl) {
-    bool found;
-{% for member in VectorMembers %}
-    found = false;
-    for (const auto& [first, second] : *m_buffers.vectorMembers) {
-      if (first == "{{ member.full_type }}") {
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
-      m_buffers.vectorMembers->emplace_back("{{ member.full_type }}", new std::vector<{{ member.full_type }}>());
-    }
-{% endfor %}
     //---- read vector members
     auto* vecMemInfo = m_buffers.vectorMembers;
     unsigned size{0};


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix leak in the buffer vectorMembers when reading SIO frames

ENDRELEASENOTES

The leak happens because at the time of this `emplace_back`, there is already an element in the vector with the string corresponding to that vector member. Then, the indexing will only find the first instance and this second one is leaked, so the fix is to check before and only if it isn't there add it. I think this is added for the first time in https://github.com/AIDASoft/podio/blob/master/python/templates/SIOBlock.cc.jinja2#L92

This helps with the `read_frame_sio` test. Before:

```
SUMMARY: AddressSanitizer: 12714 byte(s) leaked in 482 allocation(s).
```

After:

```
SUMMARY: AddressSanitizer: 11786 byte(s) leaked in 445 allocation(s).
```

I'm not sure if we need a test since `read_frame_sio` would be the one, once it doesn't have any leaks. Otherwise to reproduce we just have to read a frame with a collection with a vector member.

I did this one because after this I have a version of https://github.com/AIDASoft/podio/pull/583 without leaks.