### PR TITLE
CI: Update LCG stacks and OSs for linux workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,11 @@ jobs:
         include:
           - LCG: "dev4/x86_64-el9-gcc13-opt"
             CXX_STANDARD: 20
-          - LCG: "LCG_102/x86_64-centos7-clang12-opt"
-            RNTUPLE: OFF
+          - LCG: "LCG_105/x86_64-el9-clang16-opt"
+            RNTUPLE: ON
             CXX_STANDARD: 17
-          - LCG: "LCG_102/x86_64-centos8-gcc11-opt"
-            RNTUPLE: OFF
+          - LCG: "LCG_105/x86_64-el9-gcc13-opt"
+            RNTUPLE: ON
             CXX_STANDARD: 17
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         LCG: ["dev3/x86_64-el9-clang16-opt",
-              "dev4/x86_64-el9-clang16-opt"]
-        CXX_STANDARD: [20]
-        RNTUPLE: [ON]
-        include:
-          - LCG: "dev4/x86_64-el9-gcc13-opt"
-            CXX_STANDARD: 20
-          - LCG: "LCG_105/x86_64-el9-clang16-opt"
-            RNTUPLE: ON
-            CXX_STANDARD: 17
-          - LCG: "LCG_105/x86_64-el9-gcc13-opt"
-            RNTUPLE: ON
-            CXX_STANDARD: 17
+              "dev4/x86_64-el9-clang16-opt",
+              "dev4/x86_64-el9-gcc13-opt",
+              "LCG_105/x86_64-el9-clang16-opt",
+              "LCG_105/x86_64-el9-gcc13-opt"]
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
@@ -38,9 +30,9 @@ jobs:
           cd build
           cmake -DENABLE_SIO=ON \
             -DENABLE_JULIA=ON \
-            -DENABLE_RNTUPLE=${{ matrix.RNTUPLE }} \
+            -DENABLE_RNTUPLE=ON \
             -DCMAKE_INSTALL_PREFIX=../install \
-            -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
+            -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -DPODIO_USE_CLANG_FORMAT=AUTO \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,9 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sio: [ON]
-        LCG: ["dev3/x86_64-ubuntu2004-gcc9-opt",
-              "dev4/x86_64-ubuntu2004-gcc9-opt"]
+        LCG: ["dev3/x86_64-ubuntu2204-gcc11-opt",
+              "dev4/x86_64-ubuntu2204-gcc11-opt"]
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
@@ -26,15 +25,15 @@ jobs:
           echo "::group::Run CMake"
           mkdir build install
           cd build
-          cmake -DENABLE_SIO=${{ matrix.sio }} \
+          cmake -DENABLE_SIO=ON \
             -DENABLE_JULIA=ON \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=17 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
-                 -DUSE_EXTERNAL_CATCH2=OFF \
-                 -DPODIO_SET_RPATH=ON \
-                 -DENABLE_RNTUPLE=ON \
-                 -G Ninja ..
+            -DUSE_EXTERNAL_CATCH2=OFF \
+            -DPODIO_SET_RPATH=ON \
+            -DENABLE_RNTUPLE=ON \
+            -G Ninja ..
           echo "::endgroup::"
           echo "::group::Build"
           ninja -k0


### PR DESCRIPTION

BEGINRELEASENOTES
- Update CI workflows to run on `LCG_105` using `gcc13` and `clang16` as well as bumping the OS to EL9. Build RNTuple by default
- Update the Ubuntu based workflows to run on ubuntu 22.04

ENDRELEASENOTES

Additionally clean up the ubuntu workflow slightly to not have a matrix entry that is always ON.