### PR TITLE
Make collection iterators fulfill LegacyInputIterator and input_iterator concept

### DIFF
--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -7,7 +7,7 @@ The PODIO `Collection`s interface was designed to mimic the standard *Container*
 On the implementation level most of the differences with respect to the *Container* comes from the fact that in order to satisfy the additional semantics a `Collection` doesn't directly store [user layer objects](design.md#the-user-layer). Instead, [data layer objects](design.md#the-internal-data-layer) are stored and user layer objects are constructed and returned when needed. Similarly, the `Collection` iterators operate on the user layer objects but don't expose `Collection`'s storage directly to the users. Instead, they construct and return user layer objects when needed.
 In other words, a `Collection` utilizes the user layer type as a reference type instead of using plain references (`&` or `&&`) to stored data layer types.
 
-As a consequence some of the **standard algorithms may not work** with PODIO `Collection` iterators.  See [standard algorithm documentation](#collection-and-standard-algorithms) below.
+As a consequence some of the **standard algorithms may not work** with PODIO `Collection` iterators. See [standard algorithm documentation](#collection-and-standard-algorithms) below.
 
 The following tables list the compliance of a PODIO generated collection with the *Container* named requirement, stating which member types, interfaces, or concepts are fulfilled and which are not. Additionally, there are some comments explaining missing parts or pointing out differences in behaviour.
 
@@ -16,12 +16,12 @@ The following tables list the compliance of a PODIO generated collection with th
 | Name | Type | Requirements | Fulfilled by Collection? | Comment |
 |------|------|--------------|--------------------------|---------|
 | `value_type` | `T` | *[Erasable](https://en.cppreference.com/w/cpp/named_req/Erasable)* | ✔️ yes | Defined as an immutable user layer object type |
-| `reference` | `T&` |  | ❌ no | Not defined |
+| `reference` | `T&` | | ❌ no | Not defined |
 | `const_reference` | `const T&` | | ❌ no | Not defined |
 | `iterator` | Iterator whose `value_type` is `T` | [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) convertible to `const_iterator` | ❌ no | Defined as podio `MutableCollectionIterator`. `iterator::value_type` not defined, not [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) ([see below](#legacyforwarditerator)), not convertible to `const_iterator`|
 | `const_iterator` | Constant iterator whose `value_type` is `T` | [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no | Defined as podio `CollectionIterator`. `const_iterator::value_type` not defined, not [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) ([see below](#legacyforwarditerator))
 | `difference_type`| Signed integer | Must be the same as `std::iterator_traits::difference_type` for `iterator` and `const_iterator` | ❌ no | `std::iterator_traits::difference_type` not defined |
-| `size_type` | Unsigned integer | Large enough to represent all positive values of `difference_type` | ✔️ yes |  |
+| `size_type` | Unsigned integer | Large enough to represent all positive values of `difference_type` | ✔️ yes | |
 
 ### Container member functions and operators
 
@@ -31,18 +31,18 @@ The following tables list the compliance of a PODIO generated collection with th
 | `C(a)` | `C` | Creates a copy of `a` | ❌ no | Not defined, non-copyable by design |
 | `C(rv)` | `C` | Moves `rv` | ✔️ yes | |
 | `a = b` | `C&` | Destroys or copy-assigns all elements of `a` from elements of `b` | ❌ no | Not defined, non-copyable by design |
-| `a = rv` | `C&` | Destroys or move-assigns all elements of `a` from elements of `rv` |  ✔️ yes | |
-| `a.~C()` | `void` | Destroys all elements of `a` and frees all memory|  ✔️ yes | Invalidates all handles retrieved from this collection |
-| `a.begin()` | `(const_)iterator` | Iterator to the first element of `a` |  ✔️ yes | |
+| `a = rv` | `C&` | Destroys or move-assigns all elements of `a` from elements of `rv` | ✔️ yes | |
+| `a.~C()` | `void` | Destroys all elements of `a` and frees all memory| ✔️ yes | Invalidates all handles retrieved from this collection |
+| `a.begin()` | `(const_)iterator` | Iterator to the first element of `a` | ✔️ yes | |
 | `a.end()` | `(const_)iterator` | Iterator to one past the last element of `a` | ✔️ yes | |
 | `a.cbegin()` | `const_iterator` | Same as `const_cast<const C&>(a).begin()` | ✔️ yes | |
-| `a.cend()` | `const_iterator` | Same as `const_cast<const C&>(a).end()`|  ✔️ yes | |
+| `a.cend()` | `const_iterator` | Same as `const_cast<const C&>(a).end()`| ✔️ yes | |
 | `a == b` | Convertible to `bool` | Same as `std::equal(a.begin(), a.end(), b.begin(), b.end())`| ❌ no | Not defined |
 | `a != b` | Convertible to `bool` | Same as `!(a == b)` | ❌ no | Not defined |
 | `a.swap(b)` | `void` | Exchanges the values of `a` and `b` | ❌ no | Not defined |
 | `swap(a,b)` | `void` | Same as `a.swap(b)` | ❌ no | `a.swap(b)` not defined |
 | `a.size()` | `size_type` | Same as `std::distance(a.begin(), a.end())` | ✔️ yes | |
-| `a.max_size()` | `size_type` | `b.size()` where b is the largest possible container | ✔️ yes | |
+| `a.max_size()` | `size_type` | `b.size()` where `b` is the largest possible container | ✔️ yes | |
 | `a.empty()` | Convertible to `bool` | Same as `a.begin() == a.end()` | ✔️ yes | |
 
 ## Collection as an *AllocatorAwareContainer*
@@ -53,9 +53,9 @@ PODIO collections don't provide a customization point for allocators and use onl
 
 ### AllocatorAwareContainer types
 
-| Name |  Requirements | Fulfilled by Collection? | Comment |
+| Name | Requirements | Fulfilled by Collection? | Comment |
 |------|--------------|--------------------------|---------|
-| `allocator_type`  | `allocator_type::value_type` same as `value_type` | ❌ no | `allocator_type` not defined |
+| `allocator_type` | `allocator_type::value_type` same as `value_type` | ❌ no | `allocator_type` not defined |
 
 ### *AllocatorAwareContainer* expression and statements
 
@@ -120,7 +120,7 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |------------|-------------|-----------|-------------------------------------------|---------|
-| `i != j` |  Contextually convertible to `bool` | Same as `!(i==j)` | ✔️ yes / ✔️ yes | |
+| `i != j` | Contextually convertible to `bool` | Same as `!(i==j)` | ✔️ yes / ✔️ yes | |
 | `*i` | `reference`, convertible to `value_type` | | ❌ no / ❌ no | `reference` and `value_type` not defined |
 | `i->m` | | Same as `(*i).m` | ✔️ yes / ✔️ yes | |
 | `++r` | `It&` | | ✔️ yes / ✔️ yes | |
@@ -155,7 +155,7 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |------------|-------------|-----------|-------------------------------------------|---------|
 | `*r = o` | | | ❗ attention / ❗ attention | Defined but an assignment doesn't modify objects inside collection |
-| `++r` | `It&` | | ✔️ yes / ✔️ yes  | |
+| `++r` | `It&` | | ✔️ yes / ✔️ yes | |
 | `r++` | Convertible to `const It&` | Same as `It temp = r; ++r; return temp;` | ❌ no / ❌ no | Post-increment not defined |
 | `*r++ = o` | | Same as `*r = o; ++r;`| ❌ no / ❌ no | Post-increment not defined |
 
@@ -169,7 +169,7 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | `std::insert_iterator` | ❌ no | `insert` not defined |
 | `std::const_iterator` | ❌ no | `iterator` and `const_iterator` not *LegacyInputIterator* or `std::input_iterator` |
 | `std::move_iterator` | ❌ no | `iterator` and `const_iterator` not *LegacyInputIterator* or `std::input_iterator` |
-| `std::counted_iterator` |  ❌ no | `iterator` and `const_iterator` not `std::input_or_output_iterator` |
+| `std::counted_iterator` | ❌ no | `iterator` and `const_iterator` not `std::input_or_output_iterator` |
 
 
 ## Collection and standard algorithms

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -96,10 +96,10 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 
 | Requirement | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |-------------|-------------------------------------------|---------|
-| [*CopyConstructible*](https://en.cppreference.com/w/cpp/named_req/CopyConstructible) | ❌ no / ❌ no | Move constructor and copy constructor not defined |
-| [*CopyAssignable*](https://en.cppreference.com/w/cpp/named_req/CopyAssignable) | ❌ no / ❌ no | Move assignment and copy assignment not defined |
+| [*CopyConstructible*](https://en.cppreference.com/w/cpp/named_req/CopyConstructible) | ✔️ yes / ✔️ yes | |
+| [*CopyAssignable*](https://en.cppreference.com/w/cpp/named_req/CopyAssignable) | ✔️ yes / ✔️ yes | |
 | [*Destructible*](https://en.cppreference.com/w/cpp/named_req/Destructible) | ✔️ yes / ✔️ yes | |
-| [*Swappable*](https://en.cppreference.com/w/cpp/named_req/Swappable) | ❌ no / ❌ no | |
+| [*Swappable*](https://en.cppreference.com/w/cpp/named_req/Swappable) | ✔️ yes / ✔️ yes | |
 | `std::iterator_traits::value_type` (Until C++20 ) | ❌ no / ❌ no | Not defined |
 | `std::iterator_traits::difference_type` | ❌ no / ❌ no | Not defined |
 | `std::iterator_traits::reference` | ❌ no / ❌ no | Not defined |
@@ -131,13 +131,12 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 
 In addition to the *LegacyForwardIterator* the C++ standard specifies also the *mutable LegacyForwardIterator*, which is both *LegacyForwardIterator* and *LegacyOutputIterator*. The term **mutable** used in this context doesn't imply mutability in the sense used in the PODIO.
 
-
 | Requirement | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |-------------|-------------------------------------------|---------|
 | [*LegacyInputIterator*](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ❌ no / ❌ no | [See above](#legacyinputiterator)|
 | [*DefaultConstructible*](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible) | ❌ no / ❌ no | Value initialization not defined |
 | If *mutable* iterator then `reference` same as `value_type&` or `value_type&&`, otherwise same as `const value_type&` or `const value_type&&` | ❌ no / ❌ no | `reference` and `value_type` not defined |
-| [Multipass guarantee](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | Copy constructor not defined |
+| [Multipass guarantee](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ✔️ yes / ✔️ yes | |
 | [Singular iterators](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | Value initialization not defined |
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -136,7 +136,7 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | [*LegacyInputIterator*](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ❌ no / ❌ no | [See above](#legacyinputiterator)|
 | [*DefaultConstructible*](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible) | ❌ no / ❌ no | Value initialization not defined |
 | If *mutable* iterator then `reference` same as `value_type&` or `value_type&&`, otherwise same as `const value_type&` or `const value_type&&` | ❌ no / ❌ no | `reference` and `value_type` not defined |
-| [Multipass guarantee](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ✔️ yes / ✔️ yes | |
+| [Multipass guarantee](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | References from dereferencing equal iterators aren't bound to the same object |
 | [Singular iterators](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | Value initialization not defined |
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -83,7 +83,7 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | `std::indirectly_readable` | ❌ no | ❌ no |
 | `std::indirectly_writable` | ❌ no | ❌ no |
 | `std::weakly_incrementable` | ✔️ yes | ✔️ yes |
-| `std::incrementable` | ❌ no | ❌ no |
+| `std::incrementable` | ✔️ yes | ✔️ yes |
 | `std::input_or_output_iterator` | ✔️ yes | ✔️ yes |
 | `std::input_iterator` | ❌ no | ❌ no |
 | `std::output_iterator` | ❌ no | ❌ no |
@@ -134,10 +134,10 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | Requirement | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |-------------|-------------------------------------------|---------|
 | [*LegacyInputIterator*](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ✔️ yes / ✔️ yes | [See above](#legacyinputiterator)|
-| [*DefaultConstructible*](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible) | ❌ no / ❌ no | Value initialization not defined |
+| [*DefaultConstructible*](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible) | ✔️ yes / ✔️ yes | |
 | If *mutable* iterator then `reference` same as `value_type&` or `value_type&&`, otherwise same as `const value_type&` or `const value_type&&` | ❌ no / ❌ no | `reference` type is not a reference (`&` or `&&`) |
 | [Multipass guarantee](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | References from dereferencing equal iterators aren't bound to the same object |
-| [Singular iterators](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | Value initialization not defined |
+| [Singular iterators](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ✔️ yes / ✔️ yes | |
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |------------|-------------|-----------|-------------------------------------------|---------|

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -71,7 +71,7 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | Named requirement | `iterator` | `const_iterator` |
 |-------------------|-----------------------|-----------------------------|
 | [LegacyIterator](https://en.cppreference.com/w/cpp/named_req/Iterator) | ✔️ yes ([see below](#legacyiterator)) | ✔️ yes ([see below](#legacyiterator)) |
-| [LegacyInputIterator](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ❌ no ([see below](#legacyinputiterator)) | ❌ no ([see below](#legacyinputiterator)) |
+| [LegacyInputIterator](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ✔️ yes ([see below](#legacyinputiterator)) | ✔️ yes ([see below](#legacyinputiterator)) |
 | [LegacyForwardIterator](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no ([see below](#legacyforwarditerator)) | ❌ no ([see below](#legacyforwarditerator)) |
 | [LegacyOutputIterator](https://en.cppreference.com/w/cpp/named_req/OutputIterator) | ❌ no ([see below](#legacyoutputiterator)) | ❌ no ([see below](#legacyoutputiterator)) |
 | [LegacyBidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator) | ❌ no | ❌ no |
@@ -82,9 +82,9 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 |---------|------------------------|------------------------------|
 | `std::indirectly_readable` | ❌ no | ❌ no |
 | `std::indirectly_writable` | ❌ no | ❌ no |
-| `std::weakly_incrementable` | ❌ no | ❌ no |
+| `std::weakly_incrementable` | ✔️ yes | ✔️ yes |
 | `std::incrementable` | ❌ no | ❌ no |
-| `std::input_or_output_iterator` | ❌ no | ❌ no |
+| `std::input_or_output_iterator` | ✔️ yes | ✔️ yes |
 | `std::input_iterator` | ❌ no | ❌ no |
 | `std::output_iterator` | ❌ no | ❌ no |
 | `std::forward_iterator` | ❌ no | ❌ no |
@@ -124,8 +124,8 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | `*i` | `reference`, convertible to `value_type` | | ✔️ yes / ✔️ yes | |
 | `i->m` | | Same as `(*i).m` | ✔️ yes / ✔️ yes | |
 | `++r` | `It&` | | ✔️ yes / ✔️ yes | |
-| `(void)r++` | | Same as `(void)++r` | ❌ no / ❌ no | Post-increment not defined |
-| `*r++` | Convertible to `value_type` | Same as `value_type x = *r; ++r; return x;` | ❌ no / ❌ no | Post-increment not defined |
+| `(void)r++` | | Same as `(void)++r` | ✔️ yes / ✔️ yes | |
+| `*r++` | Convertible to `value_type` | Same as `value_type x = *r; ++r; return x;` | ✔️ yes / ✔️ yes | |
 
 ### LegacyForwardIterator
 
@@ -133,7 +133,7 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 
 | Requirement | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |-------------|-------------------------------------------|---------|
-| [*LegacyInputIterator*](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ❌ no / ❌ no | [See above](#legacyinputiterator)|
+| [*LegacyInputIterator*](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ✔️ yes / ✔️ yes | [See above](#legacyinputiterator)|
 | [*DefaultConstructible*](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible) | ❌ no / ❌ no | Value initialization not defined |
 | If *mutable* iterator then `reference` same as `value_type&` or `value_type&&`, otherwise same as `const value_type&` or `const value_type&&` | ❌ no / ❌ no | `reference` type is not a reference (`&` or `&&`) |
 | [Multipass guarantee](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | References from dereferencing equal iterators aren't bound to the same object |
@@ -141,8 +141,8 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |------------|-------------|-----------|-------------------------------------------|---------|
-| `i++` | `It` | Same as `It ip = i; ++i; return ip;` | ❌ no / ❌ no | Post-increment not defined |
-| `*i++` | `reference` | | ❌ no / ❌ no | Post-increment not defined |
+| `i++` | `It` | Same as `It ip = i; ++i; return ip;` | ✔️ yes / ✔️ yes | |
+| `*i++` | `reference` | | ✔️ yes / ✔️ yes | |
 
 ### LegacyOutputIterator
 
@@ -155,8 +155,8 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 |------------|-------------|-----------|-------------------------------------------|---------|
 | `*r = o` | | | ❗ attention / ❗ attention | Defined but an assignment doesn't modify objects inside collection |
 | `++r` | `It&` | | ✔️ yes / ✔️ yes | |
-| `r++` | Convertible to `const It&` | Same as `It temp = r; ++r; return temp;` | ❌ no / ❌ no | Post-increment not defined |
-| `*r++ = o` | | Same as `*r = o; ++r;`| ❌ no / ❌ no | Post-increment not defined |
+| `r++` | Convertible to `const It&` | Same as `It temp = r; ++r; return temp;` | ✔️ yes / ✔️ yes | |
+| `*r++ = o` | | Same as `*r = o; ++r;`| ❗ attention / ❗ attention | Defined but an assignment doesn't modify objects inside collection |
 
 ## Collection iterators and standard iterator adaptors
 
@@ -166,9 +166,9 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | `std::back_insert_iterator` | ❗ attention | Compatible only with SubsetCollections, otherwise throws `std::invalid_argument` |
 | `std::front_insert_iterator` | ❌ no | `push_front` not defined |
 | `std::insert_iterator` | ❌ no | `insert` not defined |
-| `std::const_iterator` | ❌ no | `iterator` and `const_iterator` not *LegacyInputIterator* or `std::input_iterator` |
-| `std::move_iterator` | ❌ no | `iterator` and `const_iterator` not *LegacyInputIterator* or `std::input_iterator` |
-| `std::counted_iterator` | ❌ no | `iterator` and `const_iterator` not `std::input_or_output_iterator` |
+| `std::const_iterator` (C++23) | ❌ no | C++23 not supported yet |
+| `std::move_iterator` | ✔️ yes | Limited usefulness since dereference returns `reference` not rvalue (`&&`) |
+| `std::counted_iterator` | ✔️ yes | |
 
 
 ## Collection and standard algorithms

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -167,9 +167,9 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | `std::back_insert_iterator` | ❗ attention | Compatible only with SubsetCollections, otherwise throws `std::invalid_argument` |
 | `std::front_insert_iterator` | ❌ no | `push_front` not defined |
 | `std::insert_iterator` | ❌ no | `insert` not defined |
-| `std::const_iterator` (C++23) | ❌ no | C++23 not supported yet |
+| `std::const_iterator` (C++23) | ❗ attention | `operator->` not defined as `iterator`'s and `const_iterator`'s `operator->` are non-`const`. |
 | `std::move_iterator` | ✔️ yes | Limited usefulness since dereference returns `reference` type not rvalue reference (`&&`) |
-| `std::counted_iterator` | ✔️ yes | `operator->` not defined as it requires `std::contiguous_iterator` |
+| `std::counted_iterator` | ❗ attention | `operator->` not defined as it requires `std::contiguous_iterator` |
 
 
 ## Collection as a *range*

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -167,8 +167,8 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | `std::front_insert_iterator` | ❌ no | `push_front` not defined |
 | `std::insert_iterator` | ❌ no | `insert` not defined |
 | `std::const_iterator` (C++23) | ❌ no | C++23 not supported yet |
-| `std::move_iterator` | ✔️ yes | Limited usefulness since dereference returns `reference` not rvalue (`&&`) |
-| `std::counted_iterator` | ✔️ yes | |
+| `std::move_iterator` | ✔️ yes | Limited usefulness since dereference returns `reference` type not rvalue reference (`&&`) |
+| `std::counted_iterator` | ✔️ yes | `operator->` not defined as it requires `std::contiguous_iterator` |
 
 
 ## Collection and standard algorithms

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -18,9 +18,9 @@ The following tables list the compliance of a PODIO generated collection with th
 | `value_type` | `T` | *[Erasable](https://en.cppreference.com/w/cpp/named_req/Erasable)* | ✔️ yes | Defined as an immutable user layer object type |
 | `reference` | `T&` | | ❌ no | Not defined |
 | `const_reference` | `const T&` | | ❌ no | Not defined |
-| `iterator` | Iterator whose `value_type` is `T` | [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) convertible to `const_iterator` | ❌ no | Defined as podio `MutableCollectionIterator`. `iterator::value_type` not defined, not [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) ([see below](#legacyforwarditerator)), not convertible to `const_iterator`|
-| `const_iterator` | Constant iterator whose `value_type` is `T` | [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no | Defined as podio `CollectionIterator`. `const_iterator::value_type` not defined, not [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) ([see below](#legacyforwarditerator))
-| `difference_type`| Signed integer | Must be the same as `std::iterator_traits::difference_type` for `iterator` and `const_iterator` | ❌ no | `std::iterator_traits::difference_type` not defined |
+| `iterator` | Iterator whose `value_type` is `T` | [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) convertible to `const_iterator` | ❌ no | Defined as podio `MutableCollectionIterator`. Not [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) ([see below](#legacyforwarditerator)), not convertible to `const_iterator`|
+| `const_iterator` | Constant iterator whose `value_type` is `T` | [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no | Defined as podio `CollectionIterator`. Not [*LegacyForwardIterator*](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) ([see below](#legacyforwarditerator))
+| `difference_type`| Signed integer | Must be the same as `std::iterator_traits::difference_type` for `iterator` and `const_iterator` | ✔️ yes | |
 | `size_type` | Unsigned integer | Large enough to represent all positive values of `difference_type` | ✔️ yes | |
 
 ### Container member functions and operators
@@ -70,7 +70,7 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 
 | Named requirement | `iterator` | `const_iterator` |
 |-------------------|-----------------------|-----------------------------|
-| [LegacyIterator](https://en.cppreference.com/w/cpp/named_req/Iterator) | ❌ no ([see below](#legacyiterator)) | ❌ no ([see below](#legacyiterator)) |
+| [LegacyIterator](https://en.cppreference.com/w/cpp/named_req/Iterator) | ✔️ yes ([see below](#legacyiterator)) | ✔️ yes ([see below](#legacyiterator)) |
 | [LegacyInputIterator](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ❌ no ([see below](#legacyinputiterator)) | ❌ no ([see below](#legacyinputiterator)) |
 | [LegacyForwardIterator](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no ([see below](#legacyforwarditerator)) | ❌ no ([see below](#legacyforwarditerator)) |
 | [LegacyOutputIterator](https://en.cppreference.com/w/cpp/named_req/OutputIterator) | ❌ no ([see below](#legacyoutputiterator)) | ❌ no ([see below](#legacyoutputiterator)) |
@@ -100,11 +100,11 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | [*CopyAssignable*](https://en.cppreference.com/w/cpp/named_req/CopyAssignable) | ✔️ yes / ✔️ yes | |
 | [*Destructible*](https://en.cppreference.com/w/cpp/named_req/Destructible) | ✔️ yes / ✔️ yes | |
 | [*Swappable*](https://en.cppreference.com/w/cpp/named_req/Swappable) | ✔️ yes / ✔️ yes | |
-| `std::iterator_traits::value_type` (Until C++20 ) | ❌ no / ❌ no | Not defined |
-| `std::iterator_traits::difference_type` | ❌ no / ❌ no | Not defined |
-| `std::iterator_traits::reference` | ❌ no / ❌ no | Not defined |
-| `std::iterator_traits::pointer` | ❌ no / ❌ no | Not defined |
-| `std::iterator_traits::iterator_category` | ❌ no / ❌ no | Not defined |
+| `std::iterator_traits::value_type` (Until C++20 ) | ✔️ yes / ✔️ yes | |
+| `std::iterator_traits::difference_type` | ✔️ yes / ✔️ yes | |
+| `std::iterator_traits::reference` | ✔️ yes / ✔️ yes | |
+| `std::iterator_traits::pointer` | ✔️ yes / ✔️ yes | |
+| `std::iterator_traits::iterator_category` | ✔️ yes / ✔️ yes | |
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |------------|-------------|-----------|-------------------------------------------|---------|
@@ -115,17 +115,17 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 
 | Requirement | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |-------------|-------------------------------------------|---------|
-| [*LegacyIterator*](https://en.cppreference.com/w/cpp/named_req/Iterator) | ❌ no / ❌ no | [See above](#legacyiterator) |
+| [*LegacyIterator*](https://en.cppreference.com/w/cpp/named_req/Iterator) | ✔️ yes / ✔️ yes | [See above](#legacyiterator) |
 | [*EqualityComparable*](https://en.cppreference.com/w/cpp/named_req/EqualityComparable) | ✔️ yes / ✔️ yes | |
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |------------|-------------|-----------|-------------------------------------------|---------|
 | `i != j` | Contextually convertible to `bool` | Same as `!(i==j)` | ✔️ yes / ✔️ yes | |
-| `*i` | `reference`, convertible to `value_type` | | ❌ no / ❌ no | `reference` and `value_type` not defined |
+| `*i` | `reference`, convertible to `value_type` | | ✔️ yes / ✔️ yes | |
 | `i->m` | | Same as `(*i).m` | ✔️ yes / ✔️ yes | |
 | `++r` | `It&` | | ✔️ yes / ✔️ yes | |
 | `(void)r++` | | Same as `(void)++r` | ❌ no / ❌ no | Post-increment not defined |
-| `*r++` | Convertible to `value_type` | Same as `value_type x = *r; ++r; return x;` | ❌ no / ❌ no | Post-increment and `value_type` not defined |
+| `*r++` | Convertible to `value_type` | Same as `value_type x = *r; ++r; return x;` | ❌ no / ❌ no | Post-increment not defined |
 
 ### LegacyForwardIterator
 
@@ -135,20 +135,20 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 |-------------|-------------------------------------------|---------|
 | [*LegacyInputIterator*](https://en.cppreference.com/w/cpp/named_req/InputIterator) | ❌ no / ❌ no | [See above](#legacyinputiterator)|
 | [*DefaultConstructible*](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible) | ❌ no / ❌ no | Value initialization not defined |
-| If *mutable* iterator then `reference` same as `value_type&` or `value_type&&`, otherwise same as `const value_type&` or `const value_type&&` | ❌ no / ❌ no | `reference` and `value_type` not defined |
+| If *mutable* iterator then `reference` same as `value_type&` or `value_type&&`, otherwise same as `const value_type&` or `const value_type&&` | ❌ no / ❌ no | `reference` type is not a reference (`&` or `&&`) |
 | [Multipass guarantee](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | References from dereferencing equal iterators aren't bound to the same object |
 | [Singular iterators](https://en.cppreference.com/w/cpp/named_req/ForwardIterator) | ❌ no / ❌ no | Value initialization not defined |
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |------------|-------------|-----------|-------------------------------------------|---------|
 | `i++` | `It` | Same as `It ip = i; ++i; return ip;` | ❌ no / ❌ no | Post-increment not defined |
-| `*i++` | `reference` | | ❌ no / ❌ no | Post-increment and `reference` not defined |
+| `*i++` | `reference` | | ❌ no / ❌ no | Post-increment not defined |
 
 ### LegacyOutputIterator
 
 | Requirement | Fulfilled by `iterator`/`const_iterator`? | Comment |
 |-------------|-------------------------------------------|---------|
-| [*LegacyIterator*](https://en.cppreference.com/w/cpp/named_req/Iterator) | ❌ no / ❌ no | [See above](#legacyiterator) |
+| [*LegacyIterator*](https://en.cppreference.com/w/cpp/named_req/Iterator) | ✔️ yes / ✔️ yes | [See above](#legacyiterator) |
 | Is pointer type or class type | ✔️ yes / ✔️ yes | |
 
 | Expression | Return type | Semantics | Fulfilled by `iterator`/`const_iterator`? | Comment |

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -201,7 +201,7 @@ For example:
 std::find_if(std::begin(collection), std::end(collection), predicate ); // requires InputIterator -> OK
 std::adjacent_find(std::begin(collection), std::end(collection), predicate ); // requires ForwardIterator -> might compile, unspecified result
 std::fill(std::begin(collection), std::end(collection), value ); // requires ForwardIterator and writable -> might compile, wrong result
-std::::sort(std::begin(collection), std::end(collection)); // requires RandomAccessIterator and Swappable -> might compile, wrong result
+std::sort(std::begin(collection), std::end(collection)); // requires RandomAccessIterator and Swappable -> might compile, wrong result
 ```
 
 ## Standard range algorithms

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -171,6 +171,22 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | `std::counted_iterator` | ✔️ yes | `operator->` not defined as it requires `std::contiguous_iterator` |
 
 
+## Collection as a *range*
+
+| Concept | Fulfilled by Collection? |
+|---------|--------------------------|
+| `std::ranges::range` | ✔️ yes |
+| `std::ranges::borrowed_range` | ❌ no |
+| `std::ranges::sized_range` | ✔️ yes |
+| `std::ranges::input_range` | ✔️ yes |
+| `std::ranges::output_range` | ❌ no |
+| `std::ranges::forward_range` | ❌ no |
+| `std::ranges::bidirectional_range` | ❌ no |
+| `std::ranges::random_access_range` | ❌ no |
+| `std::ranges::contiguous_range` | ❌ no |
+| `std::ranges::common_range` | ✔️ yes |
+| `std::ranges::viewable_range` | ✔️ yes |
+
 ## Collection and standard algorithms
 
 Most of the standard algorithms require the iterators to be at least *InputIterator*. The iterators of PODIO collection don't fulfil this requirement, therefore they are not compatible with standard algorithms according to the specification.

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -80,12 +80,12 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 
 | Concept | `iterator` | `const_iterator` |
 |---------|------------------------|------------------------------|
-| `std::indirectly_readable` | ❌ no | ❌ no |
+| `std::indirectly_readable` | ✔️ yes / ✔️ yes |
 | `std::indirectly_writable` | ❌ no | ❌ no |
 | `std::weakly_incrementable` | ✔️ yes | ✔️ yes |
 | `std::incrementable` | ✔️ yes | ✔️ yes |
 | `std::input_or_output_iterator` | ✔️ yes | ✔️ yes |
-| `std::input_iterator` | ❌ no | ❌ no |
+| `std::input_iterator` | ✔️ yes / ✔️ yes |
 | `std::output_iterator` | ❌ no | ❌ no |
 | `std::forward_iterator` | ❌ no | ❌ no |
 | `std::bidirectional_iterator` | ❌ no | ❌ no |

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -66,6 +66,7 @@ The PODIO Collections currently are not checked against expression and statement
 The C++ specifies a set of named requirements for iterators. Starting with C++20 the standard specifies also iterator concepts. The requirements imposed by the concepts and named requirements are similar but not identical.
 
 In the following tables a convention from `Collection` is used: `iterator` stands for PODIO `MutableCollectionIterator` and `const_iterator` stands for PODIO `CollectionIterator`.
+
 ### Iterator summary
 
 | Named requirement | `iterator` | `const_iterator` |
@@ -80,12 +81,12 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 
 | Concept | `iterator` | `const_iterator` |
 |---------|------------------------|------------------------------|
-| `std::indirectly_readable` | ✔️ yes / ✔️ yes |
+| `std::indirectly_readable` | ✔️ yes | ✔️ yes |
 | `std::indirectly_writable` | ❌ no | ❌ no |
 | `std::weakly_incrementable` | ✔️ yes | ✔️ yes |
 | `std::incrementable` | ✔️ yes | ✔️ yes |
 | `std::input_or_output_iterator` | ✔️ yes | ✔️ yes |
-| `std::input_iterator` | ✔️ yes / ✔️ yes |
+| `std::input_iterator` | ✔️ yes | ✔️ yes |
 | `std::output_iterator` | ❌ no | ❌ no |
 | `std::forward_iterator` | ❌ no | ❌ no |
 | `std::bidirectional_iterator` | ❌ no | ❌ no |

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -33,9 +33,9 @@ public:
   {{ iterator_type }} operator++(int);
 
 private:
-  size_t m_index = 0;
+  size_t m_index{0};
   {{ prefix }}{{ class.bare_type }} m_object { {{ ptr_init }} };
-  const {{ class.bare_type }}ObjPointerContainer* m_collection = nullptr;
+  const {{ class.bare_type }}ObjPointerContainer* m_collection{nullptr};
 };
 {% endwith %}
 {% endmacro %}

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -10,7 +10,7 @@ public:
   using iterator_category = std::input_iterator_tag;
 
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
-  {{ iterator_type }}(): {{ iterator_type }}(0, nullptr) {}
+  {{ iterator_type }}() = default;
 
   {{ iterator_type }}(const {{ iterator_type }}&) = default;
   {{ iterator_type }}({{ iterator_type }}&&) = default;
@@ -32,9 +32,9 @@ public:
   {{ iterator_type }} operator++(int);
 
 private:
-  size_t m_index;
-  {{ prefix }}{{ class.bare_type }} m_object;
-  const {{ class.bare_type }}ObjPointerContainer* m_collection;
+  size_t m_index = 0;
+  {{ prefix }}{{ class.bare_type }} m_object { {{ ptr_init }} };
+  const {{ class.bare_type }}ObjPointerContainer* m_collection = nullptr;
 };
 {% endwith %}
 {% endmacro %}

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -5,8 +5,11 @@ class {{ iterator_type }} {
 public:
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
 
-  {{ iterator_type }}(const {{ iterator_type }}&) = delete;
-  {{ iterator_type }}& operator=(const {{ iterator_type }}&) = delete;
+  {{ iterator_type }}(const {{ iterator_type }}&) = default;
+  {{ iterator_type }}({{ iterator_type }}&&) = default;
+  {{ iterator_type }}& operator=(const {{ iterator_type }}&) = default;
+  {{ iterator_type }}& operator=({{iterator_type}}&&) = default;
+  ~{{ iterator_type }}() = default;
 
   bool operator!=(const {{ iterator_type}}& x) const {
     return m_index != x.m_index; // TODO: may not be complete

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -7,7 +7,7 @@ public:
   using difference_type = ptrdiff_t;
   using reference = {{ prefix }}{{ class.bare_type }};
   using pointer = {{ prefix }}{{ class.bare_type }}*;
-  using iterator_category = void;
+  using iterator_category = std::input_iterator_tag;
 
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
 
@@ -28,6 +28,7 @@ public:
   reference operator*();
   pointer operator->();
   {{ iterator_type }}& operator++();
+  {{ iterator_type }} operator++(int);
 
 private:
   size_t m_index;
@@ -54,6 +55,12 @@ private:
 {{ iterator_type }}& {{ iterator_type }}::operator++() {
   ++m_index;
   return *this;
+}
+
+{{ iterator_type }} {{ iterator_type }}::operator++(int) {
+  auto copy = *this;
+  ++m_index;
+  return copy;
 }
 
 {% endwith %}

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -3,6 +3,12 @@
 {% set ptr_init = 'podio::utils::MaybeSharedPtr<' + class.bare_type +'Obj>{nullptr}' %}
 class {{ iterator_type }} {
 public:
+  using value_type = {{ class.bare_type }};
+  using difference_type = ptrdiff_t;
+  using reference = {{ prefix }}{{ class.bare_type }};
+  using pointer = {{ prefix }}{{ class.bare_type }}*;
+  using iterator_category = void;
+
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
 
   {{ iterator_type }}(const {{ iterator_type }}&) = default;
@@ -19,8 +25,8 @@ public:
     return m_index ==  x.m_index; // TODO: may not be complete
   }
 
-  {{ prefix }}{{ class.bare_type }} operator*();
-  {{ prefix }}{{ class.bare_type }}* operator->();
+  reference operator*();
+  pointer operator->();
   {{ iterator_type }}& operator++();
 
 private:
@@ -35,12 +41,12 @@ private:
 {% macro iterator_definitions(class, prefix='') %}
 {% with iterator_type = class.bare_type + prefix + 'CollectionIterator' %}
 {% set ptr_type = 'podio::utils::MaybeSharedPtr<' + class.bare_type +'Obj>' %}
-{{ prefix }}{{ class.bare_type }} {{ iterator_type }}::operator*() {
+{{ iterator_type }}::reference {{ iterator_type }}::operator*() {
   m_object.m_obj = {{ ptr_type }}((*m_collection)[m_index]);
   return m_object;
 }
 
-{{ prefix }}{{ class.bare_type }}* {{ iterator_type }}::operator->() {
+{{ iterator_type }}::pointer {{ iterator_type }}::operator->() {
   m_object.m_obj = {{ ptr_type }}((*m_collection)[m_index]);
   return &m_object;
 }

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -8,6 +8,7 @@ public:
   using reference = {{ prefix }}{{ class.bare_type }};
   using pointer = {{ prefix }}{{ class.bare_type }}*;
   using iterator_category = std::input_iterator_tag;
+  using iterator_concept = std::input_iterator_tag;
 
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
   {{ iterator_type }}() = default;
@@ -26,7 +27,7 @@ public:
     return m_index ==  x.m_index;
   }
 
-  reference operator*();
+  reference operator*() const;
   pointer operator->();
   {{ iterator_type }}& operator++();
   {{ iterator_type }} operator++(int);
@@ -43,9 +44,8 @@ private:
 {% macro iterator_definitions(class, prefix='') %}
 {% with iterator_type = class.bare_type + prefix + 'CollectionIterator' %}
 {% set ptr_type = 'podio::utils::MaybeSharedPtr<' + class.bare_type +'Obj>' %}
-{{ iterator_type }}::reference {{ iterator_type }}::operator*() {
-  m_object.m_obj = {{ ptr_type }}((*m_collection)[m_index]);
-  return m_object;
+{{ iterator_type }}::reference {{ iterator_type }}::operator*() const {
+  return reference{ {{ ptr_type }}((*m_collection)[m_index]) };
 }
 
 {{ iterator_type }}::pointer {{ iterator_type }}::operator->() {

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -19,11 +19,11 @@ public:
   ~{{ iterator_type }}() = default;
 
   bool operator!=(const {{ iterator_type}}& x) const {
-    return m_index != x.m_index; // TODO: may not be complete
+    return m_index != x.m_index;
   }
 
   bool operator==(const {{ iterator_type }}& x) const {
-    return m_index ==  x.m_index; // TODO: may not be complete
+    return m_index ==  x.m_index;
   }
 
   reference operator*();

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -10,6 +10,7 @@ public:
   using iterator_category = std::input_iterator_tag;
 
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
+  {{ iterator_type }}(): {{ iterator_type }}(0, nullptr) {}
 
   {{ iterator_type }}(const {{ iterator_type }}&) = default;
   {{ iterator_type }}({{ iterator_type }}&&) = default;

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -993,10 +993,40 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
     // TODO add runtime checks here
   }
 
+#if (__cplusplus >= 202302L)
   SECTION("Const iterator") {
-    // C++23 required
-    DOCUMENTED_STATIC_FAILURE((__cplusplus >= 202302L));
+    // iterator
+    STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(std::input_iterator<iterator>);
+    // make_const_iterator(iterator) gives basic_const_iterator not our iterator or our const_iterator
+    STATIC_REQUIRE(std::is_same_v<std::const_iterator<iterator>, std::basic_const_iterator<iterator>>);
+    {
+      auto coll = CollectionType();
+      coll.create().cellID(42);
+      auto cit = std::make_const_iterator(std::begin(coll));
+      REQUIRE((*cit).cellID() == 42);
+      // can't -> because iterators' -> is non-const
+      DOCUMENTED_STATIC_FAILURE(traits::has_member_of_pointer_v<std::const_iterator<iterator>>);
+      // REQUIRE(cit->cellID() == 42)
+      // REQUIRE(counted.base()->cellID() == 42);
+    }
+    // const_iterator
+    STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
+    STATIC_REQUIRE(std::input_iterator<const_iterator>);
+    // make_const_iterator(iterator) gives basic_const_iterator not our iterator or our const_iterator
+    STATIC_REQUIRE(std::is_same_v<std::const_iterator<const_iterator>, std::basic_const_iterator<const_iterator>>);
+    {
+      auto coll = CollectionType();
+      coll.create().cellID(42);
+      auto cit = std::make_const_iterator(std::cbegin(coll));
+      REQUIRE((*cit).cellID() == 42);
+      // can't -> because const_iterators' -> is non-const
+      DOCUMENTED_STATIC_FAILURE(traits::has_member_of_pointer_v<std::const_iterator<const_iterator>>);
+      // REQUIRE(cit->cellID() == 42)
+      // REQUIRE(counted.base()->cellID() == 42);
+    }
   }
+#endif
 
   SECTION("Move iterator") {
     // iterator

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -413,8 +413,8 @@ TEST_CASE("Collection AllocatorAwareContainer types", "[collection][container][t
 }
 // TODO add tests for AllocatorAwareContainer statements and expressions
 
-TEST_CASE("Collection and iterator concepts", "[collection][container][iterator][std]") {
 #if (__cplusplus >= 202002L)
+TEST_CASE("Collection and iterator concepts", "[collection][container][iterator][std]") {
 
   SECTION("input_or_output_iterator") {
     // weakly incrementable
@@ -495,126 +495,33 @@ TEST_CASE("Collection and iterator concepts", "[collection][container][iterator]
     // const_iterator
     STATIC_REQUIRE(std::input_iterator<const_iterator>);
   }
-
-  SECTION("output_iterator") {
-    // indirectly_writable
-    // iterator
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type>);
-    // STATIC_REQUIRE(std::is_same_v<std::iter_value_t<iterator>, std::decay_t<iterator::value_type>>);
-    // {
-    //   auto coll = CollectionType{};
-    //   coll.create().cellID(42);
-    //   auto e = iterator::value_type{13, 0, 0, 0, 0};
-    //   auto e_copy = e;
-    //   auto o = coll.begin();
-    //   *o = e;
-    //   REQUIRE(*o == e_copy);
-    // }
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type::mutable_type>);
-    // STATIC_REQUIRE(std::is_same_v<std::iter_value_t<iterator>, std::decay_t<iterator::value_type::mutable_type>>);
-    // {
-    //   auto coll = CollectionType{};
-    //   coll.create().cellID(42);
-    //   auto e = iterator::value_type::mutable_type{13, 0, 0, 0, 0};
-    //   auto e_copy =e;
-    //   auto o = coll.begin();
-    //   *o = e;
-    //   REQUIRE(*o == e_copy);
-    // }
-    // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type>);
-    // STATIC_REQUIRE(std::is_same_v<std::iter_value_t<const_iterator>, std::decay_t<const_iterator::value_type>>);
-    // {
-    //   auto coll = CollectionType{};
-    //   coll.create().cellID(42);
-    //   auto e = iterator::value_type{13, 0, 0, 0, 0};
-    //   auto e_copy = e;
-    //   auto o = coll.cbegin();
-    //   *o = e;
-    //   REQUIRE(*o == e_copy);
-    // }
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type::mutable_type>);
-    // STATIC_REQUIRE(std::is_same_v<std::iter_value_t<const_iterator>,
-    // std::decay_t<const_iterator::value_type::mutable_type>>);
-    // {
-    //   auto coll = CollectionType{};
-    //   coll.create().cellID(42);
-    //   auto e = iterator::value_type::mutable_type{13, 0, 0, 0, 0};
-    //   auto e_copy = e;
-    //   auto o = coll.cbegin();
-    //   *o = e;
-    //   REQUIRE(*o == e_copy);
-    // }
-
-    // iterator
-    DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type>);
-    DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type::mutable_type>);
-    // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type>);
-    DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type::mutable_type>);
-  }
-
-  SECTION("forward_iterator") {
-    // iterator
-    DOCUMENTED_STATIC_FAILURE(std::forward_iterator<iterator>);
-    // {
-    //   REQUIRE(iterator{} == iterator{});
-    //   auto coll = CollectionType();
-    //   coll.create();
-    //   auto i = coll.begin();
-    //   auto j = coll.begin();
-    //   REQUIRE(i == j);
-    //   REQUIRE(++i == ++j);
-    //   i = coll.begin();
-    //   REQUIRE(((void)[](auto x) { ++x; }(i), *i) == *i);
-    //   Pointers and references obtained from a forward iterator into a range remain valid while the range exists.
-    //   Is this even unit-testable?
-    // }
-    // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::forward_iterator<const_iterator>);
-    // {
-    //   REQUIRE(const_iterator{} == const_iterator{});
-    //   auto coll = CollectionType();
-    //   coll.create();
-    //   auto i = coll.cbegin();
-    //   auto j = coll.cbegin();
-    //   REQUIRE(i == j);
-    //   REQUIRE(++i == ++j);
-    //   i = coll.cbegin();
-    //   REQUIRE(((void)[](auto x) { ++x; }(i), *i) == *i);
-    //   Pointers and references obtained from a forward iterator into a range remain valid while the range exists.
-    //   Is this even unit-testable?
-    // }
-  }
-
-  SECTION("bidirectional_iterator") {
-    // iterator
-    DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<iterator>);
-    // TODO check semantic requirements
-    // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<const_iterator>);
-    // TODO check semantic requirements
-  }
-
-  SECTION("random_access_iterator") {
-    // iterator
-    DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<iterator>);
-    // TODO check semantic requirements
-    // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<const_iterator>);
-    // TODO check semantic requirements
-  }
-
-  SECTION("contiguous_iterator_iterator") {
-    // iterator
-    DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>);
-    // TODO check semantic requirements
-    // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<const_iterator>);
-    // TODO check semantic requirements
-  }
-#endif
 }
+
+TEST_CASE("Collection and unsupported iterator concepts", "[collection][container][iterator][std]") {
+  // std::indirectly_writable
+  DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type>);
+  DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type::mutable_type>);
+  DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type>);
+  DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type::mutable_type>);
+  // std::output_iterator
+  DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type>);
+  DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type::mutable_type>);
+  DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type>);
+  DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type::mutable_type>);
+  // std::forward_iterator
+  DOCUMENTED_STATIC_FAILURE(std::forward_iterator<iterator>);
+  DOCUMENTED_STATIC_FAILURE(std::forward_iterator<const_iterator>);
+  // std::bidirectional_iterator
+  DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<iterator>);
+  DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<const_iterator>);
+  // std::random_access_iterator
+  DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<iterator>);
+  DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<const_iterator>);
+  // std::contiguous_iterator
+  DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>);
+  DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<const_iterator>);
+}
+#endif // __cplusplus >= 202002L
 
 TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
   // the checks are duplicated for iterator and const_iterator as expectations on them are slightly different

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1,8 +1,10 @@
 #include "datamodel/ExampleHit.h"
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/MutableExampleHit.h"
-#include <algorithm>
+
 #include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
 #include <cstddef>
 #include <iterator>
 #include <limits>

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -892,8 +892,7 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     }
     // const_iterator
     STATIC_REQUIRE(traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::value_type>);
-    STATIC_REQUIRE(
-        traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::mutable_type>);
+    STATIC_REQUIRE(traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::mutable_type>);
     {
       auto coll = CollectionType{};
       auto item = coll.create(13ull, 0., 0., 0., 0.);

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1117,6 +1117,11 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
       REQUIRE(counted != std::default_sentinel);
       REQUIRE(counted.count() == 1);
       REQUIRE((*counted).cellID() == 42);
+      DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>); // counted-> requires std::contiguous_iterator
+      // REQUIRE(counted->cellID() == 42);
+      DOCUMENTED_STATIC_FAILURE(traits::has_member_of_pointer_v<const iterator>); // can't base()->() because
+                                                                                  // base() returns const object
+      // REQUIRE(counted.base()->cellID() == 42);
       REQUIRE(++counted == std::default_sentinel);
     }
     // const_iterator
@@ -1128,6 +1133,11 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
       REQUIRE(counted != std::default_sentinel);
       REQUIRE(counted.count() == 1);
       REQUIRE((*counted).cellID() == 42);
+      DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>); // counted-> requires std::contiguous_iterator
+      // REQUIRE(counted->cellID() == 42)
+      DOCUMENTED_STATIC_FAILURE(traits::has_member_of_pointer_v<const const_iterator>); // can't base()->() because
+                                                                                        // base() returns const object
+      // REQUIRE(counted.base()->cellID() == 42);
       REQUIRE(++counted == std::default_sentinel);
     }
   }

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -571,14 +571,14 @@ TEST_CASE("Collection and iterator concepts", "[collection][container][iterator]
     // const_iterator
     DOCUMENTED_STATIC_FAILURE(std::forward_iterator<const_iterator>);
     // {
-    //   REQUIRE(iterator{} == iterator{});
+    //   REQUIRE(const_iterator{} == const_iterator{});
     //   auto coll = CollectionType();
     //   coll.create();
-    //   auto i = coll.begin();
-    //   auto j = coll.begin();
+    //   auto i = coll.cbegin();
+    //   auto j = coll.cbegin();
     //   REQUIRE(i == j);
     //   REQUIRE(++i == ++j);
-    //   i = coll.begin();
+    //   i = coll.cbegin();
     //   REQUIRE(((void)[](auto x) { ++x; }(i), *i) == *i);
     //   Pointers and references obtained from a forward iterator into a range remain valid while the range exists.
     //   Is this even unit-testable?

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -6,6 +6,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <ranges>
 #include <stdexcept>
 #include <type_traits>
 
@@ -1143,6 +1144,41 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
   }
 #endif
 }
+
+#if (__cplusplus >= 202002L)
+TEST_CASE("Collection as range", "[collection][ranges][std]") {
+  CollectionType coll;
+  coll.create();
+
+  // std::ranges::range
+  STATIC_REQUIRE(std::ranges::range<CollectionType>);
+  // std::range::borrowed_range
+  DOCUMENTED_STATIC_FAILURE(std::ranges::borrowed_range<CollectionType>);
+  // std::range::sized_range
+  STATIC_REQUIRE(std::ranges::sized_range<CollectionType>);
+  REQUIRE(std::ranges::size(coll) == 1);
+  REQUIRE(std::ranges::size(coll) ==
+          static_cast<decltype(std::ranges::size(coll))>(std::ranges::distance(std::begin(coll), std::end(coll))));
+  // std::ranges::input_range
+  STATIC_REQUIRE(std::ranges::input_range<CollectionType>);
+  // std::range::output_range
+  DOCUMENTED_STATIC_FAILURE(std::ranges::output_range<CollectionType, CollectionType::value_type>);
+  DOCUMENTED_STATIC_FAILURE(std::ranges::output_range<CollectionType, CollectionType::value_type::mutable_type>);
+  // std::range::forward_range
+  DOCUMENTED_STATIC_FAILURE(std::ranges::forward_range<CollectionType>);
+  // std::range::bidirectional_range
+  DOCUMENTED_STATIC_FAILURE(std::ranges::bidirectional_range<CollectionType>);
+  // std::range::random_access_range
+  DOCUMENTED_STATIC_FAILURE(std::ranges::random_access_range<CollectionType>);
+  // std::range::contiguous_range
+  DOCUMENTED_STATIC_FAILURE(std::ranges::contiguous_range<CollectionType>);
+  // std::range::common_range
+  STATIC_REQUIRE(std::ranges::common_range<CollectionType>);
+  // std::range::viewable_range
+  STATIC_REQUIRE(std::ranges::viewable_range<CollectionType>);
+}
+#endif
+
 
 #undef DOCUMENTED_STATIC_FAILURE
 #undef DOCUMENTED_FAILURE

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -2,6 +2,7 @@
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/MutableExampleHit.h"
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -413,9 +414,9 @@ TEST_CASE("Collection and iterator concepts") {
   SECTION("Iterator") {
     DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<iterator>);
     DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type>);
-    DOCUMENTED_STATIC_FAILURE(std::weakly_incrementable<iterator>);
+    STATIC_REQUIRE(std::weakly_incrementable<iterator>);
     DOCUMENTED_STATIC_FAILURE(std::incrementable<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::input_or_output_iterator<iterator>);
+    STATIC_REQUIRE(std::input_or_output_iterator<iterator>);
     DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
     DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type>);
     DOCUMENTED_STATIC_FAILURE(std::forward_iterator<iterator>);
@@ -426,9 +427,9 @@ TEST_CASE("Collection and iterator concepts") {
   SECTION("Const_iterator") {
     DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<const_iterator>);
     DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type>);
-    DOCUMENTED_STATIC_FAILURE(std::weakly_incrementable<const_iterator>);
+    STATIC_REQUIRE(std::weakly_incrementable<const_iterator>);
     DOCUMENTED_STATIC_FAILURE(std::incrementable<const_iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::input_or_output_iterator<const_iterator>);
+    STATIC_REQUIRE(std::input_or_output_iterator<const_iterator>);
     DOCUMENTED_STATIC_FAILURE(std::input_iterator<const_iterator>);
     DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type>);
     DOCUMENTED_STATIC_FAILURE(std::forward_iterator<const_iterator>);
@@ -586,37 +587,36 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
       // (void)r++
       // iterator
       STATIC_REQUIRE(traits::has_preincrement_v<iterator>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<iterator>);
-      // STATIC_REQUIRE(
-      //     std::is_same_v<decltype((void)++std::declval<iterator&>()), decltype((void)std::declval<iterator&>()++)>);
+      STATIC_REQUIRE(traits::has_postincrement_v<iterator>);
+      STATIC_REQUIRE(
+          std::is_same_v<decltype((void)++std::declval<iterator&>()), decltype((void)std::declval<iterator&>()++)>);
       // const_iterator
       STATIC_REQUIRE(traits::has_preincrement_v<const_iterator>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<const_iterator>);
-      // STATIC_REQUIRE(std::is_same_v<decltype((void)++std::declval<const_iterator&>()),
-      //                               decltype((void)std::declval<const_iterator&>()++)>);
+      STATIC_REQUIRE(traits::has_postincrement_v<const_iterator>);
+      STATIC_REQUIRE(std::is_same_v<decltype((void)++std::declval<const_iterator&>()),
+                                    decltype((void)std::declval<const_iterator&>()++)>);
 
       // *r++
       // iterator
       STATIC_REQUIRE(traits::has_indirection_v<iterator>);
       STATIC_REQUIRE(traits::has_value_type_v<std::iterator_traits<iterator>>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<iterator>);
-      // STATIC_REQUIRE(
-      //     std::is_convertible_v<decltype(*std::declval<iterator&>()++), std::iterator_traits<iterator>::value_type>);
+      STATIC_REQUIRE(traits::has_postincrement_v<iterator>);
+      STATIC_REQUIRE(
+          std::is_convertible_v<decltype(*std::declval<iterator&>()++), std::iterator_traits<iterator>::value_type>);
       // const_iterator
       STATIC_REQUIRE(traits::has_indirection_v<const_iterator>);
       STATIC_REQUIRE(traits::has_value_type_v<std::iterator_traits<const_iterator>>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<const_iterator>);
-      // STATIC_REQUIRE(std::is_convertible_v<decltype(*std::declval<const_iterator&>()++),
-      //                                      std::iterator_traits<const_iterator>::value_type>);
+      STATIC_REQUIRE(traits::has_postincrement_v<const_iterator>);
+      STATIC_REQUIRE(std::is_convertible_v<decltype(*std::declval<const_iterator&>()++),
+                                           std::iterator_traits<const_iterator>::value_type>);
 
       // iterator_category - not strictly necessary but advised
       // iterator
       STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-      DOCUMENTED_STATIC_FAILURE(
-          std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+      STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
       // const_iterator
       STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
-      DOCUMENTED_STATIC_FAILURE(
+      STATIC_REQUIRE(
           std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
 
     } // end of LegacyInputIterator
@@ -717,26 +717,24 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
 
     // i++
     // iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<iterator>);
-    // STATIC_REQUIRE(std::is_same_v<decltype(std::declval<iterator&>()++), iterator>);
+    STATIC_REQUIRE(traits::has_postincrement_v<iterator>);
+    STATIC_REQUIRE(std::is_same_v<decltype(std::declval<iterator&>()++), iterator>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<const_iterator>);
-    // STATIC_REQUIRE(std::is_same_v<decltype(std::declval<const_iterator&>()++), const_iterator>);
+    STATIC_REQUIRE(traits::has_postincrement_v<const_iterator>);
+    STATIC_REQUIRE(std::is_same_v<decltype(std::declval<const_iterator&>()++), const_iterator>);
 
     // *i++
     // iterator
     STATIC_REQUIRE(traits::has_indirection_v<iterator>);
     STATIC_REQUIRE(traits::has_reference_v<std::iterator_traits<iterator>>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<iterator>);
-    // STATIC_REQUIRE(std::is_same_v<decltype(*std::declval<iterator&>()++),
-    // std::iterator_traits<iterator>::reference>);
+    STATIC_REQUIRE(traits::has_postincrement_v<iterator>);
+    STATIC_REQUIRE(std::is_same_v<decltype(*std::declval<iterator&>()++), std::iterator_traits<iterator>::reference>);
     // const_iterator
     STATIC_REQUIRE(traits::has_indirection_v<const_iterator>);
     STATIC_REQUIRE(traits::has_reference_v<std::iterator_traits<const_iterator>>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<const_iterator>);
-    // STATIC_REQUIRE(
-    //     std::is_same_v<decltype(*std::declval<const_iterator&>()++),
-    //     std::iterator_traits<const_iterator>::reference>);
+    STATIC_REQUIRE(traits::has_postincrement_v<const_iterator>);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(*std::declval<const_iterator&>()++), std::iterator_traits<const_iterator>::reference>);
 
     // iterator_category - not strictly necessary but advised
     // iterator
@@ -795,23 +793,39 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
 
     // r++
     // iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<iterator>);
-    // STATIC_REQUIRE(std::is_convertible_v<decltype(std::declval<iterator&>()++), const iterator&>);
+    STATIC_REQUIRE(traits::has_postincrement_v<iterator>);
+    STATIC_REQUIRE(std::is_convertible_v<decltype(std::declval<iterator&>()++), const iterator&>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<const_iterator>);
-    // STATIC_REQUIRE(std::is_convertible_v<decltype(std::declval<const_iterator&>()++), const const_iterator&>);
+    STATIC_REQUIRE(traits::has_postincrement_v<const_iterator>);
+    STATIC_REQUIRE(std::is_convertible_v<decltype(std::declval<const_iterator&>()++), const const_iterator&>);
 
     // *r++ = o
     // iterator
     DOCUMENTED_STATIC_FAILURE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::value_type>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::mutable_type>);
-    // TODO add runtime check for assignment validity like in '*r = o' case
+    STATIC_REQUIRE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::value_type::mutable_type>);
+    {
+      auto coll = CollectionType{};
+      auto item = coll.create(13ull, 0., 0., 0., 0.);
+      REQUIRE(coll.begin()->cellID() == 13ull);
+      auto new_item = CollectionType::value_type::mutable_type{42ull, 0., 0., 0., 0.};
+      *coll.begin()++ = new_item;
+      DOCUMENTED_FAILURE(coll.begin()->cellID() == 42ull);
+    }
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(
-        traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::value_type>);
-    DOCUMENTED_STATIC_FAILURE(
-        traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::mutable_type>);
-    // TODO add runtime check for assignment validity like in '*r = o' case
+    STATIC_REQUIRE(traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::value_type>);
+    STATIC_REQUIRE(
+        traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::value_type::mutable_type>);
+    {
+      auto coll = CollectionType{};
+      auto item = coll.create(13ull, 0., 0., 0., 0.);
+      REQUIRE(coll.cbegin()->cellID() == 13ull);
+      auto new_item = CollectionType::value_type::mutable_type{42ull, 0., 0., 0., 0.};
+      *coll.cbegin()++ = new_item;
+      DOCUMENTED_FAILURE(coll.cbegin()->cellID() == 42ull);
+      new_item.cellID(44ull);
+      *coll.cbegin()++ = static_cast<CollectionType::value_type>(new_item);
+      DOCUMENTED_FAILURE(coll.cbegin()->cellID() == 44ull);
+    }
 
     // iterator_category - not strictly necessary but advised
     // Derived either from:
@@ -832,7 +846,6 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
 }
 
 TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapter][std]") {
-  auto coll = CollectionType();
   SECTION("Reverse iterator") {
     // iterator
     STATIC_REQUIRE(traits::has_iterator_v<CollectionType>);
@@ -860,6 +873,7 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
     STATIC_REQUIRE(traits::has_push_back_v<CollectionType, const CollectionType::value_type&>);
     STATIC_REQUIRE(traits::has_push_back_v<CollectionType, CollectionType::value_type&&>);
 
+    auto coll = CollectionType();
     auto it = std::back_inserter(coll);
     // insert immutable to not-SubsetCollection
     REQUIRE_THROWS_AS(it = CollectionType::value_type{}, std::invalid_argument);
@@ -908,31 +922,46 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
     // iterator
     STATIC_REQUIRE(traits::has_iterator_v<CollectionType>);
     STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-    DOCUMENTED_STATIC_FAILURE(
-        std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
 #if (__cplusplus >= 202002L)
     DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
 #endif
-    // TODO add more checks here
+    STATIC_REQUIRE(std::is_same_v<iterator::reference, std::move_iterator<iterator>::reference>);
     // const_iterator
     STATIC_REQUIRE(traits::has_iterator_v<CollectionType>);
-    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-    DOCUMENTED_STATIC_FAILURE(
-        std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
+    STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
 #if (__cplusplus >= 202002L)
-    DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
+    DOCUMENTED_STATIC_FAILURE(std::input_iterator<const_iterator>);
 #endif
-    // TODO add more checks here
+    STATIC_REQUIRE(std::is_same_v<const_iterator::reference, std::move_iterator<const_iterator>::reference>);
   }
 
 #if (__cplusplus >= 202002L)
   SECTION("Counted iterator") {
     // iterator
-    DOCUMENTED_STATIC_FAILURE(std::input_or_output_iterator<iterator>);
+    STATIC_REQUIRE(std::input_or_output_iterator<iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create().cellID(42);
+      auto counted = std::counted_iterator(coll.begin(), coll.size());
+      REQUIRE(counted != std::default_sentinel);
+      REQUIRE(counted.count() == 1);
+      REQUIRE((*counted).cellID() == 42);
+      REQUIRE(++counted == std::default_sentinel);
+    }
     // TODO add runtime checks
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::input_or_output_iterator<const_iterator>);
-    // TODO add runtime checks
+    STATIC_REQUIRE(std::input_or_output_iterator<const_iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create().cellID(42);
+      auto counted = std::counted_iterator(coll.cbegin(), coll.size());
+      REQUIRE(counted != std::default_sentinel);
+      REQUIRE(counted.count() == 1);
+      REQUIRE((*counted).cellID() == 42);
+      REQUIRE(++counted == std::default_sentinel);
+    }
   }
 #endif
 }

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -299,21 +299,26 @@ TEST_CASE("Collection container types", "[collection][container][types][std]") {
   // iterator
   STATIC_REQUIRE(traits::has_iterator_v<CollectionType>);
   DOCUMENTED_STATIC_FAILURE(std::is_convertible_v<CollectionType::iterator, CollectionType::const_iterator>);
+  STATIC_REQUIRE(traits::has_value_type_v<CollectionType::iterator>);
+  STATIC_REQUIRE(
+      std::is_same_v<CollectionType::value_type, std::iterator_traits<CollectionType::iterator>::value_type>);
 
   // const_iterator
   STATIC_REQUIRE(traits::has_const_iterator_v<CollectionType>);
+  STATIC_REQUIRE(traits::has_value_type_v<CollectionType::const_iterator>);
+  STATIC_REQUIRE(
+      std::is_same_v<CollectionType::value_type, std::iterator_traits<CollectionType::const_iterator>::value_type>);
 
   // difference_type
   STATIC_REQUIRE(traits::has_difference_type_v<CollectionType>);
   STATIC_REQUIRE(std::is_signed_v<CollectionType::difference_type>);
   STATIC_REQUIRE(std::is_integral_v<CollectionType::difference_type>);
-  DOCUMENTED_STATIC_FAILURE(traits::has_difference_type_v<std::iterator_traits<CollectionType::iterator>>);
-  // STATIC_REQUIRE(
-  //     std::is_same_v<CollectionType::difference_type,
-  //     std::iterator_traits<CollectionType::iterator>::difference_type>);
-  DOCUMENTED_STATIC_FAILURE(traits::has_difference_type_v<std::iterator_traits<CollectionType::const_iterator>>);
-  // STATIC_REQUIRE(std::is_same_v<CollectionType::difference_type,
-  //                               std::iterator_traits<CollectionType::const_iterator>::difference_type>);
+  STATIC_REQUIRE(traits::has_difference_type_v<std::iterator_traits<CollectionType::iterator>>);
+  STATIC_REQUIRE(
+      std::is_same_v<CollectionType::difference_type, std::iterator_traits<CollectionType::iterator>::difference_type>);
+  STATIC_REQUIRE(traits::has_difference_type_v<std::iterator_traits<CollectionType::const_iterator>>);
+  STATIC_REQUIRE(std::is_same_v<CollectionType::difference_type,
+                                std::iterator_traits<CollectionType::const_iterator>::difference_type>);
 
   // size_type
   STATIC_REQUIRE(traits::has_size_type_v<CollectionType>);
@@ -477,33 +482,33 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
 #if (__cplusplus < 202002L)
         // std::iterator_traits<It>::value_type (required prior to C++20)
         // iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<std::iterator_traits<iterator>>);
+        STATIC_REQUIRE(traits::has_value_type_v<std::iterator_traits<iterator>>);
         // const_iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<std::iterator_traits<const_iterator>>);
+        STATIC_REQUIRE(traits::has_value_type_v<std::iterator_traits<const_iterator>>);
 #endif
         // std::iterator_traits<It>::difference_type
         // iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_difference_type_v<std::iterator_traits<iterator>>);
+        STATIC_REQUIRE(traits::has_difference_type_v<std::iterator_traits<iterator>>);
         // const_iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_difference_type_v<std::iterator_traits<const_iterator>>);
+        STATIC_REQUIRE(traits::has_difference_type_v<std::iterator_traits<const_iterator>>);
 
         // std::iterator_traits<It>::reference
         // iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<std::iterator_traits<iterator>>);
+        STATIC_REQUIRE(traits::has_reference_v<std::iterator_traits<iterator>>);
         // const_iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<std::iterator_traits<const_iterator>>);
+        STATIC_REQUIRE(traits::has_reference_v<std::iterator_traits<const_iterator>>);
 
         // std::iterator_traits<It>::pointer
         // iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_pointer_v<std::iterator_traits<iterator>>);
+        STATIC_REQUIRE(traits::has_pointer_v<std::iterator_traits<iterator>>);
         // const_iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_pointer_v<std::iterator_traits<const_iterator>>);
+        STATIC_REQUIRE(traits::has_pointer_v<std::iterator_traits<const_iterator>>);
 
         // std::iterator_traits<It>::iterator_category
         // iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
+        STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
         // const_iterator
-        DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
+        STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
 
         // *r
         // iterator
@@ -544,20 +549,19 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
       // *i
       // iterator
       STATIC_REQUIRE(traits::has_indirection_v<iterator>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<iterator>);
-      // STATIC_REQUIRE(std::is_same_v<std::iterator_traits<iterator>::reference,
-      // decltype(*std::declval<iterator>())>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<iterator>);
-      // STATIC_REQUIRE(std::is_convertible_v<decltype(*std::declval<iterator>()),
-      // std::iterator_traits<iterator>::value_type>);
+      STATIC_REQUIRE(traits::has_reference_v<iterator>);
+      STATIC_REQUIRE(std::is_same_v<std::iterator_traits<iterator>::reference, decltype(*std::declval<iterator>())>);
+      STATIC_REQUIRE(traits::has_value_type_v<iterator>);
+      STATIC_REQUIRE(
+          std::is_convertible_v<decltype(*std::declval<iterator>()), std::iterator_traits<iterator>::value_type>);
       // const_iterator
       STATIC_REQUIRE(traits::has_indirection_v<const_iterator>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<const_iterator>);
-      // STATIC_REQUIRE(std::is_same_v<std::iterator_traits<const_iterator>::reference,
-      // decltype(*std::declval<const_iterator>())>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<const_iterator>);
-      // STATIC_REQUIRE(std::is_convertible_v<decltype(*std::declval<const_iterator>()),
-      // std::iterator_traits<const_iterator>::value_type>);
+      STATIC_REQUIRE(traits::has_reference_v<const_iterator>);
+      STATIC_REQUIRE(
+          std::is_same_v<std::iterator_traits<const_iterator>::reference, decltype(*std::declval<const_iterator>())>);
+      STATIC_REQUIRE(traits::has_value_type_v<const_iterator>);
+      STATIC_REQUIRE(std::is_convertible_v<decltype(*std::declval<const_iterator>()),
+                                           std::iterator_traits<const_iterator>::value_type>);
 
       // i->m
       // iterator
@@ -594,61 +598,60 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
       // *r++
       // iterator
       STATIC_REQUIRE(traits::has_indirection_v<iterator>);
+      STATIC_REQUIRE(traits::has_value_type_v<std::iterator_traits<iterator>>);
       DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<iterator>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<std::iterator_traits<iterator>>);
       // STATIC_REQUIRE(
       //     std::is_convertible_v<decltype(*std::declval<iterator&>()++), std::iterator_traits<iterator>::value_type>);
       // const_iterator
       STATIC_REQUIRE(traits::has_indirection_v<const_iterator>);
+      STATIC_REQUIRE(traits::has_value_type_v<std::iterator_traits<const_iterator>>);
       DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<const_iterator>);
-      DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<std::iterator_traits<const_iterator>>);
       // STATIC_REQUIRE(std::is_convertible_v<decltype(*std::declval<const_iterator&>()++),
       //                                      std::iterator_traits<const_iterator>::value_type>);
 
       // iterator_category - not strictly necessary but advised
       // iterator
-      DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-      // STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+      STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
+      DOCUMENTED_STATIC_FAILURE(
+          std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
       // const_iterator
-      DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
-      // STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag,
-      // std::iterator_traits<const_iterator>::iterator_category>);
+      STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
+      DOCUMENTED_STATIC_FAILURE(
+          std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
 
     } // end of LegacyInputIterator
 
     // Mutable LegacyForwardIterator (LegacyForwardIterator that is also LegacyOutputIterator):
     // - reference same as value_type& or value_type&&
     // iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<iterator>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<iterator>);
-    // STATIC_REQUIRE(
-    //     std::is_same_v<std::iterator_traits<iterator>::reference, std::iterator_traits<iterator>::value_type&> ||
-    //     std::is_same_v<std::iterator_traits<iterator>::reference, std::iterator_traits<iterator>::value_type&&>);
+    STATIC_REQUIRE(traits::has_reference_v<iterator>);
+    STATIC_REQUIRE(traits::has_value_type_v<iterator>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_same_v<std::iterator_traits<iterator>::reference, std::iterator_traits<iterator>::value_type&> ||
+        std::is_same_v<std::iterator_traits<iterator>::reference, std::iterator_traits<iterator>::value_type&&>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<const_iterator>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<const_iterator>);
-    // STATIC_REQUIRE(
-    //     std::is_same_v<std::iterator_traits<const_iterator>::reference,
-    //     std::iterator_traits<const_iterator>::value_type&> ||
-    //     std::is_same_v<std::iterator_traits<const_iterator>::reference,
-    //     std::iterator_traits<const_iterator>::value_type&&>);
+    STATIC_REQUIRE(traits::has_reference_v<const_iterator>);
+    STATIC_REQUIRE(traits::has_value_type_v<const_iterator>);
+    DOCUMENTED_STATIC_FAILURE(std::is_same_v<std::iterator_traits<const_iterator>::reference,
+                                             std::iterator_traits<const_iterator>::value_type&> ||
+                              std::is_same_v<std::iterator_traits<const_iterator>::reference,
+                                             std::iterator_traits<const_iterator>::value_type&&>);
 
     // (Immutable) iterator:
     // - reference same as const value_type& or const value_type&&
     // iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<iterator>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<iterator>);
-    // STATIC_REQUIRE(std::is_same_v<std::iterator_traits<iterator>::reference,
-    //                               const std::iterator_traits<iterator>::value_type&> ||
-    //                std::is_same_v<std::iterator_traits<iterator>::reference,
-    //                               const std::iterator_traits<iterator>::value_type&&>);
+    STATIC_REQUIRE(traits::has_reference_v<iterator>);
+    STATIC_REQUIRE(traits::has_value_type_v<iterator>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_same_v<std::iterator_traits<iterator>::reference, const std::iterator_traits<iterator>::value_type&> ||
+        std::is_same_v<std::iterator_traits<iterator>::reference, const std::iterator_traits<iterator>::value_type&&>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<const_iterator>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_value_type_v<const_iterator>);
-    // STATIC_REQUIRE(std::is_same_v<std::iterator_traits<const_iterator>::reference,
-    //                               const std::iterator_traits<const_iterator>::value_type&> ||
-    //                std::is_same_v<std::iterator_traits<const_iterator>::reference,
-    //                               const std::iterator_traits<const_iterator>::value_type&&>);
+    STATIC_REQUIRE(traits::has_reference_v<const_iterator>);
+    STATIC_REQUIRE(traits::has_value_type_v<const_iterator>);
+    DOCUMENTED_STATIC_FAILURE(std::is_same_v<std::iterator_traits<const_iterator>::reference,
+                                             const std::iterator_traits<const_iterator>::value_type&> ||
+                              std::is_same_v<std::iterator_traits<const_iterator>::reference,
+                                             const std::iterator_traits<const_iterator>::value_type&&>);
 
     // DefaultConstructible
     // iterator
@@ -723,26 +726,27 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     // *i++
     // iterator
     STATIC_REQUIRE(traits::has_indirection_v<iterator>);
+    STATIC_REQUIRE(traits::has_reference_v<std::iterator_traits<iterator>>);
     DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<iterator>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<std::iterator_traits<iterator>>);
     // STATIC_REQUIRE(std::is_same_v<decltype(*std::declval<iterator&>()++),
     // std::iterator_traits<iterator>::reference>);
     // const_iterator
     STATIC_REQUIRE(traits::has_indirection_v<const_iterator>);
+    STATIC_REQUIRE(traits::has_reference_v<std::iterator_traits<const_iterator>>);
     DOCUMENTED_STATIC_FAILURE(traits::has_postincrement_v<const_iterator>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_reference_v<std::iterator_traits<const_iterator>>);
     // STATIC_REQUIRE(
     //     std::is_same_v<decltype(*std::declval<const_iterator&>()++),
     //     std::iterator_traits<const_iterator>::reference>);
 
     // iterator_category - not strictly necessary but advised
     // iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-    // STATIC_REQUIRE(std::is_base_of_v<std::forward_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_base_of_v<std::forward_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
-    // STATIC_REQUIRE(std::is_base_of_v<std::forward_iterator_tag,
-    // std::iterator_traits<const_iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_base_of_v<std::forward_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
 
   } // end of LegacyForwardIterator
 
@@ -814,14 +818,15 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     // - std::output_iterator_tag
     // - std::forward_iterator_tag (for mutable LegacyForwardIterators)
     // iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-    // STATIC_REQUIRE(std::is_base_of_v<std::output_iterator_tag, std::iterator_traits<iterator>::iterator_category> ||
-    //                std::is_base_of_v<std::forward_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_base_of_v<std::output_iterator_tag, std::iterator_traits<iterator>::iterator_category> ||
+        std::is_base_of_v<std::forward_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
-    // STATIC_REQUIRE(std::is_base_of_v<std::output_iterator_tag, std::iterator_traits<iterator>::iterator_category> ||
-    //                    std::is_base_of_v<std::forward_iterator_tag,
-    //                    std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_base_of_v<std::output_iterator_tag, std::iterator_traits<iterator>::iterator_category> ||
+        std::is_base_of_v<std::forward_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
 
   } // end of LegacyOutputIterator
 }
@@ -831,17 +836,17 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
   SECTION("Reverse iterator") {
     // iterator
     STATIC_REQUIRE(traits::has_iterator_v<CollectionType>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-    // STATIC_REQUIRE(
-    //    std::is_base_of_v<std::bidirectional_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_base_of_v<std::bidirectional_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
 #if (__cplusplus >= 202002L)
     DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<iterator>);
 #endif
     // const_iterator
     STATIC_REQUIRE(traits::has_const_iterator_v<CollectionType>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
-    // STATIC_REQUIRE(
-    //    std::is_base_of_v<std::bidirectional_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_base_of_v<std::bidirectional_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
 #if (__cplusplus >= 202002L)
     DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<iterator>);
 #endif
@@ -902,18 +907,18 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
   SECTION("Move iterator") {
     // iterator
     STATIC_REQUIRE(traits::has_iterator_v<CollectionType>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-    // STATIC_REQUIRE(
-    //    std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
 #if (__cplusplus >= 202002L)
     DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
 #endif
     // TODO add more checks here
     // const_iterator
     STATIC_REQUIRE(traits::has_iterator_v<CollectionType>);
-    DOCUMENTED_STATIC_FAILURE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
-    // STATIC_REQUIRE(
-    //    std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
+    STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
+    DOCUMENTED_STATIC_FAILURE(
+        std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
 #if (__cplusplus >= 202002L)
     DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
 #endif

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1215,24 +1215,6 @@ TEST_CASE("Collection and std algorithms", "[collection][iterator][std]") {
 
 #if (__cplusplus >= 202002L)
 
-// helper concept for unsupported algorithm compilation test
-template <typename T>
-concept is_range_adjacent_findable = requires(T coll) {
-  std::ranges::adjacent_find(coll, [](const auto& a, const auto& b) { return a.cellID() == b.cellID(); });
-};
-
-// helper concept for unsupported algorithm compilation test
-template <typename T>
-concept is_range_sortable = requires(T coll) {
-  std::ranges::sort(coll, [](const auto& a, const auto& b) { return a.cellID() < b.cellID(); });
-};
-
-// helper concept for unsupported algorithm compilation test
-template <typename T>
-concept is_range_fillable = requires(T coll) {
-  std::ranges::fill(coll, typename T::value_type{});
-};
-
 TEST_CASE("Collection and std ranges algorithms", "[collection][ranges][std]") {
   auto coll = CollectionType();
   coll.create().cellID(1);
@@ -1258,13 +1240,34 @@ TEST_CASE("Collection and std ranges algorithms", "[collection][ranges][std]") {
   REQUIRE(subcoll.size() == 2);
   REQUIRE(subcoll[0].cellID() == 5);
   REQUIRE(subcoll[1].cellID() == 3);
+}
 
+// helper concept for unsupported algorithm compilation test
+template <typename T>
+concept is_range_adjacent_findable = requires(T coll) {
+  std::ranges::adjacent_find(coll, [](const auto& a, const auto& b) { return a.cellID() == b.cellID(); });
+};
+
+// helper concept for unsupported algorithm compilation test
+template <typename T>
+concept is_range_sortable = requires(T coll) {
+  std::ranges::sort(coll, [](const auto& a, const auto& b) { return a.cellID() < b.cellID(); });
+};
+
+// helper concept for unsupported algorithm compilation test
+template <typename T>
+concept is_range_fillable = requires(T coll) {
+  std::ranges::fill(coll, typename T::value_type{});
+};
+
+TEST_CASE("Collection and unsupported std ranges algorithms", "[collection][ranges][std]") {
   // check that algorithms requiring unsupported iterator concepts won't compile
   DOCUMENTED_STATIC_FAILURE(is_range_adjacent_findable<CollectionType>);
   DOCUMENTED_STATIC_FAILURE(is_range_sortable<CollectionType>);
   DOCUMENTED_STATIC_FAILURE(is_range_fillable<CollectionType>);
 }
-#endif
+
+#endif // __cplusplus >= 202002L
 
 #undef DOCUMENTED_STATIC_FAILURE
 #undef DOCUMENTED_FAILURE

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -500,14 +500,14 @@ TEST_CASE("Collection and iterator concepts", "[collection][container][iterator]
 TEST_CASE("Collection and unsupported iterator concepts", "[collection][container][iterator][std]") {
   // std::indirectly_writable
   DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type>);
-  DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type::mutable_type>);
+  DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::mutable_type>);
   DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type>);
-  DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type::mutable_type>);
+  DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::mutable_type>);
   // std::output_iterator
   DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type>);
-  DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type::mutable_type>);
+  DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::mutable_type>);
   DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type>);
-  DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type::mutable_type>);
+  DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::mutable_type>);
   // std::forward_iterator
   DOCUMENTED_STATIC_FAILURE(std::forward_iterator<iterator>);
   DOCUMENTED_STATIC_FAILURE(std::forward_iterator<const_iterator>);
@@ -881,24 +881,24 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     // *r++ = o
     // iterator
     DOCUMENTED_STATIC_FAILURE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::value_type>);
-    STATIC_REQUIRE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::value_type::mutable_type>);
+    STATIC_REQUIRE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::mutable_type>);
     {
       auto coll = CollectionType{};
       auto item = coll.create(13ull, 0., 0., 0., 0.);
       REQUIRE(coll.begin()->cellID() == 13ull);
-      auto new_item = CollectionType::value_type::mutable_type{42ull, 0., 0., 0., 0.};
+      auto new_item = CollectionType::mutable_type{42ull, 0., 0., 0., 0.};
       *coll.begin()++ = new_item;
       DOCUMENTED_FAILURE(coll.begin()->cellID() == 42ull);
     }
     // const_iterator
     STATIC_REQUIRE(traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::value_type>);
     STATIC_REQUIRE(
-        traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::value_type::mutable_type>);
+        traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::mutable_type>);
     {
       auto coll = CollectionType{};
       auto item = coll.create(13ull, 0., 0., 0., 0.);
       REQUIRE(coll.cbegin()->cellID() == 13ull);
-      auto new_item = CollectionType::value_type::mutable_type{42ull, 0., 0., 0., 0.};
+      auto new_item = CollectionType::mutable_type{42ull, 0., 0., 0., 0.};
       *coll.cbegin()++ = new_item;
       DOCUMENTED_FAILURE(coll.cbegin()->cellID() == 42ull);
       new_item.cellID(44ull);
@@ -1103,7 +1103,7 @@ TEST_CASE("Collection as range", "[collection][ranges][std]") {
   STATIC_REQUIRE(std::ranges::input_range<CollectionType>);
   // std::range::output_range
   DOCUMENTED_STATIC_FAILURE(std::ranges::output_range<CollectionType, CollectionType::value_type>);
-  DOCUMENTED_STATIC_FAILURE(std::ranges::output_range<CollectionType, CollectionType::value_type::mutable_type>);
+  DOCUMENTED_STATIC_FAILURE(std::ranges::output_range<CollectionType, CollectionType::mutable_type>);
   // std::range::forward_range
   DOCUMENTED_STATIC_FAILURE(std::ranges::forward_range<CollectionType>);
   // std::range::bidirectional_range

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -411,31 +411,203 @@ TEST_CASE("Collection AllocatorAwareContainer types", "[collection][container][t
 
 TEST_CASE("Collection and iterator concepts") {
 #if (__cplusplus >= 202002L)
-  SECTION("Iterator") {
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type>);
+
+  SECTION("input_or_output_iterator") {
+    // weakly incrementable
+    // iterator
     STATIC_REQUIRE(std::weakly_incrementable<iterator>);
-    STATIC_REQUIRE(std::incrementable<iterator>);
-    STATIC_REQUIRE(std::input_or_output_iterator<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type>);
-    DOCUMENTED_STATIC_FAILURE(std::forward_iterator<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>);
-  }
-  SECTION("Const_iterator") {
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<const_iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type>);
+    {
+      auto coll = CollectionType();
+      coll.create();
+      auto it1 = coll.begin();
+      auto it2 = coll.begin();
+      REQUIRE(it1 == it2);
+      ++it1;
+      it2++;
+      REQUIRE(it1 == it2);
+      it1 = coll.begin();
+      REQUIRE(std::addressof(++it1) == std::addressof(it1));
+    }
+    // const_iterator
     STATIC_REQUIRE(std::weakly_incrementable<const_iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create();
+      auto it1 = coll.cbegin();
+      auto it2 = coll.cbegin();
+      REQUIRE(it1 == it2);
+      ++it1;
+      it2++;
+      REQUIRE(it1 == it2);
+      it1 = coll.cbegin();
+      REQUIRE(std::addressof(++it1) == std::addressof(it1));
+    }
+
+    // incrementable
+    // iterator
+    STATIC_REQUIRE(std::incrementable<iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create();
+      auto a = coll.begin();
+      auto b = coll.begin();
+      REQUIRE(bool(a == b));
+      REQUIRE(bool(a++ == b));
+      a = coll.begin();
+      REQUIRE(bool(a == b));
+      REQUIRE(bool(((void)a++, a) == ++b));
+    }
+    // const_iterator
     STATIC_REQUIRE(std::incrementable<const_iterator>);
-    STATIC_REQUIRE(std::input_or_output_iterator<const_iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create();
+      auto a = coll.cbegin();
+      auto b = coll.cbegin();
+      REQUIRE(bool(a == b));
+      REQUIRE(bool(a++ == b));
+      a = coll.cbegin();
+      REQUIRE(bool(a == b));
+      REQUIRE(bool(((void)a++, a) == ++b));
+    }
+
+    // input_or_output_iterator
+    // iterator
+    STATIC_REQUIRE(std::input_or_output_iterator<iterator>);
+    // const_iterator
+    STATIC_REQUIRE(std::input_or_output_iterator<iterator>);
+  }
+
+  SECTION("input_iterator") {
+    // indirectly_readable
+    // iterator
+    DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<iterator>);
+    // const_iterator
+    DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<const_iterator>);
+
+    // input_iterator
+    // iterator
+    DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
+    // const_iterator
     DOCUMENTED_STATIC_FAILURE(std::input_iterator<const_iterator>);
+  }
+
+  SECTION("output_iterator") {
+    // indirectly_writable
+    // iterator
+    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type>);
+    // STATIC_REQUIRE(std::is_same_v<std::iter_value_t<iterator>, std::decay_t<iterator::value_type>>);
+    // {
+    //   auto coll = CollectionType{};
+    //   coll.create().cellID(42);
+    //   auto e = iterator::value_type{13, 0, 0, 0, 0};
+    //   auto e_copy = e;
+    //   auto o = coll.begin();
+    //   *o = e;
+    //   REQUIRE(*o == e_copy);
+    // }
+    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type::mutable_type>);
+    // STATIC_REQUIRE(std::is_same_v<std::iter_value_t<iterator>, std::decay_t<iterator::value_type::mutable_type>>);
+    // {
+    //   auto coll = CollectionType{};
+    //   coll.create().cellID(42);
+    //   auto e = iterator::value_type::mutable_type{13, 0, 0, 0, 0};
+    //   auto e_copy =e;
+    //   auto o = coll.begin();
+    //   *o = e;
+    //   REQUIRE(*o == e_copy);
+    // }
+    // const_iterator
+    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type>);
+    // STATIC_REQUIRE(std::is_same_v<std::iter_value_t<const_iterator>, std::decay_t<const_iterator::value_type>>);
+    // {
+    //   auto coll = CollectionType{};
+    //   coll.create().cellID(42);
+    //   auto e = iterator::value_type{13, 0, 0, 0, 0};
+    //   auto e_copy = e;
+    //   auto o = coll.cbegin();
+    //   *o = e;
+    //   REQUIRE(*o == e_copy);
+    // }
+    DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type::mutable_type>);
+    // STATIC_REQUIRE(std::is_same_v<std::iter_value_t<const_iterator>,
+    // std::decay_t<const_iterator::value_type::mutable_type>>);
+    // {
+    //   auto coll = CollectionType{};
+    //   coll.create().cellID(42);
+    //   auto e = iterator::value_type::mutable_type{13, 0, 0, 0, 0};
+    //   auto e_copy = e;
+    //   auto o = coll.cbegin();
+    //   *o = e;
+    //   REQUIRE(*o == e_copy);
+    // }
+
+    // iterator
+    DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type>);
+    DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type::mutable_type>);
+    // const_iterator
     DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type>);
+    DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type::mutable_type>);
+  }
+
+  SECTION("forward_iterator") {
+    // iterator
+    DOCUMENTED_STATIC_FAILURE(std::forward_iterator<iterator>);
+    // {
+    //   REQUIRE(iterator{} == iterator{});
+    //   auto coll = CollectionType();
+    //   coll.create();
+    //   auto i = coll.begin();
+    //   auto j = coll.begin();
+    //   REQUIRE(i == j);
+    //   REQUIRE(++i == ++j);
+    //   i = coll.begin();
+    //   REQUIRE(((void)[](auto x) { ++x; }(i), *i) == *i);
+    //   Pointers and references obtained from a forward iterator into a range remain valid while the range exists.
+    //   Is this even unit-testable?
+    // }
+    // const_iterator
     DOCUMENTED_STATIC_FAILURE(std::forward_iterator<const_iterator>);
+    // {
+    //   REQUIRE(iterator{} == iterator{});
+    //   auto coll = CollectionType();
+    //   coll.create();
+    //   auto i = coll.begin();
+    //   auto j = coll.begin();
+    //   REQUIRE(i == j);
+    //   REQUIRE(++i == ++j);W
+    //   i = coll.begin();
+    //   REQUIRE(((void)[](auto x) { ++x; }(i), *i) == *i);
+    //   Pointers and references obtained from a forward iterator into a range remain valid while the range exists.
+    //   Is this even unit-testable?
+    // }
+  }
+
+  SECTION("bidirectional_iterator") {
+    // iterator
+    DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<iterator>);
+    // TODO check semantic requirements
+    // const_iterator
     DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<const_iterator>);
+    // TODO check semantic requirements
+  }
+
+  SECTION("random_access_iterator") {
+    // iterator
+    DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<iterator>);
+    // TODO check semantic requirements
+    // const_iterator
     DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<const_iterator>);
+    // TODO check semantic requirements
+  }
+
+  SECTION("contiguous_iterator_iterator") {
+    // iterator
+    DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>);
+    // TODO check semantic requirements
+    // const_iterator
     DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<const_iterator>);
+    // TODO check semantic requirements
   }
 #endif
 }

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -577,7 +577,7 @@ TEST_CASE("Collection and iterator concepts", "[collection][container][iterator]
     //   auto i = coll.begin();
     //   auto j = coll.begin();
     //   REQUIRE(i == j);
-    //   REQUIRE(++i == ++j);W
+    //   REQUIRE(++i == ++j);
     //   i = coll.begin();
     //   REQUIRE(((void)[](auto x) { ++x; }(i), *i) == *i);
     //   Pointers and references obtained from a forward iterator into a range remain valid while the range exists.

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -415,7 +415,7 @@ TEST_CASE("Collection and iterator concepts") {
     DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<iterator>);
     DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<iterator, CollectionType::value_type>);
     STATIC_REQUIRE(std::weakly_incrementable<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::incrementable<iterator>);
+    STATIC_REQUIRE(std::incrementable<iterator>);
     STATIC_REQUIRE(std::input_or_output_iterator<iterator>);
     DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
     DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::value_type>);
@@ -428,7 +428,7 @@ TEST_CASE("Collection and iterator concepts") {
     DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<const_iterator>);
     DOCUMENTED_STATIC_FAILURE(std::indirectly_writable<const_iterator, CollectionType::value_type>);
     STATIC_REQUIRE(std::weakly_incrementable<const_iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::incrementable<const_iterator>);
+    STATIC_REQUIRE(std::incrementable<const_iterator>);
     STATIC_REQUIRE(std::input_or_output_iterator<const_iterator>);
     DOCUMENTED_STATIC_FAILURE(std::input_iterator<const_iterator>);
     DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type>);
@@ -655,9 +655,9 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
 
     // DefaultConstructible
     // iterator
-    DOCUMENTED_STATIC_FAILURE(std::is_default_constructible_v<iterator>);
+    STATIC_REQUIRE(std::is_default_constructible_v<iterator>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::is_default_constructible_v<const_iterator>);
+    STATIC_REQUIRE(std::is_default_constructible_v<const_iterator>);
 
     // Multipass guarantee
     // iterator
@@ -704,16 +704,12 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     // Singular iterators
     // iterator
     STATIC_REQUIRE(traits::has_equality_comparator_v<iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::is_default_constructible_v<iterator>);
-    //{
-    //  REQUIRE(iterator{} == iterator{});
-    //}
+    STATIC_REQUIRE(std::is_default_constructible_v<iterator>);
+    { REQUIRE(iterator{} == iterator{}); }
     // const_iterator
     STATIC_REQUIRE(traits::has_equality_comparator_v<const_iterator>);
-    DOCUMENTED_STATIC_FAILURE(std::is_default_constructible_v<const_iterator>);
-    //{
-    //  REQUIRE(const_iterator{} == const_iterator{});
-    //}
+    STATIC_REQUIRE(std::is_default_constructible_v<const_iterator>);
+    { REQUIRE(const_iterator{} == const_iterator{}); }
 
     // i++
     // iterator

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -851,6 +851,7 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
 #if (__cplusplus >= 202002L)
     DOCUMENTED_STATIC_FAILURE(std::bidirectional_iterator<iterator>);
 #endif
+    // TODO add runtime checks here
     // const_iterator
     STATIC_REQUIRE(traits::has_const_iterator_v<CollectionType>);
     STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
@@ -946,7 +947,6 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
       REQUIRE((*counted).cellID() == 42);
       REQUIRE(++counted == std::default_sentinel);
     }
-    // TODO add runtime checks
     // const_iterator
     STATIC_REQUIRE(std::input_or_output_iterator<const_iterator>);
     {

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -675,6 +675,10 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
       ++a_copy;
       REQUIRE(a == b);
       REQUIRE(*a == *b);
+      // bound to the same object
+      const auto& ref_a = *a;
+      const auto& ref_b = *b;
+      DOCUMENTED_FAILURE(std::addressof(ref_a) == std::addressof(ref_b));
 
       // const_iterator
       auto ca = coll.cbegin();
@@ -688,6 +692,10 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
       ++ca_copy;
       REQUIRE(ca == cb);
       REQUIRE(*ca == *cb);
+      // bound to the same object
+      const auto& ref_ca = *ca;
+      const auto& ref_cb = *cb;
+      DOCUMENTED_FAILURE(std::addressof(ref_ca) == std::addressof(ref_cb));
     }
 
     // Singular iterators

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -481,15 +481,15 @@ TEST_CASE("Collection and iterator concepts") {
   SECTION("input_iterator") {
     // indirectly_readable
     // iterator
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<iterator>);
+    STATIC_REQUIRE(std::indirectly_readable<iterator>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::indirectly_readable<const_iterator>);
+    STATIC_REQUIRE(std::indirectly_readable<const_iterator>);
 
     // input_iterator
     // iterator
-    DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
+    STATIC_REQUIRE(std::input_iterator<iterator>);
     // const_iterator
-    DOCUMENTED_STATIC_FAILURE(std::input_iterator<const_iterator>);
+    STATIC_REQUIRE(std::input_iterator<const_iterator>);
   }
 
   SECTION("output_iterator") {
@@ -1093,7 +1093,7 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
     STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<iterator>>);
     STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<iterator>::iterator_category>);
 #if (__cplusplus >= 202002L)
-    DOCUMENTED_STATIC_FAILURE(std::input_iterator<iterator>);
+    STATIC_REQUIRE(std::input_iterator<iterator>);
 #endif
     STATIC_REQUIRE(std::is_same_v<iterator::reference, std::move_iterator<iterator>::reference>);
     // const_iterator
@@ -1101,7 +1101,7 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
     STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
     STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
 #if (__cplusplus >= 202002L)
-    DOCUMENTED_STATIC_FAILURE(std::input_iterator<const_iterator>);
+    STATIC_REQUIRE(std::input_iterator<const_iterator>);
 #endif
     STATIC_REQUIRE(std::is_same_v<const_iterator::reference, std::move_iterator<const_iterator>::reference>);
   }

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -411,7 +411,7 @@ TEST_CASE("Collection AllocatorAwareContainer types", "[collection][container][t
 }
 // TODO add tests for AllocatorAwareContainer statements and expressions
 
-TEST_CASE("Collection and iterator concepts") {
+TEST_CASE("Collection and iterator concepts", "[collection][container][iterator][std]") {
 #if (__cplusplus >= 202002L)
 
   SECTION("input_or_output_iterator") {

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -448,19 +448,19 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
 
         // CopyConstructible
         // iterator
-        DOCUMENTED_STATIC_FAILURE(std::is_move_constructible_v<iterator>);
-        DOCUMENTED_STATIC_FAILURE(std::is_copy_constructible_v<iterator>);
+        STATIC_REQUIRE(std::is_move_constructible_v<iterator>);
+        STATIC_REQUIRE(std::is_copy_constructible_v<iterator>);
         // const_iterator
-        DOCUMENTED_STATIC_FAILURE(std::is_move_constructible_v<const_iterator>);
-        DOCUMENTED_STATIC_FAILURE(std::is_copy_constructible_v<const_iterator>);
+        STATIC_REQUIRE(std::is_move_constructible_v<const_iterator>);
+        STATIC_REQUIRE(std::is_copy_constructible_v<const_iterator>);
 
         // CopyAssignable
         // iterator
-        DOCUMENTED_STATIC_FAILURE(std::is_move_assignable_v<iterator>);
-        DOCUMENTED_STATIC_FAILURE(std::is_copy_assignable_v<iterator>);
+        STATIC_REQUIRE(std::is_move_assignable_v<iterator>);
+        STATIC_REQUIRE(std::is_copy_assignable_v<iterator>);
         // const_iterator
-        DOCUMENTED_STATIC_FAILURE(std::is_move_assignable_v<const_iterator>);
-        DOCUMENTED_STATIC_FAILURE(std::is_copy_assignable_v<const_iterator>);
+        STATIC_REQUIRE(std::is_move_assignable_v<const_iterator>);
+        STATIC_REQUIRE(std::is_copy_assignable_v<const_iterator>);
 
         // Destructible
         // iterator
@@ -470,9 +470,9 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
 
         // Swappable
         // iterator
-        DOCUMENTED_STATIC_FAILURE(std::is_swappable_v<iterator&>);
+        STATIC_REQUIRE(std::is_swappable_v<iterator&>);
         // const_iterator
-        DOCUMENTED_STATIC_FAILURE(std::is_swappable_v<const_iterator&>);
+        STATIC_REQUIRE(std::is_swappable_v<const_iterator&>);
 
 #if (__cplusplus < 202002L)
         // std::iterator_traits<It>::value_type (required prior to C++20)
@@ -670,11 +670,11 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
       REQUIRE(*a == *b);
       REQUIRE(++a == ++b);
       REQUIRE(*a == *b);
-      DOCUMENTED_STATIC_FAILURE(std::is_copy_constructible_v<iterator>);
-      // auto a_copy = a;
-      // ++a_copy;
-      // REQUIRE(a == b);
-      // REQUIRE(*a == *b);
+      STATIC_REQUIRE(std::is_copy_constructible_v<iterator>);
+      auto a_copy = a;
+      ++a_copy;
+      REQUIRE(a == b);
+      REQUIRE(*a == *b);
 
       // const_iterator
       auto ca = coll.cbegin();
@@ -683,11 +683,11 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
       REQUIRE(*ca == *cb);
       REQUIRE(++ca == ++cb);
       REQUIRE(*ca == *cb);
-      DOCUMENTED_STATIC_FAILURE(std::is_copy_constructible_v<const_iterator>);
-      // auto ca_copy = ca;
-      // ++ca_copy;
-      // REQUIRE(ca == cb);
-      // REQUIRE(*ca == *cb);
+      STATIC_REQUIRE(std::is_copy_constructible_v<const_iterator>);
+      auto ca_copy = ca;
+      ++ca_copy;
+      REQUIRE(ca == cb);
+      REQUIRE(*ca == *cb);
     }
 
     // Singular iterators


### PR DESCRIPTION
BEGINRELEASENOTES
- Added missing operations and type aliases so the collection iterators fulfill *LegacyInputIterator* requirement and `std::input_iterator` concept, and the collections fulfill  `std::input_range` concept. Thanks to these the collections are compatible with standard algorithms and standard range algorithms such as `std::find`, `std::count`, `std::all_of`

ENDRELEASENOTES

Fixes: #150, fixes #272
Conflicts: #273

Implement missing features so `CollectionIterators` and `MutableCollectionIterators` fulfill the requirements imposed on the C++ iterators (#598). It's expected than not all requirements can be fulfilled as some are in direct conflict with podio design:
- *LegacyForwardIterator*: dereference should return a reference, but in podio iterators are  'proxy iterators' returning user layer objects as a proxy for reference
- *LegacyForwardItertor*:  dereferencing  two iterators that are equal should give two references bound to the same object, but in podio the returned 'proxies' are different objects
-  `std::forward_iterator`: pointers and references obtained from an iterator should be valid as range the range is valid, but in podio the iterators behave like 'stashing iterators' -> pointers point to iterator member variable limiting their validity to the lifetime of the iterator.
- *LegacyOutputIterator*/`output_iterator`: datatype assignment replaces the internal object handle instead of modifying the handle properties.

As a consequence the iterators can the podio iterators can be at most *LegacyInputIterator* and `std::input_iterator`, and collections be `std::ranges::input_range`. This PR implements missing features to achieve this.

### List of changes:
 
#### Named requirements:

- [x] *LegacyIterator*:
  - [x] copy constructor and assignment
  - [x] type aliases
- [x] *LegacyInputIterator*:
  - [x] postfix increment
- :x: *LegacForwardIterator*:
  - [x] value-initialization 
  - :x: dereference return reference not proxy
  - :x: dereferencing equal iterators returns references to the same object
- :x:  *OutputIterator*:
  - :x: assignment should modify collection
- [x] `iterator_category` is `std::input_iterator_tag` 
- [x] check selected algorithms operating on *LegacyInputIterators*

#### Concepts:

- [x] semantics checks for concepts
- [x] `std::input_or_output_iterator`
  - [x] same as *LegacyIterator* but  copyability not required
- [x] `std::input_iterator`
  - [x] `std::indirectly_readable` and `std::readable` (can dereference both `iterator` and `const iterator`)
- :x: `std::forward_iterator`
  - [x] syntax: constrains (except `iterator_concept` to be derived from`std::forward_iterator_tag`) 
  - :x: semantic: pointers obtained from iterator should remain valid as long as range is valid (no-stashing)
- [x] `iterator_concept` is `std::input_iterator_tag`
- [x] check range concepts
- [x] check selected range algorithms constrained to `std::input_iterator`

