### PR TITLE
Build podio with all available features for EDM4hep CI workflows

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -47,6 +47,8 @@ jobs:
             mkdir build && cd build
             cmake -DENABLE_SIO=ON \
               -DENABLE_JULIA=ON \
+              -DENABLE_DATASOURCE=ON \
+              -DENABLE_RNTUPLE=ON \
               -DCMAKE_INSTALL_PREFIX=../install \
               -DCMAKE_CXX_STANDARD=20 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that podio is built with all capabilities for the CI tests that use EDM4hep

ENDRELEASENOTES

After https://github.com/key4hep/EDM4hep/pull/361 EDM4hep test start to fail otherwise.