### PR TITLE
fix importing submodules in pythonizations

### DIFF
--- a/python/podio/pythonizations/__init__.py
+++ b/python/podio/pythonizations/__init__.py
@@ -1,13 +1,16 @@
 """cppyy pythonizations for podio"""
 
 from importlib import import_module
-from pkgutil import walk_packages
+from pkgutil import iter_modules
+from os import path
 from .utils.pythonizer import Pythonizer
 
 
 def load_pythonizations(namespace):
     """Register all available pythonizations for a given namespace"""
-    module_names = [name for _, name, _ in walk_packages(__path__) if not name.startswith("test_")]
+    pythonizations_dir = path.dirname(__file__)
+    # find only direct submodules of the current module
+    module_names = [name for _, name, _ in iter_modules([pythonizations_dir])]
     for module_name in module_names:
         import_module(__name__ + "." + module_name)
     pythonizers = sorted(Pythonizer.__subclasses__(), key=lambda x: x.priority())


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix pythonizations trying to import local modules as pythonizations submodules

ENDRELEASENOTES

`load_pythonizations` function was by accident sometimes trying to import some local files of downstream projects as submodules of `pythonization` module (https://github.com/key4hep/EDM4hep/pull/290#issuecomment-2333857243)

The culprit is the function `pkgutil.walk_modules` that tries to recursively find submodules on a given path. `utils` is a legit submodule of `pythonizations` found by `walk_modules`,  but then it will try to recursively find submodules somehow including `utils` also among the local modules if present. I'm not sure whether this is intended or actual bug in `pkgutils`

Anyway I replace the `walk_packages` with `iter_modules` that doesn't have this weird recursive behaviour. The "downside" is that now the pythonizations must be put directly in pythonizations directory with no nesting (which was the case anyway)