### PR TITLE
Remove warning about C++17 that is now obsolete

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,6 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "20|23")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
-if(CMAKE_CXX_STANDARD EQUAL 17)
-  message(WARNING "C++17 is deprecated and support for it will be removed in v01-03. Please use at least C++20.")
-endif()
-
 # Prevent CMake falls back to the latest standard the compiler does support
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove warning about C++17 that is now obsolete

ENDRELEASENOTES