### PR TITLE
Strip empty lines from ExtraCode includes to avoid some warnings during code generation

### DIFF
--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -410,7 +410,6 @@ have resolvable schema evolution incompatibilities:"
         """
         types_in_interfaces = defaultdict(list)
         for name, interface in self.datamodel.interfaces.items():
-            print(f"preprocessing interface {name}")
             for if_type in interface["Types"]:
                 types_in_interfaces[if_type.full_type].append(name)
 

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -605,7 +605,7 @@ have resolvable schema evolution incompatibilities:"
         podio_includes = []
         stl_includes = []
         upstream_includes = []
-        for include in (inc for inc in includes if inc):
+        for include in (inc.strip() for inc in includes if inc.strip()):
             if self.package_name in include:
                 package_includes.append(include)
             elif "podio" in include:


### PR DESCRIPTION

BEGINRELEASENOTES
- Strip strings to avoid having empty includes from ExtraCode that would otherwise generate a warning during code generation.
- Remove a debug printout from code generation

ENDRELEASENOTES

"Proper" fix for https://github.com/key4hep/EDM4hep/pull/352