### PR TITLE
fix roundtrip test failing without SIO

### DIFF
--- a/tests/scripts/dumpModelRoundTrip.sh
+++ b/tests/scripts/dumpModelRoundTrip.sh
@@ -34,11 +34,11 @@ ${PODIO_BASE}/python/podio_class_generator.py \
 # Compare to the originally generated code, that has been used to write the data
 # file. Need to diff subfolders explicitly here because $PODIO_BASE/tests contains
 # more stuff
-DIFF_EXTRA_ARGS=""
+DIFF_EXTRA_ARGS=()
 if [ ${ENABLE_SIO} = "OFF" ]; then
-    DIFF_EXTRA_ARGS="${DIFF_EXTRA_ARGS} --exclude='*SIO*'"
+    DIFF_EXTRA_ARGS+=(--exclude "*SIO*")
 fi
 
-diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${COMP_BASE_FOLDER}/${EDM_NAME} ${DIFF_EXTRA_ARGS}
-diff -ru ${OUTPUT_FOLDER}/src ${COMP_BASE_FOLDER}/src ${DIFF_EXTRA_ARGS}
+diff -ru ${OUTPUT_FOLDER}/${EDM_NAME} ${COMP_BASE_FOLDER}/${EDM_NAME} "${DIFF_EXTRA_ARGS[@]}"
+diff -ru ${OUTPUT_FOLDER}/src ${COMP_BASE_FOLDER}/src "${DIFF_EXTRA_ARGS[@]}"
 diff -u ${OUTPUT_FOLDER}/podio_generated_files.cmake ${COMP_BASE_FOLDER}/podio_generated_files.cmake


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed argument resolution in the roundtrip test to prevent failures when SIO is not present.

ENDRELEASENOTES

The argument passed to `diff` were incorrectly expanded to `'--exclude='\''*SIO*'\'''` instead of `--exclude="*SIO*"`, so the patterns were not excluded and roundtrip tests were failing.
Since escaping in strings is hard, I propose to keep the arguments as an array