### PR TITLE
Remove no longer available option from .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,6 @@ Checks: -*,
   readability-uniqueptr-delete-release,
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:             modernize-use-override.IgnoreDestructors
     value:           '1'


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove an option from `.clang-tidy` that has been removed from newer versions of `clang-tidy` (>= 18)

ENDRELEASENOTES

This will also make `clangd` fail without this fix.