### PR TITLE
Move ROOTFrameData implementation into .cc file

### DIFF
--- a/include/podio/ROOTFrameData.h
+++ b/include/podio/ROOTFrameData.h
@@ -25,37 +25,15 @@ public:
   ROOTFrameData(const ROOTFrameData&) = delete;
   ROOTFrameData& operator=(const ROOTFrameData&) = delete;
 
-  ROOTFrameData(BufferMap&& buffers, CollIDPtr&& idTable, podio::GenericParameters&& params) :
-      m_buffers(std::move(buffers)), m_idTable(std::move(idTable)), m_parameters(std::move(params)) {
-  }
+  ROOTFrameData(BufferMap&& buffers, CollIDPtr&& idTable, podio::GenericParameters&& params);
 
-  std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name) {
-    const auto bufferHandle = m_buffers.extract(name);
-    if (bufferHandle.empty()) {
-      return std::nullopt;
-    }
+  std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
 
-    return {bufferHandle.mapped()};
-  }
+  podio::CollectionIDTable getIDTable() const;
 
-  podio::CollectionIDTable getIDTable() const {
-    // Construct a copy of the internal table
-    return {m_idTable->ids(), m_idTable->names()};
-  }
+  std::unique_ptr<podio::GenericParameters> getParameters();
 
-  std::unique_ptr<podio::GenericParameters> getParameters() {
-    return std::make_unique<podio::GenericParameters>(std::move(m_parameters));
-  }
-
-  std::vector<std::string> getAvailableCollections() const {
-    std::vector<std::string> collections;
-    collections.reserve(m_buffers.size());
-    for (const auto& [name, _] : m_buffers) {
-      collections.push_back(name);
-    }
-
-    return collections;
-  }
+  std::vector<std::string> getAvailableCollections() const;
 
 private:
   // TODO: switch to something more elegant once the basic functionality and
@@ -65,13 +43,6 @@ private:
   CollIDPtr m_idTable{nullptr};
   podio::GenericParameters m_parameters{};
 };
-
-// Interim workaround for https://github.com/AIDASoft/podio#500
-inline ROOTFrameData::~ROOTFrameData() {
-  for (auto& [_, buffer] : m_buffers) {
-    buffer.deleteBuffers(buffer);
-  }
-}
 
 } // namespace podio
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,7 @@ SET(root_sources
   ROOTWriter.cc
   ROOTReader.cc
   ROOTLegacyReader.cc
+  ROOTFrameData.cc
 )
 if(ENABLE_RNTUPLE)
   list(APPEND root_sources
@@ -92,6 +93,7 @@ SET(root_headers
   ${PROJECT_SOURCE_DIR}/include/podio/ROOTReader.h
   ${PROJECT_SOURCE_DIR}/include/podio/ROOTLegacyReader.h
   ${PROJECT_SOURCE_DIR}/include/podio/ROOTWriter.h
+  ${PROJECT_SOURCE_DIR}/include/podio/ROOTFrameData.h
   )
 if(ENABLE_RNTUPLE)
   list(APPEND root_headers

--- a/src/ROOTFrameData.cc
+++ b/src/ROOTFrameData.cc
@@ -1,0 +1,44 @@
+#include "podio/ROOTFrameData.h"
+
+namespace podio {
+
+ROOTFrameData::ROOTFrameData(BufferMap&& buffers, CollIDPtr&& idTable, podio::GenericParameters&& params) :
+    m_buffers(std::move(buffers)), m_idTable(std::move(idTable)), m_parameters(std::move(params)) {
+}
+
+// Interim workaround for https://github.com/AIDASoft/podio#500
+ROOTFrameData::~ROOTFrameData() {
+  for (auto& [_, buffer] : m_buffers) {
+    buffer.deleteBuffers(buffer);
+  }
+}
+
+std::optional<podio::CollectionReadBuffers> ROOTFrameData::getCollectionBuffers(const std::string& name) {
+  const auto bufferHandle = m_buffers.extract(name);
+  if (bufferHandle.empty()) {
+    return std::nullopt;
+  }
+
+  return {bufferHandle.mapped()};
+}
+
+podio::CollectionIDTable ROOTFrameData::getIDTable() const {
+  // Construct a copy of the internal table
+  return {m_idTable->ids(), m_idTable->names()};
+}
+
+std::unique_ptr<podio::GenericParameters> ROOTFrameData::getParameters() {
+  return std::make_unique<podio::GenericParameters>(std::move(m_parameters));
+}
+
+std::vector<std::string> ROOTFrameData::getAvailableCollections() const {
+  std::vector<std::string> collections;
+  collections.reserve(m_buffers.size());
+  for (const auto& [name, _] : m_buffers) {
+    collections.push_back(name);
+  }
+
+  return collections;
+}
+
+} // namespace podio


### PR DESCRIPTION

BEGINRELEASENOTES
- Move the implementation of `ROOTFrameData` member functions into a separate cc file.

ENDRELEASENOTES