### PR TITLE
Add a workaround for avoiding opening every library in LD_LIBRARY_PATH

### DIFF
--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -78,4 +78,19 @@ std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}& value);
 
 {{ macros.std_hash(class) }}
 
+// This is needed to avoid triggering opening every library in LD_LIBRARY_PATH
+// until it's fixed in ROOT. See https://github.com/root-project/root/issues/18489
+// and https://github.com/AIDASoft/podio/issues/770
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
+constexpr std::string_view {{ class.full_type }}::typeName;
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
+constexpr std::string_view {{ class.full_type }}::typeName;
+#pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -83,7 +83,9 @@ std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}& value);
 // and https://github.com/AIDASoft/podio/issues/770
 #if defined(__clang__)
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
+#pragma clang diagnostic ignored "-Wdeprecated"
 constexpr std::string_view {{ class.full_type }}::typeName;
 #pragma clang diagnostic pop
 #elif defined(__GNUC__)


### PR DESCRIPTION
Workaround for https://github.com/AIDASoft/podio/issues/770.

BEGINRELEASENOTES
- Define `typeName` outside of each object class, in addition to the existing definition inside the class.

ENDRELEASENOTES

The redundant declaration outside of the class is deprecated, so we have to remove the warnings. With this, opening all the libraries doesn't happen for any of the EDM4hep object classes. There is the possibility to add a test but `strace` is not available in all the container images used in CI I think.