### PR TITLE
Fix duplicated includes

### DIFF
--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -591,17 +591,24 @@ have resolvable schema evolution incompatibilities:"
 
     def _sort_includes(self, includes):
         """Sort the includes in order to try to have the std includes at the bottom"""
-        package_includes = sorted(i for i in includes if self.package_name in i)
-        podio_includes = sorted(i for i in includes if "podio" in i)
-        stl_includes = sorted(i for i in includes if "<" in i and ">" in i)
-
+        package_includes = []
+        podio_includes = []
+        stl_includes = []
         upstream_includes = []
-        if self.upstream_edm:
-            upstream_includes = sorted(
-                i for i in includes if self.upstream_edm.options["includeSubfolder"] in i
-            )
+        for include in includes:
+            if self.package_name in include:
+                package_includes.append(include)
+            elif "podio" in include:
+                podio_includes.append(include)
+            elif "<" in include and ">" in include:
+                stl_includes.append(include)
+            elif self.upstream_edm and self.upstream_edm.options["includeSubfolder"] in include:
+                upstream_includes.append(include)
+            else:
+                print(f"Warning: unable to include '{include}'")
 
-        # Are their includes that fulfill more than one of the above conditions? Are
-        # there includes that fulfill none?
-
+        package_includes.sort()
+        podio_includes.sort()
+        stl_includes.sort()
+        upstream_includes.sort()
         return package_includes + upstream_includes + podio_includes + stl_includes

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -595,7 +595,7 @@ have resolvable schema evolution incompatibilities:"
         podio_includes = []
         stl_includes = []
         upstream_includes = []
-        for include in includes:
+        for include in (inc for inc in includes if inc):
             if self.package_name in include:
                 package_includes.append(include)
             elif "podio" in include:


### PR DESCRIPTION
that could happen when several of the conditions in the logic were true at the same time, for example something with `edm4hep` in the name and `<>` like the covariance matrices utils in https://github.com/key4hep/EDM4hep/blob/72265af504233f6ccc551069f7931210dbaeb062/edm4hep.yaml#L128

BEGINRELEASENOTES
- Fix duplicated includes in generated datamodels when `ExtraCode` includes are done via `<>`. 

ENDRELEASENOTES