### PR TITLE
Use `sizeof(T) == 0` instead of always_false

### DIFF
--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -272,7 +272,7 @@ public:
                          !detail::isInterfaceInitializableFrom<FromT, T>) {
       setTo(std::move(value));
     } else {
-      static_assert(sizeof(T) && false, "Argument type is ambiguous, can't determine link direction");
+      static_assert(sizeof(T) == 0, "Argument type is ambiguous, can't determine link direction");
     }
   }
 

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -272,7 +272,7 @@ public:
                          !detail::isInterfaceInitializableFrom<FromT, T>) {
       setTo(std::move(value));
     } else {
-      static_assert(detail::always_false<T>, "Argument type is ambiguous, can't determine link direction");
+      static_assert(sizeof(T) && false, "Argument type is ambiguous, can't determine link direction");
     }
   }
 

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -40,11 +40,6 @@ namespace det {
 
 namespace detail {
 
-  // A helper variable template that is always false, used for static_asserts
-  // and other compile-time checks that should always fail.
-  template <typename T>
-  inline constexpr bool always_false = false;
-
   /// Helper struct to determine whether a given type T is in a tuple of types
   /// that act as a type list in this case
   template <typename T, typename>

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -3,7 +3,6 @@
 
 #include "podio/CollectionIDTable.h"
 #include "podio/utilities/RootHelpers.h"
-#include "podio/utilities/TypeHelpers.h"
 
 #include "TBranch.h"
 #include "TTree.h"

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -106,7 +106,7 @@ consteval auto getGPBranchOffsets() {
   } else if constexpr (std::is_same_v<T, std::string>) {
     return GPBranchOffsets{7, 8};
   } else {
-    static_assert(podio::detail::always_false<T>, "Unsupported type for generic parameters");
+    static_assert(sizeof(T) && false, "Unsupported type for generic parameters");
   }
 }
 

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -59,7 +59,7 @@ consteval auto getGPKeyName() {
   } else if constexpr (std::is_same<T, std::string>::value) {
     return stringKeyName;
   } else {
-    static_assert(podio::detail::always_false<T>, "Unsupported type for generic parameters");
+    static_assert(sizeof(T) && false, "Unsupported type for generic parameters");
   }
 }
 
@@ -77,7 +77,7 @@ consteval auto getGPValueName() {
   } else if constexpr (std::is_same<T, std::string>::value) {
     return stringValueName;
   } else {
-    static_assert(podio::detail::always_false<T>, "Unsupported type for generic parameters");
+    static_assert(sizeof(T) && false, "Unsupported type for generic parameters");
   }
 }
 

--- a/src/rootUtils.h
+++ b/src/rootUtils.h
@@ -58,7 +58,7 @@ consteval auto getGPKeyName() {
   } else if constexpr (std::is_same<T, std::string>::value) {
     return stringKeyName;
   } else {
-    static_assert(sizeof(T) && false, "Unsupported type for generic parameters");
+    static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
   }
 }
 
@@ -76,7 +76,7 @@ consteval auto getGPValueName() {
   } else if constexpr (std::is_same<T, std::string>::value) {
     return stringValueName;
   } else {
-    static_assert(sizeof(T) && false, "Unsupported type for generic parameters");
+    static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
   }
 }
 
@@ -105,7 +105,7 @@ consteval auto getGPBranchOffsets() {
   } else if constexpr (std::is_same_v<T, std::string>) {
     return GPBranchOffsets{7, 8};
   } else {
-    static_assert(sizeof(T) && false, "Unsupported type for generic parameters");
+    static_assert(sizeof(T) == 0, "Unsupported type for generic parameters");
   }
 }
 


### PR DESCRIPTION
Introduced in https://github.com/AIDASoft/podio/pull/737 (also see https://github.com/AIDASoft/podio/pull/736#discussion_r1957837515) I think it is not necessary to add that and the included header can be removed.

> This is turbo pedantic but

Sorry :(

BEGINRELEASENOTES
- Use `sizeof(T) == 0` instead of `always_false`

ENDRELEASENOTES