### PR TITLE
add `std::hash` for datatype objects, interfaces and links

### DIFF
--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -5,13 +5,14 @@
 #include "podio/detail/LinkObj.h"
 #include "podio/utilities/MaybeSharedPtr.h"
 #include "podio/utilities/TypeHelpers.h"
-#include <type_traits>
 
 #ifdef PODIO_JSON_OUTPUT
   #include "nlohmann/json.hpp"
 #endif
 
+#include <functional>
 #include <ostream>
+#include <type_traits>
 #include <utility> // std::swap
 
 namespace podio {
@@ -33,6 +34,7 @@ class LinkT {
   friend LinkCollection<FromT, ToT>;
   friend LinkCollectionIteratorT<FromT, ToT, Mutable>;
   friend LinkT<FromT, ToT, !Mutable>;
+  friend std::hash<LinkT>;
 
   /// Helper member variable to check whether FromU and ToU can be used for this
   /// Link. We need this to make SFINAE trigger in some cases below
@@ -366,5 +368,12 @@ void to_json(nlohmann::json& j, const podio::LinkT<FromT, ToT, false>& link) {
 #endif
 
 } // namespace podio
+
+template <typename FromT, typename ToT, bool Mutable>
+struct std::hash<podio::LinkT<FromT, ToT, Mutable>> {
+  std::size_t operator()(const podio::LinkT<FromT, ToT, Mutable>& obj) const {
+    return std::hash<typename podio::LinkT<FromT, ToT, Mutable>::LinkObjT>{}(obj.get());
+  }
+};
 
 #endif // PODIO_DETAIL_LINK_H

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -372,7 +372,7 @@ void to_json(nlohmann::json& j, const podio::LinkT<FromT, ToT, false>& link) {
 template <typename FromT, typename ToT, bool Mutable>
 struct std::hash<podio::LinkT<FromT, ToT, Mutable>> {
   std::size_t operator()(const podio::LinkT<FromT, ToT, Mutable>& obj) const {
-    return std::hash<typename podio::LinkT<FromT, ToT, Mutable>::LinkObjT>{}(obj.get());
+    return std::hash<typename podio::LinkT<FromT, ToT, Mutable>::LinkObjT*>{}(obj.m_obj.get());
   }
 };
 

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -61,6 +61,7 @@ private:
     virtual const std::type_info& typeInfo() const = 0;
     virtual bool equal(const Concept* rhs) const = 0;
     virtual podio::detail::OrderKey objOrderKey() const = 0;
+    virtual size_t objHash() const = 0;
   };
 
   template<typename ValueT>
@@ -92,6 +93,8 @@ private:
     podio::detail::OrderKey objOrderKey() const final {
       return podio::detail::getOrderKey(m_value);
     }
+
+    size_t objHash() const final {return std::hash<ValueT>{}(m_value); }
 
 {{ macros.member_getters_model(Members, use_get_syntax) }}
 
@@ -180,8 +183,17 @@ public:
     value.m_self->print(os);
     return os;
   }
+
+  friend std::hash<{{ class.bare_type }}>;
 };
 
 {{ utils.namespace_close(class.namespace) }}
+
+template<>
+struct std::hash<{{ class.full_type }}> {
+  std::size_t operator()(const {{ class.full_type }}& obj) const {
+    return obj.m_self->objHash();
+  }
+};
 
 #endif

--- a/python/templates/MutableObject.h.jinja2
+++ b/python/templates/MutableObject.h.jinja2
@@ -60,4 +60,6 @@ private:
 
 {{ utils.namespace_close(class.namespace) }}
 
+{{ macros.std_hash(class, prefix='Mutable') }}
+
 #endif

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -76,4 +76,6 @@ std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}& value);
 
 {{ utils.namespace_close(class.namespace) }}
 
+{{ macros.std_hash(class) }}
+
 #endif

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -103,6 +103,8 @@
 
   const podio::ObjectID getObjectID() const;
 
+  friend std::hash<{{ full_type }}>;
+
   friend void swap({{ full_type }}& a, {{ full_type }}& b) {
     using std::swap;
     swap(a.m_obj, b.m_obj); // swap out the internal pointers
@@ -143,4 +145,15 @@
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 void to_json(nlohmann::json& j, const {{ prefix }}{{ type }}& value);
 #endif
+{% endmacro %}
+
+{% macro std_hash(class, prefix='') %}
+{% set namespace = class.namespace + '::' if class.namespace else '' %}
+
+template<>
+struct std::hash<{{ namespace }}{{ prefix }}{{ class.bare_type }}> {
+  std::size_t operator()(const {{ namespace }}{{ prefix }}{{ class.bare_type }}& obj) const {
+    return std::hash<{{ namespace }}{{ class.bare_type }}Obj*>{}(obj.m_obj.get());
+  }
+};
 {% endmacro %}

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -66,6 +66,10 @@ TEST_CASE("InterfaceTypes hash", "[interface-types][hash]") {
   auto wrapper1 = TypeWithEnergy(hit);
   auto hash1 = std::hash<TypeWithEnergy>{}(wrapper1);
 
+  // podio specific:
+  // interface and interfaced datatype objects have the same hash
+  REQUIRE(hash1 == std::hash<ExampleHit>{}(hit));
+
   // rehashing should give the same result
   auto rehash = std::hash<TypeWithEnergy>{}(wrapper1);
   REQUIRE(rehash == hash1);

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -15,6 +15,7 @@
 
 #include <map>
 #include <stdexcept>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -60,7 +61,7 @@ TEST_CASE("InterfaceTypes static checks", "[interface-types][static-checks]") {
   STATIC_REQUIRE(TypeWithEnergy::typeName == "TypeWithEnergy"sv);
 }
 
-TEST_CASE("InterfaceTypes STL usage", "[interface-types][basics]") {
+TEST_CASE("InterfaceTypes STL usage", "[interface-types][basics][hash]") {
   // Make sure that interface types can be used with STL map and set
   std::map<TypeWithEnergy, int> counterMap{};
 
@@ -87,6 +88,15 @@ TEST_CASE("InterfaceTypes STL usage", "[interface-types][basics]") {
   REQUIRE_FALSE(interfaces2.at(0).isAvailable());
   REQUIRE(interfaces2.at(1).isA<ExampleHit>());
   REQUIRE(interfaces2.at(2).energy() == 3.14f);
+
+  // unordered associative containers
+  std::unordered_map<TypeWithEnergy, int> counterUnorderedMap{};
+  counterUnorderedMap[empty]++;
+  counterUnorderedMap[wrapper]++;
+  counterUnorderedMap[hit]++;
+  REQUIRE(counterUnorderedMap[empty] == 1);
+  REQUIRE(counterUnorderedMap[hit] == 2);
+  REQUIRE(counterUnorderedMap[wrapper] == 2);
 }
 
 TEST_CASE("InterfaceType from immutable", "[interface-types][basics]") {

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -61,6 +61,29 @@ TEST_CASE("InterfaceTypes static checks", "[interface-types][static-checks]") {
   STATIC_REQUIRE(TypeWithEnergy::typeName == "TypeWithEnergy"sv);
 }
 
+TEST_CASE("InterfaceTypes hash", "[interface-types][hash]") {
+  auto hit = ExampleHit();
+  auto wrapper1 = TypeWithEnergy(hit);
+  auto hash1 = std::hash<TypeWithEnergy>{}(wrapper1);
+
+  // rehashing should give the same result
+  auto rehash = std::hash<TypeWithEnergy>{}(wrapper1);
+  REQUIRE(rehash == hash1);
+
+  // same object should have the same hash
+  auto wrapper2 = wrapper1;
+  auto hash2 = std::hash<TypeWithEnergy>{}(wrapper2);
+  REQUIRE(wrapper2 == wrapper1);
+  REQUIRE(hash2 == hash1);
+
+  // different objects should have different hashes
+  auto different_hit = ExampleHit();
+  auto different_wrapper = TypeWithEnergy(different_hit);
+  auto hash_different = std::hash<TypeWithEnergy>{}(different_wrapper);
+  REQUIRE(different_wrapper != wrapper1);
+  REQUIRE(hash_different != hash1);
+}
+
 TEST_CASE("InterfaceTypes STL usage", "[interface-types][basics][hash]") {
   // Make sure that interface types can be used with STL map and set
   std::map<TypeWithEnergy, int> counterMap{};

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -13,7 +13,11 @@
   #include "nlohmann/json.hpp"
 #endif
 
+#include <map>
+#include <set>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 
 // Test datatypes (spelling them out here explicitly to make sure that
 // assumptions about typedefs actually hold)
@@ -154,6 +158,64 @@ TEST_CASE("Link basics", "[links]") {
   }
 }
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+TEST_CASE("Links associative containers", "[links][hash]") {
+  ExampleHit hit1, hit2;
+  ExampleCluster cluster1, cluster2;
+  TestMutL link1, link2, link3, link4;
+  link1.set(hit1);
+  link1.set(cluster1);
+  link1.setWeight(1.0);
+  link2.set(hit2);
+  link2.set(cluster2);
+  link2.setWeight(2.0);
+  link3.set(hit1);
+  link3.set(cluster2);
+  link3.setWeight(3.0);
+  link4.set(hit1);
+  link4.set(cluster1);
+  link4.setWeight(4.0);
+
+  std::set<TestL> linkSet;
+  linkSet.insert(link1);
+  linkSet.insert(link2);
+  linkSet.insert(link2);
+  linkSet.insert(link3);
+  linkSet.insert(link4);
+  linkSet.insert(link4);
+  REQUIRE(linkSet.size() == 4);
+
+  std::map<TestL, int> linkMap;
+  linkMap[link1]++;
+  linkMap[link2]++;
+  linkMap[link2]++;
+  linkMap[link3]++;
+  linkMap[link4]++;
+  REQUIRE(linkMap[link1] == 1);
+  REQUIRE(linkMap[link2] == 2);
+  REQUIRE(linkMap[link3] == 1);
+  REQUIRE(linkMap[link4] == 1);
+
+  // unordered associative containers
+  std::set<TestL> linkUnorderedSet;
+  linkUnorderedSet.insert(link1);
+  linkUnorderedSet.insert(link2);
+  linkUnorderedSet.insert(link2);
+  linkUnorderedSet.insert(link3);
+  linkUnorderedSet.insert(link4);
+  linkUnorderedSet.insert(link4);
+  REQUIRE(linkUnorderedSet.size() == 4);
+
+  std::map<TestL, int> linkUnorderedMap;
+  linkUnorderedMap[link1]++;
+  linkUnorderedMap[link2]++;
+  linkUnorderedMap[link2]++;
+  linkUnorderedMap[link3]++;
+  linkUnorderedMap[link4]++;
+  REQUIRE(linkUnorderedMap[link1] == 1);
+  REQUIRE(linkUnorderedMap[link2] == 2);
+  REQUIRE(linkUnorderedMap[link3] == 1);
+  REQUIRE(linkUnorderedMap[link4] == 1);
+}
 
 TEST_CASE("Links templated accessors", "[links]") {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): There are quite a few

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -157,6 +157,7 @@ TEST_CASE("Link basics", "[links]") {
     REQUIRE(link != newLink);
   }
 }
+
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 TEST_CASE("Links associative containers", "[links][hash]") {
   ExampleHit hit1, hit2;
@@ -174,47 +175,51 @@ TEST_CASE("Links associative containers", "[links][hash]") {
   link4.set(hit1);
   link4.set(cluster1);
   link4.setWeight(4.0);
+  auto link5 = link2;
 
   std::set<TestL> linkSet;
   linkSet.insert(link1);
   linkSet.insert(link2);
-  linkSet.insert(link2);
   linkSet.insert(link3);
   linkSet.insert(link4);
   linkSet.insert(link4);
+  linkSet.insert(link5);
   REQUIRE(linkSet.size() == 4);
 
   std::map<TestL, int> linkMap;
   linkMap[link1]++;
   linkMap[link2]++;
-  linkMap[link2]++;
   linkMap[link3]++;
   linkMap[link4]++;
+  linkMap[link5]++;
   REQUIRE(linkMap[link1] == 1);
   REQUIRE(linkMap[link2] == 2);
   REQUIRE(linkMap[link3] == 1);
   REQUIRE(linkMap[link4] == 1);
+  REQUIRE(linkMap[link5] == 2);
 
   // unordered associative containers
   std::set<TestL> linkUnorderedSet;
   linkUnorderedSet.insert(link1);
   linkUnorderedSet.insert(link2);
-  linkUnorderedSet.insert(link2);
   linkUnorderedSet.insert(link3);
   linkUnorderedSet.insert(link4);
   linkUnorderedSet.insert(link4);
+  linkUnorderedSet.insert(link5);
   REQUIRE(linkUnorderedSet.size() == 4);
 
   std::map<TestL, int> linkUnorderedMap;
   linkUnorderedMap[link1]++;
   linkUnorderedMap[link2]++;
-  linkUnorderedMap[link2]++;
   linkUnorderedMap[link3]++;
   linkUnorderedMap[link4]++;
+  linkUnorderedMap[link5]++;
+
   REQUIRE(linkUnorderedMap[link1] == 1);
   REQUIRE(linkUnorderedMap[link2] == 2);
   REQUIRE(linkUnorderedMap[link3] == 1);
   REQUIRE(linkUnorderedMap[link4] == 1);
+  REQUIRE(linkUnorderedMap[link5] == 2);
 }
 
 TEST_CASE("Links templated accessors", "[links]") {

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -158,6 +158,46 @@ TEST_CASE("Link basics", "[links]") {
   }
 }
 
+TEST_CASE("Links hash", "[links][hash]") {
+  auto hit1 = ExampleHit();
+  auto cluster1 = ExampleCluster();
+  auto link1 = TestMutL();
+  link1.set(hit1);
+  link1.set(cluster1);
+  auto hash1 = std::hash<TestMutL>{}(link1);
+  // rehashing should give the same result
+  auto rehash = std::hash<TestMutL>{}(link1);
+  REQUIRE(rehash == hash1);
+
+  // same object should have the same hash
+  auto link2 = link1;
+  auto hash2 = std::hash<TestMutL>{}(link2);
+  REQUIRE(link2 == link1);
+  REQUIRE(hash2 == hash1);
+
+  // different objects should have different hashes
+  auto different_link = TestMutL();
+  auto hash_different = std::hash<TestMutL>{}(different_link);
+  REQUIRE(different_link != link1);
+  REQUIRE(hash_different != hash1);
+
+  // podio specific:
+  // changing  properties doesn't change hash as long as the same object is used
+  auto another_hit = ExampleHit();
+  link1.setWeight(3.14);
+  link1.set(another_hit);
+  auto hash_mod = std::hash<TestMutL>{}(link1);
+  REQUIRE(link1 == link2);
+  REQUIRE(hash_mod == hash2);
+
+  // podio specific:
+  // mutable and immutable objects should have the same hash
+  auto immutable_link = TestL(link1);
+  auto hash_immutable = std::hash<TestL>{}(immutable_link);
+  REQUIRE(immutable_link == link1);
+  REQUIRE(hash_immutable == hash1);
+}
+
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 TEST_CASE("Links associative containers", "[links][hash]") {
   ExampleHit hit1, hit2;

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -549,6 +549,7 @@ TEST_CASE("AssociativeContainer", "[basics][hash]") {
   cUnorderedSet.insert(clu5);
 
   REQUIRE(cUnorderedSet.size() == 5);
+
   std::unordered_map<ExampleCluster, int> cUnorderedMap;
   cUnorderedMap[clu1] = 1;
   cUnorderedMap[clu2] = 2;

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -2,10 +2,13 @@
 #include <cstdint>
 #include <filesystem>
 #include <map>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <thread>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "catch2/catch_test_macros.hpp"
@@ -461,7 +464,7 @@ TEST_CASE("ExtraCode declarationFile in component", "[basics][code-gen]") {
   REQUIRE(value.reset() == 0);
 }
 
-TEST_CASE("AssociativeContainer", "[basics]") {
+TEST_CASE("AssociativeContainer", "[basics][hash]") {
   auto clu1 = MutableExampleCluster();
   auto clu2 = MutableExampleCluster();
   auto clu3 = MutableExampleCluster();
@@ -494,6 +497,34 @@ TEST_CASE("AssociativeContainer", "[basics]") {
   cMap[clu3] = 42;
 
   REQUIRE(cMap[clu3] == 42);
+
+  // unordered associative containers
+
+  std::unordered_set<ExampleCluster> cUnorderedSet;
+  cUnorderedSet.insert(clu1);
+  cUnorderedSet.insert(clu2);
+  cUnorderedSet.insert(clu3);
+  cUnorderedSet.insert(clu4);
+  cUnorderedSet.insert(clu5);
+  cUnorderedSet.insert(clu1);
+  cUnorderedSet.insert(clu2);
+  cUnorderedSet.insert(clu3);
+  cUnorderedSet.insert(clu4);
+  cUnorderedSet.insert(clu5);
+
+  REQUIRE(cUnorderedSet.size() == 5);
+  std::unordered_map<ExampleCluster, int> cUnorderedMap;
+  cUnorderedMap[clu1] = 1;
+  cUnorderedMap[clu2] = 2;
+  cUnorderedMap[clu3] = 3;
+  cUnorderedMap[clu4] = 4;
+  cUnorderedMap[clu5] = 5;
+
+  REQUIRE(cUnorderedMap[clu3] == 3);
+
+  cUnorderedMap[clu3] = 42;
+
+  REQUIRE(cUnorderedMap[clu3] == 42);
 }
 
 TEST_CASE("Equality", "[basics]") {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1,6 +1,7 @@
 // STL
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <map>
 #include <set>
 #include <sstream>
@@ -462,6 +463,41 @@ TEST_CASE("ExtraCode declarationFile in component", "[basics][code-gen]") {
   value.x = 1;
   REQUIRE(value.negate() == -1);
   REQUIRE(value.reset() == 0);
+}
+
+TEST_CASE("Datatype object hash", "[hash]") {
+  auto hit1 = MutableExampleHit();
+  auto hash1 = std::hash<MutableExampleHit>{}(hit1);
+
+  // rehashing should give the same result
+  auto rehash = std::hash<MutableExampleHit>{}(hit1);
+  REQUIRE(rehash == hash1);
+
+  // same object should have the same hash
+  auto hit2 = hit1;
+  auto hash2 = std::hash<MutableExampleHit>{}(hit2);
+  REQUIRE(hit2 == hit1);
+  REQUIRE(hash2 == hash1);
+
+  // different objects should have different hashes
+  auto different_hit = MutableExampleHit();
+  auto hash_different = std::hash<MutableExampleHit>{}(different_hit);
+  REQUIRE(different_hit != hit1);
+  REQUIRE(hash_different != hash1);
+
+  // podio specific:
+  // changing  properties doesn't change hash as long as the same object is used
+  hit1.energy(42);
+  auto hash_mod = std::hash<MutableExampleHit>{}(hit1);
+  REQUIRE(hit1 == hit2);
+  REQUIRE(hash_mod == hash2);
+
+  // podio specific:
+  // mutable and immutable objects should have the same hash
+  auto immutable_hit = ExampleHit(hit1);
+  auto hash_immutable = std::hash<ExampleHit>{}(immutable_hit);
+  REQUIRE(immutable_hit == hit1);
+  REQUIRE(hash_immutable == hash1);
 }
 
 TEST_CASE("AssociativeContainer", "[basics][hash]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `std::hash` for podio datatype objects, interfaces and links. Datatypes, interfaces and links can be used in unordered associative containers such as `std::unordered_set` or `std::unordered_map`

ENDRELEASENOTES

As suggested in https://github.com/AIDASoft/podio/pull/733#issuecomment-2665089308 adding specializations of `std::hash` for datatypes, interfaces and links. In all the cases the hash boils down to hashing internal object pointer - the hashes are the same if the underlying object is the same  not if the properties are the same (similarly to what is done with `operator<` and `operator==`). 