### PR TITLE
CI: Make sure to build EDM4hep with c++20

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -48,7 +48,7 @@ jobs:
             cmake -DENABLE_SIO=ON \
               -DENABLE_JULIA=ON \
               -DCMAKE_INSTALL_PREFIX=../install \
-              -DCMAKE_CXX_STANDARD=17 \
+              -DCMAKE_CXX_STANDARD=20 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
               -DUSE_EXTERNAL_CATCH2=ON \
               -DBUILD_TESTING=OFF\
@@ -64,7 +64,7 @@ jobs:
             echo "::group::Build and test EDM4hep"
             cd $STARTDIR/edm4hep
             mkdir build && cd build
-            cmake -DCMAKE_CXX_STANDARD=17 \
+            cmake -DCMAKE_CXX_STANDARD=20 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
               -DUSE_EXTERNAL_CATCH2=ON \
               -G Ninja ..


### PR DESCRIPTION

BEGINRELEASENOTES
- Build EDM4hep with c++20 now that c++17 support has been removed from EDM4hep.

ENDRELEASENOTES