### PR TITLE
Add a deprecation warning when building with C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
+if(CMAKE_CXX_STANDARD EQUAL 17)
+  message(WARNING "C++17 is deprecated and support for it will be removed in the future. Please use at least C++20.")
+endif()
+
 # Prevent CMake falls back to the latest standard the compiler does support
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 # Set up C++ Standard
 # ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
 
 if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
 endif()
 
 if(CMAKE_CXX_STANDARD EQUAL 17)
-  message(WARNING "C++17 is deprecated and support for it will be removed in the future. Please use at least C++20.")
+  message(WARNING "C++17 is deprecated and support for it will be removed in v01-03. Please use at least C++20.")
 endif()
 
 # Prevent CMake falls back to the latest standard the compiler does support


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a deprecation warning when building with C++17 before removing support for it in https://github.com/AIDASoft/podio/pull/698

ENDRELEASENOTES