### PR TITLE
Make sure to set valid and collectionID for all links

### DIFF
--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -210,6 +210,10 @@ public:
 
   void setID(unsigned id) override {
     m_collectionID = id;
+    if (!m_isSubsetColl) {
+      std::ranges::for_each(m_storage.entries, [id](auto* obj) { obj->id = {obj->id.index, id}; });
+    }
+    m_isValid = true;
   }
 
   unsigned getID() const override {

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -318,6 +318,15 @@ TEST_CASE("LinkCollection subset collection", "[links][subset-colls]") {
 TEST_CASE("LinkCollection basics", "[links]") {
   REQUIRE(podio::detail::linkCollTypeName<ExampleCluster, ExampleHit>() ==
           "podio::LinkCollection<ExampleCluster,ExampleHit>");
+
+  auto links = TestLColl{};
+  auto link = links.create();
+  REQUIRE(link.id().collectionID == 0);
+
+  links.setID(42);
+  for (auto l : links) {
+    REQUIRE(l.id().collectionID == 42);
+  }
 }
 
 auto createLinkCollections(const size_t nElements = 3u) {


### PR DESCRIPTION
Feature parity with other collections



BEGINRELEASENOTES
- Make sure that `isValid` works the same for `LinkCollection` as it does for other collections
- Make sure to set the `collectionID` for all links in a collection

ENDRELEASENOTES