### PR TITLE
Use a virtualenv for documentation generation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,20 +25,17 @@ jobs:
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
           echo "::group::Install dependencies"
+          python3 -m venv /root/doc-gen-venv
+          source /root/doc-gen-venv/bin/activate
           python3 -m pip install -r doc/requirements.txt
-          export PATH=/root/.local/bin:$PATH
-          export PYTHONPATH=/root/.local/lib/python3.10/site-packages:$PYTHONPATH
-
+          export PYTHONPATH=$VIRTUAL_ENV/lib/python3.$(python3 -c 'import sys; print(f"{sys.version_info[1]}")')/site-packages:$PYTHONPATH
           echo -e "::endgroup::\n::group::Build podio"
           cmake -B build . --install-prefix=$(pwd)/install \
                 -GNinja -DENABLE_SIO=ON -DENABLE_RNTUPLE=ON \
                 -DBUILD_TESTING=OFF \
-                -DCMAKE_CXX_STANDARD=17
+                -DCMAKE_CXX_STANDARD=20
           cmake --build build --target install
-          export PYTHONPATH=$(pwd)/install/python:$PYTHONPATH
-          export LD_LIBRARY_PATH=$(pwd)/install/lib*/:$LD_LIBRARY_PATH
-          export ROOT_INCLUDE_PATH=$(pwd)/install/include
-
+          source ./init.sh && source ./env.sh
           echo -e "::endgroup::\n::group::build doc"
           sphinx-build -M html doc doc_output
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,9 +24,12 @@ generate-docs:
   script:
     # use the nightlies and install some dependencies on top of them
     - source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
-    - export PATH=/root/.local/bin:$PATH
-    - export PYTHONPATH=/root/.local/lib/python3.10/site-packages:$PYTHONPATH
+    - python3 -m venv /root/doc-gen-venv
+    - source /root/doc-gen-venv/bin/activate
     - python3 -m pip install -r doc/requirements.txt
+    # For some weird reason we have to make sure that we actually really pick
+    # the packages we just installed into the venv here
+    - export PYTHONPATH=$VIRTUAL_ENV/lib/python3.$(python3 -c 'import sys; print(f"{sys.version_info[1]}")')/site-packages:$PYTHONPATH
     - cmake -B build . --install-prefix=$(pwd)/install -GNinja -DENABLE_SIO=ON -DENABLE_RNTUPLE=ON -DBUILD_TESTING=OFF -DCMAKE_CXX_STANDARD=20 -DCREATE_DOC=ON
     - cmake --build build --target documentation
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Use a virtualenv for the documentation generation to make it more robust

ENDRELEASENOTES

similar changes to #654