### PR TITLE
Pass an argument by const reference instead of value and other minor fixes

### DIFF
--- a/python/templates/MutableObject.cc.jinja2
+++ b/python/templates/MutableObject.cc.jinja2
@@ -12,8 +12,6 @@
 #include "nlohmann/json.hpp"
 #endif
 
-#include <ostream>
-
 {{ utils.namespace_open(class.namespace) }}
 
 {{ macros.constructors_destructors(class.bare_type, Members, multi_relations=OneToManyRelations + VectorMembers, prefix='Mutable') }}

--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -57,7 +57,7 @@
 {%- endwith %}
 
 {% for relation in OneToOneRelations %}
-  if (m_{{ relation.name }}) delete m_{{ relation.name }};
+  delete m_{{ relation.name }};
 {% endfor %}
 }
 {%- endif %}

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -121,7 +121,7 @@
 {% macro single_relation_setters(relations, get_syntax) %}
 {% for relation in relations %}
   /// Set the {{ relation.description }}
-  void {{ relation.setter_name(get_syntax) }}({{ relation.full_type }} value);
+  void {{ relation.setter_name(get_syntax) }}(const {{ relation.full_type }}& value);
 {% endfor %}
 {%- endmacro %}
 

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -123,7 +123,7 @@ const {{ relation.full_type }} {{ class_type }}::{{ relation.getter_name(get_syn
 {% macro single_relation_setters(class, relations, get_syntax, prefix='') %}
 {% set class_type = prefix + class.bare_type %}
 {% for relation in relations %}
-void {{ class_type }}::{{ relation.setter_name(get_syntax) }}({{ relation.full_type }} value) {
+void {{ class_type }}::{{ relation.setter_name(get_syntax) }}(const {{ relation.full_type }}& value) {
   if (m_obj->m_{{ relation.name }}) {
     delete m_obj->m_{{ relation.name }};
   }

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -180,10 +180,7 @@ podio::RelationRange<{{ relation.full_type }}> {{ class_type }}::{{ relation.get
 {% macro common_object_funcs(class, prefix='') %}
 {% set full_type = prefix + class.bare_type %}
 bool {{ full_type }}::isAvailable() const {
-  if (m_obj) {
-    return true;
-  }
-  return false;
+  return m_obj;
 }
 
 const podio::ObjectID {{ full_type }}::getObjectID() const {

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -124,9 +124,7 @@ const {{ relation.full_type }} {{ class_type }}::{{ relation.getter_name(get_syn
 {% set class_type = prefix + class.bare_type %}
 {% for relation in relations %}
 void {{ class_type }}::{{ relation.setter_name(get_syntax) }}(const {{ relation.full_type }}& value) {
-  if (m_obj->m_{{ relation.name }}) {
-    delete m_obj->m_{{ relation.name }};
-  }
+  delete m_obj->m_{{ relation.name }};
   m_obj->m_{{ relation.name }} = new {{ relation.full_type }}(value);
 }
 

--- a/python/templates/macros/utils.jinja2
+++ b/python/templates/macros/utils.jinja2
@@ -30,7 +30,6 @@ namespace {{ nsp }} {
 #include "{{ incfolder }}Mutable{{ type }}.h"
 #include "{{ incfolder }}{{ type }}Obj.h"
 #include "{{ incfolder }}{{ type }}Data.h"
-#include "{{ incfolder }}{{ type }}Collection.h"
 {%- endmacro %}
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Minor cleanups for generated EDMs
  - Pass the argument by const reference in the relation setter
  - Remove a few includes that are not needed
  - Don't check for `nullptr` before deleting a (possibly `nullptr`) pointer
  - Remove `if - else` check and use implicit conversion of pointer to bool
 
ENDRELEASENOTES