### PR TITLE
Improve generated interface function name to obtain the actual type

### DIFF
--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -177,10 +177,10 @@ bool same = (energyType == cluster); // <-- true (comparisons work as expected)
 bool isCluster = energyType.isA<ExampleCluster>(); // <-- true
 bool isHit     = energyType.isA<ExampleHit>();     // <-- false
 
-auto newCluster = energyType.getValue<ExampleCluster>(); // <-- "cast back" to original type
+auto newCluster = energyType.as<ExampleCluster>(); // <-- "cast back" to original type
 
 // "Casting" only works if the types match. Otherwise there will be an exception
-auto newHit = energyType.getValue<ExampleHit>(); // <-- exception
+auto newHit = energyType.as<ExampleHit>(); // <-- exception
 ```
 
 ## Global options

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -131,14 +131,20 @@ public:
 
   /// Get the contained value as the concrete type it was put in. This will
   /// throw a std::runtime_error if T is not the type of the currently held
-  /// value. Use holds to check beforehand if necessary  template<typename T>
+  /// value. Use isA to check beforehand if necessary
   template<typename T>
-  T getValue() const {
+  T as() const {
     if (!isA<T>()) {
       throw std::runtime_error("Cannot get value as object currently holds another type");
     }
     // We can safely cast here since we check types before
     return static_cast<Model<T>*>(m_self.get())->m_value;
+  }
+
+  template<typename T>
+  [[deprecated("Use 'as' instead.")]]
+  T getValue() const {
+    return as<T>();
   }
 
   friend bool operator==(const {{ class.bare_type }}& lhs, const {{ class.bare_type }}& rhs) {

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -73,14 +73,14 @@ TEST_CASE("InterfaceType from immutable", "[interface-types][basics]") {
   WrapperT wrapper{hit};
   REQUIRE(wrapper.isA<ExampleHit>());
   REQUIRE_FALSE(wrapper.isA<ExampleCluster>());
-  REQUIRE(wrapper.getValue<ExampleHit>() == hit);
+  REQUIRE(wrapper.as<ExampleHit>() == hit);
   REQUIRE(wrapper == hit);
 
   ExampleCluster cluster{};
   wrapper = cluster;
   REQUIRE(wrapper.isA<ExampleCluster>());
-  REQUIRE(wrapper.getValue<ExampleCluster>() == cluster);
-  REQUIRE_THROWS_AS(wrapper.getValue<ExampleHit>(), std::runtime_error);
+  REQUIRE(wrapper.as<ExampleCluster>() == cluster);
+  REQUIRE_THROWS_AS(wrapper.as<ExampleHit>(), std::runtime_error);
   REQUIRE(wrapper != hit);
 }
 
@@ -91,7 +91,7 @@ TEST_CASE("InterfaceType from mutable", "[interface-types][basics]") {
   WrapperT wrapper{hit};
   REQUIRE(wrapper.isA<ExampleHit>());
   REQUIRE_FALSE(wrapper.isA<ExampleCluster>());
-  REQUIRE(wrapper.getValue<ExampleHit>() == hit);
+  REQUIRE(wrapper.as<ExampleHit>() == hit);
   REQUIRE(wrapper == hit);
   // Comparison also work against the immutable classes
   ExampleHit immutableHit = hit;
@@ -100,8 +100,8 @@ TEST_CASE("InterfaceType from mutable", "[interface-types][basics]") {
   MutableExampleCluster cluster{};
   wrapper = cluster;
   REQUIRE(wrapper.isA<ExampleCluster>());
-  REQUIRE(wrapper.getValue<ExampleCluster>() == cluster);
-  REQUIRE_THROWS_AS(wrapper.getValue<ExampleHit>(), std::runtime_error);
+  REQUIRE(wrapper.as<ExampleCluster>() == cluster);
+  REQUIRE_THROWS_AS(wrapper.as<ExampleHit>(), std::runtime_error);
   REQUIRE(wrapper != hit);
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Deprecate the `getValue` method in favor of the `as` method for generated interface types.

ENDRELEASENOTES

`getValue` mixes a bit too much implementation detail into the interface. Additionally, `as` is very short and reads well in this context.