### PR TITLE
python: install to a proper libdir prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,41 +105,15 @@ if(NOT ROOT_CXX_STANDARD VERSION_EQUAL CMAKE_CXX_STANDARD)
   message(WARNING "You are trying to build podio with a different c++ standard than ROOT. C++${CMAKE_CXX_STANDARD} was required but ROOT was built with C++${ROOT_CXX_STANDARD}")
 endif()
 
-#Check if Python version detected matches the version used to build ROOT
-SET(Python_FIND_FRAMEWORK LAST)
-IF((TARGET ROOT::PyROOT OR TARGET ROOT::ROOTTPython) AND ${ROOT_VERSION} VERSION_GREATER_EQUAL 6.19)
-  # some cmake versions don't include python patch level in PYTHON_VERSION
-  IF(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16.0 AND CMAKE_VERSION VERSION_LESS_EQUAL 3.17.2)
-    string(REGEX MATCH [23]\.[0-9]+ REQUIRE_PYTHON_VERSION ${ROOT_PYTHON_VERSION})
-  ELSE()
-    SET(REQUIRE_PYTHON_VERSION ${ROOT_PYTHON_VERSION})
-  ENDIF()
-  message( STATUS "Python version used for building ROOT ${ROOT_PYTHON_VERSION}" )
-  message( STATUS "Required python version ${REQUIRE_PYTHON_VERSION}")
-
-  if(NOT PODIO_RELAX_PYVER)
-    find_package(Python ${REQUIRE_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Development Interpreter)
-  else()
-    find_package(Python ${REQUIRE_PYTHON_VERSION} REQUIRED COMPONENTS Development Interpreter)
-    string(REPLACE "." ";" _root_pyver_tuple ${REQUIRE_PYTHON_VERSION})
-    list(GET _root_pyver_tuple 0 _root_pyver_major)
-    list(GET _root_pyver_tuple 1 _root_pyver_minor)
-    if(NOT "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}" VERSION_EQUAL "${_root_pyver_major}.${_root_pyver_minor}")
-      message(FATAL_ERROR "There is a mismatch between the major and minor versions in Python"
-        " (found ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}) and ROOT, compiled with "
-        "Python ${_root_pyver_major}.${_root_pyver_minor}")
-    endif()
-  endif()
-else()
-  find_package(Python COMPONENTS Development Interpreter)
-endif()
-
 # ROOT only sets usage requirements from 6.14, so for
 # earlier versions need to hack in INTERFACE_INCLUDE_DIRECTORIES
 if(ROOT_VERSION VERSION_LESS 6.14)
   set_property(TARGET ROOT::Core APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${ROOT_INCLUDE_DIRS}")
 endif()
 list(APPEND PODIO_IO_HANDLERS ROOT)
+
+# python setup (including python package discovery and install dir)
+podio_python_setup()
 
 #--- enable podio macros--------------------------------------------------------
 include(cmake/podioMacros.cmake)

--- a/cmake/podioBuild.cmake
+++ b/cmake/podioBuild.cmake
@@ -196,9 +196,9 @@ IF((TARGET ROOT::PyROOT OR TARGET ROOT::ROOTTPython) AND ${ROOT_VERSION} VERSION
   message( STATUS "Required python version ${REQUIRE_PYTHON_VERSION}")
 
   if(NOT PODIO_RELAX_PYVER)
-    find_package(Python ${REQUIRE_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Development Interpreter)
+    find_package(Python3 ${REQUIRE_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Development Interpreter)
   else()
-    find_package(Python ${REQUIRE_PYTHON_VERSION} REQUIRED COMPONENTS Development Interpreter)
+    find_package(Python3 ${REQUIRE_PYTHON_VERSION} REQUIRED COMPONENTS Development Interpreter)
     string(REPLACE "." ";" _root_pyver_tuple ${REQUIRE_PYTHON_VERSION})
     list(GET _root_pyver_tuple 0 _root_pyver_major)
     list(GET _root_pyver_tuple 1 _root_pyver_minor)
@@ -209,7 +209,7 @@ IF((TARGET ROOT::PyROOT OR TARGET ROOT::ROOTTPython) AND ${ROOT_VERSION} VERSION
     endif()
   endif()
 else()
-  find_package(Python COMPONENTS Development Interpreter)
+  find_package(Python3 COMPONENTS Development Interpreter)
 endif()
 
 endmacro(podio_python_setup)

--- a/cmake/podioBuild.cmake
+++ b/cmake/podioBuild.cmake
@@ -177,8 +177,11 @@ endmacro(ADD_CLANG_TIDY)
 # --- Macro to find a python version that is compatible with ROOT and to setup
 # --- the python install directory for the podio python sources
 #
-# The python install directory is exposed via the PODIO_PYTHON_INSTALL_DIR cmake
-# variable.
+# The python install directory is exposed via the podio_PYTHON_INSTALLDIR cmake
+# variable. It defaults to
+# CMAKE_INSTALL_PREFIX/lib[64]/pythonX.YY/site-packages/, where pythonX.YY is
+# the major.minor version of python and lib or lib64 is decided from checking
+# Python3_SITEARCH
 #
 # NOTE: This macro needs to be called **AFTER** find_package(ROOT) since that is
 # necessary to expose
@@ -212,4 +215,17 @@ else()
   find_package(Python3 COMPONENTS Development Interpreter)
 endif()
 
+# Setup the python install dir. See the discussion in
+# https://github.com/AIDASoft/podio/pull/599 for more details on why this is
+# done the way it is
+set(podio_python_lib_dir lib)
+if("${Python3_SITEARCH}" MATCHES "/lib64/")
+  set(podio_python_lib_dir lib64)
+endif()
+
+set(podio_PYTHON_INSTALLDIR
+  "${CMAKE_INSTALL_PREFIX}/${podio_python_lib_dir}/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages"
+  CACHE STRING
+  "The install prefix for the python bindings and the generator and templates"
+)
 endmacro(podio_python_setup)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-execute_process(COMMAND "''${Python_EXECUTABLE}"
+execute_process(COMMAND "${Python_EXECUTABLE}"
   -c "import sysconfig;print(sysconfig.get_path(\"purelib\", vars={\"base\": \".\"}))"
   OUTPUT_VARIABLE podio_PYTHON_INSTALLDIR OUTPUT_STRIP_TRAILING_WHITESPACE
   )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/ PARENT_SCOPE)
+message(A ${podio_PYTHON_INSTALLDIR})
 
 set(to_install
   podio_class_generator.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,7 +2,7 @@ execute_process(COMMAND "${Python_EXECUTABLE}"
   -c "import sysconfig;print(sysconfig.get_path(\"purelib\", vars={\"base\": \".\"}))"
   OUTPUT_VARIABLE podio_PYTHON_INSTALLDIR OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-SET(podio_PYTHON_INSTALLDIR ${podio_PYTHON_INSTALLDIR} PARENT_SCOPE)
+SET(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/podio PARENT_SCOPE)
 
 set(to_install
   podio_class_generator.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,3 @@
-set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages)
-set(podio_PYTHON_INSTALLDIR ${podio_PYTHON_INSTALLDIR} PARENT_SCOPE)
-
 set(to_install
   podio_class_generator.py
   podio_schema_evolution.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/ PARENT_SCOPE)
-message(A ${podio_PYTHON_INSTALLDIR})
+set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/)
+set(podio_PYTHON_INSTALLDIR ${podio_PYTHON_INSTALLDIR} PARENT_SCOPE)
 
 set(to_install
   podio_class_generator.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/)
+set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages)
 set(podio_PYTHON_INSTALLDIR ${podio_PYTHON_INSTALLDIR} PARENT_SCOPE)
 
 set(to_install

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,7 @@
-SET(podio_PYTHON_INSTALLDIR python)
+execute_process(COMMAND "''${Python_EXECUTABLE}"
+  -c "import sysconfig;print(sysconfig.get_path(\"purelib\", vars={\"base\": \".\"}))"
+  OUTPUT_VARIABLE podio_PYTHON_INSTALLDIR OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 SET(podio_PYTHON_INSTALLDIR ${podio_PYTHON_INSTALLDIR} PARENT_SCOPE)
 
 set(to_install

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,8 +1,4 @@
-execute_process(COMMAND "${Python_EXECUTABLE}"
-  -c "import sysconfig;print(sysconfig.get_path(\"purelib\", vars={\"base\": \".\"}))"
-  OUTPUT_VARIABLE podio_PYTHON_INSTALLDIR OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-SET(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/podio PARENT_SCOPE)
+set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/podio PARENT_SCOPE)
 
 set(to_install
   podio_class_generator.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/podio PARENT_SCOPE)
+set(podio_PYTHON_INSTALLDIR ${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/ PARENT_SCOPE)
 
 set(to_install
   podio_class_generator.py


### PR DESCRIPTION
Currently, the libraries are installed to `$PREFIX/python`, which is a non-standard prefix. Standard prefix looks more like `$PREFIX/lib/python3.XX/site-packages`.



BEGINRELEASENOTES
- The Python library is installed to lib/python3.XX/site-packages/ instead of python/

ENDRELEASENOTES