### PR TITLE
Make sure subset collections do not duplicate information when dumped to JSON

### DIFF
--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -5,6 +5,10 @@
 #include <iomanip>
 #include <ostream>
 
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
+  #include "nlohmann/json.hpp"
+#endif
+
 namespace podio {
 
 class ObjectID {
@@ -36,6 +40,12 @@ inline std::ostream& operator<<(std::ostream& os, const podio::ObjectID& id) {
   os.flags(oldFlags);
   return os << id.index;
 }
+
+#if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
+inline void to_json(nlohmann::json& j, const podio::ObjectID& id) {
+  j = nlohmann::json{{"collectionID", id.collectionID}, {"index", id.index}};
+}
+#endif
 
 } // namespace podio
 

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -250,8 +250,13 @@ const auto registeredCollection = registerCollection();
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 void to_json(nlohmann::json& j, const {{ collection_type }}& collection) {
   j = nlohmann::json::array();
+  const auto subset = collection.isSubsetCollection();
   for (auto&& elem : collection) {
-    j.emplace_back(elem);
+    if (subset) {
+      j.emplace_back(elem.id());
+    } else {
+      j.emplace_back(elem);
+    }
   }
 }
 #endif

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -249,18 +249,14 @@ void to_json(nlohmann::json& j, const {{ prefix }}{{ class.bare_type }}& value) 
   };
 
 {% for relation in single_relations %}
-    j["{{ relation.name }}"] = nlohmann::json{
-      {"collectionID", value.{{ relation.getter_name(get_syntax) }}().getObjectID().collectionID },
-      {"index", value.{{ relation.getter_name(get_syntax) }}().getObjectID().index }};
+    j["{{ relation.name }}"] = nlohmann::json{value.{{ relation.getter_name(get_syntax) }}().id()};
 
 {% endfor %}
 
 {% for relation in multi_relations %}
   j["{{ relation.name }}"] = nlohmann::json::array();
   for (const auto& v : value.{{ relation.getter_name(get_syntax) }}()) {
-    j["{{ relation.name }}"].emplace_back(nlohmann::json{
-      {"collectionID", v.getObjectID().collectionID },
-      {"index", v.getObjectID().index }});
+    j["{{ relation.name }}"].emplace_back(v.id());
   }
 
 {% endfor %}

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1168,6 +1168,29 @@ TEST_CASE("JSON", "[json]") {
   }
 }
 
+TEST_CASE("subset collection JSON", "[json]") {
+  auto clusters = ExampleClusterCollection();
+  clusters.setID(42);
+  for (int i = 0; i < 5; ++i) {
+    clusters.create(i * 1.0);
+  }
+
+  auto subsetClusters = ExampleClusterCollection();
+  subsetClusters.setID(123);
+  subsetClusters.setSubsetCollection();
+  for (int i = clusters.size() - 1; i >= 0; i--) {
+    subsetClusters.push_back(clusters[i]);
+  }
+
+  const nlohmann::json json{{"subset", subsetClusters}};
+  REQUIRE(json["subset"].size() == 5);
+
+  for (int i = 0; i < 5; ++i) {
+    REQUIRE(json["subset"][i]["collectionID"] == clusters.getID());
+    REQUIRE(json["subset"][i]["index"] == 4 - i);
+  }
+}
+
 #endif
 
 // Write a template function that can be used with different writers in order to


### PR DESCRIPTION

BEGINRELEASENOTES
- Make JSON dumping of subset collections only store the `ObjectID`s to the elements they are pointing to instead of duplicating the information.
- Add JSON conversion support to `podio::ObjectID`
  - Use this to simplify JSON conversion code for relations in objects

ENDRELEASENOTES