### PR TITLE
Document storage details

### DIFF
--- a/doc/figures/file_layout_root.svg
+++ b/doc/figures/file_layout_root.svg
@@ -1,0 +1,433 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="550.2323mm"
+   height="276.59653mm"
+   viewBox="0 0 550.2323 276.59653"
+   version="1.1"
+   id="svg1085"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="file_layout_root.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1087"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.34832352"
+     inkscape:cx="704.80455"
+     inkscape:cy="644.51577"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1082">
+    <rect
+       x="219.66945"
+       y="-117.54345"
+       width="154.38103"
+       height="54.915276"
+       id="rect1191" />
+    <rect
+       id="rect1191-7"
+       height="56.202854"
+       width="151.56081"
+       y="-117.54345"
+       x="219.66945" />
+    <rect
+       id="rect1191-4"
+       height="57.101673"
+       width="168.25653"
+       y="-117.54345"
+       x="219.66945" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(133.83225,-24.633955)">
+    <rect
+       ry="6.6823826"
+       y="80.639793"
+       x="-127.86626"
+       height="87.918266"
+       width="149.79207"
+       id="rect833-9"
+       style="fill:#f58412;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028" />
+    <text
+       id="text849-3"
+       y="130.84731"
+       x="-96.217751"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       xml:space="preserve"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         style="font-size:16.9333px;stroke-width:0.264583"
+         y="130.84731"
+         x="-96.217751"
+         id="tspan847-6"
+         sodipodi:role="line">Frame data</tspan></text>
+    <rect
+       style="fill:#f58412;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect833-9-1"
+       width="149.79207"
+       height="87.918266"
+       x="-127.86626"
+       y="168.55806"
+       ry="6.6823826"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028" />
+    <text
+       xml:space="preserve"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       x="-96.217751"
+       y="218.76558"
+       id="text849-3-5"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         sodipodi:role="line"
+         id="tspan847-6-5"
+         x="-96.217751"
+         y="218.76558"
+         style="font-size:16.9333px;stroke-width:0.264583">Frame data</tspan></text>
+    <rect
+       style="fill:#00aded;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect833-9-7"
+       width="149.79207"
+       height="87.918266"
+       x="33.64587"
+       y="80.639793"
+       ry="6.6823826"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028" />
+    <text
+       xml:space="preserve"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       x="65.294365"
+       y="130.84731"
+       id="text849-3-6"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         sodipodi:role="line"
+         id="tspan847-6-56"
+         x="65.294365"
+         y="130.84731"
+         style="font-size:16.9333px;stroke-width:0.264583">Frame data</tspan></text>
+    <rect
+       ry="6.6823826"
+       y="168.55806"
+       x="33.64587"
+       height="87.918266"
+       width="149.79207"
+       id="rect833-9-1-3"
+       style="fill:#00aded;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028" />
+    <text
+       id="text849-3-5-7"
+       y="218.76558"
+       x="65.294365"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       xml:space="preserve"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         style="font-size:16.9333px;stroke-width:0.264583"
+         y="218.76558"
+         x="65.294365"
+         id="tspan847-6-5-4"
+         sodipodi:role="line">Frame data</tspan></text>
+    <rect
+       ry="6.6823697"
+       y="119.12894"
+       x="256.38565"
+       height="38.489151"
+       width="150.10522"
+       id="rect835-1"
+       style="fill:#f58412;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028" />
+    <text
+       id="text845-2"
+       y="144.6219"
+       x="269.38638"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       xml:space="preserve"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         style="font-size:16.9333px;stroke-width:0.264583"
+         y="144.6219"
+         x="269.38638"
+         id="tspan843-7"
+         sodipodi:role="line">Frame Metadata</tspan></text>
+    <rect
+       style="fill:#00aded;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect835-1-3"
+       width="150.10522"
+       height="38.489151"
+       x="256.38565"
+       y="157.6181"
+       ry="6.6823697"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028" />
+    <text
+       xml:space="preserve"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       x="269.38638"
+       y="183.11107"
+       id="text845-2-2"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         sodipodi:role="line"
+         id="tspan843-7-0"
+         x="269.38638"
+         y="183.11107"
+         style="font-size:16.9333px;stroke-width:0.264583">Frame Metadata</tspan></text>
+    <g
+       transform="translate(299.81736,125.71875)"
+       id="g854-9-5"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028">
+      <rect
+         ry="6.6823697"
+         y="-45.078957"
+         x="-43.431427"
+         height="38.489151"
+         width="150.10522"
+         id="rect835-1-2"
+         style="fill:none;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke" />
+      <text
+         id="text845-2-5"
+         y="-19.585993"
+         x="-30.430706"
+         style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+         xml:space="preserve"><tspan
+           style="font-size:16.9333px;stroke-width:0.264583"
+           y="-19.585993"
+           x="-30.430706"
+           id="tspan843-7-4"
+           sodipodi:role="line">podio Metadata</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       id="text1189"
+       style="font-size:19.7556px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';white-space:pre;shape-inside:url(#rect1191)"
+       transform="translate(-344.71121,147.82412)"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         x="219.66992"
+         y="-99.680614"
+         id="tspan9976"><tspan
+           style="fill:#f58512"
+           id="tspan9972">Category1</tspan><tspan
+           style="shape-inside:url(#rect1191)"
+           id="tspan9974">
+</tspan></tspan><tspan
+         x="219.66992"
+         y="-74.98611"
+         id="tspan9980"><tspan
+           style="shape-inside:url(#rect1191)"
+           id="tspan9978">TTree/RNTModel</tspan></tspan></text>
+    <text
+       transform="translate(-183.72829,147.82412)"
+       style="font-size:19.7556px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';white-space:pre;shape-inside:url(#rect1191-7)"
+       id="text1189-4"
+       xml:space="preserve"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         x="219.66992"
+         y="-99.680614"
+         id="tspan9986"><tspan
+           style="fill:#00aded"
+           id="tspan9982">Category2</tspan><tspan
+           style="shape-inside:url(#rect1191-7)"
+           id="tspan9984">
+</tspan></tspan><tspan
+         x="219.66992"
+         y="-74.98611"
+         id="tspan9990"><tspan
+           style="shape-inside:url(#rect1191-7)"
+           id="tspan9988">TTree/RNTModel</tspan></tspan></text>
+    <text
+       transform="translate(39.16835,147.82412)"
+       style="font-size:19.7556px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';white-space:pre;shape-inside:url(#rect1191-4)"
+       id="text1189-0"
+       xml:space="preserve"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         x="219.66992"
+         y="-99.680614"
+         id="tspan9994"><tspan
+           style="shape-inside:url(#rect1191-4)"
+           id="tspan9992">podio_metadata
+</tspan></tspan><tspan
+         x="219.66992"
+         y="-74.98611"
+         id="tspan9998"><tspan
+           style="shape-inside:url(#rect1191-4)"
+           id="tspan9996">TTree/RNTWriter</tspan></tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect1241"
+       width="548.46838"
+       height="274.83264"
+       x="-132.9503"
+       y="25.5159"
+       ry="6.6823697"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028" />
+    <text
+       xml:space="preserve"
+       style="font-size:25.4px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       x="197.13748"
+       y="281.4671"
+       id="text1245"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028"><tspan
+         sodipodi:role="line"
+         id="tspan1243"
+         x="197.13748"
+         y="281.4671"
+         style="font-size:25.4px;stroke-width:0.264583">ROOT file</tspan></text>
+    <g
+       transform="matrix(0,-3.3467043,3.3467043,0,239.75385,171.25576)"
+       id="g5993-2-3-7"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.551;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path5967-20-5-8"
+         cx="0.72945958"
+         cy="-12.413512"
+         r="1.2107366" />
+      <circle
+         r="1.2107366"
+         cy="-9.0190382"
+         cx="0.72945958"
+         id="path5967-3-5-6-6"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.551;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <circle
+         r="1.2107366"
+         cy="-5.6245642"
+         cx="0.72945958"
+         id="path5967-1-5-2-8"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.551;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       id="g2230-5"
+       transform="translate(-326.75467,151.88947)"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028">
+      <circle
+         transform="scale(-1)"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path5967-20-5-0"
+         cx="-664.38586"
+         cy="-77.607918"
+         r="4.0519776" />
+      <circle
+         transform="scale(-1)"
+         r="4.0519776"
+         cy="-66.24762"
+         cx="-664.38586"
+         id="path5967-3-5-6-4"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <circle
+         transform="scale(-1)"
+         r="4.0519776"
+         cy="-54.887318"
+         cx="-664.38586"
+         id="path5967-1-5-2-87"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       id="g2230-1"
+       transform="translate(-555.84396,211.75784)"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028">
+      <circle
+         transform="scale(-1)"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path5967-20-5-7"
+         cx="-664.38586"
+         cy="-77.607918"
+         r="4.0519776" />
+      <circle
+         transform="scale(-1)"
+         r="4.0519776"
+         cy="-66.24762"
+         cx="-664.38586"
+         id="path5967-3-5-6-2"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <circle
+         transform="scale(-1)"
+         r="4.0519776"
+         cy="-54.887318"
+         cx="-664.38586"
+         id="path5967-1-5-2-7"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <g
+       id="g2230-2"
+       transform="translate(-717.35609,211.75784)"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_root_file.png"
+       inkscape:export-xdpi="300.01028"
+       inkscape:export-ydpi="300.01028">
+      <circle
+         transform="scale(-1)"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path5967-20-5-2"
+         cx="-664.38586"
+         cy="-77.607918"
+         r="4.0519776" />
+      <circle
+         transform="scale(-1)"
+         r="4.0519776"
+         cy="-66.24762"
+         cx="-664.38586"
+         id="path5967-3-5-6-61"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" />
+      <circle
+         transform="scale(-1)"
+         r="4.0519776"
+         cy="-54.887318"
+         cx="-664.38586"
+         id="path5967-1-5-2-0"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+  </g>
+</svg>

--- a/doc/figures/file_layout_sio.svg
+++ b/doc/figures/file_layout_sio.svg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="186.09605mm"
+   height="470.46384mm"
+   viewBox="0 0 186.09605 470.46384"
+   version="1.1"
+   id="svg1614"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="file_layout_sio.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1616"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.24630192"
+     inkscape:cx="-757.20076"
+     inkscape:cy="785.62116"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1611" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(4.6397518,174.1875)">
+    <rect
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       style="fill:#f58512;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect835"
+       width="150.10522"
+       height="38.489151"
+       x="11.211584"
+       y="-110.65507"
+       ry="6.6823697" />
+    <text
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       xml:space="preserve"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       x="24.212305"
+       y="-85.162102"
+       id="text845"><tspan
+         sodipodi:role="line"
+         id="tspan843"
+         x="24.212305"
+         y="-85.162102"
+         style="font-size:16.9333px;stroke-width:0.264583">Frame Metadata</tspan></text>
+    <rect
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       style="fill:#f58512;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect833"
+       width="149.79207"
+       height="87.918266"
+       x="11.368162"
+       y="-72.165916"
+       ry="6.6823826" />
+    <text
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       xml:space="preserve"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       x="43.016674"
+       y="-21.958393"
+       id="text849"><tspan
+         sodipodi:role="line"
+         id="tspan847"
+         x="43.016674"
+         y="-21.958393"
+         style="font-size:16.9333px;stroke-width:0.264583">Frame data</tspan></text>
+    <rect
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       ry="6.6823697"
+       y="15.752201"
+       x="11.211584"
+       height="38.489151"
+       width="150.10522"
+       id="rect835-3"
+       style="fill:#00aded;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke" />
+    <text
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       id="text845-7"
+       y="41.245167"
+       x="24.212305"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="font-size:16.9333px;stroke-width:0.264583"
+         y="41.245167"
+         x="24.212305"
+         id="tspan843-5"
+         sodipodi:role="line">Frame Metadata</tspan></text>
+    <rect
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       ry="6.6823826"
+       y="54.241352"
+       x="11.368162"
+       height="87.918266"
+       width="149.79207"
+       id="rect833-2"
+       style="fill:#00aded;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke" />
+    <text
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       id="text849-2"
+       y="104.44888"
+       x="43.016674"
+       style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="font-size:16.9333px;stroke-width:0.264583"
+         y="104.44888"
+         x="43.016674"
+         id="tspan847-8"
+         sodipodi:role="line">Frame data</tspan></text>
+    <g
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       transform="translate(-578.12167,108.29192)"
+       id="g2230">
+      <circle
+         r="4.0519776"
+         cy="-77.607918"
+         cx="-664.38586"
+         id="path5967-20-5"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+         transform="scale(-1)" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path5967-3-5-6"
+         cx="-664.38586"
+         cy="-66.24762"
+         r="4.0519776"
+         transform="scale(-1)" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.84403;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path5967-1-5-2"
+         cx="-664.38586"
+         cy="-54.887318"
+         r="4.0519776"
+         transform="scale(-1)" />
+    </g>
+    <rect
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       inkscape:export-filename="/home/tmadlener/work/presentations/2022/ftx_sft/frame_prototype/frame_sio_file.png"
+       ry="6.6823697"
+       y="-173.30556"
+       x="-3.7578068"
+       height="468.69995"
+       width="184.33217"
+       id="rect1241-8"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke" />
+    <g
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       id="g854-9-5-4"
+       transform="translate(54.643011,-110.94443)">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect835-1-2-3"
+         width="150.10522"
+         height="38.489151"
+         x="-43.431427"
+         y="-45.078957"
+         ry="6.6823697" />
+      <text
+         xml:space="preserve"
+         style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+         x="-30.430706"
+         y="-19.585993"
+         id="text845-2-5-1"><tspan
+           sodipodi:role="line"
+           id="tspan843-7-4-4"
+           x="-30.430706"
+           y="-19.585993"
+           style="font-size:16.9333px;stroke-width:0.264583">podio Metadata</tspan></text>
+    </g>
+    <g
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       transform="translate(54.643011,-285.18124)"
+       id="g2657">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.76389;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect835-1-2-2"
+         width="150.10522"
+         height="38.489151"
+         x="-43.431427"
+         y="482.12408"
+         ry="6.6823697" />
+      <text
+         xml:space="preserve"
+         style="font-size:16.9333px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+         x="-17.773129"
+         y="507.61707"
+         id="text845-2-5-0"><tspan
+           sodipodi:role="line"
+           id="tspan843-7-4-6"
+           x="-17.773129"
+           y="507.61707"
+           style="font-size:16.9333px;stroke-width:0.264583">sio Metadata</tspan></text>
+    </g>
+    <text
+       inkscape:export-ydpi="300"
+       inkscape:export-xdpi="300"
+       inkscape:transform-center-y="-447.43485"
+       inkscape:transform-center-x="-616.65671"
+       id="text1245-4"
+       y="283.02676"
+       x="46.992439"
+       style="font-size:25.4px;line-height:1.25;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="font-size:25.4px;stroke-width:0.264583"
+         y="283.02676"
+         x="46.992439"
+         id="tspan1243-9"
+         sodipodi:role="line">SIO file</tspan></text>
+  </g>
+</svg>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ Welcome to PODIO's documentation!
    examples.md
    frame.md
    userdata.md
+   storage_details.md
    cmake.md
    advanced_topics.md
    templates.md

--- a/doc/storage_details.md
+++ b/doc/storage_details.md
@@ -1,0 +1,100 @@
+# Storage details of files produced by podio
+
+This page describes some of the details of how podio stores data of generated
+EDMs and related metadata on file for the different backends.
+
+```{warning}
+We in general do not treat the file layout part of the public API for podio.
+This means that if you rely on exact details of a given file layout we might
+break things. This is especially true for the way we store *podio related metadata*
+metadata, e.g. information on collection types, their schema version, or the
+mapping of names to collection IDs. **However, we will limit breaking changes to
+cases where it is absolutely necessary.**
+```
+
+## ROOT
+
+For ROOT we offer two different options, one based on `TTree`s and one based on
+`RNTuple`s. The basic layout of files is largely the same for these two options,
+some minor differences are present in the storage of podio related metadata.
+
+The overall structure of a podio generated ROOT file looks like this
+- Each category gets its own `TTree` or `RNTupleModel`, where the name is the category name
+- Each Frame of a category will be one entry in that.
+- The Frame parameters are stored as part of each entry
+- An additional `podio_metadata` is created to hold the podio related metadata.
+
+An overview of this schema looks like this
+
+<img src="figures/file_layout_root.svg" alt="ROOT file layout schematic" width=487.5px align=center>
+
+```{note}
+For a ROOT based backend all entries of a category have to have the same
+(collection) contents. This content is defined by the **first entry that is
+written for a category**
+```
+
+### Storage of Collection data
+
+Each collection (that is not a subset collection) is decomposed into the
+following branches (or fields for `RNTuple`)
+- One branch of `std::vector<XYZData>`, with the same name as the collection
+- One branch (if any) of `std::vector<T>` per `VectorMember` (of type `T`) with the name `_<collection-name>_<vector-member-name>`
+- One branch (if any) of `std::vector<podio::ObjectID>` per `OneToOneRelation` or per `OneToManyRelation` with the name `_<collection-name>_<relation-name>`
+
+If the collection is a subset collection, then there will be only branch (or
+field for `RNTuple`) of `std::vector<podio::ObjectID>` with the name `<collection-name>_objIdx`
+
+### Storage of Frame parameters
+
+The Frame parameters are internally handled via `podio::GenericParameters`. For
+I/O they are decomposed into pairs of vectors containing the keys and values for
+each of the supported generic parameters types. In practice this means that
+there will be the following branches per supported type
+
+- One branch of `std::vector<std::string>` holding all the keys with the name of
+  `GP<Type>Keys` (where type is one of `Int`, `Float`, `Double` or `String`)
+- One branch of `std::vector<std::vector<T>>` holding all the values with the
+  name of `GP<Type>Values` (where type is one of `Int`, `Float`, `Double` or
+  `String` and `T` is one of `int`, `float`, `double` or `std::string`)
+
+### Storage of podio related metadata
+
+The podio related metadata, stored in the `podio_metadata` `TTree` (or
+`RNTupleModel`) contains the following general information once per file
+
+- The version of podio that has been used to write this file
+- The complete datamodel definitions for each datamodel that was encountered
+  when writing the file
+
+And the following information once per category
+- The mapping of collection names to collection IDs
+- The types of all the stored collections
+- The schema version of all stored collections
+- Which collections are stored as subset collections
+
+Here the `TTree` based and `RNTuple` based backends differ slighlty in the way
+these data are stored exactly. The `TTree` based backend stores the data in a
+slightly more structued way, taking advantage of ROOTs capabilities to stream
+out more complex object, e.g. the `podio::CollectionIDTable` is streamed as a
+whole. The `RNTuple` based backend on the other hand, destructures the
+information into separate fields that run in parallel.
+
+## SIO
+
+The SIO based backend stores all Frames as separate (compressed) binary records.
+Each record contains the Frame data and the corresponding podio related metadata
+to interpret the record. Additionally, it stores one additional record at the
+very beginning of the file containing the version of podio that has been used to
+write this file. After all records containing Frame data another record is
+written that contains some more podio related metadata, e.g. all datamodel
+definitions that were encountered when writing the file. This record also
+contains a `podio::SIOFileTOCRecordBlock`, which contains information about the
+file positions of all Frame records that have been written, allowing for quick
+(random) access when reading files again. To find the beginning of this record
+the very last bits of the binary record are used to encode the start position of
+this record.
+
+Schematically an SIO file written by podio looks like this
+
+<img src="figures/file_layout_sio.svg" alt="SIO file layout schematic" width=167.75px align=center>


### PR DESCRIPTION
BEGINRELEASENOTES
- Document how files written by podio look like

ENDRELEASENOTES

Follow up on and including #625 

some of the inline blocks will be rendered as admonition blocks by sphinx, so they stand out a bit more as they do in the markdown render from github.