### PR TITLE
Make sure to use the correct pylint version for pre-commit in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,6 +28,7 @@ jobs:
           pip install pre-commit
           pip install pylint==2.17.7
           pip install flake8
+          export PYTHONPATH=$VIRTUAL_ENV/lib/python3.$(python3 -c 'import sys; print(f"{sys.version_info[1]}")')/site-packages:$PYTHONPATH
           echo "::endgroup::"
           echo "::group::Run CMake"
           mkdir build


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that we pick up the correct version of `pylint` in the CI for pre-commit.

ENDRELEASENOTES

I am not sure why it's necessary, but a similar thing was already done for the documentation in #656