### PR TITLE
Add a parameter `cloneRelations` for `clone` to be able not to clone the collections

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -86,6 +86,16 @@ and via direct object access:
     }
 ```
 
+### Cloneing objects
+
+In order to clone objects it is necessary to use the `clone` method which
+returns a `Mutable` object again. `clone` takes a parameter `cloneRelations`
+which is defaulted to `true`. By default the relation information of the
+original object is simply copied over, changing this to `false` only copies the
+data but none of the relations.
+
+![](figures/object_clone.svg)
+
 ### Support for Notebook-Pattern
 
 The `notebook pattern` uses the assumption that it is better to create a small

--- a/doc/figures/object_clone.svg
+++ b/doc/figures/object_clone.svg
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="143.64011mm"
+   height="62.375492mm"
+   viewBox="0 0 143.64011 62.375492"
+   version="1.1"
+   id="svg1165"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="object_clone.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1167"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="0.98520767"
+     inkscape:cx="328.35717"
+     inkscape:cy="122.81675"
+     inkscape:window-width="1920"
+     inkscape:window-height="1163"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2142"
+       originx="-12.829697"
+       originy="-12.84241" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1162">
+    <marker
+       style="overflow:visible"
+       id="Arrow2Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.625;stroke-linejoin:round"
+         id="path2333" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Mend-2"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.625;stroke-linejoin:round"
+         id="path2333-9" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Mend-2-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mend"
+       inkscape:isstock="true">
+      <path
+         transform="scale(-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:0.625;stroke-linejoin:round"
+         id="path2333-9-5" />
+    </marker>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-12.829696,-12.84241)">
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect1376"
+       width="16.248713"
+       height="15.279936"
+       x="69.499474"
+       y="25.132219"
+       ry="0" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect1376-5"
+       width="16.248713"
+       height="15.279936"
+       x="51.936317"
+       y="59.687965"
+       ry="0" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect1376-6"
+       width="16.248713"
+       height="15.279936"
+       x="90.562683"
+       y="59.687965"
+       ry="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend)"
+       d="M 77.786357,40.605762 58.209463,59.627059"
+       id="path2144" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-2)"
+       d="M 77.786357,40.605762 98.950752,59.627058"
+       id="path2144-1"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:7.05556px;line-height:1.25;font-family:'DesySans Office';-inkscape-font-specification:'DesySans Office, Normal';stroke-width:0.264583"
+       x="65.588379"
+       y="17.997999"
+       id="text2868"><tspan
+         sodipodi:role="line"
+         id="tspan2866"
+         style="font-size:7.05556px;stroke-width:0.264583"
+         x="65.588379"
+         y="17.997999">original</tspan></text>
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect1376-2"
+       width="16.248713"
+       height="15.279936"
+       x="130.11053"
+       y="25.132219"
+       ry="0" />
+    <text
+       xml:space="preserve"
+       style="font-size:7.05556px;line-height:1.25;font-family:'DesySans Office';-inkscape-font-specification:'DesySans Office, Normal';stroke-width:0.264583"
+       x="119.59348"
+       y="18.065178"
+       id="text5469"><tspan
+         sodipodi:role="line"
+         id="tspan5467"
+         style="font-size:7.05556px;stroke-width:0.264583"
+         x="119.59348"
+         y="18.065178">clone(false)</tspan></text>
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect1376-2-1"
+       width="16.248713"
+       height="15.279936"
+       x="15.212888"
+       y="25.132219"
+       ry="0" />
+    <text
+       xml:space="preserve"
+       style="font-size:7.05556px;line-height:1.25;font-family:'DesySans Office';-inkscape-font-specification:'DesySans Office, Normal';stroke-width:0.264583"
+       x="12.423175"
+       y="18.065178"
+       id="text5469-9"><tspan
+         sodipodi:role="line"
+         id="tspan5467-4"
+         style="font-size:7.05556px;stroke-width:0.264583"
+         x="12.423175"
+         y="18.065178">clone()</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-2)"
+       d="M 23.479883,40.345861 59.796964,59.627059"
+       id="path10069"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-2-4)"
+       d="M 23.479883,40.345861 97.363251,59.627058"
+       id="path10069-0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#5e6364;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 50.270832,12.964583 0,62.441667"
+       id="path11014"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#5e6364;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 2;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 108.47917,13.229167 0,62.177083"
+       id="path11014-3"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/python/templates/MutableObject.cc.jinja2
+++ b/python/templates/MutableObject.cc.jinja2
@@ -16,7 +16,7 @@
 
 {{ utils.namespace_open(class.namespace) }}
 
-{{ macros.constructors_destructors(class.bare_type, Members, prefix='Mutable') }}
+{{ macros.constructors_destructors(class.bare_type, Members, multi_relations=OneToManyRelations + VectorMembers, prefix='Mutable') }}
 
 {{ macros.member_getters(class, Members, use_get_syntax, prefix='Mutable') }}
 {{ macros.single_relation_getters(class, OneToOneRelations, use_get_syntax, prefix='Mutable') }}

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -74,7 +74,7 @@
   {{  full_type }}& operator=({{ full_type }} other);
 
   /// create a mutable deep-copy of the object with identical relations
-  Mutable{{ type }} clone() const;
+  Mutable{{ type }} clone(bool emptyRelations=false) const;
 
   /// destructor
   ~{{  full_type }}() = default;

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -74,7 +74,8 @@
   {{  full_type }}& operator=({{ full_type }} other);
 
   /// create a mutable deep-copy of the object with identical relations
-  Mutable{{ type }} clone(bool emptyRelations=false) const;
+  /// if cloneRelations=false, the relations are not cloned and will be empty
+  Mutable{{ type }} clone(bool cloneRelations=true) const;
 
   /// destructor
   ~{{  full_type }}() = default;

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -18,9 +18,9 @@
   return *this;
 }
 
-Mutable{{ type }} {{ full_type }}::clone(bool emptyRelations) const {
+Mutable{{ type }} {{ full_type }}::clone(bool cloneRelations) const {
 {% if prefix %}
-  if (emptyRelations) {
+  if (!cloneRelations) {
     auto tmp = new {{ type }}Obj(podio::ObjectID{}, m_obj->data);
 {% for relation in multi_relations %}
     tmp->m_{{ relation.name }} = new std::vector<{{ relation.full_type }}>();
@@ -35,7 +35,7 @@ Mutable{{ type }} {{ full_type }}::clone(bool emptyRelations) const {
 {% for relation in multi_relations %}
   tmp->m_{{ relation.name }} = new std::vector<{{ relation.full_type }}>();
 {% endfor %}
-  if (!emptyRelations) {
+  if (cloneRelations) {
 {% for relation in multi_relations %}
     // If the current object has been read from a file, then the object may only have a slice of the relation vector
     // so this slice has to be copied in case we want to modify it

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -18,22 +18,41 @@
   return *this;
 }
 
-Mutable{{ type }} {{ full_type }}::clone() const {
+Mutable{{ type }} {{ full_type }}::clone(bool emptyRelations) const {
 {% if prefix %}
+  if (emptyRelations) {
+    auto tmp = new {{ type }}Obj(podio::ObjectID{}, m_obj->data);
+{% for relation in multi_relations %}
+    tmp->m_{{ relation.name }} = new std::vector<{{ relation.full_type }}>();
+    tmp->data.{{ relation.name }}_begin = 0;
+    tmp->data.{{ relation.name }}_end = 0;
+{% endfor %}
+    return Mutable{{ type }}(podio::utils::MaybeSharedPtr(tmp, podio::utils::MarkOwned));
+  }
   return Mutable{{ type }}(podio::utils::MaybeSharedPtr(new {{ type }}Obj(*m_obj), podio::utils::MarkOwned));
 {% else %}
   auto tmp = new {{ type }}Obj(podio::ObjectID{}, m_obj->data);
 {% for relation in multi_relations %}
   tmp->m_{{ relation.name }} = new std::vector<{{ relation.full_type }}>();
-  // If the current object has been read from a file, then the object may only have a slice of the relation vector
-  // so this slice has to be copied in case we want to modify it
-  tmp->m_{{ relation.name }}->reserve(m_obj->m_{{ relation.name }}->size());
-  for (size_t i = m_obj->data.{{ relation.name }}_begin; i < m_obj->data.{{ relation.name }}_end; i++) {
-    tmp->m_{{ relation.name }}->emplace_back((*m_obj->m_{{ relation.name }})[i]);
-  }
-  tmp->data.{{ relation.name }}_begin = 0;
-  tmp->data.{{ relation.name }}_end = tmp->m_{{ relation.name }}->size();
 {% endfor %}
+  if (!emptyRelations) {
+{% for relation in multi_relations %}
+    // If the current object has been read from a file, then the object may only have a slice of the relation vector
+    // so this slice has to be copied in case we want to modify it
+    tmp->m_{{ relation.name }}->reserve(m_obj->m_{{ relation.name }}->size());
+    for (size_t i = m_obj->data.{{ relation.name }}_begin; i < m_obj->data.{{ relation.name }}_end; i++) {
+      tmp->m_{{ relation.name }}->emplace_back((*m_obj->m_{{ relation.name }})[i]);
+    }
+    tmp->data.{{ relation.name }}_begin = 0;
+    tmp->data.{{ relation.name }}_end = tmp->m_{{ relation.name }}->size();
+{% endfor %}
+  }
+  else {
+{% for relation in multi_relations %}
+    tmp->data.{{ relation.name }}_begin = 0;
+    tmp->data.{{ relation.name }}_end = 0;
+{% endfor %}
+  }
   return Mutable{{ type }}(podio::utils::MaybeSharedPtr(tmp, podio::utils::MarkOwned));
 {% endif %}
 }

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1395,8 +1395,6 @@ TEST_CASE("Clone empty relations", "[relations][basics]") {
   auto newColl = ExampleClusterCollection();
   newColl.push_back(coll.at(0).clone(false));
   newColl.push_back(coll.at(1).clone(false));
-  std::cout << newColl[0].Hits().size() << '\n';
-  std::cout << newColl[1].Hits().size() << '\n';
   REQUIRE(newColl[0].Hits().empty());
   REQUIRE(newColl[1].Hits().empty());
   newColl[0].addHits(ExampleHit());

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1386,15 +1386,15 @@ TEST_CASE("Relations after cloning with SIO", "[relations][basics]") {
 
 #endif
 
-void testCloneEmptyRelations() {
+TEST_CASE("Clone empty relations", "[relations][basics]") {
   auto coll = ExampleClusterCollection();
   coll.create();
   coll.create();
   coll[0].addHits(ExampleHit());
   coll[0].addHits(ExampleHit());
   auto newColl = ExampleClusterCollection();
-  newColl.push_back(coll.at(0).clone(true));
-  newColl.push_back(coll.at(1).clone(true));
+  newColl.push_back(coll.at(0).clone(false));
+  newColl.push_back(coll.at(1).clone(false));
   std::cout << newColl[0].Hits().size() << '\n';
   std::cout << newColl[1].Hits().size() << '\n';
   REQUIRE(newColl[0].Hits().empty());
@@ -1406,16 +1406,12 @@ void testCloneEmptyRelations() {
 
   auto immCluster = ExampleCluster(coll.at(0));
   auto immCluster2 = ExampleCluster(coll.at(1));
-  auto clonedImmCluster = immCluster.clone(true);
-  auto clonedImmCluster2 = immCluster2.clone(true);
+  auto clonedImmCluster = immCluster.clone(false);
+  auto clonedImmCluster2 = immCluster2.clone(false);
   REQUIRE(clonedImmCluster.Hits().empty());
   REQUIRE(clonedImmCluster2.Hits().empty());
   clonedImmCluster.addHits(ExampleHit());
   REQUIRE(clonedImmCluster.Hits().size() == 1);
   clonedImmCluster.addHits(ExampleHit());
   REQUIRE(clonedImmCluster.Hits().size() == 2);
-}
-
-TEST_CASE("Clone empty relations", "[relations][basics]") {
-  testCloneEmptyRelations();
 }

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1399,12 +1399,21 @@ void testCloneEmptyRelations() {
   std::cout << newColl[1].Hits().size() << '\n';
   REQUIRE(newColl[0].Hits().empty());
   REQUIRE(newColl[1].Hits().empty());
+  newColl[0].addHits(ExampleHit());
+  REQUIRE(newColl[0].Hits().size() == 1);
+  newColl[0].addHits(ExampleHit());
+  REQUIRE(newColl[0].Hits().size() == 2);
 
   auto immCluster = ExampleCluster(coll.at(0));
   auto immCluster2 = ExampleCluster(coll.at(1));
-  REQUIRE(immCluster.clone(true).Hits().empty());
-  REQUIRE(immCluster2.clone(true).Hits().empty());
-
+  auto clonedImmCluster = immCluster.clone(true);
+  auto clonedImmCluster2 = immCluster2.clone(true);
+  REQUIRE(clonedImmCluster.Hits().empty());
+  REQUIRE(clonedImmCluster2.Hits().empty());
+  clonedImmCluster.addHits(ExampleHit());
+  REQUIRE(clonedImmCluster.Hits().size() == 1);
+  clonedImmCluster.addHits(ExampleHit());
+  REQUIRE(clonedImmCluster.Hits().size() == 2);
 }
 
 TEST_CASE("Clone empty relations", "[relations][basics]") {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -40,7 +40,6 @@
 #include "datamodel/ExampleForCyclicDependency1Collection.h"
 #include "datamodel/ExampleForCyclicDependency2Collection.h"
 #include "datamodel/ExampleHitCollection.h"
-#include "datamodel/ExampleMCCollection.h"
 #include "datamodel/ExampleWithArray.h"
 #include "datamodel/ExampleWithArrayComponent.h"
 #include "datamodel/ExampleWithComponent.h"
@@ -470,15 +469,8 @@ TEST_CASE("Equality", "[basics]") {
   auto clu2 = ExampleCluster::makeEmpty();
   // Empty handles always compare equal
   REQUIRE(clu == clu2);
-  REQUIRE(clu2 == clu);
   // They never compare equal to a non-empty handle
   REQUIRE(clu != cluster);
-  REQUIRE(cluster != clu);
-
-  auto coll = ExampleClusterCollection();
-  coll.create();
-  REQUIRE(coll[0] != clu);
-  REQUIRE(clu != coll[0]);
 }
 
 TEST_CASE("UserInitialization", "[basics][code-gen]") {
@@ -1393,30 +1385,3 @@ TEST_CASE("Relations after cloning with SIO", "[relations][basics]") {
 }
 
 #endif
-
-void runRelationAfterCloneEqualCheck() {
-  auto newColl = ExampleMCCollection();
-  auto coll = ExampleMCCollection();
-  coll.create();
-  coll.create();
-  coll[0].addparents(coll[0]);
-  coll[0].adddaughters(coll[1]);
-  coll[0].adddaughters(coll[0]);
-  coll[1].addparents(coll[0]);
-  newColl.push_back(coll.at(0).clone());
-  newColl.push_back(coll.at(1).clone());
-
-  REQUIRE(newColl[0].parents()[0] == newColl[0]);
-  REQUIRE(newColl[0].daughters()[0] == newColl[1]);
-  REQUIRE(newColl[0].daughters()[1] == newColl[0]);
-  REQUIRE(newColl[1].parents()[0] == newColl[0]);
-
-  REQUIRE(newColl[0].parents()[0] != newColl[1]);
-  REQUIRE(newColl[0].daughters()[0] != newColl[0]);
-  REQUIRE(newColl[0].daughters()[1] != newColl[1]);
-  REQUIRE(newColl[1].parents()[0] != newColl[1]);
-}
-
-TEST_CASE("Relations after cloning with equal check", "[relations][basics]") {
-  runRelationAfterCloneEqualCheck();
-}

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1415,8 +1415,6 @@ void runRelationAfterCloneEqualCheck() {
   REQUIRE(newColl[0].daughters()[0] != newColl[0]);
   REQUIRE(newColl[0].daughters()[1] != newColl[1]);
   REQUIRE(newColl[1].parents()[0] != newColl[1]);
-
-
 }
 
 TEST_CASE("Relations after cloning with equal check", "[relations][basics]") {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1385,3 +1385,28 @@ TEST_CASE("Relations after cloning with SIO", "[relations][basics]") {
 }
 
 #endif
+
+void testCloneEmptyRelations() {
+  auto coll = ExampleClusterCollection();
+  coll.create();
+  coll.create();
+  coll[0].addHits(ExampleHit());
+  coll[0].addHits(ExampleHit());
+  auto newColl = ExampleClusterCollection();
+  newColl.push_back(coll.at(0).clone(true));
+  newColl.push_back(coll.at(1).clone(true));
+  std::cout << newColl[0].Hits().size() << '\n';
+  std::cout << newColl[1].Hits().size() << '\n';
+  REQUIRE(newColl[0].Hits().empty());
+  REQUIRE(newColl[1].Hits().empty());
+
+  auto immCluster = ExampleCluster(coll.at(0));
+  auto immCluster2 = ExampleCluster(coll.at(1));
+  REQUIRE(immCluster.clone(true).Hits().empty());
+  REQUIRE(immCluster2.clone(true).Hits().empty());
+
+}
+
+TEST_CASE("Clone empty relations", "[relations][basics]") {
+  testCloneEmptyRelations();
+}

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -40,6 +40,7 @@
 #include "datamodel/ExampleForCyclicDependency1Collection.h"
 #include "datamodel/ExampleForCyclicDependency2Collection.h"
 #include "datamodel/ExampleHitCollection.h"
+#include "datamodel/ExampleMCCollection.h"
 #include "datamodel/ExampleWithArray.h"
 #include "datamodel/ExampleWithArrayComponent.h"
 #include "datamodel/ExampleWithComponent.h"
@@ -469,8 +470,15 @@ TEST_CASE("Equality", "[basics]") {
   auto clu2 = ExampleCluster::makeEmpty();
   // Empty handles always compare equal
   REQUIRE(clu == clu2);
+  REQUIRE(clu2 == clu);
   // They never compare equal to a non-empty handle
   REQUIRE(clu != cluster);
+  REQUIRE(cluster != clu);
+
+  auto coll = ExampleClusterCollection();
+  coll.create();
+  REQUIRE(coll[0] != clu);
+  REQUIRE(clu != coll[0]);
 }
 
 TEST_CASE("UserInitialization", "[basics][code-gen]") {
@@ -1385,3 +1393,32 @@ TEST_CASE("Relations after cloning with SIO", "[relations][basics]") {
 }
 
 #endif
+
+void runRelationAfterCloneEqualCheck() {
+  auto newColl = ExampleMCCollection();
+  auto coll = ExampleMCCollection();
+  coll.create();
+  coll.create();
+  coll[0].addparents(coll[0]);
+  coll[0].adddaughters(coll[1]);
+  coll[0].adddaughters(coll[0]);
+  coll[1].addparents(coll[0]);
+  newColl.push_back(coll.at(0).clone());
+  newColl.push_back(coll.at(1).clone());
+
+  REQUIRE(newColl[0].parents()[0] == newColl[0]);
+  REQUIRE(newColl[0].daughters()[0] == newColl[1]);
+  REQUIRE(newColl[0].daughters()[1] == newColl[0]);
+  REQUIRE(newColl[1].parents()[0] == newColl[0]);
+
+  REQUIRE(newColl[0].parents()[0] != newColl[1]);
+  REQUIRE(newColl[0].daughters()[0] != newColl[0]);
+  REQUIRE(newColl[0].daughters()[1] != newColl[1]);
+  REQUIRE(newColl[1].parents()[0] != newColl[1]);
+
+
+}
+
+TEST_CASE("Relations after cloning with equal check", "[relations][basics]") {
+  runRelationAfterCloneEqualCheck();
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a parameter `cloneRelations` for the `clone` method of the user facing handle classes to be able to clone without the relation information.

ENDRELEASENOTES

See [this comment](https://github.com/AIDASoft/podio/pull/609#issuecomment-2133079316) and [this comment](https://github.com/AIDASoft/podio/pull/609#issuecomment-2133257276)