### PR TITLE
Make collection iterators `forward_iterator`* and beyond

### DIFF
--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -89,13 +89,14 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | `std::input_iterator` | ✔️ yes | ✔️ yes |
 | `std::output_iterator` | ❌ no | ❌ no |
 | `std::forward_iterator` | ✔️ yes (see note below) | ✔️ yes (see note below) |
-| `std::bidirectional_iterator` | ✔️ yes | ✔️ yes |
-| `std::random_access_iterator` | ✔️ yes | ✔️ yes |
+| `std::bidirectional_iterator` | ✔️ yes (see note below) | ✔️ yes (see note below) |
+| `std::random_access_iterator` | ✔️ yes (see note below) | ✔️ yes (see note below) |
 | `std::contiguous_iterator` | ❌ no | ❌ no |
 
-> [!NOTE]
->The collections' iterators fulfil the `std::forward_iterator` except that the pointers obtained with `->` remain valid only as long as the iterator is valid instead of as long as the range remain valid. In practice this means a `ptr` obtained with `auto* ptr = it.operator->();` is valid only as long as `it` is valid.
->The values obtained immediately through `->` (for instance `auto& e = it->energy();`) behaves as expected for `std::forward_iterator` as their validity is tied to the validity of a collection.
+:::{note}
+The collections' iterators fulfil the `std::forward_iterator` except that the pointers obtained with `->` remain valid only as long as the iterator is valid instead of as long as the range remain valid. In practice this means a `ptr` obtained with `auto* ptr = it.operator->();` is valid only as long as `it` is valid.
+The values obtained immediately through `->` (for instance `auto& e = it->energy();`) behaves as expected for `std::forward_iterator` as their validity is tied to the validity of a collection.
+:::
 
 ### LegacyIterator
 
@@ -207,7 +208,7 @@ std::fill(std::begin(collection), std::end(collection), value ); // requires For
 std::sort(std::begin(collection), std::end(collection)); // requires RandomAccessIterator and Swappable -> might compile, wrong result
 ```
 
-## Standard range algorithms
+## Collection and standard range algorithms
 
 The arguments of standard range algorithms are checked at compile time and must fulfil certain iterator concepts, such as `std::input_iterator` or `std::ranges::input_range`.
 

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -88,10 +88,14 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | `std::input_or_output_iterator` | ✔️ yes | ✔️ yes |
 | `std::input_iterator` | ✔️ yes | ✔️ yes |
 | `std::output_iterator` | ❌ no | ❌ no |
-| `std::forward_iterator` | ❌ no | ❌ no |
+| `std::forward_iterator` | ✔️ yes (see note below) | ✔️ yes (see note below) |
 | `std::bidirectional_iterator` | ❌ no | ❌ no |
 | `std::random_access_iterator` | ❌ no | ❌ no |
 | `std::contiguous_iterator` | ❌ no | ❌ no |
+
+> [!NOTE]  
+>The collections' iterators fulfil the `std::forward_iterator` except that the pointers obtained with `->` remain valid only as long as the iterator is valid instead of as long as the range remain valid. In practice this means a `ptr` obtained with `auto* ptr = it.operator->();` is valid only as long as `it` is valid. 
+>The values obtained immediately through `->` (for instance `auto& e = it->energy();`) behaves as expected for `std::forward_iterator` as their validity is tied to the validity of a collection.
 
 ### LegacyIterator
 
@@ -180,7 +184,7 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | `std::ranges::sized_range` | ✔️ yes |
 | `std::ranges::input_range` | ✔️ yes |
 | `std::ranges::output_range` | ❌ no |
-| `std::ranges::forward_range` | ❌ no |
+| `std::ranges::forward_range` | ✔️ yes |
 | `std::ranges::bidirectional_range` | ❌ no |
 | `std::ranges::random_access_range` | ❌ no |
 | `std::ranges::contiguous_range` | ❌ no |
@@ -207,16 +211,16 @@ std::sort(std::begin(collection), std::end(collection)); // requires RandomAcces
 
 The arguments of standard range algorithms are checked at compile time and must fulfil certain iterator concepts, such as `std::input_iterator` or `std::ranges::input_range`.
 
-The iterators of PODIO collections model the `std::input_iterator` concept, so range algorithms that require this iterator type will work correctly with PODIO iterators. If an algorithm compiles, it is guaranteed to work as expected.
+The iterators of PODIO collections model the `std::forward_iterator` concept, so range algorithms that require this iterator type will work correctly with PODIO iterators. If an algorithm compiles, it is guaranteed to work as expected.
 
 In particular, the PODIO collections' iterators do not fulfil the `std::output_iterator` concept, and as a result, mutating algorithms relying on this iterator type will not compile.
 
-Similarly the collections themselves model the `std::input_range` concept and can be used in the range algorithms that require that concept. The algorithms requiring unsupported range concept, such as `std::output_range`, won't compile.
+Similarly the collections themselves model the `std::forward_range` concept and can be used in the range algorithms that require that concept. The algorithms requiring unsupported range concept, such as `std::output_range`, won't compile.
 
 For example:
 ```c++
 std::ranges::find_if(collection, predicate ); // requires input_range -> OK
-std::ranges::adjacent_find(collection, predicate ); // requires forward_range -> won't compile
+std::ranges::adjacent_find(collection, predicate ); // requires forward_range -> OK
 std::ranges::fill(collection, value ); // requires output_range -> won't compile
 std::ranges::sort(collection); // requires random_access_range and sortable -> won't compile
 ```

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -93,8 +93,8 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | `std::random_access_iterator` | ✔️ yes | ✔️ yes |
 | `std::contiguous_iterator` | ❌ no | ❌ no |
 
-> [!NOTE]  
->The collections' iterators fulfil the `std::forward_iterator` except that the pointers obtained with `->` remain valid only as long as the iterator is valid instead of as long as the range remain valid. In practice this means a `ptr` obtained with `auto* ptr = it.operator->();` is valid only as long as `it` is valid. 
+> [!NOTE]
+>The collections' iterators fulfil the `std::forward_iterator` except that the pointers obtained with `->` remain valid only as long as the iterator is valid instead of as long as the range remain valid. In practice this means a `ptr` obtained with `auto* ptr = it.operator->();` is valid only as long as `it` is valid.
 >The values obtained immediately through `->` (for instance `auto& e = it->energy();`) behaves as expected for `std::forward_iterator` as their validity is tied to the validity of a collection.
 
 ### LegacyIterator

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -94,8 +94,9 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | `std::contiguous_iterator` | ❌ no | ❌ no |
 
 :::{note}
-The collections' iterators fulfil the `std::forward_iterator` except that the pointers obtained with `->` remain valid only as long as the iterator is valid instead of as long as the range remain valid. In practice this means a `ptr` obtained with `auto* ptr = it.operator->();` is valid only as long as `it` is valid.
-The values obtained immediately through `->` (for instance `auto& e = it->energy();`) behaves as expected for `std::forward_iterator` as their validity is tied to the validity of a collection.
+The collections' iterators fulfil the `std::forward_iterator` except that the pointers obtained with `->` remain valid only as long as the iterator itself is valid instead of as long as the range remains valid. In practice, this means a `ptr` obtained with `auto* ptr = it.operator->();` is valid only as long as `it` is valid.
+The values obtained immediately through `->` (for instance, `auto& e = it->energy();`) behave as expected for `std::forward_iterator`, as their validity is tied to the collection's validity.
+Despite the exception, the collection iterators are made to still report themselves as fulfilling the forward iterator requirements since the problematic usage (`auto* ptr = it.operator->();`) is rare in normal scenarios.
 :::
 
 ### LegacyIterator

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -89,7 +89,7 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | `std::input_iterator` | ✔️ yes | ✔️ yes |
 | `std::output_iterator` | ❌ no | ❌ no |
 | `std::forward_iterator` | ✔️ yes (see note below) | ✔️ yes (see note below) |
-| `std::bidirectional_iterator` | ❌ no | ❌ no |
+| `std::bidirectional_iterator` | ✔️ yes | ✔️ yes |
 | `std::random_access_iterator` | ❌ no | ❌ no |
 | `std::contiguous_iterator` | ❌ no | ❌ no |
 
@@ -166,7 +166,7 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 
 | Adaptor | Compatible with Collection? | Comment |
 |---------|-----------------------------|---------|
-| `std::reverse_iterator` | ❌ no | `iterator` and `const_iterator` not *LegacyBidirectionalIterator* or `std::bidirectional_iterator` |
+| `std::reverse_iterator` | ❗ attention | `operator->` not defined as `iterator`'s and `const_iterator`'s `operator->` are non-`const` |
 | `std::back_insert_iterator` | ❗ attention | Compatible only with SubsetCollections, otherwise throws `std::invalid_argument` |
 | `std::front_insert_iterator` | ❌ no | `push_front` not defined |
 | `std::insert_iterator` | ❌ no | `insert` not defined |
@@ -185,7 +185,7 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | `std::ranges::input_range` | ✔️ yes |
 | `std::ranges::output_range` | ❌ no |
 | `std::ranges::forward_range` | ✔️ yes |
-| `std::ranges::bidirectional_range` | ❌ no |
+| `std::ranges::bidirectional_range` | ✔️ yes |
 | `std::ranges::random_access_range` | ❌ no |
 | `std::ranges::contiguous_range` | ❌ no |
 | `std::ranges::common_range` | ✔️ yes |
@@ -211,16 +211,17 @@ std::sort(std::begin(collection), std::end(collection)); // requires RandomAcces
 
 The arguments of standard range algorithms are checked at compile time and must fulfil certain iterator concepts, such as `std::input_iterator` or `std::ranges::input_range`.
 
-The iterators of PODIO collections model the `std::forward_iterator` concept, so range algorithms that require this iterator type will work correctly with PODIO iterators. If an algorithm compiles, it is guaranteed to work as expected.
+The iterators of PODIO collections model the `std::bidirectional_iterator` concept, so range algorithms that require this iterator type will work correctly with PODIO iterators. If an algorithm compiles, it is guaranteed to work as expected.
 
 In particular, the PODIO collections' iterators do not fulfil the `std::output_iterator` concept, and as a result, mutating algorithms relying on this iterator type will not compile.
 
-Similarly the collections themselves model the `std::forward_range` concept and can be used in the range algorithms that require that concept. The algorithms requiring unsupported range concept, such as `std::output_range`, won't compile.
+Similarly the collections themselves model the `std::bidirectional_range` concept and can be used in the range algorithms that require that concept. The algorithms requiring unsupported range concept, such as `std::output_range`, won't compile.
 
 For example:
 ```c++
 std::ranges::find_if(collection, predicate ); // requires input_range -> OK
 std::ranges::adjacent_find(collection, predicate ); // requires forward_range -> OK
+std::ranges::views::reverse(collection); //requires bidirectional_range -> OK
 std::ranges::fill(collection, value ); // requires output_range -> won't compile
 std::ranges::sort(collection); // requires random_access_range and sortable -> won't compile
 ```

--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -90,7 +90,7 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | `std::output_iterator` | ❌ no | ❌ no |
 | `std::forward_iterator` | ✔️ yes (see note below) | ✔️ yes (see note below) |
 | `std::bidirectional_iterator` | ✔️ yes | ✔️ yes |
-| `std::random_access_iterator` | ❌ no | ❌ no |
+| `std::random_access_iterator` | ✔️ yes | ✔️ yes |
 | `std::contiguous_iterator` | ❌ no | ❌ no |
 
 > [!NOTE]  
@@ -186,7 +186,7 @@ In addition to the *LegacyForwardIterator* the C++ standard specifies also the *
 | `std::ranges::output_range` | ❌ no |
 | `std::ranges::forward_range` | ✔️ yes |
 | `std::ranges::bidirectional_range` | ✔️ yes |
-| `std::ranges::random_access_range` | ❌ no |
+| `std::ranges::random_access_range` | ✔️ yes |
 | `std::ranges::contiguous_range` | ❌ no |
 | `std::ranges::common_range` | ✔️ yes |
 | `std::ranges::viewable_range` | ✔️ yes |
@@ -211,11 +211,11 @@ std::sort(std::begin(collection), std::end(collection)); // requires RandomAcces
 
 The arguments of standard range algorithms are checked at compile time and must fulfil certain iterator concepts, such as `std::input_iterator` or `std::ranges::input_range`.
 
-The iterators of PODIO collections model the `std::bidirectional_iterator` concept, so range algorithms that require this iterator type will work correctly with PODIO iterators. If an algorithm compiles, it is guaranteed to work as expected.
+The iterators of PODIO collections model the `std::random_access_iterator` concept, so range algorithms that require this iterator type will work correctly with PODIO iterators. If an algorithm compiles, it is guaranteed to work as expected.
 
 In particular, the PODIO collections' iterators do not fulfil the `std::output_iterator` concept, and as a result, mutating algorithms relying on this iterator type will not compile.
 
-Similarly the collections themselves model the `std::bidirectional_range` concept and can be used in the range algorithms that require that concept. The algorithms requiring unsupported range concept, such as `std::output_range`, won't compile.
+Similarly the collections themselves model the `std::random_access_range` concept and can be used in the range algorithms that require that concept. The algorithms requiring unsupported range concept, such as `std::output_range`, won't compile.
 
 For example:
 ```c++

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -81,6 +81,8 @@ public:
   using iterator = typename std::vector<BasicType>::iterator;
   using difference_type = typename std::vector<BasicType>::difference_type;
   using size_type = typename std::vector<BasicType>::size_type;
+  using const_reverse_iterator = typename std::vector<BasicType>::const_reverse_iterator;
+  using reverse_iterator = typename std::vector<BasicType>::reverse_iterator;
 
   UserDataCollection() = default;
   /// Constructor from an existing vector (which will be moved from!)
@@ -221,6 +223,25 @@ public:
   }
   const_iterator cend() const {
     return _vec.cend();
+  }
+  // reverse iterators
+  reverse_iterator rbegin() {
+    return _vec.rbegin();
+  }
+  const_reverse_iterator rbegin() const {
+    return _vec.rbegin();
+  }
+  const_reverse_iterator crbegin() const {
+    return _vec.crbegin();
+  }
+  reverse_iterator rend() {
+    return _vec.rend();
+  }
+  const_reverse_iterator rend() const {
+    return _vec.rend();
+  }
+  const_reverse_iterator crend() const {
+    return _vec.crend();
   }
 
   typename std::vector<BasicType>::reference operator[](size_t idx) {

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -16,6 +16,8 @@
 #include "podio/utilities/MaybeSharedPtr.h"
 #include "podio/utilities/TypeHelpers.h"
 
+#include <iterator>
+
 #ifdef PODIO_JSON_OUTPUT
   #include "nlohmann/json.hpp"
 #endif
@@ -48,6 +50,8 @@ public:
   using iterator = LinkMutableCollectionIterator<FromT, ToT>;
   using difference_type = ptrdiff_t;
   using size_type = size_t;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
 
   LinkCollection() = default;
 
@@ -171,6 +175,25 @@ public:
   }
   iterator end() {
     return iterator(m_storage.entries.size(), &m_storage.entries);
+  }
+  // reverse iterators
+  reverse_iterator rbegin() {
+    return reverse_iterator(end());
+  }
+  const_reverse_iterator rbegin() const {
+    return const_reverse_iterator(end());
+  }
+  const_reverse_iterator crbegin() const {
+    return rbegin();
+  }
+  reverse_iterator rend() {
+    return reverse_iterator(begin());
+  }
+  const_reverse_iterator rend() const {
+    return const_reverse_iterator(begin());
+  }
+  const_reverse_iterator crend() const {
+    return rend();
   }
 
   bool isValid() const override {

--- a/include/podio/detail/LinkCollectionIterator.h
+++ b/include/podio/detail/LinkCollectionIterator.h
@@ -19,7 +19,7 @@ public:
   using iterator_category = std::input_iterator_tag;
   // `std::forward_iterator` is supported except that the pointers obtained with `operator->()`
   // remain valid as long as the iterator is valid, not as long as the range is valid.
-  using iterator_concept = std::forward_iterator_tag;
+  using iterator_concept = std::bidirectional_iterator_tag;
 
   LinkCollectionIteratorT(size_t index, const LinkObjPointerContainer<FromT, ToT>* coll) :
       m_index(index), m_object(podio::utils::MaybeSharedPtr<LinkObjT>{nullptr}), m_collection(coll) {
@@ -56,6 +56,17 @@ public:
   LinkCollectionIteratorT operator++(int) {
     auto copy = *this;
     ++m_index;
+    return copy;
+  }
+
+  LinkCollectionIteratorT& operator--() {
+    --m_index;
+    return *this;
+  }
+
+  LinkCollectionIteratorT operator--(int) {
+    auto copy = *this;
+    --m_index;
     return copy;
   }
 

--- a/include/podio/detail/LinkCollectionIterator.h
+++ b/include/podio/detail/LinkCollectionIterator.h
@@ -19,7 +19,7 @@ public:
   using iterator_category = std::input_iterator_tag;
   // `std::forward_iterator` is supported except that the pointers obtained with `operator->()`
   // remain valid as long as the iterator is valid, not as long as the range is valid.
-  using iterator_concept = std::bidirectional_iterator_tag;
+  using iterator_concept = std::random_access_iterator_tag;
 
   LinkCollectionIteratorT(size_t index, const LinkObjPointerContainer<FromT, ToT>* coll) :
       m_index(index), m_object(podio::utils::MaybeSharedPtr<LinkObjT>{nullptr}), m_collection(coll) {
@@ -31,8 +31,8 @@ public:
   LinkCollectionIteratorT& operator=(LinkCollectionIteratorT&&) = default;
   ~LinkCollectionIteratorT() = default;
 
-  bool operator!=(const LinkCollectionIteratorT& other) const {
-    return m_index != other.m_index;
+  auto operator<=>(const LinkCollectionIteratorT& other) const {
+    return m_index <=> other.m_index;
   }
 
   bool operator==(const LinkCollectionIteratorT& other) const {
@@ -68,6 +68,40 @@ public:
     auto copy = *this;
     --m_index;
     return copy;
+  }
+
+  LinkCollectionIteratorT& operator+=(difference_type n) {
+    m_index += n;
+    return *this;
+  }
+
+  LinkCollectionIteratorT operator+(difference_type n) const {
+    auto copy = *this;
+    copy += n;
+    return copy;
+  }
+
+  friend LinkCollectionIteratorT operator+(difference_type n, const LinkCollectionIteratorT& it) {
+    return it + n;
+  }
+
+  LinkCollectionIteratorT& operator-=(difference_type n) {
+    m_index -= n;
+    return *this;
+  }
+
+  LinkCollectionIteratorT operator-(difference_type n) const {
+    auto copy = *this;
+    copy -= n;
+    return copy;
+  }
+
+  LinkType operator[](difference_type n) const {
+    return LinkType{podio::utils::MaybeSharedPtr<LinkObjT>((*m_collection)[m_index + n])};
+  }
+
+  difference_type operator-(const LinkCollectionIteratorT& other) const {
+    return m_index - other.m_index;
   }
 
 private:

--- a/include/podio/detail/LinkCollectionIterator.h
+++ b/include/podio/detail/LinkCollectionIterator.h
@@ -17,7 +17,9 @@ public:
   using reference = LinkType;
   using pointer = LinkType*;
   using iterator_category = std::input_iterator_tag;
-  using iterator_concept = std::input_iterator_tag;
+  // `std::forward_iterator` is supported except that the pointers obtained with `operator->()`
+  // remain valid as long as the iterator is valid, not as long as the range is valid.
+  using iterator_concept = std::forward_iterator_tag;
 
   LinkCollectionIteratorT(size_t index, const LinkObjPointerContainer<FromT, ToT>* coll) :
       m_index(index), m_object(podio::utils::MaybeSharedPtr<LinkObjT>{nullptr}), m_collection(coll) {

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -50,6 +50,8 @@ public:
   using iterator = {{ class.bare_type }}MutableCollectionIterator;
   using difference_type = ptrdiff_t;
   using size_type = size_t;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
 
   {{ class.bare_type }}Collection();
   {{ class.bare_type }}Collection({{ class.bare_type }}CollectionData&& data, bool isSubsetColl);
@@ -167,6 +169,26 @@ public:
   const_iterator cend() const {
     return end();
   }
+  // reverse iterators
+  reverse_iterator rbegin() {
+    return reverse_iterator(end());
+  }
+  const_reverse_iterator rbegin() const {
+    return const_reverse_iterator(end());
+  }
+  const_reverse_iterator crbegin() const {
+    return rbegin();
+  }
+  reverse_iterator rend() {
+    return reverse_iterator(begin());
+  }
+  const_reverse_iterator rend() const {
+    return const_reverse_iterator(begin());
+  }
+  const_reverse_iterator crend() const {
+    return rend();
+  } 
+
 
 {% for member in Members %}
   std::vector<{{ member.full_type }}> {{ member.name }}(const size_t nElem = 0) const;

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -187,7 +187,7 @@ public:
   }
   const_reverse_iterator crend() const {
     return rend();
-  } 
+  }
 
 
 {% for member in Members %}

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -10,7 +10,7 @@ public:
   using iterator_category = std::input_iterator_tag;
   // `std::forward_iterator` is supported except that the pointers obtained with `operator->()`
   // remain valid as long as the iterator is valid, not as long as the range is valid.
-  using iterator_concept = std::forward_iterator_tag;
+  using iterator_concept = std::bidirectional_iterator_tag;
 
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
   {{ iterator_type }}() = default;
@@ -33,6 +33,8 @@ public:
   pointer operator->();
   {{ iterator_type }}& operator++();
   {{ iterator_type }} operator++(int);
+  {{ iterator_type }}& operator--();
+  {{ iterator_type }} operator--(int);
 
 private:
   size_t m_index{0};
@@ -63,6 +65,17 @@ private:
 {{ iterator_type }} {{ iterator_type }}::operator++(int) {
   auto copy = *this;
   ++m_index;
+  return copy;
+}
+
+{{ iterator_type }}& {{ iterator_type }}::operator--() {
+  --m_index;
+  return *this;
+}
+
+{{ iterator_type }} {{ iterator_type }}::operator--(int) {
+  auto copy = *this;
+  --m_index;
   return copy;
 }
 

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -8,7 +8,9 @@ public:
   using reference = {{ prefix }}{{ class.bare_type }};
   using pointer = {{ prefix }}{{ class.bare_type }}*;
   using iterator_category = std::input_iterator_tag;
-  using iterator_concept = std::input_iterator_tag;
+  // `std::forward_iterator` is supported except that the pointers obtained with `operator->()`
+  // remain valid as long as the iterator is valid, not as long as the range is valid.
+  using iterator_concept = std::forward_iterator_tag;
 
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
   {{ iterator_type }}() = default;

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -10,7 +10,7 @@ public:
   using iterator_category = std::input_iterator_tag;
   // `std::forward_iterator` is supported except that the pointers obtained with `operator->()`
   // remain valid as long as the iterator is valid, not as long as the range is valid.
-  using iterator_concept = std::bidirectional_iterator_tag;
+  using iterator_concept = std::random_access_iterator_tag;
 
   {{ iterator_type }}(size_t index, const {{ class.bare_type }}ObjPointerContainer* collection) : m_index(index), m_object({{ ptr_init }}), m_collection(collection) {}
   {{ iterator_type }}() = default;
@@ -21,8 +21,8 @@ public:
   {{ iterator_type }}& operator=({{iterator_type}}&&) = default;
   ~{{ iterator_type }}() = default;
 
-  bool operator!=(const {{ iterator_type}}& x) const {
-    return m_index != x.m_index;
+  auto operator<=>(const {{ iterator_type}}& other) const {
+    return m_index <=> other.m_index;
   }
 
   bool operator==(const {{ iterator_type }}& x) const {
@@ -35,6 +35,13 @@ public:
   {{ iterator_type }} operator++(int);
   {{ iterator_type }}& operator--();
   {{ iterator_type }} operator--(int);
+  {{ iterator_type }}& operator+=(difference_type n);
+  {{ iterator_type }} operator+(difference_type n) const;
+  friend {{ iterator_type }} operator+(difference_type n, const {{ iterator_type }}& it);
+  {{ iterator_type }}& operator-=(difference_type n);
+  {{ iterator_type }} operator-(difference_type n) const;
+  reference operator[](difference_type n) const;
+  difference_type operator-(const {{ iterator_type }}& other) const;
 
 private:
   size_t m_index{0};
@@ -77,6 +84,40 @@ private:
   auto copy = *this;
   --m_index;
   return copy;
+}
+
+{{ iterator_type }}& {{ iterator_type }}::operator+=(difference_type n) {
+  m_index += n;
+  return *this;
+}
+
+{{ iterator_type }} {{ iterator_type }}::operator+(difference_type n) const {
+  auto copy = *this;
+  copy += n;
+  return copy;
+}
+
+{{ iterator_type }} operator+({{ iterator_type }}::difference_type n, const {{ iterator_type }}& it) {
+    return it + n;
+}
+
+{{ iterator_type }}& {{ iterator_type }}::operator-=(difference_type n) {
+  m_index -= n;
+  return *this;
+}
+
+{{ iterator_type }} {{ iterator_type }}::operator-(difference_type n) const {
+  auto copy = *this;
+  copy -= n;
+  return copy;
+}
+
+{{ iterator_type }}::reference {{ iterator_type }}::operator[](difference_type n) const {
+  return reference{ {{ ptr_type }}((*m_collection)[m_index + n]) };
+}
+
+{{ iterator_type }}::difference_type {{ iterator_type }}::operator-(const {{ iterator_type }}& other) const {
+    return m_index - other.m_index;
 }
 
 {% endwith %}

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -477,6 +477,19 @@ TEST_CASE("Links with interfaces", "[links][interface-types]") {
   REQUIRE(rLink.get<ExampleCluster>() == cluster);
 }
 
+TEST_CASE("Links reverse iterators", "[links][iterator]") {
+  const auto [linkColl, hitColl, clusterColl] = createLinkCollections();
+  REQUIRE(linkColl.size() > 1);
+  auto it = --linkColl.rend();
+  REQUIRE(*it == *linkColl.begin());
+  it = linkColl.rbegin();
+  REQUIRE(*it == *--linkColl.end());
+  auto cit = --linkColl.rend();
+  REQUIRE(*cit == *linkColl.cbegin());
+  cit = linkColl.crbegin();
+  REQUIRE(*cit == *--linkColl.cend());
+}
+
 #ifdef PODIO_JSON_OUTPUT
 TEST_CASE("Link JSON conversion", "[links][json]") {
   const auto& [links, hits, clusters] = createLinkCollections();

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1462,11 +1462,56 @@ TEST_CASE("Collection and unsupported std ranges algorithms", "[collection][rang
 TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][ranges][std]") {
   using link_iterator = podio::LinkCollectionIteratorT<ExampleHit, ExampleHit, true>;
   using link_const_iterator = podio::LinkCollectionIteratorT<ExampleHit, ExampleHit, false>;
+  using link_collection = podio::LinkCollection<ExampleHit, ExampleHit>;
 
   STATIC_REQUIRE(std::input_iterator<link_iterator>);
   STATIC_REQUIRE(std::input_iterator<link_const_iterator>);
   STATIC_REQUIRE(std::forward_iterator<link_iterator>);
   STATIC_REQUIRE(std::forward_iterator<link_const_iterator>);
+  SECTION("bidirectional_iterator") {
+    STATIC_REQUIRE(std::bidirectional_iterator<link_iterator>);
+    {
+      auto coll = link_collection();
+      coll.create();
+      auto a = ++coll.begin();
+      REQUIRE(std::addressof(--a) == std::addressof(a));
+      a = ++coll.begin();
+      auto b = ++coll.begin();
+      REQUIRE(a == b);
+      REQUIRE(a-- == b);
+      a = ++coll.begin();
+      REQUIRE(a == b);
+      a--;
+      --b;
+      REQUIRE(a == b);
+      a = ++coll.begin();
+      b = ++coll.begin();
+      REQUIRE(a == b);
+      REQUIRE(--(++a) == b);
+      REQUIRE(++(--a) == b);
+    }
+    STATIC_REQUIRE(std::bidirectional_iterator<link_const_iterator>);
+    {
+      auto coll = link_collection();
+      coll.create();
+      auto a = ++coll.cbegin();
+      REQUIRE(std::addressof(--a) == std::addressof(a));
+      a = ++coll.cbegin();
+      auto b = ++coll.cbegin();
+      REQUIRE(a == b);
+      REQUIRE(a-- == b);
+      a = ++coll.cbegin();
+      REQUIRE(a == b);
+      a--;
+      --b;
+      REQUIRE(a == b);
+      a = ++coll.cbegin();
+      b = ++coll.cbegin();
+      REQUIRE(a == b);
+      REQUIRE(--(++a) == b);
+      REQUIRE(++(--a) == b);
+    }
+  }
 }
 
 TEST_CASE("LinkCollection and range concepts", "[links][iterator][std]") {
@@ -1474,6 +1519,7 @@ TEST_CASE("LinkCollection and range concepts", "[links][iterator][std]") {
 
   STATIC_REQUIRE(std::ranges::input_range<link_collection>);
   STATIC_REQUIRE(std::ranges::forward_range<link_collection>);
+  STATIC_REQUIRE(std::ranges::bidirectional_range<link_collection>);
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
   STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -745,10 +745,10 @@ TEST_CASE("Collection and unsupported iterator concepts", "[collection][containe
   DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::mutable_type>);
   // std::contiguous_iterator
   DOCUMENTED_STATIC_FAILURE(std::is_lvalue_reference_v<iterator::reference>);
-  DOCUMENTED_STATIC_FAILURE(std::same_as<iterator::value_type, std::remove_cvref_t<iterator::reference>>); 
+  DOCUMENTED_STATIC_FAILURE(std::same_as<iterator::value_type, std::remove_cvref_t<iterator::reference>>);
   DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>);
   DOCUMENTED_STATIC_FAILURE(std::is_lvalue_reference_v<const_iterator::reference>);
-  STATIC_REQUIRE(std::same_as<const_iterator::value_type, std::remove_cvref_t<const_iterator::reference>>); 
+  STATIC_REQUIRE(std::same_as<const_iterator::value_type, std::remove_cvref_t<const_iterator::reference>>);
   DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<const_iterator>);
 }
 

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1459,7 +1459,7 @@ TEST_CASE("Collection and unsupported std ranges algorithms", "[collection][rang
   DOCUMENTED_STATIC_FAILURE(is_range_fillable<CollectionType>);
 }
 
-TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][ranges][std]") {
+TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][iterators][std]") {
   using link_iterator = podio::LinkCollectionIteratorT<ExampleHit, ExampleHit, true>;
   using link_const_iterator = podio::LinkCollectionIteratorT<ExampleHit, ExampleHit, false>;
   using link_collection = podio::LinkCollection<ExampleHit, ExampleHit>;
@@ -1590,7 +1590,7 @@ TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][ranges][std]"
   }
 }
 
-TEST_CASE("LinkCollection and range concepts", "[links][iterator][std]") {
+TEST_CASE("LinkCollection and range concepts", "[links][ranges][std]") {
   using link_collection = podio::LinkCollection<ExampleHit, ExampleHit>;
 
   STATIC_REQUIRE(std::ranges::input_range<link_collection>);

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1512,6 +1512,82 @@ TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][ranges][std]"
       REQUIRE(++(--a) == b);
     }
   }
+  SECTION("random_access_iterator") {
+    STATIC_REQUIRE(std::random_access_iterator<link_iterator>);
+    {
+      auto coll = link_collection();
+      coll.create();
+      coll.create();
+      coll.create();
+      coll.create();
+      auto a = coll.begin();
+      auto n = 2;
+      auto b = a + n;
+      REQUIRE((a += n) == b);
+      a = coll.begin();
+      REQUIRE(std::addressof(a += n) == std::addressof(a));
+      a = coll.begin();
+      auto k = a + n;
+      REQUIRE(k == (a += n));
+      a = coll.begin();
+      REQUIRE((a + n) == (n + a));
+      auto x = 1;
+      auto y = 2;
+      REQUIRE((a + (x + y)) == ((a + x) + y));
+      REQUIRE((a + 0) == a);
+      b = a + n;
+      REQUIRE((--b) == (a + n - 1));
+      b = a + n;
+      REQUIRE((b += -n) == a);
+      b = a + n;
+      REQUIRE((b -= +n) == a);
+      b = a + n;
+      REQUIRE(std::addressof(b -= n) == std::addressof(b));
+      b = a + n;
+      k = b - n;
+      REQUIRE(k == (b -= n));
+      b = a + n;
+      REQUIRE(a[n] == *b);
+      REQUIRE(a <= b);
+    }
+    STATIC_REQUIRE(std::random_access_iterator<link_const_iterator>);
+    {
+      auto coll = link_collection();
+      coll.create();
+      coll.create();
+      coll.create();
+      coll.create();
+      auto a = coll.cbegin();
+      auto n = 2;
+      auto b = a + n;
+      REQUIRE((a += n) == b);
+      a = coll.cbegin();
+      REQUIRE(std::addressof(a += n) == std::addressof(a));
+      a = coll.cbegin();
+      auto k = a + n;
+      REQUIRE(k == (a += n));
+      a = coll.cbegin();
+      REQUIRE((a + n) == (n + a));
+      auto x = 1;
+      auto y = 2;
+      REQUIRE((a + (x + y)) == ((a + x) + y));
+      REQUIRE((a + 0) == a);
+      b = a + n;
+      REQUIRE((--b) == (a + n - 1));
+      b = a + n;
+      REQUIRE((b += -n) == a);
+      b = a + n;
+      REQUIRE((b -= +n) == a);
+      b = a + n;
+      REQUIRE(std::addressof(b -= n) == std::addressof(b));
+      b = a + n;
+      k = b - n;
+      REQUIRE(k == (b -= n));
+      b = a + n;
+      REQUIRE(a[n] == *b);
+      REQUIRE(a <= b);
+    }
+  }
 }
 
 TEST_CASE("LinkCollection and range concepts", "[links][iterator][std]") {
@@ -1520,6 +1596,7 @@ TEST_CASE("LinkCollection and range concepts", "[links][iterator][std]") {
   STATIC_REQUIRE(std::ranges::input_range<link_collection>);
   STATIC_REQUIRE(std::ranges::forward_range<link_collection>);
   STATIC_REQUIRE(std::ranges::bidirectional_range<link_collection>);
+  STATIC_REQUIRE(std::ranges::random_access_range<link_collection>);
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
   STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -744,7 +744,11 @@ TEST_CASE("Collection and unsupported iterator concepts", "[collection][containe
   DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type>);
   DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::mutable_type>);
   // std::contiguous_iterator
+  DOCUMENTED_STATIC_FAILURE(std::is_lvalue_reference_v<iterator::reference>);
+  DOCUMENTED_STATIC_FAILURE(std::same_as<iterator::value_type, std::remove_cvref_t<iterator::reference>>); 
   DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>);
+  DOCUMENTED_STATIC_FAILURE(std::is_lvalue_reference_v<const_iterator::reference>);
+  STATIC_REQUIRE(std::same_as<const_iterator::value_type, std::remove_cvref_t<const_iterator::reference>>); 
   DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<const_iterator>);
 }
 

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -507,10 +507,12 @@ TEST_CASE("Collection and iterator concepts", "[collection][container][iterator]
       coll.create();
       auto i = coll.begin();
       auto j = coll.begin();
+      // multi-pass guarantee
       REQUIRE(i == j);
       REQUIRE(++i == ++j);
       i = coll.begin();
-      REQUIRE(((void)[](auto x) { ++x; }(i), *i) == *i);
+      REQUIRE(*i == ((void)[](auto x) { ++x; }(i), *i)); // iterating copy doesn't cause side effects that affect the
+                                                         // original iterator
     }
     // const_iterator
     STATIC_REQUIRE(std::forward_iterator<const_iterator>);
@@ -520,10 +522,12 @@ TEST_CASE("Collection and iterator concepts", "[collection][container][iterator]
       coll.create();
       auto i = coll.cbegin();
       auto j = coll.cbegin();
+      // multi-pass guarantee
       REQUIRE(i == j);
       REQUIRE(++i == ++j);
       i = coll.cbegin();
-      REQUIRE(((void)[](auto x) { ++x; }(i), *i) == *i);
+      REQUIRE(*i == ((void)[](auto x) { ++x; }(i), *i)); // iterating copy doesn't cause side effects that affect the
+                                                         // original iterator
     }
   }
 

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1459,18 +1459,21 @@ TEST_CASE("Collection and unsupported std ranges algorithms", "[collection][rang
   DOCUMENTED_STATIC_FAILURE(is_range_fillable<CollectionType>);
 }
 
-TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][iterator][std]") {
+TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][ranges][std]") {
   using link_iterator = podio::LinkCollectionIteratorT<ExampleHit, ExampleHit, true>;
   using link_const_iterator = podio::LinkCollectionIteratorT<ExampleHit, ExampleHit, false>;
 
   STATIC_REQUIRE(std::input_iterator<link_iterator>);
   STATIC_REQUIRE(std::input_iterator<link_const_iterator>);
+  STATIC_REQUIRE(std::forward_iterator<link_iterator>);
+  STATIC_REQUIRE(std::forward_iterator<link_const_iterator>);
 }
 
 TEST_CASE("LinkCollection and range concepts", "[links][iterator][std]") {
   using link_collection = podio::LinkCollection<ExampleHit, ExampleHit>;
 
   STATIC_REQUIRE(std::ranges::input_range<link_collection>);
+  STATIC_REQUIRE(std::ranges::forward_range<link_collection>);
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
   STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -571,6 +571,165 @@ TEST_CASE("Collection and iterator concepts", "[collection][container][iterator]
     REQUIRE(--(++a) == b);
     REQUIRE(++(--a) == b);
   }
+
+  SECTION("random_access_iterator") {
+    // iterator
+    STATIC_REQUIRE(std::totally_ordered<iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create();
+      coll.create();
+      coll.create();
+      auto a = coll.begin();
+      auto b = coll.begin();
+      REQUIRE(!(a < b));
+      REQUIRE(!(a > b));
+      REQUIRE((a == b));
+      b = ++coll.begin();
+      REQUIRE((a < b));
+      REQUIRE(!(a > b));
+      REQUIRE(!(a == b));
+      a = ++coll.begin();
+      b = coll.begin();
+      REQUIRE(!(a < b));
+      REQUIRE(a > b);
+      REQUIRE(!(a == b));
+      auto c = coll.begin();
+      a = c++;
+      b = c++;
+      REQUIRE(a < b);
+      REQUIRE(b < c);
+      REQUIRE(a < c);
+      REQUIRE((a > b) == (b < a));
+      REQUIRE((a >= b) == !(a < b));
+      REQUIRE((a <= b) == !(a > b));
+    }
+    STATIC_REQUIRE(std::sized_sentinel_for<iterator, iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create();
+      auto i = coll.begin();
+      auto s = coll.end();
+      auto n = 1;
+      REQUIRE(s - i == n);
+      REQUIRE(i - s == -n);
+    }
+    STATIC_REQUIRE(std::random_access_iterator<iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create().cellID(42);
+      coll.create().cellID(43);
+      coll.create().cellID(44);
+      coll.create().cellID(45);
+      auto a = coll.begin();
+      auto n = 2;
+      auto b = a + n;
+      REQUIRE((a += n) == b);
+      a = coll.begin();
+      REQUIRE(std::addressof(a += n) == std::addressof(a));
+      a = coll.begin();
+      auto k = a + n;
+      REQUIRE(k == (a += n));
+      a = coll.begin();
+      REQUIRE((a + n) == (n + a));
+      auto x = 1;
+      auto y = 2;
+      REQUIRE((a + (x + y)) == ((a + x) + y));
+      REQUIRE((a + 0) == a);
+      b = a + n;
+      REQUIRE((--b) == (a + n - 1));
+      b = a + n;
+      REQUIRE((b += -n) == a);
+      b = a + n;
+      REQUIRE((b -= +n) == a);
+      b = a + n;
+      REQUIRE(std::addressof(b -= n) == std::addressof(b));
+      b = a + n;
+      k = b - n;
+      REQUIRE(k == (b -= n));
+      b = a + n;
+      REQUIRE(a[n] == *b);
+      REQUIRE(a <= b);
+    }
+    // const_iterator
+    STATIC_REQUIRE(std::totally_ordered<const_iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create();
+      coll.create();
+      coll.create();
+      auto a = coll.cbegin();
+      auto b = coll.cbegin();
+      REQUIRE(!(a < b));
+      REQUIRE(!(a > b));
+      REQUIRE((a == b));
+      b = ++coll.cbegin();
+      REQUIRE((a < b));
+      REQUIRE(!(a > b));
+      REQUIRE(!(a == b));
+      a = ++coll.cbegin();
+      b = coll.cbegin();
+      REQUIRE(!(a < b));
+      REQUIRE(a > b);
+      REQUIRE(!(a == b));
+      auto c = coll.cbegin();
+      a = c++;
+      b = c++;
+      REQUIRE(a < b);
+      REQUIRE(b < c);
+      REQUIRE(a < c);
+      REQUIRE((a > b) == (b < a));
+      REQUIRE((a >= b) == !(a < b));
+      REQUIRE((a <= b) == !(a > b));
+    }
+    STATIC_REQUIRE(std::sized_sentinel_for<const_iterator, const_iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create();
+      auto i = coll.cbegin();
+      auto s = coll.cend();
+      auto n = 1;
+      REQUIRE(s - i == n);
+      REQUIRE(i - s == -n);
+    }
+    STATIC_REQUIRE(std::random_access_iterator<const_iterator>);
+    {
+      auto coll = CollectionType();
+      coll.create().cellID(42);
+      coll.create().cellID(43);
+      coll.create().cellID(44);
+      coll.create().cellID(45);
+      auto a = coll.cbegin();
+      auto n = 2;
+      auto b = a + n;
+      REQUIRE((a += n) == b);
+      a = coll.cbegin();
+      REQUIRE(std::addressof(a += n) == std::addressof(a));
+      a = coll.cbegin();
+      auto k = a + n;
+      REQUIRE(k == (a += n));
+      a = coll.cbegin();
+      REQUIRE((a + n) == (n + a));
+      auto x = 1;
+      auto y = 2;
+      REQUIRE((a + (x + y)) == ((a + x) + y));
+      REQUIRE((a + 0) == a);
+      b = a + n;
+      REQUIRE((--b) == (a + n - 1));
+      b = a + n;
+      REQUIRE((b += -n) == a);
+      b = a + n;
+      REQUIRE((b -= +n) == a);
+      b = a + n;
+      REQUIRE(std::addressof(b -= n) == std::addressof(b));
+      b = a + n;
+      k = b - n;
+      REQUIRE(k == (b -= n));
+      b = a + n;
+      REQUIRE(a[n] == *b);
+      REQUIRE(a <= b);
+    }
+  }
 }
 
 TEST_CASE("Collection and unsupported iterator concepts", "[collection][container][iterator][std]") {
@@ -584,9 +743,6 @@ TEST_CASE("Collection and unsupported iterator concepts", "[collection][containe
   DOCUMENTED_STATIC_FAILURE(std::output_iterator<iterator, CollectionType::mutable_type>);
   DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::value_type>);
   DOCUMENTED_STATIC_FAILURE(std::output_iterator<const_iterator, CollectionType::mutable_type>);
-  // std::random_access_iterator
-  DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<iterator>);
-  DOCUMENTED_STATIC_FAILURE(std::random_access_iterator<const_iterator>);
   // std::contiguous_iterator
   DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<iterator>);
   DOCUMENTED_STATIC_FAILURE(std::contiguous_iterator<const_iterator>);
@@ -1207,7 +1363,7 @@ TEST_CASE("Collection as range", "[collection][ranges][std]") {
   // std::range::bidirectional_range
   STATIC_REQUIRE(std::ranges::bidirectional_range<CollectionType>);
   // std::range::random_access_range
-  DOCUMENTED_STATIC_FAILURE(std::ranges::random_access_range<CollectionType>);
+  STATIC_REQUIRE(std::ranges::random_access_range<CollectionType>);
   // std::range::contiguous_range
   DOCUMENTED_STATIC_FAILURE(std::ranges::contiguous_range<CollectionType>);
   // std::range::common_range

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -226,6 +226,25 @@ TEST_CASE("Reverse iterators", "[basics]") {
   REQUIRE((*--cit).energy() == 43);
 }
 
+TEST_CASE("UserDataCollection reverse iterators", "[basics]") {
+  auto coll = podio::UserDataCollection<int>();
+  coll.push_back(42);
+  coll.push_back(43);
+  auto it = std::rbegin(coll);
+  REQUIRE(*it == 43);
+  REQUIRE(*++it == 42);
+  REQUIRE(*--it == 43);
+  it = std::rend(coll);
+  REQUIRE(*--it == 42);
+  REQUIRE(*--it == 43);
+  auto cit = std::crbegin(coll);
+  REQUIRE(*cit == 43);
+  REQUIRE(*++cit == 42);
+  cit = std::crend(coll);
+  REQUIRE(*--cit == 42);
+  REQUIRE(*--cit == 43);
+}
+
 TEST_CASE("Notebook", "[basics]") {
   auto hits = ExampleHitCollection();
   for (unsigned i = 0; i < 12; ++i) {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -206,6 +206,26 @@ TEST_CASE("Looping", "[basics]") {
   }
 }
 
+TEST_CASE("Reverse iterators", "[basics]") {
+  auto coll = ExampleHitCollection();
+  coll.create();
+  coll.create();
+  auto it = std::rbegin(coll);
+  (*it).energy(43);
+  (*++it).energy(42);
+  REQUIRE((*it).energy() == 42);
+  REQUIRE((*--it).energy() == 43);
+  it = std::rend(coll);
+  REQUIRE((*--it).energy() == 42);
+  REQUIRE((*--it).energy() == 43);
+  auto cit = std::crbegin(coll);
+  REQUIRE((*cit).energy() == 43);
+  REQUIRE((*++cit).energy() == 42);
+  cit = std::crend(coll);
+  REQUIRE((*--cit).energy() == 42);
+  REQUIRE((*--cit).energy() == 43);
+}
+
 TEST_CASE("Notebook", "[basics]") {
   auto hits = ExampleHitCollection();
   for (unsigned i = 0; i < 12; ++i) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Collection iterators fulfill `forward_iterator`, `bidirectional_iterator` and `random_access_iterator`concepts. The collections can be used with more categories of range algorithms - up to `random_access_range`, for example `std::adjacent_find`, `std::lower_bound`, `std::fold_right`, and more views like `std::ranges::views::reverse`. 
- `LinkCollection` and its iterators fulfill concepts up to `random_access_range` and `random_access_iterator`.
- Add reverse iterator methods to Collections, `LinkCollection` and `UserDataCollection`.
- **CollectionIterators of generated datamodels now define `operator<=>` instead of `operator!=`. This will require at least c++20 to compile, but should not affect existing behavior.**

ENDRELEASENOTES


**TL;DR** Iterators gain support up to `std::random_access_iterator` except that technically they don't meet a requirement for pointers obtained with `auto* ptr = it.operator->();` pattern to outlive the iterator

---- 

Here is a proposal how to make collection iterators fulfill `std::forward_iterator` which also opens the way for `std::bidirectional_iterator` and `std::random_access_iterator` by making a single **exception**

The collection iterators fulfill all the `forward_iterator` requirements **except** one semantic requirement:
>  Pointers and references obtained from a forward iterator into a range remain valid while the range exists. 

The problem here is the `operator->` that returns a pointer to data type object that is a member of the iterator (collections store data layer objects and data type are created on-the-fly so there is no data type object with lifetime livinf inside collection to which pointer we could return). Due to this the validity of obtained pointer is as long as the iterator is valid - to fulfill the requirement it should be as long the collection is valid.

In reality it's quite hard to abuse as things obtained through `->` (`iterator->energy()`) are safe since they go through the data layer that lives in the collection. The problem seems to be only getting the pointer directly with pattern like this:

```cpp
auto* ptr = iterator.operator->();
```

which is rather rare in normal usage. A pattern like this `auto particle = *(iterator.operator->());` again is okay since the pointer is used immediately 

Of course the final question is whether it's used somewhere in an implementation of the std algorithms. On top of that it should be used in a certain way like creating a temporary copy of iterator, taking pointer, disposing of the copy, using iterator

In the past there were some precedence event in the standard library that iterators were assigned some category **except** something (that was for *Legacy* iterators):
- [std::regex_iterator](https://en.cppreference.com/w/cpp/regex/regex_iterator)
  >std::regex_iterator is a read-only iterator that accesses the individual matches of a regular expression within the underlying character sequence. It meets the requirements of a [LegacyForwardIterator](https://en.cppreference.com/w/cpp/named_req/ForwardIterator), except that for dereferenceable values a and b with a == b, *a and *b will not be bound to the same object.
- [std::filesystem::path::iterator](https://en.cppreference.com/w/cpp/filesystem/path)
  >a constant [LegacyInputIterator](https://en.cppreference.com/w/cpp/named_req/InputIterator) with a value_type of path that meets all requirements of [LegacyBidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator) except that for two equal dereferenceable iterators a and b of type const_iterator, there is no requirement that *a and *b refer to the same object.
 It is unspecified whether const_iterator is actually a [LegacyBidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator)
