### PR TITLE
add `std::ranges::interfaces_view`-like methods to `RelationRange`

### DIFF
--- a/include/podio/RelationRange.h
+++ b/include/podio/RelationRange.h
@@ -26,6 +26,14 @@ public:
   ConstIteratorType end() const {
     return m_end;
   }
+  /// constant begin of the range
+  ConstIteratorType cbegin() const {
+    return begin();
+  }
+  /// constant end of the range
+  ConstIteratorType cend() const {
+    return end();
+  }
   /// convenience overload for size
   size_t size() const {
     return m_size;
@@ -34,12 +42,25 @@ public:
   bool empty() const {
     return m_begin == m_end;
   }
+  /// check whether the range is not empty
+  explicit operator bool() const {
+    return !empty();
+  }
   /// Indexed access
   ReferenceType operator[](size_t i) const {
     auto it = m_begin;
     std::advance(it, i);
     return *it;
   }
+  /// First element of the range
+  ReferenceType front() const {
+    return *m_begin;
+  }
+  /// Last element of the range
+  ReferenceType back() const {
+    return *(m_end - 1);
+  }
+
   /// Indexed access with range check
   ReferenceType at(size_t i) const {
     if (i < m_size) {

--- a/tests/root_io/relation_range.cpp
+++ b/tests/root_io/relation_range.cpp
@@ -61,8 +61,8 @@ void doTestExampleMC(ExampleMCCollection const& collection) {
   // Empty
   ASSERT_CONDITION(collection[7].daughters().empty() && collection[7].parents().empty(),
                    "RelationRange of empty collection is not empty")
-  // Equivalent but potentially quicker way of checking an empty collection
-  ASSERT_CONDITION(collection[7].daughters().empty() && collection[7].parents().empty(),
+  // checking with bool operator
+  ASSERT_CONDITION(!collection[7].daughters() || !collection[7].parents(),
                    "RelationRange of empty collection is not empty")
 
   // alternatively check if a loop is entered
@@ -96,12 +96,32 @@ void doTestExampleMC(ExampleMCCollection const& collection) {
     ASSERT_EQUAL(p.PDG(), expectedPDG[index], "ExampleMC daughters range points to wrong particle (by PDG)")
     index++;
   }
+  // front and back, cbegin and cend
+  ASSERT_EQUAL(collection[2].daughters().front().PDG(), expectedPDG.front(),
+               "ExampleMC daughters front points to wrong particle (by PDG)")
+  ASSERT_EQUAL(collection[2].daughters().back().PDG(), expectedPDG.back(),
+               "ExampleMC daughters back points to wrong particle (by PDG)")
+  ASSERT_EQUAL(collection[2].daughters().cbegin()->PDG(), expectedPDG.front(),
+               "ExampleMC daughters cbegin points to wrong particle (by PDG)")
+  ASSERT_EQUAL((collection[2].daughters().cend() - 1)->PDG(), expectedPDG.back(),
+               "ExampleMC daughters cend points to wrong particle (by PDG)")
+
   expectedPDG = {8, 6};
   index = 0;
   for (const auto& p : collection[2].parents()) {
     ASSERT_EQUAL(p.PDG(), expectedPDG[index], "ExampleMC parents range points to wrong particle (by PDG)")
     index++;
   }
+
+  // front and back, cbegin and cend
+  ASSERT_EQUAL(collection[2].parents().front().PDG(), expectedPDG.front(),
+               "ExampleMC parents front points to wrong particle (by PDG)")
+  ASSERT_EQUAL(collection[2].parents().back().PDG(), expectedPDG.back(),
+               "ExampleMC parents back points to wrong particle (by PDG)")
+  ASSERT_EQUAL(collection[2].parents().cbegin()->PDG(), expectedPDG.front(),
+               "ExampleMC parents cbegin points to wrong particle (by PDG)")
+  ASSERT_EQUAL((collection[2].parents().cend() - 1)->PDG(), expectedPDG.back(),
+               "ExampleMC parents cend points to wrong particle (by PDG)")
 
   // Indexed access with range check
   const auto parents = collection[2].parents();


### PR DESCRIPTION

BEGINRELEASENOTES
- Add `front`, `back`, `cbegin`, `cend` and `operator bool` to the `RelationRange` so it has all the methods from `std::ranges::view_interface`

ENDRELEASENOTES

Adding some methods present in `std::ranges::view_interface` but missing in `podio::RelationRange`. They aren't needed for any concept but convenient to have

Closes #753 