### PR TITLE
Remove double locking in `prepareForWrite`

### DIFF
--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -22,8 +22,9 @@
 #endif
 
 // standard includes
-#include <stdexcept>
 #include <iomanip>
+#include <mutex>
+#include <stdexcept>
 
 {{ utils.namespace_open(class.namespace) }}
 
@@ -104,19 +105,7 @@ void {{ collection_type }}::clear() {
 }
 
 void {{ collection_type }}::prepareForWrite() const {
-  // TODO: Replace this double locking pattern here with an atomic and only one
-  // lock. Problem: std::atomic is not default movable.
-  {
-    std::lock_guard lock{*m_storageMtx};
-    // If the collection has been prepared already there is nothing to do
-    if (m_isPrepared) {
-      return;
-    }
-  }
-
   std::lock_guard lock{*m_storageMtx};
-  // by the time we acquire the lock another thread might have already
-  // succeeded, so we need to check again now
   if (m_isPrepared) {
     return;
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove double locking in `prepareForWrite`; acquire the lock only once

ENDRELEASENOTES

I think this double locking is unnecessary. The first time the mutex is locked only a check is performed that is also done anyway the second time, so locking once should be enough. In addition there is a test specifically for this that passes: https://github.com/AIDASoft/podio/blob/master/tests/unittests/unittest.cpp#L345

Added originally in https://github.com/AIDASoft/podio/pull/295
