### PR TITLE
allow `^` in units in datamodel definitions

### DIFF
--- a/python/podio_gen/podio_config_reader.py
+++ b/python/podio_gen/podio_config_reader.py
@@ -37,7 +37,7 @@ class MemberParser:
     name_re = re.compile(name_str)
 
     # Units are given in square brackets
-    unit_str = r"(?:\[([a-zA-Z_*\/]+\w*)\])?"
+    unit_str = r"(?:\[([a-zA-Z_*\/^]+\w*)\])?"
     unit_re = re.compile(unit_str)
 
     # Comments can be anything after //


### PR DESCRIPTION

BEGINRELEASENOTES
- allow `^` in units in datamodel definitions

ENDRELEASENOTES

Allow using `^` in units so `[mm^2]` is a valid unit. See also https://github.com/key4hep/EDM4hep/pull/422#discussion_r2012186859