### PR TITLE
Fix schema evolution when switching component members

### DIFF
--- a/python/podio_schema_evolution.py
+++ b/python/podio_schema_evolution.py
@@ -31,7 +31,7 @@ class AddedComponent(SchemaChange):
     def __init__(self, component, name):
         self.component = component
         self.name = name
-        super().__init__(f"'{self.component.name}' has been added")
+        super().__init__(f"'{self.name}' has been added")
 
 
 class DroppedComponent(SchemaChange):

--- a/tests/schema_evolution/CMakeLists.txt
+++ b/tests/schema_evolution/CMakeLists.txt
@@ -33,4 +33,20 @@ function(PODIO_CREATE_READ_NEW_DATA_TEST sourcefile additional_libs)
   )
 endfunction()
 
+add_test(
+  NAME schema-evolution-script
+  COMMAND ${PROJECT_SOURCE_DIR}/python/podio_schema_evolution.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/datalayout_new.yaml
+    ${PROJECT_SOURCE_DIR}/tests/datalayout.yaml
+)
+
+add_test(
+  NAME schema-evolution-script-with-evol
+  COMMAND
+    ${PROJECT_SOURCE_DIR}/python/podio_schema_evolution.py
+    --evo ${CMAKE_CURRENT_SOURCE_DIR}/schema_evolution.yaml
+    ${CMAKE_CURRENT_SOURCE_DIR}/datalayout_new.yaml
+    ${PROJECT_SOURCE_DIR}/tests/datalayout.yaml
+)
+
 add_subdirectory(root_io)

--- a/tests/schema_evolution/datalayout_new.yaml
+++ b/tests/schema_evolution/datalayout_new.yaml
@@ -33,6 +33,11 @@ components :
       - int x
       - int y_new
 
+  ex2::NamespaceStructLong:
+    Members:
+      - int64_t x
+      - int64_t y_new
+
   ex2::NamespaceInNamespaceStruct:
     Members:
       - ex2::NamespaceStruct data
@@ -191,7 +196,7 @@ datatypes :
     Members:
       - std::int16_t i16Val{42} // some int16 value
       - std::array<float, 2> floats {3.14f, 1.23f} // some float values
-      - ex2::NamespaceStruct s{10, 11} // one that we happen to know works
+      - ex2::NamespaceStructLong s{10, 11} // one that we happen to know works
       - double d{9.876e5} // double val
       - CompWithInit comp // To make sure that the default initializer of the component does what it should
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a bug in the schema evolution generation script that crashes in case a datatype member that is a component is changed.
- Adapt new datalayout to include such a change
- Add new tests to run schema evolution script standalone

ENDRELEASENOTES

The tests that we had would have actually covered this, but we were not hitting a case with the schema evolutions that we had in our example datamodel.