### PR TITLE
Restore compatibility with gcc 11

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - image: "ubuntu2404"
             cvmfs_repo: "sw-nightlies.hsf.org"
-          - image: "ubuntu2204"
+          - image: "ubuntu2204"  # gcc-11 compatibility
             cvmfs_repo: "sw.hsf.org"
 
     steps:

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -47,6 +47,7 @@ jobs:
             -DUSE_EXTERNAL_CATCH2=AUTO \
             -DENABLE_RNTUPLE=ON \
             -DENABLE_DATASOURCE=ON \
+            -DPODIO_SET_RPATH=ON \
             -G Ninja ..
           echo "::endgroup::"
           echo "::group::Build"

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -22,6 +22,8 @@ jobs:
         include:
           - image: "ubuntu2404"
             cvmfs_repo: "sw-nightlies.hsf.org"
+          - image: "ubuntu2204"
+            cvmfs_repo: "sw.hsf.org"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["el9", "ubuntu2204"]
+        image: ["el9"]
         cvmfs_repo: ["sw.hsf.org", "sw-nightlies.hsf.org"]
         include:
           - image: "ubuntu2404"

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["el9" , "ubuntu2204"]
+        image: ["el9", "ubuntu2204"]
         cvmfs_repo: ["sw.hsf.org", "sw-nightlies.hsf.org"]
         include:
           - image: "ubuntu2404"

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["el9"] # , "ubuntu2204"]  # see https://github.com/AIDASoft/podio/issues/765
+        image: ["el9" , "ubuntu2204"]
         cvmfs_repo: ["sw.hsf.org", "sw-nightlies.hsf.org"]
         include:
           - image: "ubuntu2404"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev3/x86_64-ubuntu2404-gcc13-opt",
+        LCG: ["dev3/x86_64-ubuntu2204-gcc11-opt",  # gcc 11 compatibility
+              "dev3/x86_64-ubuntu2404-gcc13-opt",
               "dev4/x86_64-ubuntu2404-gcc13-opt"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        LCG: ["dev3/x86_64-ubuntu2204-gcc11-opt",  # gcc 11 compatibility
-              "dev3/x86_64-ubuntu2404-gcc13-opt",
+        LCG: ["dev3/x86_64-ubuntu2404-gcc13-opt",
               "dev4/x86_64-ubuntu2404-gcc13-opt"]
     steps:
     - uses: actions/checkout@v4

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -74,7 +74,6 @@ else()
       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
       TEST_PREFIX "UT_" # make it possible to filter easily with -R ^UT
       TEST_SPEC ${filter_tests} # discover only tests that are known to not fail
-      DL_PATHS ${CMAKE_CURRENT_BINARY_DIR}:${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$<TARGET_FILE_DIR:ROOT::Tree>:$<$<TARGET_EXISTS:SIO::sio>:$<TARGET_FILE_DIR:SIO::sio>>:$ENV{LD_LIBRARY_PATH}
         PROPERTIES
         ENVIRONMENT
         PODIO_SIOBLOCK_PATH=${PROJECT_BINARY_DIR}/tests

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -55,10 +55,6 @@ if (NOT FORCE_RUN_ALL_TESTS)
   elseif(USE_SANITIZER MATCHES "Undefined")
     set(filter_tests "~[UBSAN-FAIL]")
   endif()
-
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 11)
-    list(APPEND filter_tests "~[GCC11-FAIL]")
-  endif()
 endif()
 
 if (USE_SANITIZER MATCHES "Memory(WithOrigin)?")

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -74,7 +74,8 @@ else()
       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
       TEST_PREFIX "UT_" # make it possible to filter easily with -R ^UT
       TEST_SPEC ${filter_tests} # discover only tests that are known to not fail
-      PROPERTIES
+      DL_PATHS ${CMAKE_CURRENT_BINARY_DIR}:${PROJECT_BINARY_DIR}/src:${PROJECT_BINARY_DIR}/tests:$<TARGET_FILE_DIR:ROOT::Tree>:$<$<TARGET_EXISTS:SIO::sio>:$<TARGET_FILE_DIR:SIO::sio>>:$ENV{LD_LIBRARY_PATH}
+        PROPERTIES
         ENVIRONMENT
         PODIO_SIOBLOCK_PATH=${PROJECT_BINARY_DIR}/tests
         ENVIRONMENT

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -55,6 +55,10 @@ if (NOT FORCE_RUN_ALL_TESTS)
   elseif(USE_SANITIZER MATCHES "Undefined")
     set(filter_tests "~[UBSAN-FAIL]")
   endif()
+
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 11)
+    list(APPEND filter_tests "~[GCC11-FAIL]")
+  endif()
 endif()
 
 if (USE_SANITIZER MATCHES "Memory(WithOrigin)?")

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1342,7 +1342,17 @@ TEST_CASE("Collection as range", "[collection][ranges][std]") {
   // std::range::common_range
   STATIC_REQUIRE(std::ranges::common_range<CollectionType>);
   // std::range::viewable_range
+  // special handling of gcc 11
+#if defined(__GNUC__)
+  #if __GNUC__ < 12
+  auto view = std::ranges::ref_view(coll);
+  STATIC_REQUIRE(std::ranges::viewable_range<decltype(view)>);
+  #else
   STATIC_REQUIRE(std::ranges::viewable_range<CollectionType>);
+  #endif
+#else
+  STATIC_REQUIRE(std::ranges::viewable_range<CollectionType>);
+#endif
 }
 
 TEST_CASE("Collection and std algorithms", "[collection][iterator][std]") {
@@ -1568,7 +1578,18 @@ TEST_CASE("LinkCollection and range concepts", "[links][ranges][std]") {
   STATIC_REQUIRE(std::ranges::random_access_range<link_collection>);
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
+  // Dance around gcc11 issue
+#if defined(__GNUC__)
+  #if __GNUC__ < 12
+  auto coll = link_collection{};
+  auto view = std::ranges::ref_view(coll);
+  STATIC_REQUIRE(std::ranges::viewable_range<decltype(view)>);
+  #else
   STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);
+  #endif
+#else
+  STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);
+#endif
 }
 
 TEST_CASE("RelationRange as range", "[relations][ranges][std]") {

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1313,7 +1313,7 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
   }
 }
 
-TEST_CASE("Collection as range", "[collection][ranges][std]") {
+TEST_CASE("Collection as range", "[collection][ranges][std][GCC11-FAIL]") {
   CollectionType coll;
   coll.create();
 
@@ -1342,16 +1342,7 @@ TEST_CASE("Collection as range", "[collection][ranges][std]") {
   // std::range::common_range
   STATIC_REQUIRE(std::ranges::common_range<CollectionType>);
   // std::range::viewable_range
-  // special handling of gcc 11
-#if defined(__GNUC__)
-  #if __GNUC__ < 12
-  auto view = std::ranges::ref_view(coll);
   STATIC_REQUIRE(std::ranges::viewable_range<decltype(view)>);
-  #else
-  STATIC_REQUIRE(std::ranges::viewable_range<CollectionType>);
-  #endif
-#else
-  STATIC_REQUIRE(std::ranges::viewable_range<CollectionType>);
 #endif
 }
 
@@ -1569,7 +1560,7 @@ TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][iterators][st
   }
 }
 
-TEST_CASE("LinkCollection and range concepts", "[links][ranges][std]") {
+TEST_CASE("LinkCollection and range concepts", "[links][ranges][std][GCC11-FAIL]") {
   using link_collection = podio::LinkCollection<ExampleHit, ExampleHit>;
 
   STATIC_REQUIRE(std::ranges::input_range<link_collection>);
@@ -1579,17 +1570,7 @@ TEST_CASE("LinkCollection and range concepts", "[links][ranges][std]") {
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
   // Dance around gcc11 issue
-#if defined(__GNUC__)
-  #if __GNUC__ < 12
-  auto coll = link_collection{};
-  auto view = std::ranges::ref_view(coll);
-  STATIC_REQUIRE(std::ranges::viewable_range<decltype(view)>);
-  #else
   STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);
-  #endif
-#else
-  STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);
-#endif
 }
 
 TEST_CASE("RelationRange as range", "[relations][ranges][std]") {

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1341,11 +1341,12 @@ TEST_CASE("Collection as range", "[collection][ranges][std][GCC11-FAIL]") {
   DOCUMENTED_STATIC_FAILURE(std::ranges::contiguous_range<CollectionType>);
   // std::range::common_range
   STATIC_REQUIRE(std::ranges::common_range<CollectionType>);
-#if defined(__GNUC__)
-  #if __GNUC__ >= 12
-  // std::range::viewable_range
+#if defined(__GNUC__) && __GNUC__ < 12
+  // gcc 11 does not yet implement a fix for:
+  // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html
+  DOCUMENTED_STATIC_FAILURE(std::ranges::viewable_range<CollectionType>);
+#else
   STATIC_REQUIRE(std::ranges::viewable_range<CollectionType>);
-  #endif
 #endif
 }
 
@@ -1572,10 +1573,12 @@ TEST_CASE("LinkCollection and range concepts", "[links][ranges][std]") {
   STATIC_REQUIRE(std::ranges::random_access_range<link_collection>);
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
-#if defined(__GNUC__)
-  #if __GNUC__ >= 12
+#if defined(__GNUC__) && __GNUC__ < 12
+  // gcc 11 does not yet implement a fix for:
+  // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html
+  DOCUMENTED_STATIC_FAILURE(std::ranges::viewable_range<link_collection>);
+#else
   STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);
-  #endif
 #endif
 }
 

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1341,7 +1341,7 @@ TEST_CASE("Collection as range", "[collection][ranges][std]") {
   DOCUMENTED_STATIC_FAILURE(std::ranges::contiguous_range<CollectionType>);
   // std::range::common_range
   STATIC_REQUIRE(std::ranges::common_range<CollectionType>);
-#if defined(__GNUC__) && __GNUC__ < 12
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 12
   // gcc 11 does not yet implement a fix for:
   // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html
   DOCUMENTED_STATIC_FAILURE(std::ranges::viewable_range<CollectionType>);
@@ -1573,7 +1573,7 @@ TEST_CASE("LinkCollection and range concepts", "[links][ranges][std]") {
   STATIC_REQUIRE(std::ranges::random_access_range<link_collection>);
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
-#if defined(__GNUC__) && __GNUC__ < 12
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 12
   // gcc 11 does not yet implement a fix for:
   // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html
   DOCUMENTED_STATIC_FAILURE(std::ranges::viewable_range<link_collection>);

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1341,8 +1341,12 @@ TEST_CASE("Collection as range", "[collection][ranges][std][GCC11-FAIL]") {
   DOCUMENTED_STATIC_FAILURE(std::ranges::contiguous_range<CollectionType>);
   // std::range::common_range
   STATIC_REQUIRE(std::ranges::common_range<CollectionType>);
+#if defined(__GNUC__)
+  #if __GNUC__ >= 12
   // std::range::viewable_range
   STATIC_REQUIRE(std::ranges::viewable_range<CollectionType>);
+  #endif
+#endif
 }
 
 TEST_CASE("Collection and std algorithms", "[collection][iterator][std]") {
@@ -1559,7 +1563,7 @@ TEST_CASE("LinkCollectionIterator and iterator concepts", "[links][iterators][st
   }
 }
 
-TEST_CASE("LinkCollection and range concepts", "[links][ranges][std][GCC11-FAIL]") {
+TEST_CASE("LinkCollection and range concepts", "[links][ranges][std]") {
   using link_collection = podio::LinkCollection<ExampleHit, ExampleHit>;
 
   STATIC_REQUIRE(std::ranges::input_range<link_collection>);
@@ -1568,7 +1572,11 @@ TEST_CASE("LinkCollection and range concepts", "[links][ranges][std][GCC11-FAIL]
   STATIC_REQUIRE(std::ranges::random_access_range<link_collection>);
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
+#if defined(__GNUC__)
+  #if __GNUC__ >= 12
   STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);
+  #endif
+#endif
 }
 
 TEST_CASE("RelationRange as range", "[relations][ranges][std]") {

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1342,8 +1342,7 @@ TEST_CASE("Collection as range", "[collection][ranges][std][GCC11-FAIL]") {
   // std::range::common_range
   STATIC_REQUIRE(std::ranges::common_range<CollectionType>);
   // std::range::viewable_range
-  STATIC_REQUIRE(std::ranges::viewable_range<decltype(view)>);
-#endif
+  STATIC_REQUIRE(std::ranges::viewable_range<CollectionType>);
 }
 
 TEST_CASE("Collection and std algorithms", "[collection][iterator][std]") {
@@ -1569,7 +1568,6 @@ TEST_CASE("LinkCollection and range concepts", "[links][ranges][std][GCC11-FAIL]
   STATIC_REQUIRE(std::ranges::random_access_range<link_collection>);
   STATIC_REQUIRE(std::ranges::sized_range<link_collection>);
   STATIC_REQUIRE(std::ranges::common_range<link_collection>);
-  // Dance around gcc11 issue
   STATIC_REQUIRE(std::ranges::viewable_range<link_collection>);
 }
 

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1313,7 +1313,7 @@ TEST_CASE("Collection and std iterator adaptors", "[collection][container][adapt
   }
 }
 
-TEST_CASE("Collection as range", "[collection][ranges][std][GCC11-FAIL]") {
+TEST_CASE("Collection as range", "[collection][ranges][std]") {
   CollectionType coll;
   coll.create();
 

--- a/tools/src/podio-dump-tool.cpp
+++ b/tools/src/podio-dump-tool.cpp
@@ -70,19 +70,21 @@ std::vector<size_t> parseEventRange(const std::string_view evtRange) {
   };
 
   // Split by ',' and transform into a range of string views
-  auto splitRange = evtRange | rv::split(',') |
-      rv::transform([](auto&& subrange) { return std::string_view(subrange.begin(), subrange.end()); });
+  auto splitRange = evtRange | rv::split(',') | rv::transform([](auto&& subrange) {
+                      return std::string_view(&*subrange.begin(), std::ranges::distance(subrange));
+                    });
 
   if (std::ranges::distance(splitRange) == 1) {
     // Only one entry, check if it's a range (start:end)
-    auto colonSplitRange = evtRange | rv::split(':') |
-        rv::transform([](auto&& subrange) { return std::string_view(subrange.begin(), subrange.end()); });
+    auto colonSplitRange = evtRange | rv::split(':') | rv::transform([](auto&& subrange) {
+                             return std::string_view(&*subrange.begin(), std::ranges::distance(subrange));
+                           });
 
     const auto it = std::ranges::begin(colonSplitRange);
     const auto nextIt = std::ranges::next(it);
 
     if (std::ranges::distance(colonSplitRange) == 1) {
-      return {parseSizeOrExit(*it)};
+      return std::vector<size_t>{parseSizeOrExit(*it)};
     } else if (std::ranges::distance(colonSplitRange) == 2 && !(*nextIt).empty()) {
       size_t start = parseSizeOrExit(*it);
       size_t stop = parseSizeOrExit(*nextIt);

--- a/tools/src/podio-dump-tool.cpp
+++ b/tools/src/podio-dump-tool.cpp
@@ -17,8 +17,6 @@
 #include <string>
 #include <tuple>
 
-namespace rv = std::ranges::views;
-
 template <>
 struct fmt::formatter<podio::version::Version> : ostream_formatter {};
 
@@ -69,16 +67,12 @@ std::vector<size_t> parseEventRange(const std::string_view evtRange) {
     std::exit(1);
   };
 
-  // Split by ',' and transform into a range of string views
-  auto splitRange = evtRange | rv::split(',') | rv::transform([](auto&& subrange) {
-                      return std::string_view(&*subrange.begin(), std::ranges::distance(subrange));
-                    });
+  // Split by ',' to see if we have to handle multiple events
+  auto splitRange = podio::utils::splitString(evtRange, ',');
 
   if (std::ranges::distance(splitRange) == 1) {
     // Only one entry, check if it's a range (start:end)
-    auto colonSplitRange = evtRange | rv::split(':') | rv::transform([](auto&& subrange) {
-                             return std::string_view(&*subrange.begin(), std::ranges::distance(subrange));
-                           });
+    auto colonSplitRange = podio::utils::splitString(evtRange, ':');
 
     const auto it = std::ranges::begin(colonSplitRange);
     const auto nextIt = std::ranges::next(it);


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure compilation with gcc11 is possible again and add a workflow based on LCG_107 and Ubuntu 22 to check compatibility in CI

ENDRELEASENOTES

Fixes #765 

Thanks to Mistral who suggested the two fixes for the ranges.

- In `podio-dump-tool` it looks like gcc11 is still missing a `string_view` constructor (my interpretation)
- For the std interoperability checks it looks like gcc11 has not yet fixed https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html