### PR TITLE
Mark the collection destructor with override and remove `#include <array>`

### DIFF
--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -22,7 +22,6 @@
 
 #include <string_view>
 #include <vector>
-#include <array>
 #include <algorithm>
 #include <ostream>
 #include <mutex>
@@ -60,7 +59,7 @@ public:
   {{ class.bare_type }}Collection& operator=({{ class.bare_type }}Collection&&) = default;
 
 //  {{ class.bare_type }}Collection({{ class.bare_type }}Vector* data, uint32_t collectionID);
-  ~{{ class.bare_type }}Collection();
+  ~{{ class.bare_type }}Collection() override;
 
   constexpr static auto typeName = "{{ (class | string ).strip(':') + "Collection" }}";
   constexpr static auto valueTypeName = "{{ (class | string ).strip(':') }}";


### PR DESCRIPTION
BEGINRELEASENOTES
- Mark the collection destructor with override and remove `#include <array>`

ENDRELEASENOTES

I think for `std::array` the only use-case in a `Collection.h` file is due to https://github.com/key4hep/EDM4hep/blob/main/edm4hep.yaml#L857 and then since the `Object.h` is included and array is included there it's also not strictly needed in this file although used. In all other cases it's included without being used.