### PR TITLE
Fix handling of forced python version.

### DIFF
--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -25,7 +25,7 @@ set(PODIO_IO_HANDLERS "@PODIO_IO_HANDLERS@")
 
 include(CMakeFindDependencyMacro)
 find_dependency(ROOT @ROOT_VERSION@)
-if(@REQUIRE_PYTHON_VERSION@)
+if(NOT "@REQUIRE_PYTHON_VERSION@" STREQUAL "")
   find_dependency(Python @REQUIRE_PYTHON_VERSION@ COMPONENTS Interpreter)
 else()
   find_dependency(Python COMPONENTS Interpreter)


### PR DESCRIPTION
We run into problems if we configure with a python version different from that found by the default find_dependency call for Python.

We generate a cmake fragment with the lines

```
if(@REQUIRE_PYTHON_VERSION@)
  find_dependency(Python @REQUIRE_PYTHON_VERSION@ COMPONENTS Interpreter)
else()
  find_dependency(Python COMPONENTS Interpreter)
endif()
```

The if condition expands to something like

```
if(3.12.9)
```

cmake tries to interpret the argument here as a floating-point number, but fails to convert it, and (silently!) treats the condition as false. Need to do this test explictly as a string comparison instead.



BEGINRELEASENOTES
- Fix a build issue when the python version used is different than the one found by default by cmake.
ENDRELEASENOTES