### PR TITLE
use `always_false` to fail static assertions in `constexpr if`

### DIFF
--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -3,6 +3,7 @@
 
 #include "podio/CollectionIDTable.h"
 #include "podio/utilities/RootHelpers.h"
+#include "podio/utilities/TypeHelpers.h"
 
 #include "TBranch.h"
 #include "TTree.h"
@@ -58,7 +59,7 @@ consteval auto getGPKeyName() {
   } else if constexpr (std::is_same<T, std::string>::value) {
     return stringKeyName;
   } else {
-    static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
+    static_assert(podio::detail::always_false<T>, "Unsupported type for generic parameters");
   }
 }
 
@@ -76,7 +77,7 @@ consteval auto getGPValueName() {
   } else if constexpr (std::is_same<T, std::string>::value) {
     return stringValueName;
   } else {
-    static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
+    static_assert(podio::detail::always_false<T>, "Unsupported type for generic parameters");
   }
 }
 
@@ -105,7 +106,7 @@ consteval auto getGPBranchOffsets() {
   } else if constexpr (std::is_same_v<T, std::string>) {
     return GPBranchOffsets{7, 8};
   } else {
-    static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
+    static_assert(podio::detail::always_false<T>, "Unsupported type for generic parameters");
   }
 }
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Replace  `sizeof(T) == 0` with `always_false` to fail static assertions in `constexpr if`

ENDRELEASENOTES

This is turbo pedantic but using `else static_assert(sizeof(T) == 0,` to avoid immediate evaluation of discarded branch in if constexpr (the reason why `static_assert(false,` doesn't work in some compiler) isn't guaranteed to work as `sizeof` is strictly positive and compiler is allowed to take advantage of it. A templated variable can be used instead as this time a proper instantiation by compiler is required ([#736](https://github.com/AIDASoft/podio/pull/736#discussion_r1957837515)) 

In c++23 `else static_assert(false,` is ok and no other tricks are needed

I couldn't find any other usages of `static_assert(sizeof(T) == 0,` 
