### PR TITLE
Pass by const reference in the object constructor and member setters

### DIFF
--- a/doc/templates.md
+++ b/doc/templates.md
@@ -124,22 +124,22 @@ Defined in [`python/generator_utils.py`](/python/generator_utils.py).
 The string representation gives the definition of the member, including a potentially present description string.
 In principle all members are accessible in the templates, however, the most important ones are:
 
-| field         | description                                                                                                                                                                 |
-|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`        | The name of the member                                                                                                                                                      |
-| `namespace`   | The (potentially empty) namespace of the member                                                                                                                             |
-| `bare_type`   | The type of the member without namespace                                                                                                                                    |
-| `full_type`   | The full, namespace qualified, type of the member, essentially `{{ namespace }}::{{ bare_type }}`                                                                           |
-| `description` | The (optional) description string of the member                                                                                                                             |
-| `is_builtin`  | Flag for indicating that a member is a builtin type                                                                                                                         |
-| `is_array`    | Flag for indicating that a member is a `std::array`                                                                                                                         |
-| `array_type`  | The type of the array if the member is a `std::array`                                                                                                                       |
-| `array_size`  | The size of the array if the member is a `std::array`                                                                                                                       |
-| `getter_name` | Method for generating the correct name for getter functions, depending on the `getSyntax` option in the yaml definition file.                                               |
-| `setter_name` | Method for generating the correct name for setter functions, depending on the `getSyntax` option in the yaml definition file and on whether the member is a relation or not |
-| `signature`   | The signature of a data member that can be used in function signatures, corresponds to `{{ full_type }} {{ name }}`                                                         |
-| `jl_imports`  | Import required for `StaticArrays: MVector`                                                                                                                                 |
-| `julia_type`  | Equivalent julia type for the c++ type                                                                                                                                      |
+| field         | description                                                                                                                                                                      |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`        | The name of the member                                                                                                                                                           |
+| `namespace`   | The (potentially empty) namespace of the member                                                                                                                                  |
+| `bare_type`   | The type of the member without namespace                                                                                                                                         |
+| `full_type`   | The full, namespace qualified, type of the member, essentially `{{ namespace }}::{{ bare_type }}`                                                                                |
+| `description` | The (optional) description string of the member                                                                                                                                  |
+| `is_builtin`  | Flag for indicating that a member is a builtin type                                                                                                                              |
+| `is_array`    | Flag for indicating that a member is a `std::array`                                                                                                                              |
+| `array_type`  | The type of the array if the member is a `std::array`                                                                                                                            |
+| `array_size`  | The size of the array if the member is a `std::array`                                                                                                                            |
+| `getter_name` | Method for generating the correct name for getter functions, depending on the `getSyntax` option in the yaml definition file.                                                    |
+| `setter_name` | Method for generating the correct name for setter functions, depending on the `getSyntax` option in the yaml definition file and on whether the member is a relation or not      |
+| `signature`   | The signature of a data member that can be used in function signatures, corresponds to `const {{ full_type }}& {{ name }}` if it is a builtin type, otherwise is passed by value |
+| `jl_imports`  | Import required for `StaticArrays: MVector`                                                                                                                                      |
+| `julia_type`  | Equivalent julia type for the c++ type                                                                                                                                           |
 
 ### `DataType`
 Defined in [`python/generator_utils.py`](/python/generator_utils.py).

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -137,7 +137,7 @@ In principle all members are accessible in the templates, however, the most impo
 | `array_size`  | The size of the array if the member is a `std::array`                                                                                                                            |
 | `getter_name` | Method for generating the correct name for getter functions, depending on the `getSyntax` option in the yaml definition file.                                                    |
 | `setter_name` | Method for generating the correct name for setter functions, depending on the `getSyntax` option in the yaml definition file and on whether the member is a relation or not      |
-| `signature`   | The signature of a data member that can be used in function signatures, corresponds to `const {{ full_type }}& {{ name }}` if it is a builtin type, otherwise is passed by value |
+| `signature`   | The signature of a data member that can be used in function signatures, corresponds to `const {{ full_type }}& {{ name }}` if it is not a builtin type, otherwise is passed by value |
 | `jl_imports`  | Import required for `StaticArrays: MVector`                                                                                                                                      |
 | `julia_type`  | Equivalent julia type for the c++ type                                                                                                                                           |
 

--- a/include/podio/detail/LinkCollectionData.h
+++ b/include/podio/detail/LinkCollectionData.h
@@ -63,7 +63,7 @@ public:
     if (m_data) {
       m_data->clear();
     }
-    for (auto& pointer : m_refCollections) {
+    for (const auto& pointer : m_refCollections) {
       pointer->clear();
     }
     if (m_rel_from) {
@@ -80,14 +80,14 @@ public:
       m_rel_to->clear();
     }
 
-    for (auto& obj : entries) {
+    for (const auto& obj : entries) {
       delete obj;
     }
     entries.clear();
   }
 
   void prepareForWrite(bool isSubsetColl) {
-    for (auto& pointer : m_refCollections) {
+    for (const auto& pointer : m_refCollections) {
       pointer->clear();
     }
 

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -359,7 +359,7 @@ namespace detail {
       }
     };
 
-    readBuffers.deleteBuffers = [](podio::CollectionReadBuffers& buffers) {
+    readBuffers.deleteBuffers = [](const podio::CollectionReadBuffers& buffers) {
       if (buffers.data) {
         // If we have data then we are not a subset collection and we have
         // to clean up all type erased buffers by casting them back to

--- a/python/podio_gen/generator_utils.py
+++ b/python/podio_gen/generator_utils.py
@@ -213,7 +213,7 @@ class MemberVariable:
     @property
     def signature(self):
         """Get the signature for this member variable to be used in function definitions"""
-        return f"{self.full_type} {self.name}"
+        return f"const {self.full_type}{'&' if '::' in self.full_type and self.full_type.split('::', 1)[0] != 'std' else ''} {self.name}"
 
     @property
     def docstring(self):

--- a/python/podio_gen/generator_utils.py
+++ b/python/podio_gen/generator_utils.py
@@ -213,7 +213,7 @@ class MemberVariable:
     @property
     def signature(self):
         """Get the signature for this member variable to be used in function definitions"""
-        return f"const {self.full_type}{'&' if '::' in self.full_type and self.full_type.split('::', 1)[0] != 'std' else ''} {self.name}"
+        return f"const {self.full_type}{'' if self.is_builtin else '&'} {self.name}"
 
     @property
     def docstring(self):

--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -56,7 +56,7 @@ void {{ class_type }}::clear(bool isSubsetColl) {
     // We don't own the objects so no cleanup to do here
     entries.clear();
     // Clear the ObjectID I/O buffer
-    for (auto& pointer : m_refCollections) { pointer->clear(); }
+    for (const auto& pointer : m_refCollections) { pointer->clear(); }
     return;
   }
 
@@ -65,11 +65,11 @@ void {{ class_type }}::clear(bool isSubsetColl) {
     m_data->clear();
   }
 {% if OneToManyRelations or OneToOneRelations %}
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
+  for (const auto& pointer : m_refCollections) { pointer->clear(); }
 {% endif %}
 {% for relation in OneToManyRelations %}
   // clear relations to {{ relation.name }}. Make sure to unlink() the reference data as they may be gone already.
-  for (auto& pointer : m_rel_{{ relation.name }}_tmp) {
+  for (const auto& pointer : m_rel_{{ relation.name }}_tmp) {
     for (auto& item : *pointer) {
       item.unlink();
     }
@@ -109,7 +109,7 @@ podio::CollectionWriteBuffers {{ class_type }}::getCollectionBuffers(bool isSubs
 }
 
 void {{ class_type }}::prepareForWrite(bool isSubsetColl) {
-  for (auto& pointer : m_refCollections) { pointer->clear(); }
+  for (const auto& pointer : m_refCollections) { pointer->clear(); }
 
   // If this is a subset collection use the relation storing mechanism to
   // store the ObjectIDs of all referenced objects and nothing else
@@ -122,7 +122,7 @@ void {{ class_type }}::prepareForWrite(bool isSubsetColl) {
 
   // Normal collections have to store the data and all the relations
   m_data->reserve(entries.size());
-  for (auto& obj : entries) { m_data->push_back(obj->data); }
+  for (const auto& obj : entries) { m_data->push_back(obj->data); }
 
 {% for relation in OneToManyRelations %}
   int {{ relation.name }}_index = 0;
@@ -152,7 +152,7 @@ const auto {{ member.name }}_size = std::accumulate(entries.begin(), entries.end
 
 void {{ class_type }}::prepareAfterRead(uint32_t collectionID) {
   int index = 0;
-  for (auto& data : *m_data) {
+  for (const auto& data : *m_data) {
     auto obj = new {{ class.bare_type }}Obj({index, collectionID}, data);
 
 {% for relation in OneToManyRelations %}

--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -25,7 +25,7 @@
 
 {  }
 
-{{ obj_type }}::{{ obj_type }}(const podio::ObjectID id_, {{ class.bare_type }}Data data_) :
+{{ obj_type }}::{{ obj_type }}(const podio::ObjectID& id_, const {{ class.bare_type }}Data& data_) :
   id(id_), data(data_)
 {  }
 

--- a/python/templates/Obj.h.jinja2
+++ b/python/templates/Obj.h.jinja2
@@ -32,7 +32,7 @@ public:
   {{ obj_type }}(const {{ obj_type }}&);
   /// constructor from ObjectID and {{ class.bare_type }}Data
   /// does not initialize the internal relation containers
-  {{ obj_type }}(const podio::ObjectID id, {{ class.bare_type }}Data data);
+  {{ obj_type }}(const podio::ObjectID& id, const {{ class.bare_type }}Data& data);
   /// No assignment operator
   {{ obj_type }}& operator=(const {{ obj_type }}&) = delete;
 {% if is_trivial_type %}

--- a/python/templates/macros/collections.jinja2
+++ b/python/templates/macros/collections.jinja2
@@ -200,7 +200,7 @@ podio::CollectionReadBuffers createBuffersV{{ schemaVersion }}(bool isSubset) {
     }
   };
 
-  readBuffers.deleteBuffers = [](podio::CollectionReadBuffers& buffers) {
+  readBuffers.deleteBuffers = [](const podio::CollectionReadBuffers& buffers) {
     if (buffers.data) {
       // If we have data then we are not a subset collection and we have to
       // clean up all type erased buffers by casting them back to something that

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -28,7 +28,7 @@
 {% macro member_setters(members, get_syntax) %}
 {% for member in members %}
   /// Set the {{ member.docstring }}
-  void {{ member.setter_name(get_syntax) }}({{ member.full_type }} value);
+  void {{ member.setter_name(get_syntax) }}({{ member.signature }});
 {% if member.is_array %}
   void {{ member.setter_name(get_syntax) }}(size_t i, {{ member.array_type }} value);
 {% endif %}

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -86,7 +86,7 @@ Mutable{{ type }} {{ full_type }}::clone(bool cloneRelations) const {
 {% macro member_setters(class, members, get_syntax, prefix='') %}
 {% set class_type = prefix + class.bare_type %}
 {% for member in members %}
-void {{ class_type }}::{{ member.setter_name(get_syntax) }}({{ member.full_type }} value) { m_obj->data.{{ member.name }} = value; }
+void {{ class_type }}::{{ member.setter_name(get_syntax) }}({{ member.signature }}) { m_obj->data.{{ member.name }} = {{ member.name }}; }
 {% if member.is_array %}
 void {{ class_type }}::{{ member.setter_name(get_syntax) }}(size_t i, {{ member.array_type }} value) { m_obj->data.{{ member.name }}.at(i) = value; }
 {% endif %}

--- a/src/UserDataCollection.cc
+++ b/src/UserDataCollection.cc
@@ -34,7 +34,7 @@ namespace {
               [](podio::CollectionReadBuffers& buffers) {
                 buffers.data = podio::CollectionWriteBuffers::asVector<T>(buffers.data);
               },
-              [](podio::CollectionReadBuffers& buffers) { delete static_cast<std::vector<T>*>(buffers.data); }};
+              [](const podio::CollectionReadBuffers& buffers) { delete static_cast<std::vector<T>*>(buffers.data); }};
         });
 
     // For now passing the same schema version for from and current versions


### PR DESCRIPTION
and also add const in other places while we making these changes.

BEGINRELEASENOTES
- Pass by const reference in the object constructor and member setters. Decide based on the the `is_builtin` member in python, that excludes containers of builtin types and datamodel types.
- Add const when possible for other function parameters
- Update the documentation for the `signature` member.

ENDRELEASENOTES

It would also be possible not to pass by const reference in a few places (like in https://github.com/AIDASoft/podio/blob/dd99663c533785887bcb2c9e8fa7370f4249bd43/include/podio/detail/LinkCollectionData.h#L83), since pointers are used. It seems passing by value is preferred in those cases but probably it doesn't matter.

Related: https://github.com/AIDASoft/podio/pull/633