### PR TITLE
Use unique_ptr to manage one-to-one-relations in the Obj classes

### DIFF
--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -39,7 +39,7 @@
 {
 {% for relation in OneToOneRelations %}
   if (other.m_{{ relation.name }}) {
-    m_{{ relation.name }} = new {{ relation.full_type }}(*(other.m_{{ relation.name }}));
+    m_{{ relation.name }} = std::make_unique<{{ relation.full_type }}>(*(other.m_{{ relation.name }}));
   }
 {% endfor %}
 }
@@ -55,10 +55,6 @@
   }
 {% endif %}
 {%- endwith %}
-
-{% for relation in OneToOneRelations %}
-  delete m_{{ relation.name }};
-{% endfor %}
 }
 {%- endif %}
 

--- a/python/templates/Obj.h.jinja2
+++ b/python/templates/Obj.h.jinja2
@@ -13,6 +13,9 @@
 #include "podio/ObjectID.h"
 {% if OneToManyRelations or VectorMembers %}
 #include <vector>
+{% endif %}
+{% if OneToOneRelations %}
+#include <memory>
 {%- endif %}
 
 {{ utils.forward_decls(forward_declarations_obj) }}
@@ -42,7 +45,7 @@ public:
   podio::ObjectID id;
   {{ class.bare_type }}Data data;
 {% for relation in OneToOneRelations %}
-  {{ relation.full_type }}* m_{{ relation.name }}{nullptr};
+  std::unique_ptr<{{ relation.full_type }}> m_{{ relation.name }}{nullptr};
 {% endfor %}
 {% for relation in OneToManyRelations + VectorMembers %}
   std::vector<{{ relation.full_type }}>* m_{{ relation.name }}{nullptr};

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -38,7 +38,7 @@ Mutable{{ type }} {{ full_type }}::clone(bool cloneRelations) const {
   if (cloneRelations) {
 {% for relation in one_to_one_relations %}
   if (m_obj->m_{{ relation.name }}) {
-    tmp->m_{{ relation.name }} = new {{ relation.full_type }}(*m_obj->m_{{ relation.name }});
+    tmp->m_{{ relation.name }} = std::make_unique<{{ relation.full_type }}>((*m_obj->m_{{ relation.name }}));
   }
 {% endfor %}
 {% for relation in multi_relations %}
@@ -124,8 +124,7 @@ const {{ relation.full_type }} {{ class_type }}::{{ relation.getter_name(get_syn
 {% set class_type = prefix + class.bare_type %}
 {% for relation in relations %}
 void {{ class_type }}::{{ relation.setter_name(get_syntax) }}(const {{ relation.full_type }}& value) {
-  delete m_obj->m_{{ relation.name }};
-  m_obj->m_{{ relation.name }} = new {{ relation.full_type }}(value);
+  m_obj->m_{{ relation.name }} = std::make_unique<{{ relation.full_type }}>(value);
 }
 
 {% endfor %}


### PR DESCRIPTION

BEGINRELEASENOTES
- Use a `unique_ptr` to manage the OneToOneRelation pointers in the `Obj` classes.

ENDRELEASENOTES

I am not entirely sure why they were not managed by smart pointers before. It's possible that this was not possible before we introduced the `MaybeSharedPtr`s.