### PR TITLE
Switch to el9 for pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v4
       with:
-        container: centos7
+        container: el9
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           echo "::group::Setup pre-commit"
@@ -34,7 +34,7 @@ jobs:
           cmake .. -DENABLE_SIO=ON \
             -DENABLE_JULIA=ON \
             -DENABLE_RNTUPLE=ON \
-            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "\
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DUSE_EXTERNAL_CATCH2=OFF


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to EL9 and c++20 for running pre-commit

ENDRELEASENOTES