### PR TITLE
Add const to void* in OrderKey.h

### DIFF
--- a/include/podio/detail/OrderKey.h
+++ b/include/podio/detail/OrderKey.h
@@ -14,14 +14,14 @@ namespace podio::detail {
 /// from different datamodels in an interface type.
 class OrderKey {
 public:
-  OrderKey(void* orderKey) noexcept : m_orderKey(orderKey) {
+  OrderKey(const void* orderKey) noexcept : m_orderKey(orderKey) {
   }
   friend bool operator<(const OrderKey& lhs, const OrderKey& rhs) noexcept {
-    return std::less<void*>{}(lhs.m_orderKey, rhs.m_orderKey);
+    return std::less<const void*>{}(lhs.m_orderKey, rhs.m_orderKey);
   }
 
 private:
-  void* m_orderKey;
+  const void* m_orderKey;
 };
 } // namespace podio::detail
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add const to void* in OrderKey.h

ENDRELEASENOTES

Because there is no reason for it not to be const