### PR TITLE
Add a simple test that only reads partial frames to check proper cleanup

### DIFF
--- a/cmake/podioTest.cmake
+++ b/cmake/podioTest.cmake
@@ -15,6 +15,7 @@ function(PODIO_SET_TEST_ENV test)
       ENABLE_SIO=${ENABLE_SIO}
       PODIO_BUILD_BASE=${PROJECT_BINARY_DIR}
       LSAN_OPTIONS=suppressions=${PROJECT_SOURCE_DIR}/tests/root_io/leak_sanitizer_suppressions.txt
+      TSAN_OPTIONS=suppressions=${PROJECT_SOURCE_DIR}/tests/root_io/thread_sanitizer_suppressions.txt
   )
   set_property(TEST ${test}
     PROPERTY ENVIRONMENT "${test_environment}"

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -18,6 +18,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     write_python_frame_root
     read_python_frame_root
     read_and_write_frame_root
+    read_partioal_root
 
     param_reading_rdataframe
 

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -18,7 +18,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
     write_python_frame_root
     read_python_frame_root
     read_and_write_frame_root
-    read_partioal_root
+    read_partial_root
 
     param_reading_rdataframe
 
@@ -108,6 +108,7 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
       read_rntuple
       write_interface_rntuple
       read_interface_rntuple
+      read_partial_rntuple
     )
 
   endif()

--- a/tests/read_partial.h
+++ b/tests/read_partial.h
@@ -1,0 +1,39 @@
+#ifndef PODIO_TESTS_READ_PARTIAL_H // NOLINT(llvm-header-guard): folder structure not suitable
+#define PODIO_TESTS_READ_PARTIAL_H // NOLINT(llvm-header-guard): folder structure not suitable
+
+#include "podio/Frame.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+void read_partial_collections(const podio::Frame& event, const std::vector<std::string>& collsToRead) {
+  for (const auto& name : collsToRead) {
+    event.get(name);
+  }
+}
+
+/**
+ * This is a test case that will always work in normal builds and will only fail
+ * in builds with sanitizers enabled, where they will start to fail in case of
+ * e.g. memory leaks.
+ */
+template <typename ReaderT>
+int read_partial_frames(const std::string& filename) {
+  auto reader = ReaderT();
+  try {
+    reader.openFile(filename);
+  } catch (const std::runtime_error& e) {
+    std::cerr << "File " << filename << " could not be opened. aborting." << std::endl;
+    return 1;
+  }
+
+  for (auto i = 0u; i < reader.getEntries(podio::Category::Event); ++i) {
+    const auto event = podio::Frame(reader.readEntry(podio::Category::Event, i));
+    read_partial_collections(event, {"mcparticles", "info", "hits", "clusters"});
+  }
+
+  return 0;
+}
+#endif // PODIO_TESTS_READ_PARTIAL_H

--- a/tests/root_io/CMakeLists.txt
+++ b/tests/root_io/CMakeLists.txt
@@ -8,6 +8,7 @@ set(root_dependent_tests
   read_and_write_frame_root.cpp
   write_interface_root.cpp
   read_interface_root.cpp
+  read_partial_root.cpp
   )
 if(ENABLE_RNTUPLE)
   set(root_dependent_tests
@@ -17,6 +18,7 @@ if(ENABLE_RNTUPLE)
       read_python_frame_rntuple.cpp
       write_interface_rntuple.cpp
       read_interface_rntuple.cpp
+      read_partial_rntuple.cpp
      )
 endif()
 if(ENABLE_DATASOURCE)
@@ -39,13 +41,20 @@ set_tests_properties(
   read_frame_root
   read_frame_root_multiple
   read_and_write_frame_root
+  read_partial_root
 
   PROPERTIES
     DEPENDS write_frame_root
 )
 
 if(ENABLE_RNTUPLE)
-  set_property(TEST read_rntuple PROPERTY DEPENDS write_rntuple)
+  set_tests_properties(
+    read_rntuple
+    read_partial_rntuple
+
+    PROPERTIES
+      DEPENDS write_rntuple
+  )
   set_property(TEST read_interface_rntuple PROPERTY DEPENDS write_interface_rntuple)
 endif()
 

--- a/tests/root_io/read_partial_rntuple.cpp
+++ b/tests/root_io/read_partial_rntuple.cpp
@@ -1,0 +1,7 @@
+#include "read_partial.h"
+
+#include "podio/RNTupleReader.h"
+
+int main() {
+  return read_partial_frames<podio::RNTupleReader>("example_rntuple.root");
+}

--- a/tests/root_io/read_partial_root.cpp
+++ b/tests/root_io/read_partial_root.cpp
@@ -1,0 +1,7 @@
+#include "read_partial.h"
+
+#include "podio/ROOTReader.h"
+
+int main() {
+  return read_partial_frames<podio::ROOTReader>("example_frame.root");
+}

--- a/tests/root_io/thread_sanitizer_suppressions.txt
+++ b/tests/root_io/thread_sanitizer_suppressions.txt
@@ -1,0 +1,2 @@
+# Ignore race conditions in libROOTNTuple
+race:ROOTNTuple

--- a/tests/sio_io/CMakeLists.txt
+++ b/tests/sio_io/CMakeLists.txt
@@ -5,7 +5,9 @@ set(sio_dependent_tests
   read_python_frame_sio.cpp
   write_interface_sio.cpp
   read_interface_sio.cpp
+  read_partial_sio.cpp
 )
+
 set(sio_libs podio::podioSioIO podio::podioIO)
 foreach( sourcefile ${sio_dependent_tests} )
   CREATE_PODIO_TEST(${sourcefile} "${sio_libs}")
@@ -14,6 +16,7 @@ endforeach()
 set_tests_properties(
   read_frame_sio
   read_and_write_frame_sio
+  read_partial_sio
 
   PROPERTIES
     DEPENDS

--- a/tests/sio_io/read_partial_sio.cpp
+++ b/tests/sio_io/read_partial_sio.cpp
@@ -1,0 +1,7 @@
+#include "read_partial.h"
+
+#include "podio/SIOReader.h"
+
+int main() {
+  return read_partial_frames<podio::SIOReader>("example_frame.sio");
+}


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a dedicated test case to check that no memory is leaked in case only parts of a Frame are actually requested.

ENDRELEASENOTES

This is a followup on #500 and the discussion from [yesterdays Key4hep meeting](https://indico.cern.ch/event/1482623/) to actually add a test case that checks that there are indeed no leaks when only part of the collections are requested from a Frame. 