### PR TITLE
Formalize common interface for collections with a concept

### DIFF
--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -206,6 +206,10 @@ public:
 
   // ----- some wrappers for std::vector and access to the complete std::vector (if really needed)
 
+  typename std::vector<BasicType>::reference create() {
+    return _vec.emplace_back();
+  }
+
   iterator begin() {
     return _vec.begin();
   }
@@ -249,6 +253,13 @@ public:
   }
   typename std::vector<BasicType>::const_reference operator[](size_t idx) const {
     return _vec[idx];
+  }
+
+  typename std::vector<BasicType>::reference at(size_t idx) {
+    return _vec.at(idx);
+  }
+  typename std::vector<BasicType>::const_reference at(size_t idx) const {
+    return _vec.at(idx);
   }
 
   void resize(size_t count) {

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -280,7 +280,7 @@ concept CollectionType = requires(T t, const T ct) {
   typename T::reverse_iterator;
   requires std::random_access_iterator<typename T::reverse_iterator>;
   // member functions
-  { t.create() } -> std::convertible_to<typename T::mutable_type>;
+  requires std::same_as<std::remove_cvref_t<decltype(t.create())>, typename T::mutable_type>;
   { t.push_back(std::declval<std::add_lvalue_reference_t<std::add_const_t<typename T::mutable_type>>>()) };
   { t.push_back(std::declval<std::add_lvalue_reference_t<std::add_const_t<typename T::value_type>>>()) };
   { t.begin() } -> std::same_as<typename T::iterator>;
@@ -295,10 +295,14 @@ concept CollectionType = requires(T t, const T ct) {
   { t.rend() } -> std::same_as<typename T::reverse_iterator>;
   { t.crend() } -> std::same_as<typename T::const_reverse_iterator>;
   { ct.rend() } -> std::same_as<typename T::const_reverse_iterator>;
-  { t[std::declval<typename T::size_type>()] } -> std::convertible_to<typename T::mutable_type>;
-  { ct[std::declval<typename T::size_type>()] } -> std::convertible_to<typename T::value_type>;
-  { t.at(std::declval<typename T::size_type>()) } -> std::convertible_to<typename T::mutable_type>;
-  { ct.at(std::declval<typename T::size_type>()) } -> std::convertible_to<typename T::value_type>;
+  requires std::same_as<std::remove_cvref_t<decltype(t[std::declval<typename T::size_type>()])>,
+                        typename T::mutable_type>;
+  requires std::same_as<std::remove_cvref_t<decltype(ct[std::declval<typename T::size_type>()])>,
+                        typename T::value_type>;
+  requires std::same_as<std::remove_cvref_t<decltype(t.at(std::declval<typename T::size_type>()))>,
+                        typename T::mutable_type>;
+  requires std::same_as<std::remove_cvref_t<decltype(ct.at(std::declval<typename T::size_type>()))>,
+                        typename T::value_type>;
 };
 
 namespace utils {

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -254,7 +254,7 @@ concept CollectionType = requires(T t, const T ct) {
   requires std::default_initializable<T>;
   requires std::destructible<T>;
   requires std::movable<T>;
-  requires std::move_constructible<T>;
+  requires !std::copyable<T>;
   requires std::ranges::random_access_range<T>;
   // typeName's
   { T::typeName } -> std::convertible_to<std::string_view>;

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -247,63 +247,59 @@ class CollectionBase;
 
 /// Concept for checking whether a passed type T is a collection
 template <typename T>
-concept CollectionType = requires(T t, const T ct) {
-  // general concepts
-  requires !std::is_abstract_v<T>;
-  requires std::derived_from<T, CollectionBase>;
-  requires std::default_initializable<T>;
-  requires std::destructible<T>;
-  requires std::movable<T>;
-  requires !std::copyable<T>;
-  requires std::ranges::random_access_range<T>;
-  // typeName's
-  { T::typeName } -> std::convertible_to<std::string_view>;
-  { std::bool_constant<(T::typeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
-  { T::valueTypeName } -> std::convertible_to<std::string_view>;
-  { std::bool_constant<(T::valueTypeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
-  { T::dataTypeName } -> std::convertible_to<std::string_view>;
-  { std::bool_constant<(T::dataTypeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
-  // typedefs
-  typename T::value_type;
-  typename T::mutable_type;
-  requires std::convertible_to<typename T::mutable_type, typename T::value_type>;
-  typename T::difference_type;
-  requires std::signed_integral<typename T::difference_type>;
-  typename T::size_type;
-  requires std::unsigned_integral<typename T::size_type>;
-  typename T::const_iterator;
-  requires std::random_access_iterator<typename T::const_iterator>;
-  typename T::iterator;
-  requires std::random_access_iterator<typename T::iterator>;
-  typename T::const_reverse_iterator;
-  requires std::random_access_iterator<typename T::const_reverse_iterator>;
-  typename T::reverse_iterator;
-  requires std::random_access_iterator<typename T::reverse_iterator>;
-  // member functions
-  requires std::same_as<std::remove_cvref_t<decltype(t.create())>, typename T::mutable_type>;
-  { t.push_back(std::declval<std::add_lvalue_reference_t<std::add_const_t<typename T::mutable_type>>>()) };
-  { t.push_back(std::declval<std::add_lvalue_reference_t<std::add_const_t<typename T::value_type>>>()) };
-  { t.begin() } -> std::same_as<typename T::iterator>;
-  { t.cbegin() } -> std::same_as<typename T::const_iterator>;
-  { ct.begin() } -> std::same_as<typename T::const_iterator>;
-  { t.end() } -> std::same_as<typename T::iterator>;
-  { t.cend() } -> std::same_as<typename T::const_iterator>;
-  { ct.end() } -> std::same_as<typename T::const_iterator>;
-  { t.rbegin() } -> std::same_as<typename T::reverse_iterator>;
-  { t.crbegin() } -> std::same_as<typename T::const_reverse_iterator>;
-  { ct.rbegin() } -> std::same_as<typename T::const_reverse_iterator>;
-  { t.rend() } -> std::same_as<typename T::reverse_iterator>;
-  { t.crend() } -> std::same_as<typename T::const_reverse_iterator>;
-  { ct.rend() } -> std::same_as<typename T::const_reverse_iterator>;
-  requires std::same_as<std::remove_cvref_t<decltype(t[std::declval<typename T::size_type>()])>,
-                        typename T::mutable_type>;
-  requires std::same_as<std::remove_cvref_t<decltype(ct[std::declval<typename T::size_type>()])>,
-                        typename T::value_type>;
-  requires std::same_as<std::remove_cvref_t<decltype(t.at(std::declval<typename T::size_type>()))>,
-                        typename T::mutable_type>;
-  requires std::same_as<std::remove_cvref_t<decltype(ct.at(std::declval<typename T::size_type>()))>,
-                        typename T::value_type>;
-};
+concept CollectionType = !std::is_abstract_v<T> && std::derived_from<T, CollectionBase> &&
+    std::default_initializable<T> && std::destructible<T> && std::movable<T> && !std::copyable<T> &&
+    std::ranges::random_access_range<T> && requires(T t, const T ct) {
+      // typeName's
+      { T::typeName } -> std::convertible_to<std::string_view>;
+      { std::bool_constant<(T::typeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
+      { T::valueTypeName } -> std::convertible_to<std::string_view>;
+      {
+        std::bool_constant<(T::valueTypeName, true)>()
+      } -> std::same_as<std::true_type>; // ~is annotated with constexpr
+      { T::dataTypeName } -> std::convertible_to<std::string_view>;
+      { std::bool_constant<(T::dataTypeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
+      // typedefs
+      typename T::value_type;
+      typename T::mutable_type;
+      requires std::convertible_to<typename T::mutable_type, typename T::value_type>;
+      typename T::difference_type;
+      requires std::signed_integral<typename T::difference_type>;
+      typename T::size_type;
+      requires std::unsigned_integral<typename T::size_type>;
+      typename T::const_iterator;
+      requires std::random_access_iterator<typename T::const_iterator>;
+      typename T::iterator;
+      requires std::random_access_iterator<typename T::iterator>;
+      typename T::const_reverse_iterator;
+      requires std::random_access_iterator<typename T::const_reverse_iterator>;
+      typename T::reverse_iterator;
+      requires std::random_access_iterator<typename T::reverse_iterator>;
+      // member functions
+      requires std::same_as<std::remove_cvref_t<decltype(t.create())>, typename T::mutable_type>;
+      { t.push_back(std::declval<std::add_lvalue_reference_t<std::add_const_t<typename T::mutable_type>>>()) };
+      { t.push_back(std::declval<std::add_lvalue_reference_t<std::add_const_t<typename T::value_type>>>()) };
+      { t.begin() } -> std::same_as<typename T::iterator>;
+      { t.cbegin() } -> std::same_as<typename T::const_iterator>;
+      { ct.begin() } -> std::same_as<typename T::const_iterator>;
+      { t.end() } -> std::same_as<typename T::iterator>;
+      { t.cend() } -> std::same_as<typename T::const_iterator>;
+      { ct.end() } -> std::same_as<typename T::const_iterator>;
+      { t.rbegin() } -> std::same_as<typename T::reverse_iterator>;
+      { t.crbegin() } -> std::same_as<typename T::const_reverse_iterator>;
+      { ct.rbegin() } -> std::same_as<typename T::const_reverse_iterator>;
+      { t.rend() } -> std::same_as<typename T::reverse_iterator>;
+      { t.crend() } -> std::same_as<typename T::const_reverse_iterator>;
+      { ct.rend() } -> std::same_as<typename T::const_reverse_iterator>;
+      requires std::same_as<std::remove_cvref_t<decltype(t[std::declval<typename T::size_type>()])>,
+                            typename T::mutable_type>;
+      requires std::same_as<std::remove_cvref_t<decltype(ct[std::declval<typename T::size_type>()])>,
+                            typename T::value_type>;
+      requires std::same_as<std::remove_cvref_t<decltype(t.at(std::declval<typename T::size_type>()))>,
+                            typename T::mutable_type>;
+      requires std::same_as<std::remove_cvref_t<decltype(ct.at(std::declval<typename T::size_type>()))>,
+                            typename T::value_type>;
+    };
 
 namespace utils {
   template <typename... T>

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -276,7 +276,9 @@ concept CollectionType = !std::is_abstract_v<T> && std::derived_from<T, Collecti
       typename T::reverse_iterator;
       requires std::random_access_iterator<typename T::reverse_iterator>;
       // member functions
-      requires std::same_as<std::remove_cvref_t<decltype(t.create())>, typename T::mutable_type>;
+      requires std::same_as<std::remove_reference_t<decltype(t.create())>,
+                            typename T::mutable_type>; // UserDataCollection::create() returns reference which has to be
+                                                       // stripped to be same as expected typedef
       { t.push_back(std::declval<std::add_lvalue_reference_t<std::add_const_t<typename T::mutable_type>>>()) };
       { t.push_back(std::declval<std::add_lvalue_reference_t<std::add_const_t<typename T::value_type>>>()) };
       { t.begin() } -> std::same_as<typename T::iterator>;
@@ -291,11 +293,13 @@ concept CollectionType = !std::is_abstract_v<T> && std::derived_from<T, Collecti
       { t.rend() } -> std::same_as<typename T::reverse_iterator>;
       { t.crend() } -> std::same_as<typename T::const_reverse_iterator>;
       { ct.rend() } -> std::same_as<typename T::const_reverse_iterator>;
-      requires std::same_as<std::remove_cvref_t<decltype(t[std::declval<typename T::size_type>()])>,
+      // UserDataCollection element access returns by reference or const reference which has to be stripped to be same
+      // as expected typedef
+      requires std::same_as<std::remove_reference_t<decltype(t[std::declval<typename T::size_type>()])>,
                             typename T::mutable_type>;
       requires std::same_as<std::remove_cvref_t<decltype(ct[std::declval<typename T::size_type>()])>,
                             typename T::value_type>;
-      requires std::same_as<std::remove_cvref_t<decltype(t.at(std::declval<typename T::size_type>()))>,
+      requires std::same_as<std::remove_reference_t<decltype(t.at(std::declval<typename T::size_type>()))>,
                             typename T::mutable_type>;
       requires std::same_as<std::remove_cvref_t<decltype(ct.at(std::declval<typename T::size_type>()))>,
                             typename T::value_type>;

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -257,12 +257,12 @@ concept CollectionType = requires(T t, const T ct) {
   requires std::move_constructible<T>;
   requires std::ranges::random_access_range<T>;
   // typeName's
-  // { T::typeName } -> std::convertible_to<std::string_view>;
-  // { std::bool_constant<(T::typeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
-  // { T::valueTypeName } -> std::convertible_to<std::string_view>;
-  // { std::bool_constant<(T::valueTypeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
-  // { T::dataTypeName } -> std::convertible_to<std::string_view>;
-  // { std::bool_constant<(T::dataTypeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
+  { T::typeName } -> std::convertible_to<std::string_view>;
+  { std::bool_constant<(T::typeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
+  { T::valueTypeName } -> std::convertible_to<std::string_view>;
+  { std::bool_constant<(T::valueTypeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
+  { T::dataTypeName } -> std::convertible_to<std::string_view>;
+  { std::bool_constant<(T::dataTypeName, true)>() } -> std::same_as<std::true_type>; // ~is annotated with constexpr
   // typedefs
   typename T::value_type;
   typename T::mutable_type;

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -3,6 +3,7 @@
 
 #include "podio/LinkCollection.h"
 #include "podio/LinkNavigator.h"
+#include "podio/utilities/TypeHelpers.h"
 
 #include "datamodel/ExampleClusterCollection.h"
 #include "datamodel/ExampleHitCollection.h"
@@ -297,6 +298,9 @@ TEST_CASE("Links templated accessors", "[links]") {
   }
 }
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+TEST_CASE("LinkCollection collection concept", "[links][concepts]") {
+  STATIC_REQUIRE(podio::CollectionType<TestLColl>);
+}
 
 TEST_CASE("LinkCollection constness", "[links][static-checks][const-correctness]") {
   // Test type-aliases in LinkCollection

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "catch2/catch_test_macros.hpp"
@@ -410,6 +411,19 @@ TEST_CASE("UserDataCollection print", "[basics]") {
   coll.print(sstr);
 
   REQUIRE(sstr.str() == "[1, 2, 3]");
+}
+
+TEST_CASE("UserDataCollection access", "[basics]") {
+  auto coll = podio::UserDataCollection<int32_t>();
+  auto& x = coll.create();
+  x = 42;
+  REQUIRE(coll.size() == 1);
+  REQUIRE(coll.at(0) == 42);
+  coll.at(0) = 43;
+  REQUIRE(coll[0] == 43);
+  coll[0] = 44;
+  REQUIRE(std::as_const(coll).at(0) == 44);
+  REQUIRE(std::as_const(coll)[0] == 44);
 }
 
 /*

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -23,6 +23,7 @@
 #include "podio/ROOTReader.h"
 #include "podio/ROOTWriter.h"
 #include "podio/podioVersion.h"
+#include "podio/utilities/TypeHelpers.h"
 
 #ifndef PODIO_ENABLE_SIO
   #define PODIO_ENABLE_SIO 0
@@ -390,6 +391,15 @@ TEST_CASE("thread-safe prepareForWrite", "[basics][multithread]") {
   }
 }
 
+TEST_CASE("UserDataCollection collection concept", "[concepts]") {
+  // check each type in tuple
+  std::apply(
+      []<typename... Ts>(Ts...) {
+        ([]<typename T>(T) { STATIC_REQUIRE(podio::CollectionType<podio::UserDataCollection<T>>); }(Ts{}), ...);
+      },
+      podio::SupportedUserDataTypes{});
+}
+
 TEST_CASE("UserDataCollection print", "[basics]") {
   auto coll = podio::UserDataCollection<int32_t>();
   coll.push_back(1);
@@ -607,6 +617,11 @@ TEST_CASE("UserInitialization", "[basics][code-gen]") {
   REQUIRE(ex.comp().i == 42);
   REQUIRE(ex.comp().arr[0] == 1.2);
   REQUIRE(ex.comp().arr[1] == 3.4);
+}
+
+TEST_CASE("Collection concepts", "[collections][concepts]") {
+  STATIC_REQUIRE(podio::CollectionType<ExampleClusterCollection>);
+  STATIC_REQUIRE(podio::CollectionType<ExampleHitCollection>);
 }
 
 TEST_CASE("Collection size and empty", "[basics][collections]") {


### PR DESCRIPTION

BEGINRELEASENOTES
- Formalize expected collection interface with a concept
- Add `at` and `create` to `UserDataCollection`

ENDRELEASENOTES

This is an idea to formalize to some degree the expected interface of a podio collection.
Currently we have three types of collections: `UserDataCollection`, link collection and datatype collection. Each of them implements some common methods and type aliases that aren't and can't be part of abstract class `CollectionBase`. 
Yet from time to time we discover that one of them is missing something that the others have or worse we discover that some generic code doesn't work with some collection (for example #731, #718, #598)

The concept can be at first used in tests to ensure at compile time that none of the collections is missing part of expected interface.
Secondly it could be possibly used in derived packages to constrain templates better than `std::is_base_of<podio::CollectionBase, T>`

I propose to include the following:
- being a concrete class derived from `CollectionBase` (which also handles that all the interfaces from `CollectionBase` are there)
- constructors, assignments,
- implementing ranges
- constexpr static strings with human readable types (`typeName`), after #748
- typedefs,
- `create()`, `push_back(obj)`,
- all combinations of `begin()` and `end()`,
- element access with `operator[]` and `at`

Perhaps something else worth having in all collections is still missing?
Datatype collections have LCIO-style `operator->` but I'm not sure if the others also should have it?