### PR TITLE
Delete all the non-virtual default destructors

### DIFF
--- a/include/podio/CollectionBufferFactory.h
+++ b/include/podio/CollectionBufferFactory.h
@@ -39,7 +39,6 @@ public:
   CollectionBufferFactory& operator=(CollectionBufferFactory const&) = delete;
   CollectionBufferFactory(CollectionBufferFactory&&) = delete;
   CollectionBufferFactory& operator=(CollectionBufferFactory&&) = delete;
-  ~CollectionBufferFactory() = default;
 
   /// Mutable instance only used for the initial registration of functions
   /// during library loading

--- a/include/podio/CollectionIDTable.h
+++ b/include/podio/CollectionIDTable.h
@@ -14,7 +14,6 @@ class CollectionIDTable {
 
 public:
   CollectionIDTable();
-  ~CollectionIDTable() = default;
 
   CollectionIDTable(const CollectionIDTable&) = delete;
   CollectionIDTable& operator=(const CollectionIDTable&) = delete;

--- a/include/podio/DatamodelRegistry.h
+++ b/include/podio/DatamodelRegistry.h
@@ -55,7 +55,6 @@ public:
   // Mutable instance only used for the initial registration!
   static DatamodelRegistry& mutInstance();
 
-  ~DatamodelRegistry() = default;
   DatamodelRegistry(const DatamodelRegistry&) = delete;
   DatamodelRegistry& operator=(const DatamodelRegistry&) = delete;
   DatamodelRegistry(DatamodelRegistry&&) = delete;

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -92,7 +92,6 @@ class Frame {
   struct FrameModel final : FrameConcept, public ICollectionProvider {
 
     FrameModel(std::unique_ptr<FrameDataT> data);
-    ~FrameModel() = default;
     FrameModel(const FrameModel&) = delete;
     FrameModel& operator=(const FrameModel&) = delete;
     FrameModel(FrameModel&&) = default;
@@ -178,13 +177,6 @@ public:
 
   /// Frame move assignment operator
   Frame& operator=(Frame&&) = default;
-
-  /// Frame destructor
-  ///
-  /// @note Since the Frame owns all the collections that have been put into it,
-  /// or that can be obtained from it, this invalidates all references to these
-  /// collections.
-  ~Frame() = default;
 
   /// Get a collection from the Frame by name.
   ///

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -66,7 +66,6 @@ public:
   GenericParameters(GenericParameters&&) = default;
   GenericParameters& operator=(GenericParameters&&) = default;
 
-  ~GenericParameters() = default;
 
   template <typename T>
   std::optional<T> get(const std::string& key) const;

--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -66,7 +66,6 @@ public:
   GenericParameters(GenericParameters&&) = default;
   GenericParameters& operator=(GenericParameters&&) = default;
 
-
   template <typename T>
   std::optional<T> get(const std::string& key) const;
 

--- a/include/podio/LinkNavigator.h
+++ b/include/podio/LinkNavigator.h
@@ -67,7 +67,6 @@ public:
   LinkNavigator& operator=(const LinkNavigator&) = default;
   LinkNavigator(LinkNavigator&&) = default;
   LinkNavigator& operator=(LinkNavigator&&) = default;
-  ~LinkNavigator() = default;
 
   /// Get all the *From* objects and weights that have links with the passed
   /// object

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -33,8 +33,6 @@ class RNTupleReader {
 public:
   /// Create a RNTupleReader
   RNTupleReader() = default;
-  /// Destructor
-  ~RNTupleReader() = default;
   /// The RNTupleReader is not copy-able
   RNTupleReader(const RNTupleReader&) = delete;
   /// The RNTupleReader is not copy-able

--- a/include/podio/ROOTLegacyReader.h
+++ b/include/podio/ROOTLegacyReader.h
@@ -46,9 +46,6 @@ class ROOTLegacyReader {
 public:
   /// Create a SIOLegacyReader
   ROOTLegacyReader() = default;
-  /// Destructor
-  ~ROOTLegacyReader() = default;
-
   /// The SIOLegacyReader is not copy-able
   ROOTLegacyReader(const ROOTLegacyReader&) = delete;
   /// The SIOLegacyReader is not copy-able

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -45,9 +45,6 @@ class ROOTReader {
 public:
   /// Create a ROOTReader
   ROOTReader() = default;
-  /// Destructor
-  ~ROOTReader() = default;
-
   /// The ROOTReader is not copy-able
   ROOTReader(const ROOTReader&) = delete;
   /// The ROOTReader is not copy-able

--- a/include/podio/Reader.h
+++ b/include/podio/Reader.h
@@ -42,8 +42,6 @@ private:
     ReaderModel(ReaderModel&&) = default;
     ReaderModel& operator=(ReaderModel&&) = default;
 
-    ~ReaderModel() = default;
-
     podio::Frame readNextFrame(const std::string& name) override {
       auto maybeFrame = m_reader->readNextEntry(name);
       if (maybeFrame) {
@@ -100,7 +98,6 @@ public:
   Reader& operator=(const Reader&) = delete;
   Reader(Reader&&) = default;
   Reader& operator=(Reader&&) = default;
-  ~Reader() = default;
 
   /// Read the next frame of a given category
   ///

--- a/include/podio/SIOLegacyReader.h
+++ b/include/podio/SIOLegacyReader.h
@@ -28,9 +28,6 @@ class SIOLegacyReader {
 public:
   /// Create a SIOLegacyReader
   SIOLegacyReader();
-  /// Destructor
-  ~SIOLegacyReader() = default;
-
   /// The SIOLegacyReader is not copy-able
   SIOLegacyReader(const SIOLegacyReader&) = delete;
   /// The SIOLegacyReader is not copy-able

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -27,9 +27,6 @@ class SIOReader {
 public:
   /// Create an SIOReader
   SIOReader();
-  /// SIOReader destructor
-  ~SIOReader() = default;
-
   /// The SIOReader is not copy-able
   SIOReader(const SIOReader&) = delete;
   /// The SIOReader is not copy-able

--- a/include/podio/SchemaEvolution.h
+++ b/include/podio/SchemaEvolution.h
@@ -61,7 +61,6 @@ public:
   SchemaEvolution& operator=(const SchemaEvolution&) = delete;
   SchemaEvolution(SchemaEvolution&&) = delete;
   SchemaEvolution& operator=(SchemaEvolution&&) = delete;
-  ~SchemaEvolution() = default;
 
   /// Mutable instance only used for the initial registration of functions
   /// during library loading

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -85,7 +85,6 @@ public:
   UserDataCollection& operator=(const UserDataCollection&) = delete;
   UserDataCollection(UserDataCollection&&) = default;
   UserDataCollection& operator=(UserDataCollection&&) = default;
-  ~UserDataCollection() = default;
 
   /// The schema version of UserDataCollections
   static constexpr SchemaVersionT schemaVersion = 1;

--- a/include/podio/Writer.h
+++ b/include/podio/Writer.h
@@ -38,8 +38,6 @@ private:
     WriterModel(WriterModel&&) = default;
     WriterModel& operator=(WriterModel&&) = default;
 
-    ~WriterModel() = default;
-
     void writeFrame(const podio::Frame& frame, const std::string& category,
                     const std::vector<std::string>& collections) override {
       return m_writer->writeFrame(frame, category, collections);
@@ -65,12 +63,6 @@ public:
   Writer& operator=(const Writer&) = delete;
   Writer(Writer&&) = default;
   Writer& operator=(Writer&&) = default;
-
-  /// Destructor
-  ///
-  /// This also takes care of writing all the necessary metadata to read files
-  /// back again.
-  ~Writer() = default;
 
   /// Store the given frame with the given category
   ///

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -107,9 +107,6 @@ public:
     return {nullptr};
   }
 
-  /// Destructor
-  ~LinkT() = default;
-
   /// Get the weight of the link
   float getWeight() const {
     return m_obj->data.weight;

--- a/include/podio/detail/LinkCollectionData.h
+++ b/include/podio/detail/LinkCollectionData.h
@@ -42,7 +42,6 @@ public:
   LinkCollectionData& operator=(const LinkCollectionData&) = delete;
   LinkCollectionData(LinkCollectionData&&) = default;
   LinkCollectionData& operator=(LinkCollectionData&&) = default;
-  ~LinkCollectionData() = default;
 
   podio::CollectionWriteBuffers getCollectionBuffers(bool isSubsetColl) {
     return {isSubsetColl ? nullptr : (void*)&m_data, (void*)m_data.get(), &m_refCollections, &m_vecInfo};

--- a/include/podio/detail/LinkObj.h
+++ b/include/podio/detail/LinkObj.h
@@ -37,9 +37,6 @@ public:
   /// No assignment operator
   LinkObj& operator=(const LinkObj&) = delete;
 
-  /// Destructor
-  ~LinkObj() = default;
-
 public:
   podio::ObjectID id{};
   LinkData data{1.0f};

--- a/include/podio/utilities/DatamodelRegistryIOHelpers.h
+++ b/include/podio/utilities/DatamodelRegistryIOHelpers.h
@@ -44,7 +44,6 @@ public:
   }
 
   DatamodelDefinitionHolder() = default;
-  ~DatamodelDefinitionHolder() = default;
   DatamodelDefinitionHolder(const DatamodelDefinitionHolder&) = delete;
   DatamodelDefinitionHolder& operator=(const DatamodelDefinitionHolder&) = delete;
   DatamodelDefinitionHolder(DatamodelDefinitionHolder&&) = default;

--- a/include/podio/utilities/RootHelpers.h
+++ b/include/podio/utilities/RootHelpers.h
@@ -30,7 +30,6 @@ namespace root_utils {
   /// get them from a TTree/TChain for every event.
   struct CollectionBranches {
     CollectionBranches() = default;
-    ~CollectionBranches() = default;
     CollectionBranches(const CollectionBranches&) = delete;
     CollectionBranches& operator=(const CollectionBranches&) = delete;
     CollectionBranches(CollectionBranches&&) = default;
@@ -51,7 +50,6 @@ namespace root_utils {
   template <typename T>
   struct ParamStorage {
     ParamStorage() = default;
-    ~ParamStorage() = default;
     ParamStorage(const ParamStorage&) = delete;
     ParamStorage& operator=(const ParamStorage&) = delete;
     ParamStorage(ParamStorage&&) = default;

--- a/python/templates/CollectionData.h.jinja2
+++ b/python/templates/CollectionData.h.jinja2
@@ -59,11 +59,6 @@ public:
   {{ class_type }}({{ class_type }}&& other) = default;
   {{ class_type }}& operator=({{ class_type }}&& other) = default;
 
-  /**
-   * Destructor
-   */
-  ~{{ class_type }}() = default;
-
   void clear(bool isSubsetColl);
 
   podio::CollectionWriteBuffers getCollectionBuffers(bool isSubsetColl);

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -65,7 +65,6 @@ private:
 
   template<typename ValueT>
   struct Model final : Concept {
-    ~Model() = default;
     Model(ValueT value) : m_value(value) {}
 
     std::unique_ptr<Concept> clone() const final {
@@ -115,7 +114,6 @@ public:
     return *this;
   }
 
-  ~{{ class.bare_type }}() = default;
   {{ class.bare_type }}({{ class.bare_type }}&&) = default;
   {{ class.bare_type }}& operator=({{ class.bare_type }}&&) = default;
 

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -76,9 +76,6 @@
   /// create a mutable deep-copy of the object with identical relations
   /// if cloneRelations=false, the relations are not cloned and will be empty
   Mutable{{ type }} clone(bool cloneRelations=true) const;
-
-  /// destructor
-  ~{{  full_type }}() = default;
 {% endmacro %}
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Delete all the non-virtual default destructors. See https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c20-if-you-can-avoid-defining-default-operations-do

ENDRELEASENOTES

Triggered because `UserDataCollection`'s destructor was overriding without override and that was flagged in my editor, at that point all of them may as well be deleted. The side effect is a possibly useful comment in `Frame.h` and `Writer.h` removed.