### PR TITLE
Add `RVec`s to root dictionaries

### DIFF
--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -322,15 +322,17 @@ function(PODIO_ADD_ROOT_IO_DICT dict_name CORE_LIB HEADERS SELECTION_XML)
     ${CORE_LIB}
     podio::podio
     ROOT::Core
+    ROOT::ROOTVecOps
     )
   target_include_directories(${dict_name} PUBLIC
     $<BUILD_INTERFACE:${ARG_OUTPUT_FOLDER}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
-  PODIO_GENERATE_DICTIONARY(${dict_name} ${HEADERS} SELECTION ${selectionfile}
+  PODIO_GENERATE_DICTIONARY(${dict_name} ${HEADERS} "${ROOT_INCLUDE_DIRS}/ROOT/RVec.hxx" SELECTION ${selectionfile}
     OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}${dict_name}${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
   set_target_properties(${dict_name}-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  target_compile_options(${dict_name} PRIVATE "-Wno-effc++")
   add_dependencies(${dict_name} ${CORE_LIB})
 endfunction()
 

--- a/python/templates/selection.xml.jinja2
+++ b/python/templates/selection.xml.jinja2
@@ -4,6 +4,7 @@
         <class name="{{ namespace }}{{ full_name }}" ClassVersion="{{ version }}"/>
 {% if vector %}
         <class name="std::vector<{{ namespace }}{{ full_name }}>" ClassVersion="{{ version }}"/>
+        <class name="ROOT::VecOps::RVec<{{ namespace }}{{ full_name }}>" ClassVersion="{{ version }}"/>
 {%- endif -%}
 {%- endmacro -%}
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,15 +33,16 @@ FUNCTION(PODIO_ADD_LIB_AND_DICT libname headers sources selection )
   target_include_directories(${dictname} PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-  target_link_libraries(${dictname} PUBLIC podio::${libname} podio::podio ROOT::Core ROOT::Tree)
+  target_link_libraries(${dictname} PUBLIC podio::${libname} podio::podio ROOT::Core ROOT::Tree ROOT::ROOTVecOps)
   if(ENABLE_RNTUPLE)
     target_link_libraries(${dictname} PUBLIC ROOT::ROOTNTuple)
   endif()
-  PODIO_GENERATE_DICTIONARY(${dictname} ${headers} SELECTION ${selection}
+  PODIO_GENERATE_DICTIONARY(${dictname} ${headers} "${ROOT_INCLUDE_DIRS}/ROOT/RVec.hxx" SELECTION ${selection}
     OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}${dictname}${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
   # prevent generating dictionary twice
   set_target_properties(${dictname}-dictgen PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  target_compile_options(${dictname} PRIVATE "-Wno-effc++")
   target_sources(${dictname} PRIVATE ${dictname}.cxx)
 ENDFUNCTION()
 

--- a/src/selection.xml
+++ b/src/selection.xml
@@ -31,6 +31,7 @@
     <class name="podio::version::Version"/>
     <class name="podio::ObjectID"/>
     <class name="vector<podio::ObjectID>"/>
+    <class name="ROOT::VecOps::RVec<podio::ObjectID>"/>
 
     <class name="podio::UserDataCollection<float>"/>
     <class name="podio::UserDataCollection<double>"/>
@@ -45,6 +46,7 @@
 
     <class name="podio::LinkData"/>
     <class name="std::vector<podio::LinkData>"/>
+    <class name="ROOT::VecOps::RVec<podio::LinkData>"/>
 
     <function name="podio::utils::is_glob_pattern"/>
     <function name="podio::utils::expand_glob"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- Add definitions of `ROOT::VecOps::RVec` to podio dictionary and dictionary for better integration with `RDataFrame`.

ENDRELEASENOTES

Podio's dictionary and generated datamodels' dictionaries include definitions of `std::vector` of objects. For better interoperability with `RDataFrame` definitions with `ROOT::VecOps::RVec` should be added (see key4hep/EDM4hep#416).

Here I propose to add `ROOT::VecOps::RVec` for each `std::vector` in a `selection.xml`.  I'm not sure if the same treatment should apply to definitions like `<class name="std::vector<std::tuple<int, std::string, bool, unsigned int>>"/>` and `<class name="std::vector<std::vector<std::string>>"/>` that are in podio's `selection.xml`.

`-Wno-effc++` is added to  silence the errors coming from `ROOT/RVec.hxx`.`Weffc++` is currently in the `CMAKE_CXX_FLAGS`

Closes key4hep/EDM4hep#416

- [ ] Add test

@Zehvogel 