### PR TITLE
Remove iterator-testing code redundant in C++20

### DIFF
--- a/doc/collections_as_container.md
+++ b/doc/collections_as_container.md
@@ -101,7 +101,6 @@ In the following tables a convention from `Collection` is used: `iterator` stand
 | [*CopyAssignable*](https://en.cppreference.com/w/cpp/named_req/CopyAssignable) | ✔️ yes / ✔️ yes | |
 | [*Destructible*](https://en.cppreference.com/w/cpp/named_req/Destructible) | ✔️ yes / ✔️ yes | |
 | [*Swappable*](https://en.cppreference.com/w/cpp/named_req/Swappable) | ✔️ yes / ✔️ yes | |
-| `std::iterator_traits::value_type` (Until C++20 ) | ✔️ yes / ✔️ yes | |
 | `std::iterator_traits::difference_type` | ✔️ yes / ✔️ yes | |
 | `std::iterator_traits::reference` | ✔️ yes / ✔️ yes | |
 | `std::iterator_traits::pointer` | ✔️ yes / ✔️ yes | |

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -561,11 +561,6 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
         // const_iterator
         STATIC_REQUIRE(std::is_swappable_v<const_iterator&>);
 
-        // std::iterator_traits<It>::value_type (required prior to C++20)
-        // iterator
-        STATIC_REQUIRE(traits::has_value_type_v<std::iterator_traits<iterator>>);
-        // const_iterator
-        STATIC_REQUIRE(traits::has_value_type_v<std::iterator_traits<const_iterator>>);
         // std::iterator_traits<It>::difference_type
         // iterator
         STATIC_REQUIRE(traits::has_difference_type_v<std::iterator_traits<iterator>>);

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1030,9 +1030,7 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
     STATIC_REQUIRE(traits::has_iterator_v<CollectionType>);
     STATIC_REQUIRE(traits::has_iterator_category_v<std::iterator_traits<const_iterator>>);
     STATIC_REQUIRE(std::is_base_of_v<std::input_iterator_tag, std::iterator_traits<const_iterator>::iterator_category>);
-#if (__cplusplus >= 202002L)
     STATIC_REQUIRE(std::input_iterator<const_iterator>);
-#endif
     STATIC_REQUIRE(std::is_same_v<const_iterator::reference, std::move_iterator<const_iterator>::reference>);
   }
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Removed redundant check for C++20
- Removed iterator test that is no longer required in C++

ENDRELEASENOTES

Some leftovers from #698
The tests`std::iterator_traits<It>::value_type` were originally surrounded by `#if (__cplusplus < 202002L)` and could be removed

