### PR TITLE
[WIP] Enable RNTuple for the sanitizer builds

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -44,6 +44,7 @@ jobs:
               -DUSE_EXTERNAL_CATCH2=OFF \
               -DENABLE_SIO=ON \
               -DENABLE_JULIA=ON \
+              -DENABLE_RNTUPLE=ON \
               -G Ninja ..
             echo "::endgroup::"
             echo "::group::Build"

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -19,6 +19,10 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     read_python_frame_root
     read_and_write_frame_root
 
+    write_python_frame_rntuple
+    read_python_frame_rntuple
+    read_and_write_frame_rntuple
+
     write_frame_root
     read_frame_root
 
@@ -34,6 +38,8 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     podio-dump-detailed-root
     podio-dump-legacy_root_v00-16-06
     podio-dump-legacy_root-detailed_v00-16-06
+    podio-dump-rntuple
+    podio-dump-detailed-rntuple
 
     podio-dump-sio
     podio-dump-detailed-sio
@@ -42,6 +48,8 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
 
     datamodel_def_store_roundtrip_root
     datamodel_def_store_roundtrip_root_extension
+    datamodel_def_store_roundtrip_rntuple
+    datamodel_def_store_roundtrip_rntuple_extension
     datamodel_def_store_roundtrip_sio
     datamodel_def_store_roundtrip_sio_extension
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -94,7 +94,7 @@ if(BUILD_TESTING)
 
   if (ENABLE_RNTUPLE)
     CREATE_DUMP_TEST(podio-dump-rntuple "write_rntuple" ${PROJECT_BINARY_DIR}/tests/root_io/example_rntuple.root)
-    CREATE_DUMP_TEST(podio-dump-rntuple-detailed "write_rntuple" --detailed --category events --entries 1:3 ${PROJECT_BINARY_DIR}/tests/root_io/example_rntuple.root)
+    CREATE_DUMP_TEST(podio-dump-detailed-rntuple "write_rntuple" --detailed --category events --entries 1:3 ${PROJECT_BINARY_DIR}/tests/root_io/example_rntuple.root)
   endif()
 
 endif()


### PR DESCRIPTION

BEGINRELEASENOTES
- Enable RNTuple for the sanitizer CI builds.

ENDRELEASENOTES

These are currently not enabled by default. There is a leak in libCling.so where we don't have too much control over. I am not sure if we gain too much other than the information about which parts can actually run under sanitized builds (and which can't)