### PR TITLE
Change C-style casts to static_cast and remove unnecessary semicolons

### DIFF
--- a/cmake/podioBuild.cmake
+++ b/cmake/podioBuild.cmake
@@ -50,7 +50,7 @@ macro(podio_set_compiler_flags)
   # build Catch2 locally without them
   SET(CXX_FLAGS_CMAKE_DEFAULTS "${CMAKE_CXX_FLAGS}")
 
-  SET(COMPILER_FLAGS -Wshadow -Wformat-security -Wno-long-long -Wdeprecated -fdiagnostics-color=auto -Wall -Wextra -pedantic -Weffc++)
+  SET(COMPILER_FLAGS -Wshadow -Wformat-security -Wno-long-long -Wdeprecated -fdiagnostics-color=auto -Wall -Wextra -pedantic -Weffc++ -Wextra-semi -Wold-style-cast)
 
   # AppleClang/Clang specific warning flags
   if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")

--- a/cmake/podioBuild.cmake
+++ b/cmake/podioBuild.cmake
@@ -50,7 +50,7 @@ macro(podio_set_compiler_flags)
   # build Catch2 locally without them
   SET(CXX_FLAGS_CMAKE_DEFAULTS "${CMAKE_CXX_FLAGS}")
 
-  SET(COMPILER_FLAGS -Wshadow -Wformat-security -Wno-long-long -Wdeprecated -fdiagnostics-color=auto -Wall -Wextra -pedantic -Weffc++ -Wextra-semi -Wold-style-cast)
+  SET(COMPILER_FLAGS -Wshadow -Wformat-security -Wno-long-long -Wdeprecated -fdiagnostics-color=auto -Wall -Wextra -pedantic -Weffc++)
 
   # AppleClang/Clang specific warning flags
   if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")

--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -41,7 +41,7 @@ public:
   /// return registered names
   const std::vector<std::string>& names() const {
     return m_names;
-  };
+  }
 
   /// return the ids
   const std::vector<uint32_t>& ids() const {

--- a/include/podio/DataSource.h
+++ b/include/podio/DataSource.h
@@ -94,7 +94,7 @@ protected:
 
   std::string AsString() override {
     return "Podio data source";
-  };
+  }
 
 private:
   /// Number of slots/threads

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -114,7 +114,7 @@ class Frame {
     /// Get a const reference to the internally used GenericParameters
     const podio::GenericParameters& parameters() const override {
       return *m_parameters;
-    };
+    }
 
     bool get(uint32_t collectionID, podio::CollectionBase*& collection) const override;
 

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -161,7 +161,7 @@ public:
   /// clear the collection and all internal states
   void clear() override {
     _vec.clear();
-  };
+  }
 
   /// check if this collection is a subset collection - no subset possible
   bool isSubsetCollection() const override {

--- a/podioVersion.in.h
+++ b/podioVersion.in.h
@@ -2,8 +2,8 @@
 #define PODIO_PODIOVERSION_H
 
 #include <cstdint>
-#include <sstream>
 #include <ostream>
+#include <sstream>
 #include <tuple>
 #if __cplusplus >= 202002L
   #include <compare>
@@ -78,8 +78,9 @@ static constexpr Version build_version{podio_VERSION_MAJOR, podio_VERSION_MINOR,
 
 /// Decode a version from a 64 bit unsigned
 static constexpr Version decode_version(unsigned long version) noexcept {
-  return Version{(uint16_t)PODIO_MAJOR_VERSION(version), (uint16_t)PODIO_MINOR_VERSION(version),
-                 (uint16_t)PODIO_PATCH_VERSION(version)};
+  return Version{static_cast<uint16_t>(PODIO_MAJOR_VERSION(version)),
+                 static_cast<uint16_t>(PODIO_MINOR_VERSION(version)),
+                 static_cast<uint16_t>(PODIO_PATCH_VERSION(version))};
 }
 } // namespace podio::version
 

--- a/podioVersion.in.h
+++ b/podioVersion.in.h
@@ -64,7 +64,7 @@ struct Version {
     std::stringstream ss;
     ss << *this;
     return ss.str();
-  };
+  }
 
   friend std::ostream& operator<<(std::ostream&, const Version& v);
 };

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -146,7 +146,7 @@ void {{ collection_type }}::push_back(const Mutable{{ class.bare_type }}& object
     auto obj = object.m_obj;
     if (obj->id.index == podio::ObjectID::untracked) {
       const auto size = m_storage.entries.size();
-      obj->id = {(int)size, m_collectionID};
+      obj->id = {static_cast<int>(size), m_collectionID};
       m_storage.entries.push_back(obj.release());
 {% if OneToManyRelations or VectorMembers %}
       m_storage.createRelations(obj.get());

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -72,7 +72,7 @@ public:
   void print(std::ostream& os=std::cout, bool flush=true) const final;
 
   /// operator to allow pointer like calling of members a la LCIO
-  {{ class.bare_type }}Collection* operator->() { return ({{ class.bare_type }}Collection*) this; }
+  {{ class.bare_type }}Collection* operator->() { return static_cast<{{ class.bare_type }}Collection*>(this); }
 
   /// Append a new object to the collection, and return this object.
   Mutable{{ class.bare_type }} create();

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -136,7 +136,7 @@ public:
       );
     }
     m_isValid = true;
-  };
+  }
 
   uint32_t getID() const final {
     return m_collectionID;

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -97,8 +97,8 @@ podio::CollectionWriteBuffers {{ class_type }}::getCollectionBuffers(bool isSubs
 {% endif -%}
 
   return {
-    isSubsetColl ? nullptr : (void*)&m_data,
-    isSubsetColl ? nullptr : (void*)m_data.get(),
+    isSubsetColl ? nullptr : static_cast<void*>(&m_data),
+    isSubsetColl ? nullptr : static_cast<void*>(m_data.get()),
     &m_refCollections, // only need to store the ObjectIDs of the referenced objects
     &m_vecmem_info
   };

--- a/src/DataSource.cc
+++ b/src/DataSource.cc
@@ -145,7 +145,7 @@ std::vector<void*> DataSource::GetColumnReadersImpl(std::string_view columnName,
 
   std::vector<void*> columnReaders(m_nSlots);
   for (size_t slotIndex = 0; slotIndex < m_nSlots; ++slotIndex) {
-    columnReaders[slotIndex] = (void*)&m_Collections[columnIndex][slotIndex];
+    columnReaders[slotIndex] = static_cast<void*>(&m_Collections[columnIndex][slotIndex]);
   }
 
   return columnReaders;

--- a/src/MurmurHash3.cpp
+++ b/src/MurmurHash3.cpp
@@ -131,7 +131,7 @@ void MurmurHash3_x86_32(const void* key, int len, uint32_t seed, void* out) {
     k1 = ROTL32(k1, 15);
     k1 *= c2;
     h1 ^= k1;
-  };
+  }
 
   //----------
   // finalization
@@ -281,7 +281,7 @@ void MurmurHash3_x86_128(const void* key, const int len, uint32_t seed, void* ou
     k1 = ROTL32(k1, 15);
     k1 *= c2;
     h1 ^= k1;
-  };
+  }
 
   //----------
   // finalization
@@ -418,7 +418,7 @@ void MurmurHash3_x64_128(const void* key, const int len, const uint32_t seed, vo
     k1 = ROTL64(k1, 31);
     k1 *= c2;
     h1 ^= k1;
-  };
+  }
 
   //----------
   // finalization

--- a/src/MurmurHash3.cpp
+++ b/src/MurmurHash3.cpp
@@ -46,6 +46,10 @@ inline uint64_t rotl64(uint64_t x, int8_t r) {
 
 #endif // !defined(_MSC_VER)
 
+// Disable -Wold-style-cast for this file
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
 //-----------------------------------------------------------------------------
 // Block read - if your platform needs to do endian-swapping or can only
 // handle aligned reads, do the conversion here
@@ -440,3 +444,5 @@ void MurmurHash3_x64_128(const void* key, const int len, const uint32_t seed, vo
 }
 
 //-----------------------------------------------------------------------------
+
+#pragma GCC diagnostic pop

--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -112,9 +112,9 @@ void RNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& cat
     auto collBuffers = coll->getBuffers();
     if (collBuffers.vecPtr) {
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
-      entry->BindRawPtr(name, (void*)collBuffers.vecPtr);
+      entry->BindRawPtr(name, static_cast<void*>(collBuffers.vecPtr));
 #else
-      entry->CaptureValueUnsafe(name, (void*)collBuffers.vecPtr);
+      entry->CaptureValueUnsafe(name, static_cast<void*>(collBuffers.vecPtr));
 #endif
     }
 
@@ -148,7 +148,7 @@ void RNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& cat
         for (auto& [type, vec] : (*vmInfo)) {
           const auto typeName = "vector<" + type + ">";
           const auto brName = root_utils::vecBranch(name, relVecNames.vectorMembers[i]);
-          auto ptr = *(std::vector<int>**)vec;
+          auto ptr = *static_cast<std::vector<int>**>(vec);
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 31, 0)
           entry->BindRawPtr(brName, ptr);
 #else

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -85,15 +85,13 @@ void checkInterfaceCollection(const podio::Frame& event) {
   ASSERT(iface1.aSingleEnergyType() == clusters[0], "OneToOneRelation aSingleEnergy not persisted as expected")
 
   const auto iface0Rels = iface0.manyEnergies();
-  ASSERT(iface0Rels.size() == 3,
-         "OneToManyRelation to interface does not have the expected number of related elements")
+  ASSERT(iface0Rels.size() == 3, "OneToManyRelation to interface does not have the expected number of related elements")
   ASSERT(iface0Rels[0] == hits[0], "OneToManyRelations to interface not persisted correctly")
   ASSERT(iface0Rels[1] == clusters[0], "OneToManyRelations to interface not persisted correctly")
   ASSERT(iface0Rels[2] == particles[0], "OneToManyRelations to interface not persisted correctly")
 
   const auto iface1Rels = iface1.manyEnergies();
-  ASSERT(iface1Rels.size() == 3,
-         "OneToManyRelation to interface does not have the expected number of related elements")
+  ASSERT(iface1Rels.size() == 3, "OneToManyRelation to interface does not have the expected number of related elements")
   ASSERT(iface1Rels[0] == particles[0], "OneToManyRelations to interface not persisted correctly")
   ASSERT(iface1Rels[1] == hits[0], "OneToManyRelations to interface not persisted correctly")
   ASSERT(iface1Rels[2] == clusters[0], "OneToManyRelations to interface not persisted correctly")

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -20,59 +20,59 @@
 
 void processExtensions(const podio::Frame& event, int iEvent, podio::version::Version) {
   const auto& extColl = event.get<extension::ContainedTypeCollection>("extension_Contained");
-  ASSERT(extColl.isValid(), "extension_Contained collection should be present");
-  ASSERT(extColl.size() == 1, "extension_Contained collection should have one element");
+  ASSERT(extColl.isValid(), "extension_Contained collection should be present")
+  ASSERT(extColl.size() == 1, "extension_Contained collection should have one element")
   auto extElem = extColl[0];
   const auto& polVec = extElem.getAVector();
-  ASSERT(polVec.r == iEvent * 123.f, "polVec.r value not as expected");
-  ASSERT(polVec.phi == 0.15f, "polVec.phi value not as expected");
-  ASSERT(polVec.rho == 3.14f, "polVec.phi value not as expected");
+  ASSERT(polVec.r == iEvent * 123.f, "polVec.r value not as expected")
+  ASSERT(polVec.phi == 0.15f, "polVec.phi value not as expected")
+  ASSERT(polVec.rho == 3.14f, "polVec.phi value not as expected")
 
   const auto& extCompColl = event.get<extension::ExternalComponentTypeCollection>("extension_ExternalComponent");
-  ASSERT(extCompColl.isValid(), "extension_ExternalComponent collection should be present");
-  ASSERT(extCompColl.size() == 1, "extension_ExternalComponent should have one element");
+  ASSERT(extCompColl.isValid(), "extension_ExternalComponent collection should be present")
+  ASSERT(extCompColl.size() == 1, "extension_ExternalComponent should have one element")
   auto extCompElem = extCompColl[0];
   ASSERT((extCompElem.getAStruct().p == std::array{iEvent, iEvent - 2, iEvent + 4, iEvent * 8}),
-         "aStruct.p value not as expected");
-  ASSERT(extCompElem.getAComponent().aStruct.data.x == 42 * iEvent, "aComponent.aStruct.x value not as expected");
-  ASSERT(extCompElem.getAComponent().nspStruct.x == iEvent, "aComponent.nspStruct.x value not as expected");
-  ASSERT(extCompElem.getAComponent().nspStruct.y == iEvent * 2, "aComponent.nspStruct.y value not as expected");
+         "aStruct.p value not as expected")
+  ASSERT(extCompElem.getAComponent().aStruct.data.x == 42 * iEvent, "aComponent.aStruct.x value not as expected")
+  ASSERT(extCompElem.getAComponent().nspStruct.x == iEvent, "aComponent.nspStruct.x value not as expected")
+  ASSERT(extCompElem.getAComponent().nspStruct.y == iEvent * 2, "aComponent.nspStruct.y value not as expected")
 
   const auto& extRelColl = event.get<extension::ExternalRelationTypeCollection>("extension_ExternalRelation");
-  ASSERT(extRelColl.isValid(), "extension_ExternalRelation collection should be present");
-  ASSERT(extRelColl.size() == 3, "extension_ExternalRelation collection should contain 3 elements");
+  ASSERT(extRelColl.isValid(), "extension_ExternalRelation collection should be present")
+  ASSERT(extRelColl.size() == 3, "extension_ExternalRelation collection should contain 3 elements")
 
   const auto& hits = event.get<ExampleHitCollection>("hits");
   auto elem0 = extRelColl[0];
-  ASSERT(elem0.getWeight() == iEvent * 100.f, "weight of first element not as expected");
-  ASSERT(elem0.getSingleHit() == hits[0], "single hit relation not as expected");
+  ASSERT(elem0.getWeight() == iEvent * 100.f, "weight of first element not as expected")
+  ASSERT(elem0.getSingleHit() == hits[0], "single hit relation not as expected")
 
   const auto& clusters = event.get<ExampleClusterCollection>("clusters");
   auto elem1 = extRelColl[1];
   const auto relClusters = elem1.getClusters();
-  ASSERT(relClusters.size() == 2, "element should have two related clusters");
-  ASSERT(relClusters[0] == clusters[1], "first related cluster not as expected");
-  ASSERT(relClusters[1] == clusters[0], "first related cluster not as expected");
+  ASSERT(relClusters.size() == 2, "element should have two related clusters")
+  ASSERT(relClusters[0] == clusters[1], "first related cluster not as expected")
+  ASSERT(relClusters[1] == clusters[0], "first related cluster not as expected")
 
   auto elem2 = extRelColl[2];
   const auto& structs = elem2.getSomeStructs();
-  ASSERT(structs.size() == 3, "element should have 3 struct vector members");
-  ASSERT(structs[0].y == 0, "struct value not as expected");
-  ASSERT(structs[1].y == iEvent, "struct value not as expected");
-  ASSERT(structs[2].y == 2 * iEvent, "struct value not as expected");
+  ASSERT(structs.size() == 3, "element should have 3 struct vector members")
+  ASSERT(structs[0].y == 0, "struct value not as expected")
+  ASSERT(structs[1].y == iEvent, "struct value not as expected")
+  ASSERT(structs[2].y == 2 * iEvent, "struct value not as expected")
 }
 
 void checkVecMemSubsetColl(const podio::Frame& event) {
   const auto& subsetColl = event.get<ExampleWithVectorMemberCollection>("VectorMemberSubsetColl");
   const auto& origColl = event.get<ExampleWithVectorMemberCollection>("WithVectorMember");
-  ASSERT(subsetColl.isSubsetCollection(), "subset collection not read back as a subset collection");
-  ASSERT(subsetColl.size() == 1, "subset collection should have size 1");
-  ASSERT(subsetColl[0] == origColl[0], "subset coll does not have the right contents");
+  ASSERT(subsetColl.isSubsetCollection(), "subset collection not read back as a subset collection")
+  ASSERT(subsetColl.size() == 1, "subset collection should have size 1")
+  ASSERT(subsetColl[0] == origColl[0], "subset coll does not have the right contents")
 }
 
 void checkInterfaceCollection(const podio::Frame& event) {
   const auto& interfaceColl = event.get<ExampleWithInterfaceRelationCollection>("interface_examples");
-  ASSERT(interfaceColl.size() == 2, "interface_examples should have two elements");
+  ASSERT(interfaceColl.size() == 2, "interface_examples should have two elements")
 
   const auto& hits = event.get<ExampleHitCollection>("hits");
   const auto& particles = event.get<ExampleMCCollection>("mcparticles");
@@ -81,22 +81,22 @@ void checkInterfaceCollection(const podio::Frame& event) {
   const auto iface0 = interfaceColl[0];
   const auto iface1 = interfaceColl[1];
 
-  ASSERT(iface0.aSingleEnergyType() == hits[0], "OneToOneRelation aSingleEnergy not persisted as expected");
-  ASSERT(iface1.aSingleEnergyType() == clusters[0], "OneToOneRelation aSingleEnergy not persisted as expected");
+  ASSERT(iface0.aSingleEnergyType() == hits[0], "OneToOneRelation aSingleEnergy not persisted as expected")
+  ASSERT(iface1.aSingleEnergyType() == clusters[0], "OneToOneRelation aSingleEnergy not persisted as expected")
 
   const auto iface0Rels = iface0.manyEnergies();
   ASSERT(iface0Rels.size() == 3,
-         "OneToManyRelation to interface does not have the expected number of related elements");
-  ASSERT(iface0Rels[0] == hits[0], "OneToManyRelations to interface not persisted correctly");
-  ASSERT(iface0Rels[1] == clusters[0], "OneToManyRelations to interface not persisted correctly");
-  ASSERT(iface0Rels[2] == particles[0], "OneToManyRelations to interface not persisted correctly");
+         "OneToManyRelation to interface does not have the expected number of related elements")
+  ASSERT(iface0Rels[0] == hits[0], "OneToManyRelations to interface not persisted correctly")
+  ASSERT(iface0Rels[1] == clusters[0], "OneToManyRelations to interface not persisted correctly")
+  ASSERT(iface0Rels[2] == particles[0], "OneToManyRelations to interface not persisted correctly")
 
   const auto iface1Rels = iface1.manyEnergies();
   ASSERT(iface1Rels.size() == 3,
-         "OneToManyRelation to interface does not have the expected number of related elements");
-  ASSERT(iface1Rels[0] == particles[0], "OneToManyRelations to interface not persisted correctly");
-  ASSERT(iface1Rels[1] == hits[0], "OneToManyRelations to interface not persisted correctly");
-  ASSERT(iface1Rels[2] == clusters[0], "OneToManyRelations to interface not persisted correctly");
+         "OneToManyRelation to interface does not have the expected number of related elements")
+  ASSERT(iface1Rels[0] == particles[0], "OneToManyRelations to interface not persisted correctly")
+  ASSERT(iface1Rels[1] == hits[0], "OneToManyRelations to interface not persisted correctly")
+  ASSERT(iface1Rels[2] == clusters[0], "OneToManyRelations to interface not persisted correctly")
 }
 
 template <typename ReaderT>

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -39,8 +39,7 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 void processEvent(const podio::Frame& event, int eventNum, podio::version::Version fileVersion) {
   const float evtWeight = event.getParameter<float>("UserEventWeight").value();
   if (evtWeight != 100.f * eventNum) {
-    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << 100.f * eventNum
-              << std::endl;
+    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << 100.f * eventNum << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
   }
 

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -20,12 +20,10 @@
 
 // STL
 #include <cassert>
-#include <exception>
 #include <iostream>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
-#include <type_traits>
 #include <vector>
 
 template <typename FixedWidthT>
@@ -40,8 +38,8 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 
 void processEvent(const podio::Frame& event, int eventNum, podio::version::Version fileVersion) {
   const float evtWeight = event.getParameter<float>("UserEventWeight").value();
-  if (evtWeight != (float)100. * eventNum) {
-    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << (float)100. * eventNum << std::endl;
+  if (evtWeight != static_cast<float>(100. * eventNum)) {
+    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << static_cast<float>(100. * eventNum) << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
   }
 
@@ -196,7 +194,7 @@ void processEvent(const podio::Frame& event, int eventNum, podio::version::Versi
     }
 
     for (auto pr : mcpRefs) {
-      if ((unsigned)pr.getObjectID().collectionID == mcpRefs.getID()) {
+      if (static_cast<unsigned>(pr.getObjectID().collectionID) == mcpRefs.getID()) {
         throw std::runtime_error(
             "objects of a reference collection should have a different collectionID than the reference collection");
       }
@@ -380,7 +378,7 @@ void processEvent(const podio::Frame& event, int eventNum, podio::version::Versi
   if (fileVersion >= podio::version::Version{0, 13, 2}) {
     auto& usrInts = event.get<podio::UserDataCollection<uint64_t>>("userInts");
 
-    if (usrInts.size() != (unsigned)eventNum + 1) {
+    if (usrInts.size() != static_cast<unsigned>(eventNum + 1)) {
       throw std::runtime_error("Could not read all userInts properly (expected: " + std::to_string(eventNum + 1) +
                                ", actual: " + std::to_string(usrInts.size()) + ")");
     }

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -39,7 +39,8 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 void processEvent(const podio::Frame& event, int eventNum, podio::version::Version fileVersion) {
   const float evtWeight = event.getParameter<float>("UserEventWeight").value();
   if (evtWeight != static_cast<float>(100. * eventNum)) {
-    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << static_cast<float>(100. * eventNum) << std::endl;
+    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << static_cast<float>(100. * eventNum)
+              << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
   }
 

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -39,7 +39,7 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 void processEvent(const podio::Frame& event, int eventNum, podio::version::Version fileVersion) {
   const float evtWeight = event.getParameter<float>("UserEventWeight").value();
   if (evtWeight != 100.f * eventNum) {
-    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << 100.f * eventNum)
+    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << 100.f * eventNum
               << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
   }

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -38,8 +38,8 @@ bool check_fixed_width_value(FixedWidthT actual, FixedWidthT expected, const std
 
 void processEvent(const podio::Frame& event, int eventNum, podio::version::Version fileVersion) {
   const float evtWeight = event.getParameter<float>("UserEventWeight").value();
-  if (evtWeight != static_cast<float>(100. * eventNum)) {
-    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << static_cast<float>(100. * eventNum)
+  if (evtWeight != 100.f * eventNum) {
+    std::cout << " read UserEventWeight: " << evtWeight << " - expected : " << 100.f * eventNum)
               << std::endl;
     throw std::runtime_error("Couldn't read event meta data parameters 'UserEventWeight'");
   }

--- a/tests/root_io/read_and_write_associated.cpp
+++ b/tests/root_io/read_and_write_associated.cpp
@@ -24,7 +24,7 @@ void writeCollection() {
     item1.Number(i);
     info.push_back(item1);
 
-    event.putParameter("UserEventWeight", (float)100. * i);
+    event.putParameter("UserEventWeight", static_cast<float>(100. * i));
     std::cout << " event number: " << i << std::endl;
     event.putParameter("UserEventName", std::to_string(i));
 

--- a/tests/root_io/read_and_write_associated.cpp
+++ b/tests/root_io/read_and_write_associated.cpp
@@ -24,7 +24,7 @@ void writeCollection() {
     item1.Number(i);
     info.push_back(item1);
 
-    event.putParameter("UserEventWeight", static_cast<float>(100. * i));
+    event.putParameter("UserEventWeight", 100.f * i);
     std::cout << " event number: " << i << std::endl;
     event.putParameter("UserEventName", std::to_string(i));
 

--- a/tests/root_io/relation_range.cpp
+++ b/tests/root_io/relation_range.cpp
@@ -60,22 +60,22 @@ void fillExampleMCCollection(ExampleMCCollection& collection) {
 void doTestExampleMC(ExampleMCCollection const& collection) {
   // Empty
   ASSERT_CONDITION(collection[7].daughters().empty() && collection[7].parents().empty(),
-                   "RelationRange of empty collection is not empty");
+                   "RelationRange of empty collection is not empty")
   // Equivalent but potentially quicker way of checking an empty collection
   ASSERT_CONDITION(collection[7].daughters().empty() && collection[7].parents().empty(),
-                   "RelationRange of empty collection is not empty");
+                   "RelationRange of empty collection is not empty")
 
   // alternatively check if a loop is entered
   for (const auto& p [[maybe_unused]] : collection[7].daughters()) {
     throw std::runtime_error("Range based for loop entered on a supposedly empty range");
   }
 
-  ASSERT_EQUAL(collection[0].daughters().size(), 3, "Range has wrong size");
+  ASSERT_EQUAL(collection[0].daughters().size(), 3, "Range has wrong size")
   // check daughter relations are OK
   std::vector<int> expectedPDG = {1, 5, 4};
   int index = 0;
   for (const auto& p : collection[0].daughters()) {
-    ASSERT_EQUAL(p.PDG(), expectedPDG[index], "ExampleMC daughters range points to wrong particle (by PDG)");
+    ASSERT_EQUAL(p.PDG(), expectedPDG[index], "ExampleMC daughters range points to wrong particle (by PDG)")
     index++;
   }
 
@@ -83,23 +83,23 @@ void doTestExampleMC(ExampleMCCollection const& collection) {
   const auto daughters = collection[0].daughters();
   for (size_t i = 0; i < expectedPDG.size(); ++i) {
     const auto daughter = daughters[i];
-    ASSERT_EQUAL(daughter.PDG(), expectedPDG[i], "ExampleMC daughter points to the wrong particle (by PDG)");
+    ASSERT_EQUAL(daughter.PDG(), expectedPDG[i], "ExampleMC daughter points to the wrong particle (by PDG)")
   }
 
   // mothers and daughters
-  ASSERT_EQUAL(collection[2].daughters().size(), 2, "Range has wrong size");
-  ASSERT_EQUAL(collection[2].parents().size(), 2, "Range has wrong size");
+  ASSERT_EQUAL(collection[2].daughters().size(), 2, "Range has wrong size")
+  ASSERT_EQUAL(collection[2].parents().size(), 2, "Range has wrong size")
 
   expectedPDG = {1, 9};
   index = 0;
   for (const auto& p : collection[2].daughters()) {
-    ASSERT_EQUAL(p.PDG(), expectedPDG[index], "ExampleMC daughters range points to wrong particle (by PDG)");
+    ASSERT_EQUAL(p.PDG(), expectedPDG[index], "ExampleMC daughters range points to wrong particle (by PDG)")
     index++;
   }
   expectedPDG = {8, 6};
   index = 0;
   for (const auto& p : collection[2].parents()) {
-    ASSERT_EQUAL(p.PDG(), expectedPDG[index], "ExampleMC parents range points to wrong particle (by PDG)");
+    ASSERT_EQUAL(p.PDG(), expectedPDG[index], "ExampleMC parents range points to wrong particle (by PDG)")
     index++;
   }
 
@@ -107,7 +107,7 @@ void doTestExampleMC(ExampleMCCollection const& collection) {
   const auto parents = collection[2].parents();
   for (size_t i = 0; i < expectedPDG.size(); ++i) {
     const auto parent = parents.at(i);
-    ASSERT_EQUAL(parent.PDG(), expectedPDG[i], "ExampleMC parents points to the wrong particle (by PDG)");
+    ASSERT_EQUAL(parent.PDG(), expectedPDG[i], "ExampleMC parents points to the wrong particle (by PDG)")
   }
 
   try {
@@ -115,22 +115,22 @@ void doTestExampleMC(ExampleMCCollection const& collection) {
     throw std::runtime_error("Trying to access out of bounds in a RelationRange::at should throw");
   } catch (const std::out_of_range& err) {
     ASSERT_EQUAL(err.what(), std::string("index out of bounds for RelationRange"),
-                 "Access out of bounds throws wrong exception");
+                 "Access out of bounds throws wrong exception")
   }
 
   // realistic case
   auto mcp6 = collection[6];
-  ASSERT_EQUAL(mcp6.daughters().size(), 1, "Wrong number of daughters");
+  ASSERT_EQUAL(mcp6.daughters().size(), 1, "Wrong number of daughters")
   auto parent = mcp6.parents(0);
-  ASSERT_EQUAL(parent.daughters().size(), 1, "Wrong number of daughters");
+  ASSERT_EQUAL(parent.daughters().size(), 1, "Wrong number of daughters")
 
   for (const auto& p : mcp6.parents()) {
     // loop will only run once as per the above assertion
-    ASSERT_EQUAL(p, parent, "parent-daughter relation is not as expected");
+    ASSERT_EQUAL(p, parent, "parent-daughter relation is not as expected")
   }
   for (const auto& p : parent.daughters()) {
     // loop will only run once as per the above assertion
-    ASSERT_EQUAL(p, mcp6, "daughter-parent relation is not as expected");
+    ASSERT_EQUAL(p, mcp6, "daughter-parent relation is not as expected")
   }
 }
 
@@ -146,12 +146,12 @@ void testExampleWithVectorMember() {
   ex.addcount(2);
   ex.addcount(10);
 
-  ASSERT_EQUAL(ex.count().size(), 3, "vector member range has wrong size");
+  ASSERT_EQUAL(ex.count().size(), 3, "vector member range has wrong size")
 
   std::vector<int> expected = {1, 2, 10};
   int index = 0;
   for (const int c : ex.count()) {
-    ASSERT_EQUAL(c, expected[index], "wrong content in range-based for loop");
+    ASSERT_EQUAL(c, expected[index], "wrong content in range-based for loop")
     index++;
   }
 }
@@ -164,21 +164,21 @@ void testExampleReferencingType() {
   ex.addRefs(ex1);
   ex.addRefs(ex2);
 
-  ASSERT_EQUAL(ex.Refs().size(), 2, "Wrong number of references");
+  ASSERT_EQUAL(ex.Refs().size(), 2, "Wrong number of references")
 
   int index = 0;
   for (const auto& e : ex.Refs()) {
     if (index == 0) {
-      ASSERT_EQUAL(e, ex1, "First element of range is not as expected");
+      ASSERT_EQUAL(e, ex1, "First element of range is not as expected")
     } else {
-      ASSERT_EQUAL(e, ex2, "Second element of range is not as expected");
+      ASSERT_EQUAL(e, ex2, "Second element of range is not as expected")
     }
 
     index++;
   }
 
-  ASSERT_CONDITION(!ex.Refs().empty(), "Relation range of element with relations should not be empty");
-  ASSERT_CONDITION(ex1.Refs().empty(), "Relation range of element with no relations should be empty");
+  ASSERT_CONDITION(!ex.Refs().empty(), "Relation range of element with relations should not be empty")
+  ASSERT_CONDITION(ex1.Refs().empty(), "Relation range of element with no relations should be empty")
 }
 
 void testWithIO() {
@@ -200,8 +200,8 @@ void testWithIO() {
   for (int i = 0; i < 10; ++i) {
     const auto event = podio::Frame(reader.readNextEntry(podio::Category::Event));
     auto& readColl = event.get<ExampleMCCollection>("mcparticles");
-    ASSERT_CONDITION(readColl.isValid(), "Collection 'mcparticles' should be present");
-    ASSERT_EQUAL(readColl.size(), 10, "'mcparticles' should have 10 entries");
+    ASSERT_CONDITION(readColl.isValid(), "Collection 'mcparticles' should be present")
+    ASSERT_EQUAL(readColl.size(), 10, "'mcparticles' should have 10 entries")
 
     doTestExampleMC(readColl);
   }

--- a/tests/schema_evolution/read_new_data.h
+++ b/tests/schema_evolution/read_new_data.h
@@ -57,7 +57,7 @@ int readExampleWithARelation(const podio::Frame& event) {
   const auto& coll = event.get<ex42::ExampleWithARelationCollection>("floatToDoubleMemberTest");
   auto elem = coll[0];
 
-  ASSERT_EQUAL(elem.number(), static_cast<double>(3.14), "Conversion from float to double member does not work as expected")
+  ASSERT_EQUAL(elem.number(), (double)3.14f, "Conversion from float to double member does not work as expected")
 
   return 0;
 }

--- a/tests/schema_evolution/read_new_data.h
+++ b/tests/schema_evolution/read_new_data.h
@@ -57,7 +57,8 @@ int readExampleWithARelation(const podio::Frame& event) {
   const auto& coll = event.get<ex42::ExampleWithARelationCollection>("floatToDoubleMemberTest");
   auto elem = coll[0];
 
-  ASSERT_EQUAL(elem.number(), static_cast<double>(3.14), "Conversion from float to double member does not work as expected")
+  ASSERT_EQUAL(elem.number(), static_cast<double>(3.14),
+               "Conversion from float to double member does not work as expected")
 
   return 0;
 }

--- a/tests/schema_evolution/read_new_data.h
+++ b/tests/schema_evolution/read_new_data.h
@@ -57,7 +57,7 @@ int readExampleWithARelation(const podio::Frame& event) {
   const auto& coll = event.get<ex42::ExampleWithARelationCollection>("floatToDoubleMemberTest");
   auto elem = coll[0];
 
-  ASSERT_EQUAL(elem.number(), (double)3.14f, "Conversion from float to double member does not work as expected")
+  ASSERT_EQUAL(elem.number(), static_cast<double>(3.14), "Conversion from float to double member does not work as expected")
 
   return 0;
 }

--- a/tests/schema_evolution/read_new_data.h
+++ b/tests/schema_evolution/read_new_data.h
@@ -57,7 +57,7 @@ int readExampleWithARelation(const podio::Frame& event) {
   const auto& coll = event.get<ex42::ExampleWithARelationCollection>("floatToDoubleMemberTest");
   auto elem = coll[0];
 
-  ASSERT_EQUAL(elem.number(), static_cast<double>(3.14),
+  ASSERT_EQUAL(elem.number(), static_cast<double>(3.14f),
                "Conversion from float to double member does not work as expected")
 
   return 0;

--- a/tests/schema_evolution/read_new_data.h
+++ b/tests/schema_evolution/read_new_data.h
@@ -22,9 +22,9 @@ int readSimpleStruct(const podio::Frame& event) {
   auto elem = coll[0];
   const auto sstruct = elem.s();
 
-  ASSERT_EQUAL(sstruct.y, 0, "New component member not 0 initialized");
-  ASSERT_EQUAL(sstruct.x, 42, "Existing component member changed");
-  ASSERT_EQUAL(sstruct.z, 123, "Existing component member changed");
+  ASSERT_EQUAL(sstruct.y, 0, "New component member not 0 initialized")
+  ASSERT_EQUAL(sstruct.x, 42, "Existing component member changed")
+  ASSERT_EQUAL(sstruct.z, 123, "Existing component member changed")
 
   return 0;
 }
@@ -33,12 +33,12 @@ int readExampleHit(const podio::Frame& event) {
   const auto& coll = event.get<ExampleHitCollection>("datatypeMemberAdditionTest");
   auto elem = coll[0];
 
-  ASSERT_EQUAL(elem.t(), 0, "New datatype member variable not 0 initialized");
-  ASSERT_EQUAL(elem.x(), 1.23, "Member variables unrelated to schema evolution have changed");
-  ASSERT_EQUAL(elem.y(), 1.23, "Member variables unrelated to schema evolution have changed");
-  ASSERT_EQUAL(elem.z(), 1.23, "Member variables unrelated to schema evolution have changed");
-  ASSERT_EQUAL(elem.energy(), 0, "Member variables unrelated to schema evolution have changed");
-  ASSERT_EQUAL(elem.cellID(), 0xcaffee, "Member variables unrelated to schema evolution have changed");
+  ASSERT_EQUAL(elem.t(), 0, "New datatype member variable not 0 initialized")
+  ASSERT_EQUAL(elem.x(), 1.23, "Member variables unrelated to schema evolution have changed")
+  ASSERT_EQUAL(elem.y(), 1.23, "Member variables unrelated to schema evolution have changed")
+  ASSERT_EQUAL(elem.z(), 1.23, "Member variables unrelated to schema evolution have changed")
+  ASSERT_EQUAL(elem.energy(), 0, "Member variables unrelated to schema evolution have changed")
+  ASSERT_EQUAL(elem.cellID(), 0xcaffee, "Member variables unrelated to schema evolution have changed")
 
   return 0;
 }
@@ -47,8 +47,8 @@ int readExampleWithNamespace(const podio::Frame& event) {
   const auto& coll = event.get<ex42::ExampleWithNamespaceCollection>("componentMemberRenameTest");
   auto elem = coll[0];
 
-  ASSERT_EQUAL(elem.y_new(), 42, "Renamed component member variable does not have the expected value");
-  ASSERT_EQUAL(elem.x(), 123, "Member variables unrelated to schema evolution have changed");
+  ASSERT_EQUAL(elem.y_new(), 42, "Renamed component member variable does not have the expected value")
+  ASSERT_EQUAL(elem.x(), 123, "Member variables unrelated to schema evolution have changed")
 
   return 0;
 }
@@ -57,7 +57,7 @@ int readExampleWithARelation(const podio::Frame& event) {
   const auto& coll = event.get<ex42::ExampleWithARelationCollection>("floatToDoubleMemberTest");
   auto elem = coll[0];
 
-  ASSERT_EQUAL(elem.number(), (double)3.14f, "Conversion from float to double member does not work as expected");
+  ASSERT_EQUAL(elem.number(), static_cast<double>(3.14), "Conversion from float to double member does not work as expected")
 
   return 0;
 }

--- a/tests/unittests/frame.cpp
+++ b/tests/unittests/frame.cpp
@@ -295,7 +295,7 @@ TEST_CASE("Frame parameters multithread insert", "[frame][basics][multithread]")
     threads.emplace_back([&frame, i]() {
       frame.putParameter(makeName("int_par", i), i);
 
-      frame.putParameter(makeName("float_par", i), (float)i);
+      frame.putParameter(makeName("float_par", i), static_cast<float>(i));
 
       frame.putParameter(makeName("string_par", i), std::to_string(i));
     });
@@ -307,7 +307,7 @@ TEST_CASE("Frame parameters multithread insert", "[frame][basics][multithread]")
 
   for (int i = 0; i < nThreads; ++i) {
     REQUIRE(frame.getParameter<int>(makeName("int_par", i)) == i);
-    REQUIRE(frame.getParameter<float>(makeName("float_par", i)) == (float)i);
+    REQUIRE(frame.getParameter<float>(makeName("float_par", i)) == static_cast<float>(i));
     REQUIRE(frame.getParameter<std::string>(makeName("string_par", i)) == std::to_string(i));
   }
 }
@@ -331,10 +331,10 @@ TEST_CASE("Frame parameters multithread insert and read", "[frame][basics][multi
   for (int i = 0; i < nThreads; ++i) {
     threads.emplace_back([&frame, i, &successes]() {
       frame.putParameter(makeName("int", i), i);
-      frame.putParameter(makeName("float", i), (float)i);
+      frame.putParameter(makeName("float", i), static_cast<float>(i));
 
       CHECK_INCREASE(frame.getParameter<int>("int_par") == 42, successes[i]);
-      CHECK_INCREASE(frame.getParameter<float>(makeName("float", i)) == (float)i, successes[i]);
+      CHECK_INCREASE(frame.getParameter<float>(makeName("float", i)) == static_cast<float>(i), successes[i]);
 
       frame.putParameter(makeName("string", i), std::to_string(i));
       CHECK_INCREASE(frame.getParameter<std::string>("string_par") == "some string", successes[i]);
@@ -350,7 +350,7 @@ TEST_CASE("Frame parameters multithread insert and read", "[frame][basics][multi
       constexpr int nParams = 100;
       for (int k = 0; k < nParams; ++k) {
         frame.putParameter(makeName("intPar", i) + std::to_string(k), i * k);
-        frame.putParameter(makeName("floatPar", i) + std::to_string(k), (float)i * k);
+        frame.putParameter(makeName("floatPar", i) + std::to_string(k), static_cast<float>(i) * k);
         frame.putParameter(makeName("stringPar", i) + std::to_string(k), std::to_string(i * k));
       }
     });
@@ -365,7 +365,7 @@ TEST_CASE("Frame parameters multithread insert and read", "[frame][basics][multi
     REQUIRE(successes[i] == 7);
 
     REQUIRE(frame.getParameter<int>(makeName("int", i)) == i);
-    REQUIRE(frame.getParameter<float>(makeName("float", i)) == (float)i);
+    REQUIRE(frame.getParameter<float>(makeName("float", i)) == static_cast<float>(i));
     REQUIRE(frame.getParameter<std::string>(makeName("string", i)) == std::to_string(i));
   }
 }

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -774,7 +774,7 @@ void checkCollections(/*const*/ ExampleHitCollection& hits, /*const*/ ExampleClu
     REQUIRE(hitRelationBuffer->size() == nElements * 1);          // Each cluster has one hit in these tests
     for (size_t iHit = 0; iHit < nElements * 1; ++iHit) {
       const auto& hitID = (*hitRelationBuffer)[iHit];
-      REQUIRE(hitID.index == (int)iHit);
+      REQUIRE(hitID.index == static_cast<int>(iHit));
       REQUIRE(static_cast<unsigned>(hitID.collectionID) == hits.getID());
     }
   }
@@ -787,7 +787,7 @@ void checkCollections(/*const*/ ExampleHitCollection& hits, /*const*/ ExampleClu
     // Now we are really descending into implementation details
     const auto* countBuffer = *static_cast<std::vector<int>**>((*vecMemVecBuffers)[0].second);
     REQUIRE(countBuffer->size() == nElements * 2);
-    for (int iC = 0; iC < (int)nElements; ++iC) {
+    for (int iC = 0; iC < static_cast<int>(nElements); ++iC) {
       REQUIRE((*countBuffer)[iC * 2] == iC);
       REQUIRE((*countBuffer)[iC * 2 + 1] == 42 + iC);
     }


### PR DESCRIPTION
I have been playing a bit with some warnings in Key4hep and I get some from included files from podio. The C-style cast may be useful. I guess these don't hurt anyway.

BEGINRELEASENOTES
- Change C-style casts to static_cast and remove unnecessary semicolons

ENDRELEASENOTES