### PR TITLE
Don't format templates and test extra_code

### DIFF
--- a/python/templates/.clang-format
+++ b/python/templates/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true

--- a/tests/extra_code/.clang-format
+++ b/tests/extra_code/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION

BEGINRELEASENOTES
- Added .clang-format config files to avoid formatting jinja2 templates and tests' extra_code

ENDRELEASENOTES

Added `.clang-format` config files to avoid formatting files which are not supposed to be formatted with clang-format