### PR TITLE
Remove or change a few headers for objects and collections

### DIFF
--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -7,7 +7,6 @@
 #define {{ package_name.upper() }}_{{ class.bare_type }}Collection_H
 
 // datamodel specific includes
-#include "{{ incfolder }}{{ class.bare_type }}Data.h"
 #include "{{ incfolder }}{{ class.bare_type }}.h"
 #include "{{ incfolder }}Mutable{{ class.bare_type }}.h"
 #include "{{ incfolder }}{{ class.bare_type }}Obj.h"
@@ -16,15 +15,13 @@
 // podio specific includes
 #include "podio/ICollectionProvider.h"
 #include "podio/CollectionBase.h"
-#include "podio/CollectionIDTable.h"
 
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json_fwd.hpp"
 #endif
 
-#include <string>
+#include <string_view>
 #include <vector>
-#include <deque>
 #include <array>
 #include <algorithm>
 #include <ostream>

--- a/python/templates/MutableObject.h.jinja2
+++ b/python/templates/MutableObject.h.jinja2
@@ -15,8 +15,7 @@
 
 #include "podio/utilities/MaybeSharedPtr.h"
 
-#include <ostream>
-#include <cstddef>
+#include <cstdint>
 
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json_fwd.hpp"

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -14,7 +14,7 @@
 #include "podio/utilities/MaybeSharedPtr.h"
 
 #include <ostream>
-#include <cstddef>
+#include <cstdint>
 
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json_fwd.hpp"


### PR DESCRIPTION
like in https://github.com/AIDASoft/podio/pull/633 a few headers are not being used. For collections I don't think any collection is using `deque`, right? In any case it makes sense not to include it for every collection.

BEGINRELEASENOTES
- Remove or change a few headers for objects and collections

ENDRELEASENOTES