### PR TITLE
Fix `podio::Link::typeName` that was wrongly including "Collection"

### DIFF
--- a/include/podio/detail/LinkFwd.h
+++ b/include/podio/detail/LinkFwd.h
@@ -13,7 +13,7 @@ namespace podio {
 namespace detail {
 
   constexpr std::string_view link_coll_name_prefix = "podio::LinkCollection<";
-  constexpr std::string_view link_name_prefix = "podio::LinkCollection<";
+  constexpr std::string_view link_name_prefix = "podio::Link<";
   constexpr std::string_view link_name_infix = ",";
   constexpr std::string_view link_name_suffix = ">";
 

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -423,6 +423,7 @@ TEST_CASE("LinkCollection subset collection", "[links][subset-colls]") {
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 TEST_CASE("LinkCollection basics", "[links]") {
+  STATIC_REQUIRE(TestL::typeName == "podio::Link<ExampleHit,ExampleCluster>");
   STATIC_REQUIRE(TestLColl::typeName == "podio::LinkCollection<ExampleHit,ExampleCluster>");
 
   auto links = TestLColl{};


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix `podio::Link::typeName` that was wrongly including "Collection"

ENDRELEASENOTES