### PR TITLE
Make sure that reader still works with newer ROOT versions

### DIFF
--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -46,9 +46,12 @@ Reader makeReader(const std::vector<std::string>& filenames) {
     for (auto key : *file->GetListOfKeys()) {
       auto tkey = dynamic_cast<TKey*>(key);
 
-      if (tkey && std::string(tkey->GetClassName()) == "ROOT::Experimental::RNTuple") {
-        hasRNTuple = true;
-        break;
+      if (tkey) {
+        const auto className = std::string(tkey->GetClassName());
+        if (className == "ROOT::Experimental::RNTuple" || className == "ROOT::RNTuple") {
+          hasRNTuple = true;
+          break;
+        }
       }
     }
     if (hasRNTuple) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that `makeReader` still recognizes files with RNTuple inside after they have been marked non-experimental in ROOT.

ENDRELEASENOTES

This should fix the issues in CI we see in some other PRs that build against the root nightlies.