### PR TITLE
Add ccache to workflows to speed up CI and add more Key4hep workflows

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -34,7 +34,7 @@ jobs:
           path: catch2
           ref: v3.4.0
       - uses: cvmfs-contrib/github-action-cvmfs@v4
-      - uses: tmadlener/run-lcg-view@ccache
+      - uses: aidasoft/run-lcg-view@v5
         with:
           release-platform: ${{ matrix.LCG }}
           ccache-key: ccache-edm4hep-${{ matrix.LCG }}

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -30,7 +30,7 @@ jobs:
           path: catch2
           ref: v3.4.0
       - uses: cvmfs-contrib/github-action-cvmfs@v4
-      - uses: aidasoft/run-lcg-view@v4
+      - uses: tmadlener/run-lcg-view@ccache
         with:
           release-platform: ${{ matrix.LCG }}
           run: |
@@ -51,6 +51,7 @@ jobs:
               -DENABLE_RNTUPLE=ON \
               -DCMAKE_INSTALL_PREFIX=../install \
               -DCMAKE_CXX_STANDARD=20 \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
               -DUSE_EXTERNAL_CATCH2=ON \
               -DBUILD_TESTING=OFF\
@@ -68,6 +69,7 @@ jobs:
             mkdir build && cd build
             cmake -DCMAKE_CXX_STANDARD=20 \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DUSE_EXTERNAL_CATCH2=ON \
               -G Ninja ..
             ninja -k0

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: tmadlener/run-lcg-view@ccache
         with:
           release-platform: ${{ matrix.LCG }}
+          ccache-key: ccache-edm4hep-${{ matrix.LCG }}
           run: |
             STARTDIR=$(pwd)
             echo "::group::Build Catch2"

--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -13,8 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        image: ["el9", "ubuntu2204"]
+        cvmfs_repo: ["sw.hsf.org", "sw-nightlies.hsf.org"]
         include:
-          - release: "sw-nightlies.hsf.org/key4hep"
+          - image: "ubuntu2404"
+            cvmfs_repo: "sw-nightlies.hsf.org"
 
     steps:
     - uses: actions/checkout@v4
@@ -22,8 +25,8 @@ jobs:
     - uses: key4hep/key4hep-actions/cache-external-data@main
     - uses: aidasoft/run-lcg-view@v4
       with:
-        container: el9
-        view-path: /cvmfs/${{ matrix.release }}
+        container: ${{ matrix.image }}
+        view-path: /cvmfs/${{ matrix.cvmfs_repo }}/key4hep
         run: |
           echo "::group::Run CMake"
           mkdir -p build install

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: tmadlener/run-lcg-view@ccache
+    - uses: aidasoft/run-lcg-view@v5
       with:
         container: ${{ matrix.image }}
         view-path: /cvmfs/${{ matrix.cvmfs_repo }}/key4hep

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         container: ${{ matrix.image }}
         view-path: /cvmfs/${{ matrix.cvmfs_repo }}/key4hep
+        ccache-key: ccache-key4hep-${{ matrix.image }}-${{ matrix.cvmfs_repo }}
         run: |
           echo "::group::Run CMake"
           mkdir -p build install

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: tmadlener/run-lcg-view@ccache
       with:
         container: ${{ matrix.image }}
         view-path: /cvmfs/${{ matrix.cvmfs_repo }}/key4hep

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -36,6 +36,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DUSE_EXTERNAL_CATCH2=AUTO \
             -DENABLE_RNTUPLE=ON \
             -DENABLE_DATASOURCE=ON \

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["el9", "ubuntu2204"]
+        image: ["el9"] # , "ubuntu2204"]  # see https://github.com/AIDASoft/podio/issues/765
         cvmfs_repo: ["sw.hsf.org", "sw-nightlies.hsf.org"]
         include:
           - image: "ubuntu2404"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: tmadlener/run-lcg-view@ccache
+    - uses: aidasoft/run-lcg-view@v5
       with:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-el9-${{ matrix.LCG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: tmadlener/run-lcg-view@ccache
       with:
         release-platform: ${{ matrix.LCG }}
+        ccache-key: ccache-el9-${{ matrix.LCG }}
         run: |
           echo "::group::Run CMake"
           export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"
@@ -41,6 +42,7 @@ jobs:
             -DENABLE_DATASOURCE=ON \
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=20 \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -DPODIO_USE_CLANG_FORMAT=AUTO \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: tmadlener/run-lcg-view@ccache
+    - uses: aidasoft/run-lcg-view@v5
       with:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-ubuntu-${{ matrix.LCG }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: aidasoft/run-lcg-view@v4
+    - uses: tmadlener/run-lcg-view@ccache
       with:
         release-platform: ${{ matrix.LCG }}
         run: |
@@ -34,6 +34,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=../install \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DUSE_EXTERNAL_CATCH2=OFF \
             -DPODIO_SET_RPATH=ON \
             -DENABLE_RNTUPLE=ON \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,6 +23,7 @@ jobs:
     - uses: tmadlener/run-lcg-view@ccache
       with:
         release-platform: ${{ matrix.LCG }}
+        ccache-key: ccache-ubuntu-${{ matrix.LCG }}
         run: |
           echo "::group::Run CMake"
           export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"


### PR DESCRIPTION
BEGINRELEASENOTES
- Use `ccache` in CI to speed up workflows
- Add more workflows based on Key4hep
- Cancel concurrent workflows for changes pushed before they finished

ENDRELEASENOTES

Adding more Key4hep workflows was triggered by [this comment](https://github.com/AIDASoft/podio/pull/620#issuecomment-2793451009). Depending on whether we should keep support for gcc11, we would need to keep the ubuntu22 based Key4hep workflow. Otherwise this can be removed.

- [x] Needs https://github.com/AIDASoft/run-lcg-view/pull/8