### PR TITLE
Fix some minor issues with the Reader and Writer interfaces

### DIFF
--- a/include/podio/Reader.h
+++ b/include/podio/Reader.h
@@ -7,8 +7,7 @@
 namespace podio {
 
 class Reader {
-public:
-  // ROOT dictionary generation needs this to be public for some reason
+private:
   struct ReaderConcept {
     virtual ~ReaderConcept() = default;
 

--- a/include/podio/Reader.h
+++ b/include/podio/Reader.h
@@ -8,24 +8,30 @@ namespace podio {
 
 class Reader {
 public:
+  // ROOT dictionary generation needs this to be public for some reason
   struct ReaderConcept {
     virtual ~ReaderConcept() = default;
 
     virtual podio::Frame readNextFrame(const std::string& name) = 0;
     virtual podio::Frame readFrame(const std::string& name, size_t index) = 0;
-    virtual size_t getEntries(const std::string& name) = 0;
+    virtual size_t getEntries(const std::string& name) const = 0;
     virtual podio::version::Version currentFileVersion() const = 0;
     virtual std::vector<std::string_view> getAvailableCategories() const = 0;
     virtual const std::string_view getDatamodelDefinition(const std::string& name) const = 0;
     virtual std::vector<std::string> getAvailableDatamodels() const = 0;
   };
 
+private:
   template <typename T>
-  struct ReaderModel final : public ReaderConcept {
+  struct ReaderModel final : ReaderConcept {
     ReaderModel(std::unique_ptr<T> reader) : m_reader(std::move(reader)) {
     }
     ReaderModel(const ReaderModel&) = delete;
     ReaderModel& operator=(const ReaderModel&) = delete;
+    ReaderModel(ReaderModel&&) = default;
+    ReaderModel& operator=(ReaderModel&&) = default;
+
+    ~ReaderModel() = default;
 
     podio::Frame readNextFrame(const std::string& name) override {
       auto maybeFrame = m_reader->readNextEntry(name);
@@ -43,7 +49,7 @@ public:
       throw std::runtime_error("Failed reading category " + name + " at frame " + std::to_string(index) +
                                " (reading beyond bounds?)");
     }
-    size_t getEntries(const std::string& name) override {
+    size_t getEntries(const std::string& name) const override {
       return m_reader->getEntries(name);
     }
     podio::version::Version currentFileVersion() const override {
@@ -67,8 +73,17 @@ public:
 
   std::unique_ptr<ReaderConcept> m_self{nullptr};
 
+public:
   template <typename T>
   Reader(std::unique_ptr<T>);
+
+  Reader(const Reader&) = delete;
+  Reader& operator=(const Reader&) = delete;
+
+  Reader(Reader&&) = default;
+  Reader& operator=(Reader&&) = default;
+
+  ~Reader() = default;
 
   podio::Frame readNextFrame(const std::string& name) {
     return m_self->readNextFrame(name);
@@ -82,10 +97,10 @@ public:
   podio::Frame readEvent(size_t index) {
     return readFrame(podio::Category::Event, index);
   }
-  size_t getEntries(const std::string& name) {
+  size_t getEntries(const std::string& name) const {
     return m_self->getEntries(name);
   }
-  size_t getEvents() {
+  size_t getEvents() const {
     return getEntries(podio::Category::Event);
   }
   podio::version::Version currentFileVersion() const {

--- a/include/podio/Writer.h
+++ b/include/podio/Writer.h
@@ -11,11 +11,8 @@ public:
   struct WriterConcept {
     virtual ~WriterConcept() = default;
 
-    virtual void writeFrame(const podio::Frame& frame, const std::string& category) = 0;
     virtual void writeFrame(const podio::Frame& frame, const std::string& category,
                             const std::vector<std::string>& collections) = 0;
-    virtual void writeEvent(const podio::Frame& frame) = 0;
-    virtual void writeEvent(const podio::Frame& frame, const std::vector<std::string>& collections) = 0;
     virtual void finish() = 0;
   };
 
@@ -31,18 +28,9 @@ private:
 
     ~WriterModel() = default;
 
-    void writeFrame(const podio::Frame& frame, const std::string& category) override {
-      return m_writer->writeFrame(frame, category);
-    }
     void writeFrame(const podio::Frame& frame, const std::string& category,
                     const std::vector<std::string>& collections) override {
       return m_writer->writeFrame(frame, category, collections);
-    }
-    void writeEvent(const podio::Frame& frame) override {
-      return writeFrame(frame, podio::Category::Event);
-    }
-    void writeEvent(const podio::Frame& frame, const std::vector<std::string>& collections) override {
-      return writeFrame(frame, podio::Category::Event, collections);
     }
     void finish() override {
       return m_writer->finish();
@@ -65,16 +53,16 @@ public:
   ~Writer() = default;
 
   void writeFrame(const podio::Frame& frame, const std::string& category) {
-    return m_self->writeFrame(frame, category);
+    return m_self->writeFrame(frame, category, frame.getAvailableCollections());
   }
   void writeFrame(const podio::Frame& frame, const std::string& category, const std::vector<std::string>& collections) {
     return m_self->writeFrame(frame, category, collections);
   }
   void writeEvent(const podio::Frame& frame) {
-    return writeFrame(frame, podio::Category::Event);
+    writeFrame(frame, podio::Category::Event, frame.getAvailableCollections());
   }
   void writeEvent(const podio::Frame& frame, const std::vector<std::string>& collections) {
-    return writeFrame(frame, podio::Category::Event, collections);
+    writeFrame(frame, podio::Category::Event, collections);
   }
   void finish() {
     return m_self->finish();

--- a/include/podio/Writer.h
+++ b/include/podio/Writer.h
@@ -2,12 +2,12 @@
 #define PODIO_WRITER_H
 
 #include "podio/Frame.h"
-#include "podio/podioVersion.h"
 
 namespace podio {
 
 class Writer {
 public:
+  // ROOT dictionary generation needs this to be public for some reason
   struct WriterConcept {
     virtual ~WriterConcept() = default;
 
@@ -19,8 +19,9 @@ public:
     virtual void finish() = 0;
   };
 
+private:
   template <typename T>
-  struct WriterModel final : public WriterConcept {
+  struct WriterModel final : WriterConcept {
     WriterModel(std::unique_ptr<T> writer) : m_writer(std::move(writer)) {
     }
     WriterModel(const WriterModel&) = delete;
@@ -51,6 +52,7 @@ public:
 
   std::unique_ptr<WriterConcept> m_self{nullptr};
 
+public:
   template <typename T>
   Writer(std::unique_ptr<T> reader) : m_self(std::make_unique<WriterModel<T>>(std::move(reader))) {
   }

--- a/include/podio/Writer.h
+++ b/include/podio/Writer.h
@@ -6,8 +6,7 @@
 namespace podio {
 
 class Writer {
-public:
-  // ROOT dictionary generation needs this to be public for some reason
+private:
   struct WriterConcept {
     virtual ~WriterConcept() = default;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,7 +148,11 @@ set(io_headers
   ${PROJECT_SOURCE_DIR}/include/podio/Reader.h
   )
 
-PODIO_ADD_LIB_AND_DICT(podioIO "${io_headers}" "${io_sources}" io_selection.xml)
+add_library(podioIO SHARED ${io_sources})
+add_library(podio::podioIO ALIAS podioIO)
+target_include_directories(podioIO PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(podioIO PUBLIC podio::podio podio::podioRootIO)
 if(ENABLE_SIO)
   target_link_libraries(podioIO PUBLIC podio::podioSioIO)
@@ -172,8 +176,6 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/libpodioDict_rdict.pcm
   ${CMAKE_CURRENT_BINARY_DIR}/podioRootIODictDict.rootmap
   ${CMAKE_CURRENT_BINARY_DIR}/libpodioRootIODict_rdict.pcm
-  ${CMAKE_CURRENT_BINARY_DIR}/podioIODictDict.rootmap
-  ${CMAKE_CURRENT_BINARY_DIR}/libpodioIODict_rdict.pcm
   DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 if (ENABLE_SIO)

--- a/src/io_selection.xml
+++ b/src/io_selection.xml
@@ -1,6 +1,0 @@
-<lcgdict>
-  <selection>
-    <class name="podio::Reader"/>
-    <class name="podio::Writer"/>
-  </selection>
-</lcgdict>


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix minor issues with the `Reader` and `Writer` interface classes
  - Make sure that only the public API is public
  - Fix some const correctness issues by marking `const` methods as such
  - Remove unnecessary and (partially) unused APIs from the `Writer` interface
- Remove the dictionary generation for `podioIO` as we don't need the dictionaries 

ENDRELEASENOTES