### PR TITLE
Mark GenericParameters::print as const to allow proper usage

### DIFF
--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -112,7 +112,7 @@ public:
     _stringMap.clear();
   }
 
-  void print(std::ostream& os = std::cout, bool flush = true);
+  void print(std::ostream& os = std::cout, bool flush = true) const;
 
   /// Check if no parameter is stored (i.e. if all internal maps are empty)
   bool empty() const {

--- a/src/GenericParameters.cc
+++ b/src/GenericParameters.cc
@@ -58,7 +58,7 @@ void printMap(const MapType& map, std::ostream& os) {
   os.flags(osflags);
 }
 
-void GenericParameters::print(std::ostream& os, bool flush) {
+void GenericParameters::print(std::ostream& os, bool flush) const {
   os << "int parameters\n\n";
   printMap(getMap<int>(), os);
   os << "\nfloat parameters\n";


### PR DESCRIPTION

BEGINRELEASENOTES
- Make `GenericParameters::print` const-correct to allow proper usage

ENDRELEASENOTES