### PR TITLE
Add pythonization for freezing class attribute and preventing creating new attrubes by mistake

### DIFF
--- a/python/podio/pythonizations/freeze_class.py
+++ b/python/podio/pythonizations/freeze_class.py
@@ -1,0 +1,31 @@
+"""Prevent creating new attributes for existing objects
+The new attributes created in Python won't be visible for podio IO
+therefore preventing the addition of new attributes for podio objects
+might be desirable and help detecting miss-assignments"""
+
+from .utils.pythonizer import Pythonizer
+
+
+class FreezeClassPythonizer(Pythonizer):
+    """Prevent setting new attributes"""
+
+    @classmethod
+    def priority(cls):
+        """This most likely should be the last pythonization loaded
+        otherwise it may interfere with creating attributes during other pythonizations"""
+        return 99
+
+    @classmethod
+    def filter(cls, class_, name):
+        return True
+
+    @classmethod
+    def modify(cls, class_, name):
+        def freeze_setattr(self, attr, val):
+            object_type = type(self)
+            if attr not in object_type.__dict__:
+                raise AttributeError(f"'{object_type}' object has no attribute '{attr}'")
+            old_setattr(self, attr, val)
+
+        old_setattr = class_.__setattr__
+        class_.__setattr__ = freeze_setattr

--- a/python/podio/pythonizations/freeze_class.py
+++ b/python/podio/pythonizations/freeze_class.py
@@ -1,7 +1,7 @@
 """Prevent creating new attributes for existing objects
 The new attributes created in Python won't be visible for podio IO
 therefore preventing the addition of new attributes for podio objects
-might be desirable and help detecting miss-assignments"""
+might be desirable and help detecting mis-assignments"""
 
 from .utils.pythonizer import Pythonizer
 

--- a/python/podio/test_CodeGen.py
+++ b/python/podio/test_CodeGen.py
@@ -49,3 +49,15 @@ class CollectionSubscriptTest(unittest.TestCase):
         with self.assertRaises(IndexError):
             _ = collection[20]
         _ = collection[0]
+
+
+class AttributeCreationTest(unittest.TestCase):
+    """Setting new attributes test"""
+
+    def test_disable_new_attribute_creation(self):
+        component = nsp.AnotherNamespaceStruct()
+        self.assertEqual(component.x, 0)
+        component.x = 1
+        self.assertEqual(component.x, 1)
+        with self.assertRaises(AttributeError):
+            component.not_existing_attribute = 0

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -42,6 +42,11 @@ components :
     Members:
       - ex2::NamespaceStruct data
 
+  nsp::AnotherNamespaceStruct:
+    Members:
+      - int x
+      - int y
+
   StructWithFixedWithTypes:
     Members:
       - uint16_t fixedUnsigned16 // unsigned int with exactly 16 bits


### PR DESCRIPTION

BEGINRELEASENOTES
- Added pythonization for "freezing" class disallowing setting non-existent attributes

ENDRELEASENOTES

Pythonization proposed in key4hep/EDM4hep#357. Adding new attributes to existing objects is a feature in python. Unfortunately in the context of podio this is a very error prone behaviour that already lead to some bugs in the past.

For instance a typo in attribute name will silently create new attribute. With this pythonization an exception will be thrown
The error message is consistent with `__slots__` which is conventionally used in standard python to construct classes with frozen attributes