### PR TITLE
update collection `max_size` to include limits due to ObjectID

### DIFF
--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -1,6 +1,7 @@
 #ifndef PODIO_DETAIL_LINKCOLLECTIONIMPL_H
 #define PODIO_DETAIL_LINKCOLLECTIONIMPL_H
 
+#include "podio/ObjectID.h"
 #include "podio/detail/Link.h"
 #include "podio/detail/LinkCollectionData.h"
 #include "podio/detail/LinkCollectionIterator.h"
@@ -137,7 +138,13 @@ public:
 
   /// maximal number of elements in the collection
   std::size_t max_size() const override {
-    return m_storage.entries.max_size();
+    const auto maxStorage = m_storage.entries.max_size();
+    if (!m_isSubsetColl) {
+      // non-subset collections shouldn't have more elements than the maximum index of ObjectID
+      const auto maxIndex = std::numeric_limits<decltype(ObjectID::index)>::max();
+      return std::min<size_t>(maxIndex, maxStorage);
+    }
+    return maxStorage;
   }
 
   /// Is the collection empty

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -60,7 +60,13 @@ std::size_t {{ collection_type }}::size() const {
 }
 
 std::size_t {{ collection_type }}::max_size() const {
-  return m_storage.entries.max_size();
+  const auto maxStorage = m_storage.entries.max_size();
+  if (!m_isSubsetColl) {
+    // non-subset collections shouldn't have more elements than the maximum index of ObjectID
+    const auto maxIndex = std::numeric_limits<decltype(podio::ObjectID::index)>::max();
+    return std::min<size_t>(maxIndex, maxStorage);
+  }
+  return maxStorage;
 }
 
 bool {{ collection_type }}::empty() const {


### PR DESCRIPTION
BEGINRELEASENOTES
- Update `max_size` reported by collections to include limit due to `ObjectID` index type

ENDRELEASENOTES

Collections probably shouldn't have more elements than maximal `int` as otherwise `ObjectID` index will overflow. For subset collections it's fine as their elements have ObjectID referring to other non-subset collections. It's also fine for `UserDataCollection` since it isn't using `ObjectID`

As far as I can say `max_size` was added as part of "Container" interface and as far as I can say isn't actively used by anything in the stack. But if we can report a more realistic number then why not