### PR TITLE
add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION

BEGINRELEASENOTES
- Added .editorconfig for basic cross-editor configuration for generic files

ENDRELEASENOTES

Editorconfig is a popular tool for portable configuration of editors. It's automatically recognized by some editors (vim, neovim, github editor) or has a plugin for the others (emacs, vscode, clion, sublime). The tool takes lower precedence than any language specific config so there shouldn't be conflicts

Here I propose a very basic config that will automatically add newline at the end of any file so hopefully there will be less small corrections like in https://github.com/AIDASoft/podio/pull/660#discussion_r1743364648