### PR TITLE
Fix a few typos in documentation

### DIFF
--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -212,7 +212,7 @@ this schema version is a single integer. This makes it rather hard to use in
 typical versioning, where one might differentiate between *major*, *minor* (and
 *patch*) versions. Hence, the versioning of a datamodel and its schema version
 are coupled but do not necessarily have to be the same. podio offers hooks to
-store this important meta information into the produce files. The
+store this important meta information into the produce files.
 The version of the datamodel can be passed to the generator via the
 `--datamodel-version` argument. It expects the version to conform to this
 regular expression: `"v?\d+[\.|-]\d+([\.|-]\d+)?$"`, i.e. that the major and

--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -212,14 +212,14 @@ this schema version is a single integer. This makes it rather hard to use in
 typical versioning, where one might differentiate between *major*, *minor* (and
 *patch*) versions. Hence, the versioning of a datamodel and its schema version
 are coupled but do not necessarily have to be the same. podio offers hooks to
-store this important meta information into the produce files. In order to do you
-can pass the version of the datamodel to the generator via the
+store this important meta information into the produce files. The
+The version of the datamodel can be passed to the generator via the
 `--datamodel-version` argument. It expects the version to conform to this
 regular expression: `"v?\d+[\.|-]\d+([\.|-]\d+)?$"`, i.e. that the major and
 minor version are present, separated by either a dot or comma with an optional
 patch version and an optional `v` prefix.
 
-If this this information is passed to the generator it will be injected into the
+If this information is passed to the generator it will be injected into the
 podio internals and will be stored in the output files. They can be retrieved
 via the `currentFileVersion(const std::string&)` methods of the various readers.
 

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -55,7 +55,7 @@ By default a `.h` and a `.cc` file will be generated, but this can be overridden
 With that in place it is now only necessary to call `_fill_templates` with the appropriate template name and the pre processed data.
 Note that for most templates this means that they have to be filled for each datatype or component individually.
 
-If additional preprocessing is necessary, it will be necessary to also add that to the the language specific generators.
+If additional preprocessing is necessary, it will be necessary to also add that to the language specific generators.
 The main entry point to the generation is the `process` method which essentially just delegates to other methods.
 
 ## Available information in the templates
@@ -99,10 +99,10 @@ The following keys / variables are filled for each datatype
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `class`                       | The (immutable, user-facing) class as `DataType` (see [below](#datatype))                                                                                |
 | `Members`                     | The members of the datatype as a list of `MemberVariable`s (see [below](#membervariable))                                                                                                        |
-| `OneToOneRelations`           | The one-to-one relation members of the datatype as  a list of `MemberVariable`s                                                                                     |
+| `OneToOneRelations`           | The one-to-one relation members of the datatype as a list of `MemberVariable`s                                                                                     |
 | `OneToManyRelations`          | The one-to-many relation members of the datatype as a list of `MemberVariable`s                                                                                    |
 | `VectorMembers`               | The vector members of the datatype as a list of `MemberVariable`s                                                                                                  |
-| `includes`                    | The include directives for the the user facing classes header files                                                                                      |
+| `includes`                    | The include directives for the user facing classes header files                                                                                      |
 | `includes_cc`                 | The include directives for the implementations of the user facing classes                                                                                 |
 | `includes_data`               | The necessary include directives for the `Data` POD types                                                                                                |
 | `includes_obj`                | The include directives for the `Obj` classes headers.                                                                                                    |

--- a/include/podio/Reader.h
+++ b/include/podio/Reader.h
@@ -91,7 +91,7 @@ private:
 public:
   /// Create a reader from a low level reader
   ///
-  /// @tparam T The type of the low level reader (will bededuced)
+  /// @tparam T The type of the low level reader (will be deduced)
   /// @param actualReader a low level reader that provides access to FrameDataT
   template <typename T>
   Reader(std::unique_ptr<T> actualReader);

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -55,7 +55,7 @@ EXPECTED_PARAM_NAMES = {
 
 
 class FrameTest(unittest.TestCase):
-    """General unittests for for python bindings of the Frame"""
+    """General unittests for python bindings of the Frame"""
 
     def test_frame_invalid_access(self):
         """Check that the advertised exceptions are raised on invalid access."""

--- a/python/podio_gen/generator_base.py
+++ b/python/podio_gen/generator_base.py
@@ -78,7 +78,7 @@ class ClassGeneratorBaseMixin:
                          component dictionary further. When called only the
                          "class" key will be populated. Return a dictionary or
                          None. If None, this will not be put into the "components"
-                         list. This function also has to to take care of filling
+                         list. This function also has to take care of filling
                          the necessary templates!
 
     do_process_datatype(name: str, datatype: dict): do some language specific

--- a/src/ROOTLegacyReader.cc
+++ b/src/ROOTLegacyReader.cc
@@ -133,7 +133,7 @@ void ROOTLegacyReader::openFiles(const std::vector<std::string>& filenames) {
   delete versionPtr;
 
   // Check if the CollectionTypeInfo branch is there and assume that the file
-  // has been written with with podio pre #197 (<0.13.1) if that is not the case
+  // has been written with podio pre #197 (<0.13.1) if that is not the case
   if (auto* collInfoBranch = root_utils::getBranch(metadatatree, "CollectionTypeInfo")) {
     auto collectionInfo = new std::vector<root_utils::CollectionWriteInfoT>;
 

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -92,7 +92,7 @@ struct GPBranchOffsets {
 constexpr auto nParamBranches = std::tuple_size_v<podio::SupportedGenericDataTypes> * 2;
 
 /// Get the branch offsets for a given parameter type. In this case it is
-/// assumed that the integer branches start immediately after the branche for
+/// assumed that the integer branches start immediately after the branch for
 /// the collections
 template <typename T>
 constexpr auto getGPBranchOffsets() {

--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -123,7 +123,7 @@ int read_frames(const std::string& filename, bool assertBuildVersion = true) {
 
   const auto extensionModelVersion = reader.currentFileVersion("extension_model");
   if (extensionModelVersion) {
-    std::cerr << "The (build) version of the extension model was available althought it shouldn't be. Its value is "
+    std::cerr << "The (build) version of the extension model was available although it shouldn't be. Its value is "
               << extensionModelVersion.value() << std::endl;
   }
 

--- a/tests/root_io/param_reading_rdataframe.py
+++ b/tests/root_io/param_reading_rdataframe.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Small test case for checking that utilities work as expeced in RDataFrame"""
+"""Small test case for checking that utilities work as expected in RDataFrame"""
 
 import sys
 import ROOT


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed typos

ENDRELEASENOTES

These are some typos from #651 that I forgot to submit on time and rdataframe PR typos and some random typos I spotted