### PR TITLE
Add an static_assert for the GenericParameters and remove the EnableIf

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -236,7 +236,7 @@ public:
   /// @param value The value of the parameter. A copy will be put into the Frame
   template <typename T>
   inline void putParameter(const std::string& key, T value) {
-    static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
+    static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
     m_self->parameters().set(key, std::move(value));
   }
 
@@ -285,7 +285,7 @@ public:
   /// @returns   An optional holding the value if it is present
   template <typename T>
   inline auto getParameter(const std::string& key) const {
-    static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
+    static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
     return m_self->parameters().get<T>(key);
   }
 
@@ -306,7 +306,7 @@ public:
   /// @returns  A vector of keys for this parameter type
   template <typename T>
   inline std::vector<std::string> getParameterKeys() const {
-    static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
+    static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
     return m_self->parameters().getKeys<T>();
   }
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -304,8 +304,9 @@ public:
   /// @tparam T The desired parameter type
   ///
   /// @returns  A vector of keys for this parameter type
-  template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
+  template <typename T>
   inline std::vector<std::string> getParameterKeys() const {
+    static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
     return m_self->parameters().getKeys<T>();
   }
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -234,8 +234,9 @@ public:
   ///              is supported by GenericParameters
   /// @param key   The name under which this parameter should be stored
   /// @param value The value of the parameter. A copy will be put into the Frame
-  template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
+  template <typename T>
   inline void putParameter(const std::string& key, T value) {
+    static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
     m_self->parameters().set(key, std::move(value));
   }
 
@@ -246,8 +247,8 @@ public:
   ///
   /// @param key   The name under which this parameter should be stored
   /// @param value The value of the parameter. A copy will be put into the Frame
-  inline void putParameter(const std::string& key, std::string value) {
-    putParameter<std::string>(key, std::move(value));
+  inline void putParameter(const std::string& key, const char* value) {
+    putParameter<std::string>(key, value);
   }
 
   /// Add a vector of strings value the parameters of the Frame.

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -236,7 +236,7 @@ public:
   /// @param value The value of the parameter. A copy will be put into the Frame
   template <typename T>
   inline void putParameter(const std::string& key, T value) {
-    static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
+    static_assert(podio::isSupportedGenericDataType<T>, "Unsupported parameter type");
     m_self->parameters().set(key, std::move(value));
   }
 
@@ -285,7 +285,7 @@ public:
   /// @returns   An optional holding the value if it is present
   template <typename T>
   inline auto getParameter(const std::string& key) const {
-    static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
+    static_assert(podio::isSupportedGenericDataType<T>, "Unsupported parameter type");
     return m_self->parameters().get<T>(key);
   }
 
@@ -306,7 +306,7 @@ public:
   /// @returns  A vector of keys for this parameter type
   template <typename T>
   inline std::vector<std::string> getParameterKeys() const {
-    static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
+    static_assert(podio::isSupportedGenericDataType<T>, "Unsupported parameter type");
     return m_self->parameters().getKeys<T>();
   }
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -283,8 +283,9 @@ public:
   /// @param key The key under which the value is stored
   ///
   /// @returns   An optional holding the value if it is present
-  template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
+  template <typename T>
   inline auto getParameter(const std::string& key) const {
+    static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
     return m_self->parameters().get<T>(key);
   }
 

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -204,7 +204,7 @@ private:
 
 template <typename T>
 std::optional<T> GenericParameters::get(const std::string& key) const {
-  static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
+  static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
   const auto& map = getMap<T>();
   auto& mtx = getMutex<T>();
   std::lock_guard lock{mtx};
@@ -224,7 +224,7 @@ std::optional<T> GenericParameters::get(const std::string& key) const {
 
 template <typename T>
 void GenericParameters::set(const std::string& key, T value) {
-  static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
+  static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
   auto& map = getMap<T>();
   auto& mtx = getMutex<T>();
 
@@ -252,7 +252,7 @@ size_t GenericParameters::getN(const std::string& key) const {
 
 template <typename T>
 std::vector<std::string> GenericParameters::getKeys() const {
-  static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
+  static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
   std::vector<std::string> keys;
   const auto& map = getMap<T>();
   keys.reserve(map.size());
@@ -267,7 +267,7 @@ std::vector<std::string> GenericParameters::getKeys() const {
 
 template <typename T>
 std::tuple<std::vector<std::string>, std::vector<std::vector<T>>> GenericParameters::getKeysAndValues() const {
-  static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
+  static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
   std::vector<std::vector<T>> values;
   std::vector<std::string> keys;
   auto& mtx = getMutex<T>();

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -81,16 +81,16 @@ public:
 
   ~GenericParameters() = default;
 
-  template <typename T, typename = EnableIfValidGenericDataType<T>>
+  template <typename T>
   std::optional<T> get(const std::string& key) const;
 
   /// Store (a copy of) the passed value under the given key
-  template <typename T, typename = EnableIfValidGenericDataType<T>>
+  template <typename T>
   void set(const std::string& key, T value);
 
   /// Overload for catching const char* setting for string values
-  void set(const std::string& key, std::string value) {
-    set<std::string>(key, std::move(value));
+  void set(const std::string& key, const char* value) {
+    set<std::string>(key, std::string(value));
   }
 
   /// Overload for catching initializer list setting of string vector values
@@ -113,11 +113,11 @@ public:
   size_t getN(const std::string& key) const;
 
   /// Get all available keys for a given type
-  template <typename T, typename = EnableIfValidGenericDataType<T>>
+  template <typename T>
   std::vector<std::string> getKeys() const;
 
   /// Get all the available values for a given type
-  template <typename T, typename = EnableIfValidGenericDataType<T>>
+  template <typename T>
   std::tuple<std::vector<std::string>, std::vector<std::vector<T>>> getKeysAndValues() const;
 
   /// erase all elements
@@ -202,8 +202,9 @@ private:
   mutable MutexPtr m_doubleMtx{nullptr}; ///< The mutex guarding the double map
 };
 
-template <typename T, typename>
+template <typename T>
 std::optional<T> GenericParameters::get(const std::string& key) const {
+  static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
   const auto& map = getMap<T>();
   auto& mtx = getMutex<T>();
   std::lock_guard lock{mtx};
@@ -221,8 +222,9 @@ std::optional<T> GenericParameters::get(const std::string& key) const {
   }
 }
 
-template <typename T, typename>
+template <typename T>
 void GenericParameters::set(const std::string& key, T value) {
+  static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
   auto& map = getMap<T>();
   auto& mtx = getMutex<T>();
 
@@ -248,8 +250,9 @@ size_t GenericParameters::getN(const std::string& key) const {
   return 0;
 }
 
-template <typename T, typename>
+template <typename T>
 std::vector<std::string> GenericParameters::getKeys() const {
+  static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
   std::vector<std::string> keys;
   const auto& map = getMap<T>();
   keys.reserve(map.size());
@@ -262,8 +265,9 @@ std::vector<std::string> GenericParameters::getKeys() const {
   return keys;
 }
 
-template <typename T, typename>
+template <typename T>
 std::tuple<std::vector<std::string>, std::vector<std::vector<T>>> GenericParameters::getKeysAndValues() const {
+  static_assert(podio::isSupportedGenericDataType<T>, "The type is not supported by the GenericParameters");
   std::vector<std::vector<T>> values;
   std::vector<std::string> keys;
   auto& mtx = getMutex<T>();

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -204,7 +204,7 @@ private:
 
 template <typename T>
 std::optional<T> GenericParameters::get(const std::string& key) const {
-  static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
+  static_assert(podio::isSupportedGenericDataType<T>, "Unsupported parameter type");
   const auto& map = getMap<T>();
   auto& mtx = getMutex<T>();
   std::lock_guard lock{mtx};
@@ -224,7 +224,7 @@ std::optional<T> GenericParameters::get(const std::string& key) const {
 
 template <typename T>
 void GenericParameters::set(const std::string& key, T value) {
-  static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
+  static_assert(podio::isSupportedGenericDataType<T>, "Unsupported parameter type");
   auto& map = getMap<T>();
   auto& mtx = getMutex<T>();
 
@@ -252,7 +252,7 @@ size_t GenericParameters::getN(const std::string& key) const {
 
 template <typename T>
 std::vector<std::string> GenericParameters::getKeys() const {
-  static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
+  static_assert(podio::isSupportedGenericDataType<T>, "Unsupported parameter type");
   std::vector<std::string> keys;
   const auto& map = getMap<T>();
   keys.reserve(map.size());
@@ -267,7 +267,7 @@ std::vector<std::string> GenericParameters::getKeys() const {
 
 template <typename T>
 std::tuple<std::vector<std::string>, std::vector<std::vector<T>>> GenericParameters::getKeysAndValues() const {
-  static_assert(podio::isSupportedGenericDataType<T>, "T is not a supported parameter type");
+  static_assert(podio::isSupportedGenericDataType<T>, "Unsupported parameter type");
   std::vector<std::vector<T>> values;
   std::vector<std::string> keys;
   auto& mtx = getMutex<T>();

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -32,7 +32,7 @@ SUPPORTED_PARAMETER_TYPES = (
 
 def _get_cpp_types(type_str):
     """Get all possible c++ types from the passed py_type string."""
-    types = list(filter(lambda t: type_str in t, SUPPORTED_PARAMETER_TYPES))
+    types = [t for t in SUPPORTED_PARAMETER_TYPES if type_str in t]
     if not types:
         raise ValueError(f"{type_str} cannot be mapped to a valid parameter type")
 
@@ -43,7 +43,7 @@ def _get_cpp_vector_types(type_str):
     """Get the possible std::vector<cpp_type> from the passed py_type string."""
     # Gather a list of all types that match the type_str (c++ or python)
     types = _get_cpp_types(type_str)
-    return [f"std::vector<{t}>" for t in map(lambda x: x[0], types)]
+    return [f"std::vector<{t[0]}>" for t in types]
 
 
 def _is_collection_base(thing):

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -264,7 +264,7 @@ class Frame:
                 cpp_types = _get_cpp_types(as_type)
                 if len(cpp_types) == 0:
                     raise ValueError(f"Cannot put a parameter of type {as_type} into a Frame")
-                self._frame.putParameter[cpp_types[0]](key, value)
+                self._frame.putParameter[cpp_types[0][0]](key, value)
 
             # If we have a single integer, a std::string overload kicks in with higher
             # priority than the template for some reason. So we explicitly select the

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -264,6 +264,8 @@ class Frame:
                 cpp_types = _get_cpp_types(as_type)
                 if len(cpp_types) == 0:
                     raise ValueError(f"Cannot put a parameter of type {as_type} into a Frame")
+                # The first [0] gets the tuple, the second [0] gets the actual C++ type
+                # from SUPPORTED_PARAMETER_TYPES
                 self._frame.putParameter[cpp_types[0][0]](key, value)
 
             # If we have a single integer, a std::string overload kicks in with higher


### PR DESCRIPTION
This was discussed in https://github.com/key4hep/k4FWCore/pull/223#issuecomment-2354758322.

BEGINRELEASENOTES
- Remove EnableIf for GenericParameters and add `static_assert` in its place to make errors easier to read and debug.

ENDRELEASENOTES