### PR TITLE
Store the collection information in a struct instead of a tuple

### DIFF
--- a/doc/storage_details.md
+++ b/doc/storage_details.md
@@ -62,23 +62,29 @@ there will be the following branches per supported type
 
 The podio related metadata, stored in the `podio_metadata` `TTree` (or
 `RNTupleModel`) contains the following general information once per file
-
 - The version of podio that has been used to write this file
 - The complete datamodel definitions for each datamodel that was encountered
   when writing the file
 
-And the following information once per category
-- The mapping of collection names to collection IDs
-- The types of all the stored collections
-- The schema version of all stored collections
-- Which collections are stored as subset collections
+And the following information once per category for each collection in that category
+- The collection ID
+- The collection name
+- The collection type
+- Whether the collection is a subset collection
+- The collection schema version
+- The collection storage type (which is different from the collection type and
+  describes the format in which the data is actually stored rather than how it
+  can be accessed in memory)
 
-Here the `TTree` based and `RNTuple` based backends differ slightly in the way
-these data are stored exactly. The `TTree` based backend stores the data in a
-slightly more structured way, taking advantage of ROOTs capabilities to stream
-out more complex object, e.g. the `podio::CollectionIDTable` is streamed as a
-whole. The `RNTuple` based backend on the other hand, destructures the
-information into separate fields that run in parallel.
+From a technical point of view this information is stored as a
+`std::vector<podio::root_utils::CollectionWriteInfo>`.
+
+```{note}
+The exact details of how this information is stored in podio files has changed
+several times. The readers provided by podio handle these changes transparently,
+but other readers might have to adapt for these changes. **Notable changes
+happened before v01-00, and v01-03.**
+```
 
 ## SIO
 

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -172,14 +172,7 @@ private:
   std::unordered_map<std::string, std::vector<unsigned>> m_readerEntries{};
   std::unordered_map<std::string, unsigned> m_totalEntries{};
 
-  // struct CollectionInfo {
-  //   std::vector<unsigned int> id{};
-  //   std::vector<std::string> name{};
-  //   std::vector<std::string> type{};
-  //   std::vector<short> isSubsetCollection{};
-  //   std::vector<SchemaVersionT> schemaVersion{};
-  // };
-
+  /// Map each category to the collections that have been written and are available
   std::unordered_map<std::string, std::vector<podio::root_utils::CollectionWriteInfo>> m_collectionInfo{};
 
   std::vector<std::string> m_availableCategories{};

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -5,6 +5,7 @@
 #include "podio/SchemaEvolution.h"
 #include "podio/podioVersion.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
+#include "podio/utilities/RootHelpers.h"
 
 #include <string>
 #include <string_view>
@@ -171,15 +172,15 @@ private:
   std::unordered_map<std::string, std::vector<unsigned>> m_readerEntries{};
   std::unordered_map<std::string, unsigned> m_totalEntries{};
 
-  struct CollectionInfo {
-    std::vector<unsigned int> id{};
-    std::vector<std::string> name{};
-    std::vector<std::string> type{};
-    std::vector<short> isSubsetCollection{};
-    std::vector<SchemaVersionT> schemaVersion{};
-  };
+  // struct CollectionInfo {
+  //   std::vector<unsigned int> id{};
+  //   std::vector<std::string> name{};
+  //   std::vector<std::string> type{};
+  //   std::vector<short> isSubsetCollection{};
+  //   std::vector<SchemaVersionT> schemaVersion{};
+  // };
 
-  std::unordered_map<std::string, CollectionInfo> m_collectionInfo{};
+  std::unordered_map<std::string, std::vector<podio::root_utils::CollectionWriteInfo>> m_collectionInfo{};
 
   std::vector<std::string> m_availableCategories{};
 

--- a/include/podio/RNTupleWriter.h
+++ b/include/podio/RNTupleWriter.h
@@ -117,12 +117,9 @@ private:
   struct CategoryInfo {
     std::unique_ptr<root_compat::RNTupleWriter> writer{nullptr}; ///< The RNTupleWriter for this category
 
-    // The following are assumed to run in parallel!
-    std::vector<uint32_t> ids{};                  ///< The ids of all collections
-    std::vector<std::string> names{};             ///< The names of all collections
-    std::vector<std::string> types{};             ///< The types of all collections
-    std::vector<short> subsetCollections{};       ///< The flags identifying the subcollections
-    std::vector<SchemaVersionT> schemaVersions{}; ///< The schema versions of all collections
+    /// Collection info for this category
+    std::vector<root_utils::CollectionWriteInfo> collInfo{};
+    std::vector<std::string> names{}; ///< The names of all collections to write
 
     // Storage for the keys & values of all the parameters of this category
     // (resp. at least the current entry)

--- a/include/podio/ROOTLegacyReader.h
+++ b/include/podio/ROOTLegacyReader.h
@@ -116,7 +116,7 @@ public:
 private:
   std::pair<TTree*, unsigned> getLocalTreeAndEntry(const std::string& treename);
 
-  void createCollectionBranches(const std::vector<root_utils::CollectionWriteInfoT>& collInfo);
+  void createCollectionBranches(const std::vector<root_utils::CollectionWriteInfo>& collInfo);
 
   podio::GenericParameters readEventMetaData();
 

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -105,7 +105,7 @@ private:
   struct CategoryInfo {
     TTree* tree{nullptr};                                     ///< The TTree to which this category is written
     std::vector<root_utils::CollectionBranches> branches{};   ///< The branches for this category
-    std::vector<root_utils::CollectionWriteInfoT> collInfo{}; ///< Collection info for this category
+    std::vector<root_utils::CollectionWriteInfo> collInfo{}; ///< Collection info for this category
     podio::CollectionIDTable idTable{};                       ///< The collection id table for this category
     std::vector<std::string> collsToWrite{};                  ///< The collections to write for this category
 

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -103,11 +103,10 @@ private:
   /// Helper struct to group together all necessary state to write / process a
   /// given category. Created during the first writing of a category
   struct CategoryInfo {
-    TTree* tree{nullptr};                                     ///< The TTree to which this category is written
-    std::vector<root_utils::CollectionBranches> branches{};   ///< The branches for this category
+    TTree* tree{nullptr};                                    ///< The TTree to which this category is written
+    std::vector<root_utils::CollectionBranches> branches{};  ///< The branches for this category
     std::vector<root_utils::CollectionWriteInfo> collInfo{}; ///< Collection info for this category
-    podio::CollectionIDTable idTable{};                       ///< The collection id table for this category
-    std::vector<std::string> collsToWrite{};                  ///< The collections to write for this category
+    std::vector<std::string> collsToWrite{};                 ///< The collections to write for this category
 
     // Storage for the keys & values of all the parameters of this category
     // (resp. at least the current entry)

--- a/include/podio/utilities/RootHelpers.h
+++ b/include/podio/utilities/RootHelpers.h
@@ -18,7 +18,13 @@ namespace root_utils {
   // A collection of additional information that describes the collection: the
   // collectionID, the collection (data) type, whether it is a subset
   // collection, and its schema version
-  using CollectionWriteInfoT = std::tuple<uint32_t, std::string, bool, unsigned int>;
+  struct CollectionWriteInfoT {
+    uint32_t collectionID{static_cast<uint32_t>(-1)};
+    std::string dataType{};
+    bool isSubset{false};
+    unsigned int schemaVersion{0};
+  };
+
   // for backwards compatibility
   using CollectionInfoWithoutSchemaT = std::tuple<int, std::string, bool>;
 

--- a/include/podio/utilities/RootHelpers.h
+++ b/include/podio/utilities/RootHelpers.h
@@ -18,12 +18,14 @@ namespace root_utils {
   // A collection of additional information that describes the collection: the
   // collectionID, the collection (data) type, whether it is a subset
   // collection, and its schema version
-  struct CollectionWriteInfoT {
+  struct CollectionWriteInfo {
     uint32_t collectionID{static_cast<uint32_t>(-1)};
     std::string dataType{};
     bool isSubset{false};
     unsigned int schemaVersion{0};
   };
+  // The format used until version 1.2
+  using CollectionWriteInfoT = std::tuple<uint32_t, std::string, bool, unsigned int>;
 
   // for backwards compatibility
   using CollectionInfoWithoutSchemaT = std::tuple<int, std::string, bool>;

--- a/include/podio/utilities/RootHelpers.h
+++ b/include/podio/utilities/RootHelpers.h
@@ -19,10 +19,11 @@ namespace root_utils {
   // collectionID, the collection (data) type, whether it is a subset
   // collection, and its schema version
   struct CollectionWriteInfo {
-    uint32_t collectionID{static_cast<uint32_t>(-1)};
-    std::string dataType{};
-    bool isSubset{false};
-    unsigned int schemaVersion{0};
+    uint32_t collectionID{static_cast<uint32_t>(-1)}; ///< collection id
+    std::string dataType{};                           ///< The fully qualified data type
+    bool isSubset{false};                             ///< Whether this collection is a subset collection or not
+    unsigned int schemaVersion{0};                    ///< The schema version of the collection type
+    std::string name{};                               ///< The name of the collection
   };
   // The format used until version 1.2
   using CollectionWriteInfoT = std::tuple<uint32_t, std::string, bool, unsigned int>;

--- a/include/podio/utilities/RootHelpers.h
+++ b/include/podio/utilities/RootHelpers.h
@@ -20,10 +20,11 @@ namespace root_utils {
   // collection, and its schema version
   struct CollectionWriteInfo {
     uint32_t collectionID{static_cast<uint32_t>(-1)}; ///< collection id
-    std::string dataType{};                           ///< The fully qualified data type
+    std::string dataType{};                           ///< The fully qualified data type of the collection
     bool isSubset{false};                             ///< Whether this collection is a subset collection or not
     unsigned int schemaVersion{0};                    ///< The schema version of the collection type
     std::string name{};                               ///< The name of the collection
+    std::string storageType{};                        ///< The type in which the data is actually stored
   };
   // The format used until version 1.2
   using CollectionWriteInfoT = std::tuple<uint32_t, std::string, bool, unsigned int>;

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -4,11 +4,13 @@
 #include "podio/CollectionIDTable.h"
 #include "podio/DatamodelRegistry.h"
 #include "podio/GenericParameters.h"
+#include "podio/utilities/RootHelpers.h"
 #include "rootUtils.h"
 
 #include <ROOT/RError.hxx>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 
 // Adjust for the move of this out of ROOT v7 in
@@ -48,27 +50,32 @@ bool RNTupleReader::initCategory(const std::string& category) {
   // Assume that the metadata is the same in all files
   auto filename = m_filenames[0];
 
-  auto& collInfo = m_collectionInfo[category];
+  // auto& collInfo = m_collectionInfo[category];
 
-  auto id = m_metadata_readers[filename]->GetView<std::vector<unsigned int>>(root_utils::idTableName(category));
-  collInfo.id = id(0);
+  auto collInfo = m_metadata_readers[filename]->GetView<std::vector<root_utils::CollectionWriteInfo>>(
+      {root_utils::collInfoName(category)});
 
-  auto collectionName =
-      m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collectionName(category));
-  collInfo.name = collectionName(0);
+  m_collectionInfo[category] = collInfo(0);
 
-  auto collectionType =
-      m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collInfoName(category));
-  collInfo.type = collectionType(0);
+  // auto id = m_metadata_readers[filename]->GetView<std::vector<unsigned int>>(root_utils::idTableName(category));
+  // collInfo.collectionID = id(0);
 
-  auto subsetCollection =
-      m_metadata_readers[filename]->GetView<std::vector<short>>(root_utils::subsetCollection(category));
-  collInfo.isSubsetCollection = subsetCollection(0);
+  // auto collectionName =
+  //     m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collectionName(category));
+  // collInfo.name = collectionName(0);
 
-  auto schemaVersion = m_metadata_readers[filename]->GetView<std::vector<SchemaVersionT>>("schemaVersion_" + category);
-  collInfo.schemaVersion = schemaVersion(0);
+  // auto collectionType =
+  //     m_metadata_readers[filename]->GetView<std::vector<std::string>>(root_utils::collInfoName(category));
+  // collInfo.type = collectionType(0);
 
-  m_idTables[category] = std::make_shared<CollectionIDTable>(collInfo.id, collInfo.name);
+  // auto subsetCollection =
+  //     m_metadata_readers[filename]->GetView<std::vector<short>>(root_utils::subsetCollection(category));
+  // collInfo.isSubset = subsetCollection(0);
+
+  // auto schemaVersion = m_metadata_readers[filename]->GetView<std::vector<SchemaVersionT>>("schemaVersion_" +
+  // category); collInfo.schemaVersion = schemaVersion(0);
+
+  m_idTables[category] = root_utils::makeCollIdTable(collInfo(0));
 
   return true;
 }
@@ -162,7 +169,7 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
   // Make sure to not silently ignore non-existant but requested collections
   if (!collsToRead.empty()) {
     for (const auto& name : collsToRead) {
-      if (std::ranges::find(collInfo.name, name) == collInfo.name.end()) {
+      if (std::ranges::find(collInfo, name, &root_utils::CollectionWriteInfo::name) == collInfo.end()) {
         throw std::invalid_argument(name + " is not available from Frame");
       }
     }
@@ -184,47 +191,46 @@ std::unique_ptr<ROOTFrameData> RNTupleReader::readEntry(const std::string& categ
   // we set all the fields there in any case.
   auto dentry = m_readers[category][readerIndex]->GetModel().CreateEntry();
 
-  for (size_t i = 0; i < collInfo.id.size(); ++i) {
-    if (!collsToRead.empty() && std::ranges::find(collsToRead, collInfo.name[i]) == collsToRead.end()) {
+  for (size_t i = 0; i < collInfo.size(); ++i) {
+    if (!collsToRead.empty() && std::ranges::find(collsToRead, collInfo[i].name) == collsToRead.end()) {
       continue;
     }
-    const auto& collType = collInfo.type[i];
+    const auto& collType = collInfo[i].dataType;
     const auto& bufferFactory = podio::CollectionBufferFactory::instance();
-    auto maybeBuffers =
-        bufferFactory.createBuffers(collType, collInfo.schemaVersion[i], collInfo.isSubsetCollection[i]);
+    auto maybeBuffers = bufferFactory.createBuffers(collType, collInfo[i].schemaVersion, collInfo[i].isSubset);
     auto collBuffers = maybeBuffers.value_or(podio::CollectionReadBuffers{});
 
     if (!maybeBuffers) {
-      std::cout << "WARNING: Buffers couldn't be created for collection " << collInfo.name[i] << " of type "
-                << collInfo.type[i] << " and schema version " << collInfo.schemaVersion[i] << std::endl;
+      std::cout << "WARNING: Buffers couldn't be created for collection " << collInfo[i].name << " of type "
+                << collInfo[i].dataType << " and schema version " << collInfo[i].schemaVersion << std::endl;
       return nullptr;
     }
 
-    if (collInfo.isSubsetCollection[i]) {
-      auto brName = root_utils::subsetBranch(collInfo.name[i]);
+    if (collInfo[i].isSubset) {
+      auto brName = root_utils::subsetBranch(collInfo[i].name);
       auto vec = new std::vector<podio::ObjectID>;
       dentry->BindRawPtr(brName, vec);
       collBuffers.references->at(0) = std::unique_ptr<std::vector<podio::ObjectID>>(vec);
     } else {
-      dentry->BindRawPtr(collInfo.name[i], collBuffers.data);
+      dentry->BindRawPtr(collInfo[i].name, collBuffers.data);
 
       const auto relVecNames = podio::DatamodelRegistry::instance().getRelationNames(collType);
       for (size_t j = 0; j < relVecNames.relations.size(); ++j) {
         const auto relName = relVecNames.relations[j];
         auto vec = new std::vector<podio::ObjectID>;
-        const auto brName = root_utils::refBranch(collInfo.name[i], relName);
+        const auto brName = root_utils::refBranch(collInfo[i].name, relName);
         dentry->BindRawPtr(brName, vec);
         collBuffers.references->at(j) = std::unique_ptr<std::vector<podio::ObjectID>>(vec);
       }
 
       for (size_t j = 0; j < relVecNames.vectorMembers.size(); ++j) {
         const auto vecName = relVecNames.vectorMembers[j];
-        const auto brName = root_utils::vecBranch(collInfo.name[i], vecName);
+        const auto brName = root_utils::vecBranch(collInfo[i].name, vecName);
         dentry->BindRawPtr(brName, collBuffers.vectorMembers->at(j).second);
       }
     }
 
-    buffers.emplace(collInfo.name[i], std::move(collBuffers));
+    buffers.emplace(collInfo[i].name, std::move(collBuffers));
   }
 
   m_readers[category][readerIndex]->LoadEntry(localEntry, *dentry);

--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -96,7 +96,7 @@ void RNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& cat
     catInfo.collInfo.reserve(collections.size());
     for (const auto& [name, coll] : collections) {
       catInfo.collInfo.emplace_back(coll->getID(), std::string(coll->getTypeName()), coll->isSubsetCollection(),
-                                    coll->getSchemaVersion(), name);
+                                    coll->getSchemaVersion(), name, root_utils::getStorageTypeName(coll));
     }
   } else {
     if (!root_utils::checkConsistentColls(catInfo.collInfo, collsToWrite)) {

--- a/src/ROOTLegacyReader.cc
+++ b/src/ROOTLegacyReader.cc
@@ -178,7 +178,7 @@ unsigned ROOTLegacyReader::getEntries(const std::string& name) const {
 void ROOTLegacyReader::createCollectionBranches(const std::vector<root_utils::CollectionWriteInfo>& collInfo) {
   size_t collectionIndex{0};
 
-  for (const auto& [collID, collType, isSubsetColl, collSchemaVersion, _] : collInfo) {
+  for (const auto& [collID, collType, isSubsetColl, collSchemaVersion, _, __] : collInfo) {
     // We only write collections that are in the collectionIDTable, so no need
     // to check here
     const auto name = m_table->name(collID).value();

--- a/src/ROOTLegacyReader.cc
+++ b/src/ROOTLegacyReader.cc
@@ -178,7 +178,7 @@ unsigned ROOTLegacyReader::getEntries(const std::string& name) const {
 void ROOTLegacyReader::createCollectionBranches(const std::vector<root_utils::CollectionWriteInfo>& collInfo) {
   size_t collectionIndex{0};
 
-  for (const auto& [collID, collType, isSubsetColl, collSchemaVersion] : collInfo) {
+  for (const auto& [collID, collType, isSubsetColl, collSchemaVersion, _] : collInfo) {
     // We only write collections that are in the collectionIDTable, so no need
     // to check here
     const auto name = m_table->name(collID).value();

--- a/src/ROOTLegacyReader.cc
+++ b/src/ROOTLegacyReader.cc
@@ -152,7 +152,12 @@ void ROOTLegacyReader::openFiles(const std::vector<std::string>& filenames) {
       collInfoBranch->SetAddress(&collectionInfo);
       collInfoBranch->GetEntry(0);
     }
-    createCollectionBranches(*collectionInfo);
+    std::vector<root_utils::CollectionWriteInfo> collInfo;
+    collInfo.reserve(collectionInfo->size());
+    for (auto& [id, typeName, isSubsetColl, schemaVersion] : *collectionInfo) {
+      collInfo.emplace_back(id, std::move(typeName), isSubsetColl, schemaVersion);
+    }
+    createCollectionBranches(collInfo);
     delete collectionInfo;
   } else {
     std::cout << "PODIO: Reconstructing CollectionTypeInfo branch from other sources in file: \'"
@@ -170,7 +175,7 @@ unsigned ROOTLegacyReader::getEntries(const std::string& name) const {
   return m_chain->GetEntries();
 }
 
-void ROOTLegacyReader::createCollectionBranches(const std::vector<root_utils::CollectionWriteInfoT>& collInfo) {
+void ROOTLegacyReader::createCollectionBranches(const std::vector<root_utils::CollectionWriteInfo>& collInfo) {
   size_t collectionIndex{0};
 
   for (const auto& [collID, collType, isSubsetColl, collSchemaVersion] : collInfo) {

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -354,7 +354,7 @@ createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable
   std::vector<detail::NamedCollInfo> storedClasses;
   storedClasses.reserve(collInfo.size());
 
-  for (const auto& [collID, collType, isSubsetColl, collSchemaVersion, _] : collInfo) {
+  for (const auto& [collID, collType, isSubsetColl, collSchemaVersion, _, __] : collInfo) {
     // We only write collections that are in the collectionIDTable, so no need
     // to check here
     const auto name = idTable.name(collID).value();
@@ -406,7 +406,7 @@ createCollectionBranches(TChain* chain, const podio::CollectionIDTable& idTable,
   std::vector<detail::NamedCollInfo> storedClasses;
   storedClasses.reserve(collInfo.size());
 
-  for (const auto& [collID, collType, isSubsetColl, collSchemaVersion, _] : collInfo) {
+  for (const auto& [collID, collType, isSubsetColl, collSchemaVersion, _, __] : collInfo) {
     // We only write collections that are in the collectionIDTable, so no need
     // to check here
     const auto name = idTable.name(collID).value();

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -20,11 +20,11 @@ namespace podio {
 
 std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>
 createCollectionBranches(TChain* chain, const podio::CollectionIDTable& idTable,
-                         const std::vector<root_utils::CollectionWriteInfoT>& collInfo);
+                         const std::vector<root_utils::CollectionWriteInfo>& collInfo);
 
 std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>
 createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable& idTable,
-                                   const std::vector<root_utils::CollectionWriteInfoT>& collInfo);
+                                   const std::vector<root_utils::CollectionWriteInfo>& collInfo);
 
 template <typename T>
 void ROOTReader::readParams(ROOTReader::CategoryInfo& catInfo, podio::GenericParameters& params, bool reloadBranches,
@@ -185,7 +185,7 @@ void ROOTReader::initCategory(CategoryInfo& catInfo, const std::string& category
 
   auto* collInfoBranch = root_utils::getBranch(m_metaChain.get(), root_utils::collInfoName(category));
 
-  auto collInfo = new std::vector<root_utils::CollectionWriteInfoT>();
+  auto collInfo = new std::vector<root_utils::CollectionWriteInfo>();
   if (m_fileVersion < podio::version::Version{0, 16, 4}) {
     auto oldCollInfo = new std::vector<root_utils::CollectionInfoWithoutSchemaT>();
     collInfoBranch->SetAddress(&oldCollInfo);
@@ -325,7 +325,7 @@ std::vector<std::string_view> ROOTReader::getAvailableCategories() const {
 
 std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>
 createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable& idTable,
-                                   const std::vector<root_utils::CollectionWriteInfoT>& collInfo) {
+                                   const std::vector<root_utils::CollectionWriteInfo>& collInfo) {
 
   size_t collectionIndex{0};
   std::vector<root_utils::CollectionBranches> collBranches;
@@ -377,7 +377,7 @@ createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable
 
 std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>
 createCollectionBranches(TChain* chain, const podio::CollectionIDTable& idTable,
-                         const std::vector<root_utils::CollectionWriteInfoT>& collInfo) {
+                         const std::vector<root_utils::CollectionWriteInfo>& collInfo) {
 
   size_t collectionIndex{0};
   std::vector<root_utils::CollectionBranches> collBranches;

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -213,15 +213,7 @@ void ROOTReader::initCategory(CategoryInfo& catInfo, const std::string& category
   // Recreate the idTable form the collection info if necessary, otherwise read
   // it directly
   if (m_fileVersion >= podio::version::Version{1, 2, 99}) {
-    std::vector<uint32_t> ids;
-    ids.reserve(collInfo->size());
-    std::vector<std::string> names;
-    names.reserve(collInfo->size());
-    for (const auto& [id, _1, _2, _3, name] : *collInfo) {
-      ids.emplace_back(id);
-      names.emplace_back(name);
-    }
-    catInfo.table = std::make_shared<podio::CollectionIDTable>(std::move(ids), std::move(names));
+    catInfo.table = root_utils::makeCollIdTable(*collInfo);
   } else {
     catInfo.table = std::make_shared<podio::CollectionIDTable>();
     auto* table = catInfo.table.get();

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -119,7 +119,7 @@ void ROOTWriter::initBranches(CategoryInfo& catInfo, const std::vector<root_util
 
     catInfo.branches.emplace_back(std::move(branches));
     catInfo.collInfo.emplace_back(coll->getID(), std::string(coll->getTypeName()), coll->isSubsetCollection(),
-                                  coll->getSchemaVersion(), name);
+                                  coll->getSchemaVersion(), name, root_utils::getStorageTypeName(coll));
   }
 
   fillParams(catInfo, parameters);

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -56,7 +56,7 @@ void ROOTWriter::writeFrame(const podio::Frame& frame, const std::string& catego
   } else {
     // Make sure that the category contents are consistent with the initial
     // frame in the category
-    if (!root_utils::checkConsistentColls(catInfo.collsToWrite, collsToWrite)) {
+    if (!root_utils::checkConsistentColls(catInfo.collInfo, collsToWrite)) {
       throw std::runtime_error("Trying to write category '" + category + "' with inconsistent collection content. " +
                                root_utils::getInconsistentCollsMsg(catInfo.collsToWrite, collsToWrite));
     }

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -32,7 +32,6 @@ void ROOTWriter::writeFrame(const podio::Frame& frame, const std::string& catego
   // Use the TTree as proxy here to decide whether this category has already
   // been initialized
   if (catInfo.tree == nullptr) {
-    catInfo.idTable = frame.getCollectionIDTableForWrite();
     catInfo.collsToWrite = podio::utils::sortAlphabeticaly(collsToWrite);
     catInfo.tree = new TTree(category.c_str(), (category + " data tree").c_str());
     catInfo.tree->SetDirectory(m_file.get());
@@ -54,7 +53,6 @@ void ROOTWriter::writeFrame(const podio::Frame& frame, const std::string& catego
   // collections
   if (catInfo.branches.empty()) {
     initBranches(catInfo, collections, const_cast<podio::GenericParameters&>(frame.getParameters()));
-
   } else {
     // Make sure that the category contents are consistent with the initial
     // frame in the category
@@ -120,8 +118,8 @@ void ROOTWriter::initBranches(CategoryInfo& catInfo, const std::vector<root_util
     }
 
     catInfo.branches.emplace_back(std::move(branches));
-    catInfo.collInfo.emplace_back(catInfo.idTable.collectionID(name).value(), std::string(coll->getTypeName()),
-                                  coll->isSubsetCollection(), coll->getSchemaVersion());
+    catInfo.collInfo.emplace_back(coll->getID(), std::string(coll->getTypeName()), coll->isSubsetCollection(),
+                                  coll->getSchemaVersion(), name);
   }
 
   fillParams(catInfo, parameters);
@@ -175,7 +173,6 @@ void ROOTWriter::finish() {
 
   // Store the collection id table and collection info for reading in the meta tree
   for (/*const*/ auto& [category, info] : m_categories) {
-    metaTree->Branch(root_utils::idTableName(category).c_str(), &info.idTable);
     metaTree->Branch(root_utils::collInfoName(category).c_str(), &info.collInfo);
   }
 

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -1,6 +1,7 @@
 #ifndef PODIO_ROOT_UTILS_H // NOLINT(llvm-header-guard): internal headers confuse clang-tidy
 #define PODIO_ROOT_UTILS_H // NOLINT(llvm-header-guard): internal headers confuse clang-tidy
 
+#include "podio/CollectionBase.h"
 #include "podio/CollectionIDTable.h"
 #include "podio/utilities/MiscHelpers.h"
 #include "podio/utilities/RootHelpers.h"
@@ -199,6 +200,10 @@ inline std::string subsetBranch(const std::string& name) {
   return name + "_objIdx";
 }
 
+inline std::string getStorageTypeName(const podio::CollectionBase* coll) {
+  return "std::vector<" + std::string(coll->getDataTypeName()) + ">";
+}
+
 /**
  * Reset all the branches that by getting them from the TTree again
  */
@@ -365,7 +370,7 @@ inline std::shared_ptr<podio::CollectionIDTable> makeCollIdTable(const std::vect
   ids.reserve(collInfo.size());
   std::vector<std::string> names{};
   names.reserve(collInfo.size());
-  for (const auto& [id, _1, _2, _3, name] : collInfo) {
+  for (const auto& [id, _1, _2, _3, name, _5] : collInfo) {
     ids.emplace_back(id);
     names.emplace_back(name);
   }

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -259,7 +259,7 @@ inline void readBranchesData(const CollectionBranches& branches, Long64_t entry)
  * collections
  */
 inline auto reconstructCollectionInfo(TTree* eventTree, podio::CollectionIDTable const& idTable) {
-  std::vector<CollectionWriteInfoT> collInfo;
+  std::vector<CollectionWriteInfo> collInfo;
 
   for (size_t iColl = 0; iColl < idTable.names().size(); ++iColl) {
     const auto collID = idTable.ids()[iColl];

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -358,6 +358,8 @@ inline std::string getInconsistentCollsMsg(const std::vector<std::string>& exist
   return sstr.str();
 }
 
+/// Create a collection id table from the information in the
+/// CollectionWriteInfos
 inline std::shared_ptr<podio::CollectionIDTable> makeCollIdTable(const std::vector<CollectionWriteInfo>& collInfo) {
   std::vector<uint32_t> ids{};
   ids.reserve(collInfo.size());

--- a/src/root_selection.xml
+++ b/src/root_selection.xml
@@ -5,5 +5,8 @@
     <class name="podio::ROOTWriter"/>
     <class name="podio::RNTupleReader"/>
     <class name="podio::RNTupleWriter"/>
+
+    <class name="podio::root_utils::CollectionWriteInfoT"/>
+    <class name="std::vector<podio::root_utils::CollectionWriteInfoT>"/>
   </selection>
 </lcgdict>

--- a/src/root_selection.xml
+++ b/src/root_selection.xml
@@ -6,7 +6,7 @@
     <class name="podio::RNTupleReader"/>
     <class name="podio::RNTupleWriter"/>
 
-    <class name="podio::root_utils::CollectionWriteInfoT"/>
-    <class name="std::vector<podio::root_utils::CollectionWriteInfoT>"/>
+    <class name="podio::root_utils::CollectionWriteInfo"/>
+    <class name="std::vector<podio::root_utils::CollectionWriteInfo>"/>
   </selection>
 </lcgdict>


### PR DESCRIPTION
BEGINRELEASENOTES
- Store the collection information in a proper `struct` instead of using a `tuple` to facilitate access for non podio based backends (e.g. Julia)
- Harmonize the format of RNTuple and TTree based ROOT backends
  - Both now store the collection information into the `podio_metadata` TTree / Model as a `vector<podio::root_utils::CollectionWriteInfo>`, which contains all the necessary information for reading a collection.
  - The collection ID and the name are part of this struct, so the `CollectionIDTable` is no longer written separately.
- **This is a breaking change in the format if you rely on reading the metadata about the stored collections.**

ENDRELEASENOTES

Fixes #705 

@peremato This addresses the TTree part of the problem. I just realized that RNTuple stores this in several vectors that run in parallel. I suppose it would be easiest for you (and also for us) to have similar layouts for TTree and RNTuple?

- [x] Harmonize the TTree and RNTuple formats.
- [x] #744 included here
- [x] https://github.com/key4hep/EDM4hep/pull/413
- [x] #745 included here
- [x] Documentation update
- [x] Backwards compatibility for RNTuple? given #757, I think we don't have to worry too much about backwards compatibility with RNTuple