### PR TITLE
[temp-fix] Set JULIA_DEPOT_PATH to a writable directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         run: |
           echo "::group::Run CMake"
+          export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"
           mkdir build install
           cd build
           cmake -DENABLE_SIO=ON \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,6 +23,7 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         run: |
           echo "::group::Run CMake"
+          export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"
           mkdir build install
           cd build
           cmake -DENABLE_SIO=ON \


### PR DESCRIPTION
BEGINRELEASENOTES
- Temporarily set the `JULIA_DEPOT_PATH` to a writable directory to make CI pass.

ENDRELEASENOTES

At least until LCG stacks have been fixed.