### PR TITLE
CI: Switch to stacks that have newer ROOT

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["LCG_104/x86_64-el9-gcc13-opt",
+        LCG: ["LCG_106/x86_64-el9-gcc13-opt",
               "dev4/x86_64-el9-gcc14-opt",
-              "LCG_104/x86_64-el9-clang16-opt"]
+              "dev3/x86_64-el9-clang16-opt"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to software stacks with a newer version of ROOT for building and testing EDM4hep in CI, because we need a newer version of ROOT to run all the backwards compatibility tests in EDM4hep.

ENDRELEASENOTES

https://github.com/key4hep/EDM4hep/pull/358 tries to read a file that has been written with ROOT 6.32.04. The RNTuple on file format has changed in 6.32. Hence, trying to read these files will fail with older versions of ROOT.