### PR TITLE
Add a tool to merge several podio files into a single one

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,6 +3,7 @@ install(PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/podio-vis DESTINATION ${CMAKE_INSTALL
 if(ENABLE_RNTUPLE)
   install(PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/podio-ttree-to-rntuple DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
+install(PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/podio-merge-files DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Add a very basic test of podio-vis
 if(BUILD_TESTING)

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -2,6 +2,8 @@
 """podio-merge-files tool to merge any number of podio files into one"""
 
 import argparse
+import sys
+import podio
 import podio.root_io
 from podio import reading
 
@@ -41,13 +43,29 @@ elif root_format == reading.RootFileFormat.RNTUPLE:
 else:
     raise ValueError(f"Input file {args.files[0]} is not a TTree or RNTuple file")
 
+categories = list(reader.categories)
+metadata_available = True
+try:
+    categories.remove(args.metadata_category_name)
+except ValueError:
+    metadata_available = False
 
 for category in reader.categories:
-    if category == args.metadata_category_name and args.metadata == "none":
-        continue
-    if category == args.metadata_category_name and args.metadata == "first":
-        all_frames = [reader.get(category)[0]]
-    else:
-        all_frames = reader.get(category)
+    all_frames = reader.get(category)
     for frame in all_frames:
         writer.write_frame(frame, category)
+
+if args.metadata == "none":
+    sys.exit(0)
+
+if not metadata_available:
+    print(f"Warning: metadata category '{args.metadata_category_name}' not found in input files, it will be created")
+    all_frames = [podio.Frame()]
+else:
+    if args.metadata == "first":
+        all_frames = [reader.get(args.metadata_category_name)[0]]
+    else:
+        all_frames = reader.get(args.metadata_category_name)
+for frame in all_frames:
+    frame.put_parameter("MergeInputFiles", args.files)
+    writer.write_frame(frame, args.metadata_category_name)

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -17,9 +17,11 @@ parser.add_argument(
     default="first",
     help="metadata to include in the output file, default: only the one from the first event, other options: all events, none",
 )
-parser.add_argument("--metadata-category-name",
-                    default="metadata",
-                    help="name of the metadata category in the output file, default: metadata")
+parser.add_argument(
+    "--metadata-category-name",
+    default="metadata",
+    help="name of the metadata category in the output file, default: metadata",
+)
 args = parser.parse_args()
 
 all_files = set()

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -15,7 +15,8 @@ parser.add_argument(
     "--metadata",
     choices=["none", "all", "first"],
     default="first",
-    help="metadata to include in the output file, default: only the one from the first event, other options: all events, none",
+    help="metadata to include in the output file, default: "
+         "only the one from the first event, other options: all events, none",
 )
 parser.add_argument(
     "--metadata-category-name",

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -53,7 +53,7 @@ is_metadata_available = True  # pylint: disable=invalid-name
 try:
     categories.remove(args.metadata_category_name)
 except ValueError:
-    is_metadata_available = False
+    is_metadata_available = False  # pylint: disable=invalid-name
 
 for category in reader.categories:
     all_frames = reader.get(category)

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""podio-merge-files tool to merge any number of podio files into one"""
+
+import argparse
+import podio.root_io
+from podio import reading
+
+parser = argparse.ArgumentParser(
+    description="Merge any number of podio files into one, can merge TTree and RNTuple files"
+)
+
+parser.add_argument("--output-file", help="name of the output file", required=True)
+parser.add_argument("files", nargs="+", help="which files to merge")
+parser.add_argument(
+    "--metadata",
+    choices=["none", "all", "first"],
+    default="first",
+    help="metadata to include in the output file, default: only the one from the first event, other options: all events, none",
+)
+parser.add_argument("--metadata-category-name",
+                    default="metadata",
+                    help="name of the metadata category in the output file, default: metadata")
+args = parser.parse_args()
+
+all_files = set()
+for f in args.files:
+    if f in all_files:
+        raise ValueError(f"File {f} is present more than once in the input list")
+    all_files.add(f)
+
+root_format = reading._determine_root_format(args.files[0])
+if root_format == reading.RootFileFormat.TTREE:
+    reader = podio.root_io.Reader(args.files)
+    writer = podio.root_io.Writer(args.output_file)
+elif root_format == reading.RootFileFormat.RNTUPLE:
+    reader = podio.root_io.RNTupleReader(args.files)
+    writer = podio.root_io.RNTupleWriter(args.output_file)
+else:
+    raise ValueError(f"Input file {args.files[0]} is not a TTree or RNTuple file")
+
+
+for category in reader.categories:
+    if category == args.metadata_category_name and args.metadata == "none":
+        continue
+    if category == args.metadata_category_name and args.metadata == "first":
+        all_frames = [reader.get(category)[0]]
+    else:
+        all_frames = reader.get(category)
+    for frame in all_frames:
+        writer.write_frame(frame, category)

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -25,6 +25,11 @@ parser.add_argument(
     default="metadata",
     help="name of the metadata category in the output file, default: metadata",
 )
+parser.add_argument(
+    "--metadata-parameter-name",
+    default="MergeInputFiles",
+    help="name of the metadata category in the output file, default: metadata",
+)
 args = parser.parse_args()
 
 all_files = set()
@@ -69,5 +74,5 @@ else:
     else:
         all_frames = reader.get(args.metadata_category_name)
 for frame in all_frames:
-    frame.put_parameter("MergeInputFiles", args.files)
+    frame.put_parameter(args.metadata_parameter_name, args.files)
     writer.write_frame(frame, args.metadata_category_name)

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -56,7 +56,7 @@ if args.metadata == "none":
 
 if not is_metadata_available:
     print(
-        f"Warning: metadata category 'metadata'"
+        "Warning: metadata category 'metadata'"
         " not found in input files, it will be created"
     )
     all_frames = [podio.Frame()]

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -20,16 +20,6 @@ parser.add_argument(
     help="metadata to include in the output file, default: "
     "only the one from the first file, other options: all files, none",
 )
-parser.add_argument(
-    "--metadata-category-name",
-    default="metadata",
-    help="name of the metadata category in the output file, default: metadata",
-)
-parser.add_argument(
-    "--metadata-parameter-name",
-    default="MergeInputFiles",
-    help="name of the metadata category in the output file, default: metadata",
-)
 args = parser.parse_args()
 
 all_files = set()
@@ -51,13 +41,12 @@ else:
 categories = list(reader.categories)
 is_metadata_available = True  # pylint: disable=invalid-name
 try:
-    categories.remove(args.metadata_category_name)
+    categories.remove("metadata")
 except ValueError:
     is_metadata_available = False  # pylint: disable=invalid-name
 
-for category in reader.categories:
+for category in categories:
     all_frames = reader.get(category)
-    print(all_frames, len(all_frames))
     for frame in all_frames:
         writer.write_frame(frame, category)
 
@@ -66,15 +55,15 @@ if args.metadata == "none":
 
 if not is_metadata_available:
     print(
-        f"Warning: metadata category '{args.metadata_category_name}'"
+        f"Warning: metadata category 'metadata'"
         " not found in input files, it will be created"
     )
     all_frames = [podio.Frame()]
 else:
     if args.metadata == "first":
-        all_frames = [reader.get(args.metadata_category_name)[0]]
+        all_frames = [reader.get("metadata")[0]]
     else:
-        all_frames = reader.get(args.metadata_category_name)
+        all_frames = reader.get("metadata")
 for frame in all_frames:
-    frame.put_parameter(args.metadata_parameter_name, args.files)
-    writer.write_frame(frame, args.metadata_category_name)
+    frame.put_parameter("MergedInputFiles", args.files)
+    writer.write_frame(frame, "metadata")

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -65,7 +65,8 @@ if args.metadata == "none":
 
 if not metadata_available:
     print(
-        f"Warning: metadata category '{args.metadata_category_name}' not found in input files, it will be created"
+        f"Warning: metadata category '{args.metadata_category_name}'"
+        " not found in input files, it will be created"
     )
     all_frames = [podio.Frame()]
 else:

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -18,7 +18,7 @@ parser.add_argument(
     choices=["none", "all", "first"],
     default="first",
     help="metadata to include in the output file, default: "
-         "only the one from the first file, other options: all files, none",
+    "only the one from the first file, other options: all files, none",
 )
 parser.add_argument(
     "--metadata-category-name",
@@ -59,7 +59,9 @@ if args.metadata == "none":
     sys.exit(0)
 
 if not metadata_available:
-    print(f"Warning: metadata category '{args.metadata_category_name}' not found in input files, it will be created")
+    print(
+        f"Warning: metadata category '{args.metadata_category_name}' not found in input files, it will be created"
+    )
     all_frames = [podio.Frame()]
 else:
     if args.metadata == "first":

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -55,10 +55,7 @@ if args.metadata == "none":
     sys.exit(0)
 
 if not is_metadata_available:
-    print(
-        "Warning: metadata category 'metadata'"
-        " not found in input files, it will be created"
-    )
+    print("Warning: metadata category 'metadata' not found in the input files, it will be created")
     all_frames = [podio.Frame()]
 else:
     if args.metadata == "first":

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -16,7 +16,7 @@ parser.add_argument(
     choices=["none", "all", "first"],
     default="first",
     help="metadata to include in the output file, default: "
-         "only the one from the first event, other options: all events, none",
+         "only the one from the first file, other options: all files, none",
 )
 parser.add_argument(
     "--metadata-category-name",

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -41,6 +41,7 @@ else:
 categories = list(reader.categories)
 is_metadata_available = True  # pylint: disable=invalid-name
 try:
+    # All frames will be copied as they are except the metadata ones
     categories.remove("metadata")
 except ValueError:
     is_metadata_available = False  # pylint: disable=invalid-name

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -38,32 +38,33 @@ for f in args.files:
         raise ValueError(f"File {f} is present more than once in the input list")
     all_files.add(f)
 
-root_format = reading._determine_root_format(args.files[0])
-if root_format == reading.RootFileFormat.TTREE:
+ROOT_FORMAT = reading._determine_root_format(args.files[0])  # pylint: disable=protected-access
+if ROOT_FORMAT == reading.RootFileFormat.TTREE:
     reader = podio.root_io.Reader(args.files)
     writer = podio.root_io.Writer(args.output_file)
-elif root_format == reading.RootFileFormat.RNTUPLE:
+elif ROOT_FORMAT == reading.RootFileFormat.RNTUPLE:
     reader = podio.root_io.RNTupleReader(args.files)
     writer = podio.root_io.RNTupleWriter(args.output_file)
 else:
     raise ValueError(f"Input file {args.files[0]} is not a TTree or RNTuple file")
 
 categories = list(reader.categories)
-metadata_available = True
+is_metadata_available = True  # pylint: disable=invalid-name
 try:
     categories.remove(args.metadata_category_name)
 except ValueError:
-    metadata_available = False
+    is_metadata_available = False
 
 for category in reader.categories:
     all_frames = reader.get(category)
+    print(all_frames, len(all_frames))
     for frame in all_frames:
         writer.write_frame(frame, category)
 
 if args.metadata == "none":
     sys.exit(0)
 
-if not metadata_available:
+if not is_metadata_available:
     print(
         f"Warning: metadata category '{args.metadata_category_name}'"
         " not found in input files, it will be created"


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a tool to merge several podio files into a single one:
  - Metadata for every event can be saved or not
  - The same format as the first input file will be used (TTree or RNTuple)
  - Metadata about the input file names will be saved

ENDRELEASENOTES

Useful not to have to deal with many small files, even though the readers can read them fine. 