### PR TITLE
Set the PODIO_SET_RPATH option to True by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message(STATUS "Setting C++ standard: '${CMAKE_CXX_STANDARD}'.")
 
 set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
 
-option(PODIO_SET_RPATH "Link libraries with built-in RPATH (run-time search path)" OFF)
+option(PODIO_SET_RPATH "Link libraries with built-in RPATH (run-time search path)" ON)
 include(cmake/podioBuild.cmake)
 podio_set_compiler_flags()
 podio_set_rpath()


### PR DESCRIPTION

BEGINRELEASENOTES
- Set the `PODIO_SET_RPATH` cmake option to `ON` by default

ENDRELEASENOTES

See discussion in key4hep/key4hep-spack#736 for a rationale.