### PR TITLE
make `LinkCollectionIterator` fulfil `std::input_iterator` concept

### DIFF
--- a/include/podio/detail/LinkCollectionIterator.h
+++ b/include/podio/detail/LinkCollectionIterator.h
@@ -3,6 +3,7 @@
 
 #include "podio/detail/LinkFwd.h"
 #include "podio/utilities/MaybeSharedPtr.h"
+#include <iterator>
 
 namespace podio {
 template <typename FromT, typename ToT, bool Mutable>
@@ -11,20 +12,33 @@ class LinkCollectionIteratorT {
   using LinkObjT = LinkObj<FromT, ToT>;
 
 public:
+  using value_type = LinkType;
+  using difference_type = ptrdiff_t;
+  using reference = LinkType;
+  using pointer = LinkType*;
+  using iterator_category = std::input_iterator_tag;
+  using iterator_concept = std::input_iterator_tag;
+
   LinkCollectionIteratorT(size_t index, const LinkObjPointerContainer<FromT, ToT>* coll) :
       m_index(index), m_object(podio::utils::MaybeSharedPtr<LinkObjT>{nullptr}), m_collection(coll) {
   }
-
-  LinkCollectionIteratorT(const LinkCollectionIteratorT&) = delete;
-  LinkCollectionIteratorT& operator=(const LinkCollectionIteratorT&) = delete;
+  LinkCollectionIteratorT() = default;
+  LinkCollectionIteratorT(const LinkCollectionIteratorT&) = default;
+  LinkCollectionIteratorT& operator=(const LinkCollectionIteratorT&) = default;
+  LinkCollectionIteratorT(LinkCollectionIteratorT&&) = default;
+  LinkCollectionIteratorT& operator=(LinkCollectionIteratorT&&) = default;
+  ~LinkCollectionIteratorT() = default;
 
   bool operator!=(const LinkCollectionIteratorT& other) const {
-    return m_index != other.m_index; // TODO: may not be complete
+    return m_index != other.m_index;
   }
 
-  LinkType operator*() {
-    m_object.m_obj = podio::utils::MaybeSharedPtr<LinkObjT>((*m_collection)[m_index]);
-    return m_object;
+  bool operator==(const LinkCollectionIteratorT& other) const {
+    return m_index == other.m_index;
+  }
+
+  LinkType operator*() const {
+    return LinkType{podio::utils::MaybeSharedPtr<LinkObjT>((*m_collection)[m_index])};
   }
 
   LinkType* operator->() {
@@ -37,10 +51,16 @@ public:
     return *this;
   }
 
+  LinkCollectionIteratorT operator++(int) {
+    auto copy = *this;
+    ++m_index;
+    return copy;
+  }
+
 private:
-  size_t m_index;
-  LinkType m_object;
-  const LinkObjPointerContainer<FromT, ToT>* m_collection;
+  size_t m_index{0};
+  LinkType m_object{podio::utils::MaybeSharedPtr<LinkObjT>{nullptr}};
+  const LinkObjPointerContainer<FromT, ToT>* m_collection{nullptr};
 };
 } // namespace podio
 

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1,6 +1,7 @@
 #include "datamodel/ExampleHit.h"
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/MutableExampleHit.h"
+#include "podio/LinkCollection.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -1182,6 +1183,23 @@ TEST_CASE("Collection and unsupported std ranges algorithms", "[collection][rang
   DOCUMENTED_STATIC_FAILURE(is_range_adjacent_findable<CollectionType>);
   DOCUMENTED_STATIC_FAILURE(is_range_sortable<CollectionType>);
   DOCUMENTED_STATIC_FAILURE(is_range_fillable<CollectionType>);
+}
+
+TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][iterator][std]") {
+  using link_iterator = podio::LinkCollectionIteratorT<ExampleHit, ExampleHit, true>;
+  using link_const_iterator = podio::LinkCollectionIteratorT<ExampleHit, ExampleHit, false>;
+
+  STATIC_REQUIRE(std::input_iterator<link_iterator>);
+  STATIC_REQUIRE(std::input_iterator<link_const_iterator>);
+}
+
+TEST_CASE("LinkCollection and range concepts", "[links][iterator][std]") {
+  using link_collection = podio::LinkCollection<ExampleHit, ExampleHit>;
+
+  STATIC_REQUIRE(std::ranges::input_range<link_collection>);
+  STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
+  STATIC_REQUIRE(std::ranges::common_range<link_collection>);
+  STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);
 }
 
 #undef DOCUMENTED_STATIC_FAILURE


### PR DESCRIPTION
BEGINRELEASENOTES
- Updated `LinkCollectionIterator` to fulifl the same iterator concept and iterator category as other collection iterators. `LinkCollection` fulfills the same range concepts as other collections. Algorithms like `std::ranges::find` or `std::count` are supported.

ENDRELEASENOTES

This is an update for `LinkCollectionIterator` to behave like component collection iterator -> be *LegacyInputIterator* and fulfil `std::input_iterator` which make it compatible with a broad range of standard algorithms.

For `LinkCollection` I don't add a documentation page with all the requirements. The test are also simpler and the tests for not supported requirements are skipped