### PR TITLE
[ci] Switch to LCG_106b for sanitizer workflows

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: cvmfs-contrib/github-action-cvmfs@v4
       - uses: aidasoft/run-lcg-view@v4
         with:
-          release-platform: LCG_105/x86_64-el9-${{ matrix.compiler }}-opt
+          release-platform: LCG_106b/x86_64-el9-${{ matrix.compiler }}-opt
           run: |
             echo "::group::Run CMake"
             mkdir build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,9 @@ jobs:
         LCG: ["dev3/x86_64-el9-clang16-opt",
               "dev4/x86_64-el9-clang16-opt",
               "dev4/x86_64-el9-gcc13-opt",
-              "LCG_105/x86_64-el9-clang16-opt",
-              "LCG_105/x86_64-el9-gcc13-opt"]
+              "LCG_106b/x86_64-el9-clang16-opt",
+              "LCG_106b/x86_64-el9-gcc13-opt",
+              "LCG_104/x86_64-el9-gcc13-opt"]
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
@@ -31,7 +32,7 @@ jobs:
           cd build
           cmake -DENABLE_SIO=ON \
             -DENABLE_JULIA=ON \
-            -DENABLE_RNTUPLE=ON \
+            -DENABLE_RNTUPLE=$([[ ${{ matrix.LCG }} == LCG_104/* ]] && echo "OFF" || echo "ON") \
             -DENABLE_DATASOURCE=ON \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=20 \


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to a `LCG_106b` for the sanitizer workflows in CI to pick up a newer version of ROOT.
- Swtich to `LCG_106b` for tests with RNTuple
- Add an `LCG_104` (root v6.28.04) based workflow for ensuring compatibility with the minimal version of ROOT

ENDRELEASENOTES