### PR TITLE
fix setting link with interface without specific link direction

### DIFF
--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -272,7 +272,7 @@ public:
                          !detail::isInterfaceInitializableFrom<FromT, T>) {
       setTo(std::move(value));
     } else {
-      static_assert(false, "Argument type is ambiguous, can't determine link direction");
+      static_assert(detail::always_false<T>, "Argument type is ambiguous, can't determine link direction");
     }
   }
 

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -5,6 +5,7 @@
 #include "podio/detail/LinkObj.h"
 #include "podio/utilities/MaybeSharedPtr.h"
 #include "podio/utilities/TypeHelpers.h"
+#include <type_traits>
 
 #ifdef PODIO_JSON_OUTPUT
   #include "nlohmann/json.hpp"
@@ -262,8 +263,16 @@ public:
   void set(T value) {
     if constexpr (std::is_same_v<T, FromT>) {
       setFrom(std::move(value));
-    } else {
+    } else if constexpr (std::is_same_v<T, ToT>) {
       setTo(std::move(value));
+    } else if constexpr (detail::isInterfaceInitializableFrom<FromT, T> &&
+                         !detail::isInterfaceInitializableFrom<ToT, T>) {
+      setFrom(std::move(value));
+    } else if constexpr (detail::isInterfaceInitializableFrom<ToT, T> &&
+                         !detail::isInterfaceInitializableFrom<FromT, T>) {
+      setTo(std::move(value));
+    } else {
+      static_assert(false, "Argument type is ambiguous, can't determine link direction");
     }
   }
 

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -40,6 +40,11 @@ namespace det {
 
 namespace detail {
 
+  // A helper variable template that is always false, used for static_asserts
+  // and other compile-time checks that should always fail.
+  template <typename T>
+  inline constexpr bool always_false = false;
+
   /// Helper struct to determine whether a given type T is in a tuple of types
   /// that act as a type list in this case
   template <typename T, typename>

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -460,6 +460,21 @@ TEST_CASE("Links with interfaces", "[links][interface-types]") {
   link.set(hit);
   REQUIRE(link.get<TypeWithEnergy>() == hit);
   REQUIRE(link.get<ExampleCluster>() == cluster);
+
+  // Check determining `set` direction for a link going in a reverse direction
+  using ReverseInterfaceLinkCollection =
+      podio::LinkCollection<TestInterfaceLinkCollection::to_type, TestInterfaceLinkCollection::from_type>;
+  auto rColl = ReverseInterfaceLinkCollection{};
+  auto rLink = rColl.create();
+
+  rLink.set(cluster);
+  rLink.set(iface);
+  REQUIRE(rLink.get<TypeWithEnergy>() == iface);
+  REQUIRE(rLink.get<ExampleCluster>() == cluster);
+
+  rLink.set(hit);
+  REQUIRE(rLink.get<TypeWithEnergy>() == hit);
+  REQUIRE(rLink.get<ExampleCluster>() == cluster);
 }
 
 #ifdef PODIO_JSON_OUTPUT


### PR DESCRIPTION
BEGINRELEASENOTES
- fix setting link with interface without specifying link direction

ENDRELEASENOTES

Changing `set` to be symmetric with respect to `ToT` and `FromT` as well as detecting possible ambiguity when linking two different interfaces

closes #735 