### PR TITLE
Make podio build version read from file accessible from python

### DIFF
--- a/python/podio/__init__.py
+++ b/python/podio/__init__.py
@@ -11,7 +11,7 @@ except ImportError:
     raise
 
 from .frame import Frame
-from . import root_io, reading
+from . import root_io, reading, version
 
 try:
     # We try to import the sio bindings which may fail if ROOT is not able to
@@ -21,10 +21,4 @@ try:
 except ImportError:
     pass
 
-__all__ = [
-    "__version__",
-    "Frame",
-    "root_io",
-    "sio_io",
-    "reading",
-]
+__all__ = ["__version__", "Frame", "root_io", "sio_io", "reading", "version"]

--- a/python/podio/base_reader.py
+++ b/python/podio/base_reader.py
@@ -81,7 +81,7 @@ class BaseReaderMixin:
             return ""
         return self._reader.getDatamodelDefinition(edm_name).data()
 
-    def get_podio_version(self):
+    def current_file_version(self):
         """Get the podio (build) version that was used to write this file
 
         Returns:

--- a/python/podio/base_reader.py
+++ b/python/podio/base_reader.py
@@ -80,3 +80,12 @@ class BaseReaderMixin:
         if self._is_legacy:
             return ""
         return self._reader.getDatamodelDefinition(edm_name).data()
+
+    def get_podio_version(self):
+        """Get the podio (build) version that was used to write this file
+
+        Returns:
+            podio.version.Version: The build version of podio that was use to
+                write this file
+        """
+        return self._reader.currentFileVersion()

--- a/python/podio/version.py
+++ b/python/podio/version.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Module that facilitates working with the podio::version::Version"""
+
+import ROOT
+
+# NOTE: It is necessary that this can be found on the ROOT_INCLUDE_PATH
+#
+# We check whether we can actually load the header to not break python bindings
+# in environments with *ancient* podio versions
+if ROOT.gInterpreter.LoadFile("podio/podioVersion.h") == 0:  # noqa: E402
+    from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
+
+build_version = podio.version.build_version
+
+
+def version_as_str(ver):
+    """Stringify the version into the usual format
+
+    Args:
+        ver (podio.version.Version): A podio version
+
+    Returns:
+        str: A stringified version of the version, in the format
+            MAJOR.MINOR.PATCH
+    """
+    return f"{ver.major}.{ver.minor}.{ver.patch}"

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -23,7 +23,8 @@ def print_general_info(reader, filename):
     legacy_text = " (this is a legacy file!)" if reader.is_legacy else ""
     print(
         f"input file: {filename}{legacy_text}\n"
-        f"            (written with podio version: {version_as_str(reader.current_file_version())})\n"
+        "            (written with podio version: "
+        f"{version_as_str(reader.current_file_version())})\n"
     )
     print(
         "datamodel model definitions stored in this file: "

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -8,6 +8,7 @@ import yaml
 from tabulate import tabulate
 
 from podio_version import __version__
+from podio.version import version_as_str
 
 
 def print_general_info(reader, filename):
@@ -20,11 +21,15 @@ def print_general_info(reader, filename):
         reader (root_io.Reader, sio_io.Reader): An initialized reader
     """
     legacy_text = " (this is a legacy file!)" if reader.is_legacy else ""
-    print(f"input file: {filename}{legacy_text}\n")
+    print(
+        f"input file: {filename}{legacy_text}\n"
+        f"            (written with podio version: {version_as_str(reader.get_podio_version())})\n"
+    )
     print(
         "datamodel model definitions stored in this file: "
         f'{", ".join(reader.datamodel_definitions)}'
     )
+
     print()
     print("Frame categories in this file:")
     cats = [(c, len(reader.get(c))) for c in reader.categories]

--- a/tools/podio-dump
+++ b/tools/podio-dump
@@ -23,7 +23,7 @@ def print_general_info(reader, filename):
     legacy_text = " (this is a legacy file!)" if reader.is_legacy else ""
     print(
         f"input file: {filename}{legacy_text}\n"
-        f"            (written with podio version: {version_as_str(reader.get_podio_version())})\n"
+        f"            (written with podio version: {version_as_str(reader.current_file_version())})\n"
     )
     print(
         "datamodel model definitions stored in this file: "


### PR DESCRIPTION
BEGINRELEASENOTES
- Add convenience bindings and formatting utility functionality to retrieve the podio build version from a file via python.

ENDRELEASENOTES

Factored out of #651 where I realized this was missing.