### PR TITLE
Fix one to one relations for cloned objects

### DIFF
--- a/python/templates/Object.cc.jinja2
+++ b/python/templates/Object.cc.jinja2
@@ -16,7 +16,7 @@
 
 {{ utils.namespace_open(class.namespace) }}
 
-{{ macros.constructors_destructors(class.bare_type, Members, OneToManyRelations + VectorMembers) }}
+{{ macros.constructors_destructors(class.bare_type, Members, one_to_one_relations=OneToOneRelations, multi_relations=OneToManyRelations + VectorMembers) }}
 
 {{ class.bare_type }}::{{ class.bare_type }}(const Mutable{{ class.bare_type }}& other): {{ class.bare_type }}(other.m_obj) {}
 

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -1,4 +1,4 @@
-{% macro constructors_destructors(type, members, multi_relations=[], prefix='') %}
+{% macro constructors_destructors(type, members, one_to_one_relations=[], multi_relations=[], prefix='') %}
 {% set full_type = prefix + type %}
 
 {{ full_type }}::{{ full_type }}() :
@@ -36,6 +36,11 @@ Mutable{{ type }} {{ full_type }}::clone(bool cloneRelations) const {
   tmp->m_{{ relation.name }} = new std::vector<{{ relation.full_type }}>();
 {% endfor %}
   if (cloneRelations) {
+{% for relation in one_to_one_relations %}
+  if (m_obj->m_{{ relation.name }}) {
+    tmp->m_{{ relation.name }} = new {{ relation.full_type }}(*m_obj->m_{{ relation.name }});
+  }
+{% endfor %}
 {% for relation in multi_relations %}
     // If the current object has been read from a file, then the object may only have a slice of the relation vector
     // so this slice has to be copied in case we want to modify it

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1254,7 +1254,8 @@ void runRelationAfterCloneCheck(const std::string& filename = "unittest_relation
   // OneToOne relations
   auto oneToOneColl = ExampleWithOneRelationCollection();
   auto obj = oneToOneColl.create();
-  obj.cluster(clusterColl[1]); // energy is 200
+  obj.cluster(clusterColl[1]);
+
   frame.put(std::move(oneToOneColl), "oneToOne");
   frame.put(std::move(hitColl), "hits");
   frame.put(std::move(clusterColl), "clusters");

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -699,6 +699,7 @@ auto createCollections(const size_t nElements = 3u) {
     auto cluster = clusterColl.create();
     // create a few relations as well
     cluster.addHits(hit);
+    cluster.energy(150.f * i);
 
     auto vecMem = vecMemColl.create();
     vecMem.addcount(i);
@@ -1245,14 +1246,20 @@ template <typename ReaderT, typename WriterT>
 void runRelationAfterCloneCheck(const std::string& filename = "unittest_relations_after_cloning.root") {
   auto [hitColl, clusterColl, vecMemColl, userDataColl] = createCollections();
   auto frame = podio::Frame();
-  frame.put(std::move(hitColl), "hits");
-  frame.put(std::move(clusterColl), "clusters");
-  frame.put(std::move(vecMemColl), "vectors");
   // Empty relations
   auto emptyColl = ExampleClusterCollection();
   emptyColl.create();
   emptyColl.create();
   frame.put(std::move(emptyColl), "emptyClusters");
+  // OneToOne relations
+  auto oneToOneColl = ExampleWithOneRelationCollection();
+  auto obj = oneToOneColl.create();
+  obj.cluster(clusterColl[1]); // energy is 200
+  frame.put(std::move(oneToOneColl), "oneToOne");
+  frame.put(std::move(hitColl), "hits");
+  frame.put(std::move(clusterColl), "clusters");
+  frame.put(std::move(vecMemColl), "vectors");
+
   auto writer = WriterT(filename);
   writer.writeFrame(frame, podio::Category::Event);
   writer.finish();
@@ -1298,6 +1305,12 @@ void runRelationAfterCloneCheck(const std::string& filename = "unittest_relation
   newClusterCollection.push_back(nEmptyCluster);
   newHitCollection.push_back(hit);
   newHitCollection.push_back(anotherHit);
+
+  auto& collWithOneRelation = readFrame.get<ExampleWithOneRelationCollection>("oneToOne");
+  REQUIRE(collWithOneRelation.size() == 1);
+  auto nObj = collWithOneRelation[0].clone();
+  REQUIRE(collWithOneRelation[0].cluster().energy() == 150.);
+  REQUIRE(nObj.cluster().energy() == 150.);
 
   // Test cloned objects after writing and reading
   auto newName = std::filesystem::path(filename)


### PR DESCRIPTION
Fixes https://github.com/AIDASoft/podio/issues/631. In https://github.com/AIDASoft/podio/pull/583, one to one relations were not added together with the one to many relations.

BEGINRELEASENOTES
- Fix one to one relations for cloned objects by copying the one to one relations too.
- Add a test that checks values for cloned objects from a non mutable object.

ENDRELEASENOTES