### PR TITLE
Don't rely on ROOT JIT to define python build_version

### DIFF
--- a/python/podio/version.py
+++ b/python/podio/version.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Module that facilitates working with the podio::version::Version"""
 
-from podio import __version__
+from podio import __version__  # pylint: disable=wrong-import-order
 
 import ROOT
 

--- a/python/podio/version.py
+++ b/python/podio/version.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Module that facilitates working with the podio::version::Version"""
 
+from podio import __version__
+
 import ROOT
 
 # NOTE: It is necessary that this can be found on the ROOT_INCLUDE_PATH
@@ -37,5 +39,7 @@ def parse(*args):
     return ver
 
 
-# The version with which podio has been built. Same as __version__
-build_version = podio.version.build_version
+# The version with which podio has been built.
+# Same as defined in C++ as static constexpr podio::version::build_version
+# See: https://github.com/key4hep/key4hep-spack/issues/670
+build_version = __version__

--- a/python/podio/version.py
+++ b/python/podio/version.py
@@ -42,4 +42,4 @@ def parse(*args):
 # The version with which podio has been built.
 # Same as defined in C++ as static constexpr podio::version::build_version
 # See: https://github.com/key4hep/key4hep-spack/issues/670
-build_version = __version__
+build_version = parse(__version__)


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the (potential) import error for `podio.version.build_version` by not relying on ROOTs JIT, but rather parsing the python `__version__` into the correct type.

ENDRELEASENOTES

Fixes https://github.com/key4hep/key4hep-spack/issues/670