### PR TITLE
Drop unused comparison templates

### DIFF
--- a/include/podio/utilities/MaybeSharedPtr.h
+++ b/include/podio/utilities/MaybeSharedPtr.h
@@ -151,14 +151,6 @@ void swap(MaybeSharedPtr<T>& a, MaybeSharedPtr<T>& b) {
   template <typename U>                                                                                                \
   bool operator op(const MaybeSharedPtr<U>& lhs, const MaybeSharedPtr<U>& rhs) {                                       \
     return lhs.m_ptr op rhs.m_ptr;                                                                                     \
-  }                                                                                                                    \
-  template <typename U>                                                                                                \
-  bool operator op(const MaybeSharedPtr<U>& lhs, const U* rhs) {                                                       \
-    return lhs.m_ptr op rhs;                                                                                           \
-  }                                                                                                                    \
-  template <typename U>                                                                                                \
-  bool operator op(const U* lhs, const MaybeSharedPtr<U>& rhs) {                                                       \
-    return lhs op rhs.m_ptr;                                                                                           \
   }
 
 DEFINE_COMPARISON_OPERATOR(==)


### PR DESCRIPTION
BEGINRELEASENOTES
- Drop unused comparison templates

ENDRELEASENOTES

It has been a while since they have been introduced and are not in use so they can be deleted.