### PR TITLE
Refactor the read tests partially

### DIFF
--- a/tests/read_frame.h
+++ b/tests/read_frame.h
@@ -18,11 +18,6 @@
 
 #include <iostream>
 
-#define ASSERT(condition, msg)                                                                                         \
-  if (!(condition)) {                                                                                                  \
-    throw std::runtime_error(msg);                                                                                     \
-  }
-
 void processExtensions(const podio::Frame& event, int iEvent, podio::version::Version) {
   const auto& extColl = event.get<extension::ContainedTypeCollection>("extension_Contained");
   ASSERT(extColl.isValid(), "extension_Contained collection should be present")

--- a/tests/read_test.h
+++ b/tests/read_test.h
@@ -12,7 +12,6 @@
 #include "datamodel/ExampleWithNamespace.h"
 #include "datamodel/ExampleWithOneRelationCollection.h"
 #include "datamodel/ExampleWithVectorMemberCollection.h"
-#include "datamodel/MutableExampleHit.h"
 #include "datamodel/TestInterfaceLinkCollection.h"
 #include "datamodel/TestLinkCollection.h"
 #include "datamodel/TypeWithEnergy.h"

--- a/tests/write_frame.h
+++ b/tests/write_frame.h
@@ -78,7 +78,7 @@ auto createMCCollection() {
     for (auto p : mc.daughters()) {
       int dIndex = p.getObjectID().index;
       auto d = mcps[dIndex];
-      d.addparents(p);
+      d.addparents(mc);
     }
   }
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Start to refactor the read tests partially to break up the large `processEvent` function into smaller more manageable chunks.
- Fix a small logic bug in the creation of the test files

ENDRELEASENOTES

This is pulled out of #504 and probably part of a larger effort of cleaning up the I/O test code further. For now I have just done the ones that are necessary for #504 