### PR TITLE
add `mutable_type` typedef to collection and user collection

### DIFF
--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -72,6 +72,7 @@ private:
 
 public:
   using value_type = typename std::vector<BasicType>::value_type;
+  using mutable_type = value_type;
   using const_iterator = typename std::vector<BasicType>::const_iterator;
   using iterator = typename std::vector<BasicType>::iterator;
   using difference_type = typename std::vector<BasicType>::difference_type;

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -45,6 +45,7 @@ A Collection is identified by an ID.
 class {{ class.bare_type }}Collection : public podio::CollectionBase {
 public:
   using value_type = {{ class.bare_type }};
+  using mutable_type = Mutable{{ class.bare_type }};
   using const_iterator = {{ class.bare_type }}CollectionIterator;
   using iterator = {{ class.bare_type }}MutableCollectionIterator;
   using difference_type = ptrdiff_t;

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -749,23 +749,23 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     // *r = o
     // iterator
     DOCUMENTED_STATIC_FAILURE(traits::has_dereference_assignment_v<iterator, CollectionType::value_type>);
-    STATIC_REQUIRE(traits::has_dereference_assignment_v<iterator, CollectionType::value_type::mutable_type>);
+    STATIC_REQUIRE(traits::has_dereference_assignment_v<iterator, CollectionType::mutable_type>);
     {
       auto coll = CollectionType{};
       auto item = coll.create(13ull, 0., 0., 0., 0.);
       REQUIRE(coll.begin()->cellID() == 13ull);
-      auto new_item = CollectionType::value_type::mutable_type{42ull, 0., 0., 0., 0.};
+      auto new_item = CollectionType::mutable_type{42ull, 0., 0., 0., 0.};
       *coll.begin() = new_item;
       DOCUMENTED_FAILURE(coll.begin()->cellID() == 42ull);
     }
     // const_iterator
     STATIC_REQUIRE(traits::has_dereference_assignment_v<const_iterator, CollectionType::value_type>);
-    STATIC_REQUIRE(traits::has_dereference_assignment_v<const_iterator, CollectionType::value_type::mutable_type>);
+    STATIC_REQUIRE(traits::has_dereference_assignment_v<const_iterator, CollectionType::mutable_type>);
     {
       auto coll = CollectionType{};
       auto item = coll.create(13ull, 0., 0., 0., 0.);
       REQUIRE(coll.cbegin()->cellID() == 13ull);
-      auto new_item = CollectionType::value_type::mutable_type{42ull, 0., 0., 0., 0.};
+      auto new_item = CollectionType::mutable_type{42ull, 0., 0., 0., 0.};
       *coll.cbegin() = new_item;
       DOCUMENTED_FAILURE(coll.cbegin()->cellID() == 42ull);
       new_item.cellID(44ull);
@@ -793,13 +793,13 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     // iterator
     DOCUMENTED_STATIC_FAILURE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::value_type>);
     DOCUMENTED_STATIC_FAILURE(
-        traits::has_dereference_assignment_increment_v<iterator, CollectionType::value_type::mutable_type>);
+        traits::has_dereference_assignment_increment_v<iterator, CollectionType::mutable_type>);
     // TODO add runtime check for assignment validity like in '*r = o' case
     // const_iterator
     DOCUMENTED_STATIC_FAILURE(
         traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::value_type>);
     DOCUMENTED_STATIC_FAILURE(
-        traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::value_type::mutable_type>);
+        traits::has_dereference_assignment_increment_v<const_iterator, CollectionType::mutable_type>);
     // TODO add runtime check for assignment validity like in '*r = o' case
 
     // iterator_category - not strictly necessary but advised
@@ -852,7 +852,7 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
     // insert immutable to not-SubsetCollection
     REQUIRE_THROWS_AS(it = CollectionType::value_type{}, std::invalid_argument);
     // insert mutable (implicit cast to immutable) to not-SubsetCollection
-    REQUIRE_THROWS_AS(it = CollectionType::value_type::mutable_type{}, std::invalid_argument);
+    REQUIRE_THROWS_AS(it = CollectionType::mutable_type{}, std::invalid_argument);
     auto subColl = CollectionType{};
     subColl.setSubsetCollection(true);
     auto subIt = std::back_inserter(subColl);

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -792,8 +792,7 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     // *r++ = o
     // iterator
     DOCUMENTED_STATIC_FAILURE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::value_type>);
-    DOCUMENTED_STATIC_FAILURE(
-        traits::has_dereference_assignment_increment_v<iterator, CollectionType::mutable_type>);
+    DOCUMENTED_STATIC_FAILURE(traits::has_dereference_assignment_increment_v<iterator, CollectionType::mutable_type>);
     // TODO add runtime check for assignment validity like in '*r = o' case
     // const_iterator
     DOCUMENTED_STATIC_FAILURE(


### PR DESCRIPTION

BEGINRELEASENOTES
- Add `mutable_type` typedef to collection to simplify inferring mutable type. Add `mutable_type` typedef to user collection for compatibility with other collections.

ENDRELEASENOTES

As suggested in https://github.com/AIDASoft/podio/pull/626#discussion_r1888819801 some code can be simplify if had a typedef for mutable type instead of going through patter like `collection::value_type::mutable_type`

`mutable_type` is already present in link collection. I propose to add it to user data collection so all the collections offer similar API even if in that case it's redundant
