### PR TITLE
Add typeName member to link collections

### DIFF
--- a/include/podio/LinkCollection.h
+++ b/include/podio/LinkCollection.h
@@ -12,7 +12,7 @@
 /// buffer creation functionality with the CollectionBufferFactory.
 #define PODIO_DECLARE_LINK(FromT, ToT)                                                                                 \
   const static auto PODIO_PP_CONCAT(REGISTERED_LINK_, __COUNTER__) =                                                   \
-      podio::detail::registerLinkCollection<FromT, ToT>(podio::detail::linkCollTypeName<FromT, ToT>());
+      podio::detail::registerLinkCollection<FromT, ToT>(podio::LinkCollection<FromT, ToT>::typeName);
 
 #if PODIO_ENABLE_SIO && __has_include("podio/detail/LinkSIOBlock.h")
   #include <podio/detail/LinkSIOBlock.h>

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -4,7 +4,9 @@
 #include "podio/detail/LinkFwd.h"
 #include "podio/detail/LinkObj.h"
 #include "podio/utilities/MaybeSharedPtr.h"
+#include "podio/utilities/StaticConcatenate.h"
 #include "podio/utilities/TypeHelpers.h"
+#include <string_view>
 
 #ifdef PODIO_JSON_OUTPUT
   #include "nlohmann/json.hpp"
@@ -58,6 +60,9 @@ public:
   using value_type = podio::Link<FromT, ToT>;
   using collection_type = podio::LinkCollection<FromT, ToT>;
 
+  static constexpr std::string_view typeName =
+      utils::static_concatenate_v<detail::link_name_prefix, FromT::typeName, detail::link_name_infix, ToT::typeName,
+                                  detail::link_name_suffix>;
   /// Constructor
   LinkT() : m_obj(new LinkObjT{}, podio::utils::MarkOwned) {
   }

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -412,27 +412,7 @@ void to_json(nlohmann::json& j, const podio::LinkCollection<FromT, ToT>& collect
   }
 }
 #endif
-namespace detail {
-  /// Get the collection type name for a LinkCollection
-  ///
-  /// @tparam FromT the From type of the link
-  /// @tparam ToT the To type of the link
-  /// @returns a type string that is a valid c++ template instantiation
-  template <typename FromT, typename ToT>
-  [[deprecated("Use LinkCollection<FromT, ToT>::typeName instead")]] inline const std::string_view linkCollTypeName() {
-    return LinkCollection<FromT, ToT>::typeName;
-  }
 
-  /// Get the value type name for a LinkCollection
-  ///
-  /// @tparam FromT the From type of the link
-  /// @tparam ToT the To type of the link
-  /// @returns a type string that is a valid c++ template instantiation
-  template <typename FromT, typename ToT>
-  [[deprecated("Use LinkCollection<FromT, ToT>::valueTypeName instead")]] inline const std::string_view linkTypeName() {
-    return LinkCollection<FromT, ToT>::valueTypeName;
-  }
-} // namespace detail
 } // namespace podio
 
 #endif // PODIO_DETAIL_LINKCOLLECTIONIMPL_H

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -15,9 +15,11 @@
 #include "podio/ICollectionProvider.h"
 #include "podio/SchemaEvolution.h"
 #include "podio/utilities/MaybeSharedPtr.h"
+#include "podio/utilities/StaticConcatenate.h"
 #include "podio/utilities/TypeHelpers.h"
 
 #include <iterator>
+#include <string_view>
 
 #ifdef PODIO_JSON_OUTPUT
   #include "nlohmann/json.hpp"
@@ -211,16 +213,24 @@ public:
     return m_storage.getCollectionBuffers(m_isSubsetColl);
   }
 
+  constexpr static std::string_view typeName =
+      podio::utils::static_concatenate_v<podio::detail::link_coll_name_prefix, FromT::typeName,
+                                         podio::detail::link_name_infix, ToT::typeName,
+                                         podio::detail::link_name_suffix>;
+
+  constexpr static std::string_view valueTypeName = value_type::typeName;
+  constexpr static std::string_view dataTypeName = "podio::LinkData";
+
   const std::string_view getTypeName() const override {
-    return podio::detail::linkCollTypeName<FromT, ToT>();
+    return typeName;
   }
 
   const std::string_view getValueTypeName() const override {
-    return podio::detail::linkTypeName<FromT, ToT>();
+    return valueTypeName;
   }
 
   const std::string_view getDataTypeName() const override {
-    return "podio::LinkData";
+    return dataTypeName;
   }
 
   bool isSubsetCollection() const override {
@@ -336,7 +346,7 @@ namespace detail {
   template <typename FromT, typename ToT>
   podio::CollectionReadBuffers createLinkBuffers(bool subsetColl) {
     auto readBuffers = podio::CollectionReadBuffers{};
-    readBuffers.type = podio::detail::linkCollTypeName<FromT, ToT>();
+    readBuffers.type = podio::LinkCollection<FromT, ToT>::typeName;
     readBuffers.schemaVersion = podio::LinkCollection<FromT, ToT>::schemaVersion;
     readBuffers.data = subsetColl ? nullptr : new LinkDataContainer();
 

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -412,7 +412,27 @@ void to_json(nlohmann::json& j, const podio::LinkCollection<FromT, ToT>& collect
   }
 }
 #endif
+namespace detail {
+  /// Get the collection type name for a LinkCollection
+  ///
+  /// @tparam FromT the From type of the link
+  /// @tparam ToT the To type of the link
+  /// @returns a type string that is a valid c++ template instantiation
+  template <typename FromT, typename ToT>
+  [[deprecated("Use LinkCollection<FromT, ToT>::typeName instead")]] inline const std::string_view linkCollTypeName() {
+    return LinkCollection<FromT, ToT>::typeName;
+  }
 
+  /// Get the value type name for a LinkCollection
+  ///
+  /// @tparam FromT the From type of the link
+  /// @tparam ToT the To type of the link
+  /// @returns a type string that is a valid c++ template instantiation
+  template <typename FromT, typename ToT>
+  [[deprecated("Use LinkCollection<FromT, ToT>::valueTypeName instead")]] inline const std::string_view linkTypeName() {
+    return LinkCollection<FromT, ToT>::valueTypeName;
+  }
+} // namespace detail
 } // namespace podio
 
 #endif // PODIO_DETAIL_LINKCOLLECTIONIMPL_H

--- a/include/podio/detail/LinkFwd.h
+++ b/include/podio/detail/LinkFwd.h
@@ -12,29 +12,10 @@
 namespace podio {
 namespace detail {
 
-  /// Get the collection type name for a LinkCollection
-  ///
-  /// @tparam FromT the From type of the link
-  /// @tparam ToT the To type of the link
-  /// @returns a type string that is a valid c++ template instantiation
-  template <typename FromT, typename ToT>
-  inline const std::string_view linkCollTypeName() {
-    const static std::string typeName =
-        std::string("podio::LinkCollection<") + std::string(FromT::typeName) + "," + std::string(ToT::typeName) + ">";
-    return std::string_view{typeName};
-  }
-
-  /// Get the value type name for a LinkCollection
-  ///
-  /// @tparam FromT the From type of the link
-  /// @tparam ToT the To type of the link
-  /// @returns a type string that is a valid c++ template instantiation
-  template <typename FromT, typename ToT>
-  inline const std::string_view linkTypeName() {
-    const static std::string typeName =
-        std::string("podio::Link<") + std::string(FromT::typeName) + "," + std::string(ToT::typeName) + ">";
-    return std::string_view{typeName};
-  }
+  constexpr std::string_view link_coll_name_prefix = "podio::LinkCollection<";
+  constexpr std::string_view link_name_prefix = "podio::LinkCollection<";
+  constexpr std::string_view link_name_infix = ",";
+  constexpr std::string_view link_name_suffix = ">";
 
   /// Get an SIO friendly type name for a LinkCollection (necessary for
   /// registration in the SIOBlockFactory)

--- a/include/podio/detail/LinkFwd.h
+++ b/include/podio/detail/LinkFwd.h
@@ -20,7 +20,7 @@ namespace detail {
   template <typename FromT, typename ToT>
   inline const std::string_view linkCollTypeName() {
     const static std::string typeName =
-        std::string("podio::LinkCollection<") + FromT::typeName + "," + ToT::typeName + ">";
+        std::string("podio::LinkCollection<") + std::string(FromT::typeName) + "," + std::string(ToT::typeName) + ">";
     return std::string_view{typeName};
   }
 
@@ -31,7 +31,8 @@ namespace detail {
   /// @returns a type string that is a valid c++ template instantiation
   template <typename FromT, typename ToT>
   inline const std::string_view linkTypeName() {
-    const static std::string typeName = std::string("podio::Link<") + FromT::typeName + "," + ToT::typeName + ">";
+    const static std::string typeName =
+        std::string("podio::Link<") + std::string(FromT::typeName) + "," + std::string(ToT::typeName) + ">";
     return std::string_view{typeName};
   }
 
@@ -44,7 +45,7 @@ namespace detail {
   /// types
   template <typename FromT, typename ToT>
   inline const std::string& linkSIOName() {
-    static auto n = std::string("LINK_FROM_") + FromT::typeName + "_TO_" + ToT::typeName;
+    static auto n = std::string("LINK_FROM_") + std::string(FromT::typeName) + "_TO_" + std::string(ToT::typeName);
     std::replace(n.begin(), n.end(), ':', '_');
     return n;
   }

--- a/include/podio/detail/LinkSIOBlock.h
+++ b/include/podio/detail/LinkSIOBlock.h
@@ -21,7 +21,7 @@ public:
       SIOBlock(podio::detail::linkSIOName<FromT, ToT>(),
                sio::version::encode_version(LinkCollection<FromT, ToT>::schemaVersion, 0)) {
     podio::SIOBlockFactory::instance().registerBlockForCollection(
-        std::string(podio::detail::linkTypeName<FromT, ToT>()), this);
+        std::string(podio::LinkCollection<FromT, ToT>::valueTypeName), this);
   }
 
   LinkSIOBlock(const std::string& name) :
@@ -32,7 +32,7 @@ public:
     auto& bufferFactory = podio::CollectionBufferFactory::instance();
     // TODO:
     // - Error handling of empty optional
-    auto maybeBuffers = bufferFactory.createBuffers(std::string(podio::detail::linkCollTypeName<FromT, ToT>()),
+    auto maybeBuffers = bufferFactory.createBuffers(std::string(podio::LinkCollection<FromT, ToT>::typeName),
                                                     sio::version::major_version(version), m_subsetColl);
     m_buffers = maybeBuffers.value();
 

--- a/include/podio/utilities/StaticConcatenate.h
+++ b/include/podio/utilities/StaticConcatenate.h
@@ -10,14 +10,15 @@ namespace podio::utils {
 template <const std::string_view&... strs>
 struct static_concatenate {
   static constexpr auto init_arr() {
-    constexpr auto total_size = (strs.size() + ... + 0);
+    constexpr auto total_size = (strs.size() + ... + 1); // reserve space for '\0'
     auto arr = std::array<char, total_size>();
     auto it = arr.begin();
     ((it = std::ranges::copy(strs, it).out), ...);
+    arr.back() = '\0';
     return arr;
   }
   constexpr static auto array = init_arr();
-  constexpr static auto value = std::string_view(array.data(), array.size());
+  constexpr static auto value = std::string_view(array.data(), array.size() - 1); // skip '\0'
 };
 
 /// Variable template for concatenating a set of string_views into a single string_view at compile time

--- a/include/podio/utilities/StaticConcatenate.h
+++ b/include/podio/utilities/StaticConcatenate.h
@@ -1,0 +1,28 @@
+#ifndef PODIO_UTILITIES_STATICCONCATENATE_H
+#define PODIO_UTILITIES_STATICCONCATENATE_H
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+namespace podio::utils {
+
+/// Helper struct to concatenate a set of string_views into a single string_view at compile time
+template <const std::string_view&... strs>
+struct static_concatenate {
+  static constexpr auto init_arr() {
+    constexpr auto total_size = (strs.size() + ... + 0);
+    auto arr = std::array<char, total_size>();
+    auto it = arr.begin();
+    ((it = std::ranges::copy(strs, it).out), ...);
+    return arr;
+  }
+  constexpr static auto array = init_arr();
+  constexpr static auto value = std::string_view(array.data(), array.size());
+};
+
+/// Variable template for concatenating a set of string_views into a single string_view at compile time
+template <const std::string_view&... strs>
+inline constexpr std::string_view static_concatenate_v = static_concatenate<strs...>::value;
+
+} // namespace podio::utils
+#endif // PODIO_UTILITIES_STATICCONCATENATE_H

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -64,9 +64,9 @@ public:
 //  {{ class.bare_type }}Collection({{ class.bare_type }}Vector* data, uint32_t collectionID);
   ~{{ class.bare_type }}Collection() override;
 
-  constexpr static auto typeName = "{{ (class | string ).strip(':') + "Collection" }}";
-  constexpr static auto valueTypeName = "{{ (class | string ).strip(':') }}";
-  constexpr static auto dataTypeName = "{{ (class | string ).strip(':') + "Data" }}";
+  constexpr static std::string_view typeName = "{{ (class | string ).strip(':') + "Collection" }}";
+  constexpr static std::string_view valueTypeName = "{{ (class | string ).strip(':') }}";
+  constexpr static std::string_view dataTypeName = "{{ (class | string ).strip(':') + "Data" }}";
 
   void clear() final;
 

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -130,7 +130,7 @@ public:
     return {{ Types[0] }}::makeEmpty();
   }
 
-  static constexpr auto typeName = "{{ class.full_type }}";
+  static constexpr std::string_view typeName = "{{ class.full_type }}";
 
   /// check whether the object is actually available
   bool isAvailable() const { return m_self->isAvailable(); }

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -54,7 +54,7 @@ public:
 
 public:
 
-  static constexpr auto typeName = "{{ class.full_type }}";
+  static constexpr std::string_view typeName = "{{ class.full_type }}";
 
 {{ macros.member_getters(Members, use_get_syntax) }}
 {{ macros.single_relation_getters(OneToOneRelations, use_get_syntax) }}

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -423,8 +423,7 @@ TEST_CASE("LinkCollection subset collection", "[links][subset-colls]") {
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("LinkCollection basics", "[links]") {
-  REQUIRE(podio::detail::linkCollTypeName<ExampleCluster, ExampleHit>() ==
-          "podio::LinkCollection<ExampleCluster,ExampleHit>");
+  STATIC_REQUIRE(TestLColl::typeName == "podio::LinkCollection<ExampleHit,ExampleCluster>");
 
   auto links = TestLColl{};
   auto link = links.create();


### PR DESCRIPTION
BEGINRELEASENOTES
- Change type of `typeName` members to `std::string_view`. Add utility to concatenate `std::string_view`s at compile time.
- Add `typeName` static member to link collections. `typeName` can be checked at compilation time.
- Deprecate `linkCollTypeName` and `linkTypeName` helper functions.

ENDRELEASENOTES

Adding utility to concatenate multiple `std::string_view`s at compile time. Then using the utility to add missing `typeName` member for link collections.

The `linkCollTypeName` and `linkTypeName` functions will be now redundant so I propose to deprecate them. The only usage of them I could find is in EDM4hep in schema evolution

Closes #731