### PR TITLE
fix printout on import when not built with data source

### DIFF
--- a/python/podio/data_source.py
+++ b/python/podio/data_source.py
@@ -2,7 +2,10 @@
 
 from ROOT import gSystem
 
-if gSystem.Load("libpodioDataSourceDict") < 0:
+if (
+    not gSystem.DynamicPathName("libpodioDataSourceDict", True)
+    or gSystem.Load("libpodioDataSourceDict") < 0
+):
     raise ImportError("Error when loading libpodioDataSourceDict")
 
 from ROOT import podio  # pylint: disable=wrong-import-position


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed missing libpodioDataSourceDict printout on import podio when built without data source

ENDRELEASENOTES

Missed from #674. When library is not found root will make a long printout. This is fixed by first checking if the file exists which can be actually silenced to just return value
