### PR TITLE
Re-enable RNTuple support for ROOT 6.32

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -43,7 +43,7 @@ jobs:
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror -Wno-error=deprecated-declarations " \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DUSE_EXTERNAL_CATCH2=AUTO \
-            -DENABLE_RNTUPLE=OFF \
+            -DENABLE_RNTUPLE=ON \
             -DENABLE_DATASOURCE=ON \
             -G Ninja ..
           echo "::endgroup::"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,7 +35,7 @@ jobs:
           cd build
           cmake .. -DENABLE_SIO=ON \
             -DENABLE_JULIA=ON \
-            -DENABLE_RNTUPLE=OFF \
+            -DENABLE_RNTUPLE=ON \
             -DENABLE_DATASOURCE=ON \
             -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror "\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,12 +81,16 @@ set(root_components_needed RIO Tree)
 set(root_min_version 6.28.04)
 if(ENABLE_RNTUPLE)
   list(APPEND root_components_needed ROOTNTuple)
-  set(root_min_version 6.34)
+  set(root_min_version 6.32)
 endif()
 if(ENABLE_DATASOURCE)
   list(APPEND root_components_needed ROOTDataFrame)
 endif()
 find_package(ROOT ${root_min_version} REQUIRED COMPONENTS ${root_components_needed})
+
+if(ENABLE_RNTUPLE AND ROOT_VERSION VERSION_LESS 6.34)
+  message(WARNING "You are building RNTuple support against a version of ROOT that does not yet guarantee RNTuple backwards compatibility")
+endif()
 
 # ROOT_CXX_STANDARD was introduced in https://github.com/root-project/root/pull/6466
 # before that it's an empty variable so we check if it's any number > 0


### PR DESCRIPTION

BEGINRELEASENOTES
- Keep RNTuple support enabled for ROOT 6.32, but emit a warning at CMake stage

ENDRELEASENOTES

See discussion in #757 