### PR TITLE
Make accessing single elements in empty parameter vectors return an empty optional

### DIFF
--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -219,6 +219,9 @@ std::optional<T> GenericParameters::get(const std::string& key) const {
     return it->second;
   } else {
     const auto& iv = it->second;
+    if (iv.empty()) {
+      return std::nullopt;
+    }
     return iv[0];
   }
 }

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -138,6 +138,13 @@ class FrameTest(unittest.TestCase):
         frame.put_parameter("float_as_float", 3.14, as_type="float")
         self.assertAlmostEqual(frame.get_parameter("float_as_float"), 3.14, places=5)
 
+    def test_frame_empty_parameters(self):
+        """Check that working with empty parameters works"""
+        frame = Frame()
+        frame.put_parameter("empty_param", [], as_type="int")
+        vals = frame.get_parameter("empty_param")
+        self.assertEqual(len(vals), 0)
+
 
 class FrameReadTest(unittest.TestCase):
     """Unit tests for the Frame python bindings for Frames read from file.

--- a/tests/unittests/frame.cpp
+++ b/tests/unittests/frame.cpp
@@ -50,6 +50,12 @@ TEST_CASE("Frame parameters", "[frame][basics]") {
   // Can't rely on an insertion order here
   REQUIRE(std::find(stringKeys.begin(), stringKeys.end(), "aString") != stringKeys.end());
   REQUIRE(std::find(stringKeys.begin(), stringKeys.end(), "someStrings") != stringKeys.end());
+
+  // Check the cases with empty vectors as parameters
+  event.putParameter("emptyVec", std::vector<int>{});
+  const auto emptyVec = event.getParameter<std::vector<int>>("emptyVec").value();
+  REQUIRE(emptyVec.empty());
+  REQUIRE_FALSE(event.getParameter<int>("emptyVec").has_value());
 }
 
 // NOTE: Due to the extremely small tasks that are done in these tests, they will

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1070,6 +1070,21 @@ TEST_CASE("GenericParameters", "[generic-parameters]") {
   REQUIRE_FALSE(gp.get<std::vector<std::string>>("Missing"));
 }
 
+TEST_CASE("GenericParameters empty vector single value access", "[generic-parameters]") {
+  auto gp = podio::GenericParameters();
+  gp.set("empty-ints", std::vector<int>{});
+
+  // Getting the whole vector works
+  const auto maybeVec = gp.get<std::vector<int>>("empty-ints");
+  REQUIRE(maybeVec.has_value());
+  const auto& vec = maybeVec.value();
+  REQUIRE(vec.empty());
+
+  // Trying to get a single (i.e. the first) value will not work
+  const auto maybeVal = gp.get<int>("empty-ints");
+  REQUIRE_FALSE(maybeVal.has_value());
+}
+
 TEST_CASE("GenericParameters constructors", "[generic-parameters]") {
   // Tests for making sure that generic parameters can be moved / copied correctly
   auto originalParams = podio::GenericParameters{};


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix small issue in `GenericParameters` where trying to access a single element of a parameter that was stored as an empty vector resulted in a crash. Instead make this return an empty optional now.

ENDRELEASENOTES

@dirkzerwas this is the fix for the issue in our email discussion.

This seems to be the most reasonable thing to do. The other option would be to return an empty / default constructed value in this case. However, since we introduced the `std::optional` return type for avoiding exactly that (see #580), I don't think that makes a lot of sense and would make the API inconsistent again.