### PR TITLE
Revert part of #676 because there is no implicit conversion to std::string

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -234,9 +234,8 @@ public:
   ///              is supported by GenericParameters
   /// @param key   The name under which this parameter should be stored
   /// @param value The value of the parameter. A copy will be put into the Frame
-  template <typename T>
+  template <typename T, typename = podio::EnableIfValidGenericDataType<T>>
   inline void putParameter(const std::string& key, T value) {
-    static_assert(podio::isSupportedGenericDataType<T>, "Unsupported parameter type");
     m_self->parameters().set(key, std::move(value));
   }
 
@@ -247,8 +246,8 @@ public:
   ///
   /// @param key   The name under which this parameter should be stored
   /// @param value The value of the parameter. A copy will be put into the Frame
-  inline void putParameter(const std::string& key, const char* value) {
-    putParameter<std::string>(key, value);
+  inline void putParameter(const std::string& key, std::string value) {
+    putParameter<std::string>(key, std::move(value));
   }
 
   /// Add a vector of strings value the parameters of the Frame.


### PR DESCRIPTION
BEGINRELEASENOTES
- Revert part of #676 because there is no implicit conversion to std::string when trying to put a parameter that can be converted to std::string, therefore it will fail with the static_assert when compiling

ENDRELEASENOTES

There are several parts in the stack that rely on implicit conversion (such as from `G4STring` in k4geo, for example) and #676 disallows that. Alternatively we could keep the `static_assert` and add another template for anything that can be converted to string but I think the original implementation with the EnableIf is just cleaner. With the getters it should be fine since we are not going to be doing weird conversions (I hope) so the rest of the PR doesn't need to be reversed.