### PR TITLE
Add missing include for gcc14

### DIFF
--- a/include/podio/utilities/DatamodelRegistryIOHelpers.h
+++ b/include/podio/utilities/DatamodelRegistryIOHelpers.h
@@ -4,6 +4,7 @@
 #include "podio/CollectionBase.h"
 #include "podio/DatamodelRegistry.h"
 
+#include <algorithm>
 #include <set>
 #include <string>
 #include <tuple>


### PR DESCRIPTION

BEGINRELEASENOTES
- DatamodelRegistryIOHelpers: add missing include of algorithm for gcc14

ENDRELEASENOTES

https://lcgapp-services.cern.ch/cdash/upload/7a781494243f92e42c17822ca24273df5513de5e/podio-00.17.04-build.log