### PR TITLE
Improve readability of ObjectIDs that are dumped

### DIFF
--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -34,7 +34,7 @@ inline std::ostream& operator<<(std::ostream& os, const podio::ObjectID& id) {
   const auto oldFlags = os.flags();
   os << std::hex << std::setw(8) << id.collectionID;
   os.flags(oldFlags);
-  return os << id.index;
+  return os << "|" << id.index;
 }
 
 } // namespace podio


### PR DESCRIPTION

BEGINRELEASENOTES
- Improve the readability of dumped `ObjectID`s from `XXXXXXXi` to `XXXXXXXX|i` (i.e. adding a separator between the hex collection ID and the index)

ENDRELEASENOTES