### PR TITLE
Make sure that link weights are stored in a struct

### DIFF
--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -188,7 +188,7 @@ public:
   }
 
   const std::string_view getDataTypeName() const override {
-    return "float";
+    return "podio::LinkData";
   }
 
   bool isSubsetCollection() const override {

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -43,5 +43,8 @@
     <class name="podio::UserDataCollection<uint32_t>"/>
     <class name="podio::UserDataCollection<uint64_t>"/>
 
+    <class name="podio::LinkData"/>
+    <class name="std::vector<podio::LinkData>"/>
+
   </selection>
 </lcgdict>


### PR DESCRIPTION
Otherwise ROOT does something clever and simply stores the float without the struct. Which makes the switch over a bit less transparent.



BEGINRELEASENOTES
- Make sure that the weights of the links end up as a `vector<LinkData>` in the ROOT files instead of a `vector<float>`

ENDRELEASENOTES

Pulled this out of #691 as it is really an unrelated fix that has nothing to do with that.