### PR TITLE
Support Unity builds by adding a header guard and changing a few function names

### DIFF
--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -203,10 +203,10 @@ namespace {
 
 // The usual trick with an IIFE and a static variable inside a function and then
 // making sure to call that function during shared library loading
-bool registerCollection() {
+bool register{{ class.bare_type }}Collection() {
   const static auto reg = []() {
     auto& factory = podio::CollectionBufferFactory::mutInstance();
-    factory.registerCreationFunc("{{ class.full_type }}Collection", {{ package_name }}::meta::schemaVersion, createBuffers);
+    factory.registerCreationFunc("{{ class.full_type }}Collection", {{ package_name }}::meta::schemaVersion, create{{ class.bare_type }}Buffers);
 
     // Make the SchemaEvolution aware of the current version by
     // registering a no-op function for this and all preceding versions
@@ -243,7 +243,7 @@ bool registerCollection() {
   return reg;
 }
 
-const auto registeredCollection = registerCollection();
+const auto registered{{ class.bare_type }}Collection = register{{ class.bare_type }}Collection();
 } // namespace
 
 

--- a/python/templates/DatamodelDefinition.h.jinja2
+++ b/python/templates/DatamodelDefinition.h.jinja2
@@ -1,5 +1,8 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT
 
+#ifndef {{ package_name }}DATAMODEL_DEFINITION_H
+#define {{ package_name }}DATAMODEL_DEFINITION_H
+
 #include "podio/DatamodelRegistry.h"
 #include "podio/SchemaEvolution.h"
 
@@ -72,3 +75,5 @@ namespace static_registration {
 }
 
 } // namespace {{ package_name }}::meta
+
+#endif

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -153,7 +153,7 @@ void {{ class.bare_type }}Collection::print(std::ostream& os, bool flush) const 
 {% macro create_buffers(class, package_name, collection_type, OneToManyRelations, OneToOneRelations, VectorMembers, schemaVersion) %}
 
 {% if schemaVersion == -1 %}
-podio::CollectionReadBuffers createBuffers(bool isSubset) {
+podio::CollectionReadBuffers create{{ class.bare_type }}Buffers(bool isSubset) {
 {% else %}
 podio::CollectionReadBuffers createBuffersV{{ schemaVersion }}(bool isSubset) {
 {% endif %}


### PR DESCRIPTION
See [Unity builds](https://en.wikipedia.org/wiki/Unity_build). To enable unity builds just add `-DCMAKE_UNITY_BUILD=ON` to the cmake command.

Some timings on my machine, only one run, building without optimizations and with Ninja:

<html><head></head><body>

Task | Normal | Unity
-- | -- | --
Build EDM4hep (with add_subdirectory) | 22.4 s | 8 s
Build podio+EDM4hep (with add_subdirectory) | 47.5 s | 20.3 s
Touch Frame.h and rebuild (podio+EDM4hep) | 10.8 s | 12.4 s
Touch ROOTReader.cc and rebuild (podio+EDM4hep) | 1.6 s | 3.9 s
Touch read_events.h and rebuild (EDM4hep) | 1.4 s | 1.4 s

</body></html>

Not great for development but interesting for builds from scratch at little cost, one include guard and different names for some functions, which may be better for debugging and setting breakpoints.


BEGINRELEASENOTES
- Support Unity builds Add missing include guards and make sure some functions such as `createBuffer` have a different name for each collection.

ENDRELEASENOTES