### PR TITLE
CI: use different dev4 stack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
         CXX_STANDARD: [20]
         RNTUPLE: [ON]
         include:
-          - LCG: "dev4/x86_64-centos7-gcc11-opt"
-            CXX_STANDARD: 17
+          - LCG: "dev4/x86_64-el9-gcc13-opt"
+            CXX_STANDARD: 20
           - LCG: "LCG_102/x86_64-centos7-clang12-opt"
             RNTUPLE: OFF
             CXX_STANDARD: 17


### PR DESCRIPTION
dev4 centos7 is now longer updating ROOT, so this gives misleading results



BEGINRELEASENOTES
- CI: alma9-gcc13 dev stack

ENDRELEASENOTES