### PR TITLE
Make ROOT load libraries without the .so extension

### DIFF
--- a/doc/python.md
+++ b/doc/python.md
@@ -10,7 +10,7 @@ To load the Python bindings from a generated C++ model dictionary, first make su
 ```python
 import ROOT
 
-res = ROOT.gSystem.Load('libGeneratedModelDict.so')
+res = ROOT.gSystem.Load('libGeneratedModelDict')
 if res < 0:
     raise RuntimeError('Failed to load libGeneratedModelDict.so')
 ```

--- a/doc/python.md
+++ b/doc/python.md
@@ -12,7 +12,7 @@ import ROOT
 
 res = ROOT.gSystem.Load('libGeneratedModelDict')
 if res < 0:
-    raise RuntimeError('Failed to load libGeneratedModelDict.so')
+    raise RuntimeError('Failed to load libGeneratedModelDict')
 ```
 
 For reference usage, see the [Python module of EDM4hep](https://github.com/key4hep/EDM4hep/blob/main/python/edm4hep/__init__.py).

--- a/python/podio/__init__.py
+++ b/python/podio/__init__.py
@@ -7,7 +7,7 @@ from .__version__ import __version__
 try:
     from ROOT import podio  # noqa: F401
 except ImportError:
-    print("Unable to load podio, make sure that libpodio.so is in LD_LIBRARY_PATH")
+    print("Unable to load podio, make sure that libpodio is in LD_LIBRARY_PATH")
     raise
 
 from .frame import Frame

--- a/tests/write_frame.py
+++ b/tests/write_frame.py
@@ -6,7 +6,7 @@ import importlib
 
 import ROOT
 
-if ROOT.gSystem.Load("libTestDataModelDict.so") < 0:  # noqa: E402
+if ROOT.gSystem.Load("libTestDataModelDict") < 0:  # noqa: E402
     raise RuntimeError("Could not load TestDataModel dictionary")
 
 from ROOT import (  # pylint: disable=wrong-import-position


### PR DESCRIPTION
BEGINRELEASENOTES
- Make ROOT load libraries without the .so extension

ENDRELEASENOTES

See https://github.com/key4hep/EDM4hep/pull/339 and https://github.com/key4hep/EDM4hep/issues/338. This means no one is running the tests on MacOS :smile: 