### PR TITLE
Remove unnecessary empty link library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,7 +136,7 @@ if(ENABLE_SIO)
     )
 
   PODIO_ADD_LIB_AND_DICT(podioSioIO "${sio_headers}" "${sio_sources}" sio_selection.xml)
-  target_link_libraries(podioSioIO PUBLIC podio::podio SIO::sio ${CMAKE_DL_LIBS} ${PODIO_FS_LIBS})
+  target_link_libraries(podioSioIO PUBLIC podio::podio SIO::sio ${CMAKE_DL_LIBS})
   target_compile_definitions(podioSioIO PUBLIC PODIO_ENABLE_SIO=1)
 
   LIST(APPEND INSTALL_LIBRARIES podioSioIO podioSioIODict)


### PR DESCRIPTION
Removed in #662



BEGINRELEASENOTES
- Remove a leftover empty CMake variable. The corresponding code has been removed in [#662](https://github.com/AIDASoft/podio/pull/662).

ENDRELEASENOTES