### PR TITLE
Clean up the ROOT readers and writers

### DIFF
--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -2,7 +2,6 @@
 #define PODIO_RNTUPLEREADER_H
 
 #include "podio/ROOTFrameData.h"
-#include "podio/SchemaEvolution.h"
 #include "podio/podioVersion.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 #include "podio/utilities/RootHelpers.h"
@@ -150,10 +149,10 @@ private:
   /**
    * Read and reconstruct the generic parameters of the Frame
    */
-  GenericParameters readEventMetaData(const std::string& name, unsigned localEntry, unsigned readerIndex);
+  GenericParameters readEventMetaData(const std::string& name, const unsigned localEntry, const unsigned readerIndex);
 
   template <typename T>
-  void readParams(const std::string& name, unsigned entNum, unsigned readerIndex, GenericParameters& params);
+  void readParams(const std::string& name, const unsigned entNum, const unsigned readerIndex, GenericParameters& params);
 
   std::unique_ptr<root_compat::RNTupleReader> m_metadata{};
 

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -152,7 +152,8 @@ private:
   GenericParameters readEventMetaData(const std::string& name, const unsigned localEntry, const unsigned readerIndex);
 
   template <typename T>
-  void readParams(const std::string& name, const unsigned entNum, const unsigned readerIndex, GenericParameters& params);
+  void readParams(const std::string& name, const unsigned entNum, const unsigned readerIndex,
+                  GenericParameters& params);
 
   std::unique_ptr<root_compat::RNTupleReader> m_metadata{};
 

--- a/include/podio/RNTupleWriter.h
+++ b/include/podio/RNTupleWriter.h
@@ -2,7 +2,6 @@
 #define PODIO_RNTUPLEWRITER_H
 
 #include "podio/Frame.h"
-#include "podio/SchemaEvolution.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 #include "podio/utilities/RootHelpers.h"
 

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -9,6 +9,7 @@
 #include "TChain.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -1,7 +1,6 @@
 #ifndef PODIO_ROOTWRITER_H
 #define PODIO_ROOTWRITER_H
 
-#include "podio/CollectionIDTable.h"
 #include "podio/utilities/DatamodelRegistryIOHelpers.h"
 #include "podio/utilities/RootHelpers.h"
 

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -35,7 +35,8 @@ void RNTupleReader::readParams(const std::string& name, const unsigned localEntr
   params.loadFrom(keyView(localEntry), valueView(localEntry));
 }
 
-GenericParameters RNTupleReader::readEventMetaData(const std::string& name, const unsigned localEntry, const unsigned readerIndex) {
+GenericParameters RNTupleReader::readEventMetaData(const std::string& name, const unsigned localEntry,
+                                                   const unsigned readerIndex) {
   GenericParameters params;
 
   readParams<int>(name, localEntry, readerIndex, params);

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -52,7 +52,7 @@ bool RNTupleReader::initCategory(const std::string& category) {
     return false;
   }
   // Assume that the metadata is the same in all files
-  const auto filename = m_filenames[0];
+  const auto& filename = m_filenames[0];
 
   auto collInfo = m_metadata_readers[filename]->GetView<std::vector<root_utils::CollectionWriteInfo>>(
       {root_utils::collInfoName(category)});

--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -250,7 +250,8 @@ void RNTupleWriter::finish() {
     }
   }
 
-  const auto edmField = metadata->MakeField<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
+  const auto edmField =
+      metadata->MakeField<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
   *edmField = std::move(edmDefinitions);
 
   const auto availableCategoriesField = metadata->MakeField<std::vector<std::string>>(root_utils::availableCategories);
@@ -265,7 +266,8 @@ void RNTupleWriter::finish() {
   }
 
   metadata->Freeze();
-  const auto metadataWriter = root_compat::RNTupleWriter::Append(std::move(metadata), root_utils::metaTreeName, *m_file, {});
+  const auto metadataWriter =
+      root_compat::RNTupleWriter::Append(std::move(metadata), root_utils::metaTreeName, *m_file, {});
 
   metadataWriter->Fill();
 

--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -1,6 +1,5 @@
 #include "podio/RNTupleWriter.h"
 #include "podio/DatamodelRegistry.h"
-#include "podio/SchemaEvolution.h"
 #include "podio/podioVersion.h"
 #include "podio/utilities/RootHelpers.h"
 #include "rootUtils.h"
@@ -67,7 +66,7 @@ void RNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& cat
 
   // Use the writer as proxy to check whether this category has been initialized
   // already and do so if not
-  const bool new_category = (catInfo.writer == nullptr);
+  const bool new_category = catInfo.writer == nullptr;
   if (new_category) {
     // This is the minimal information that we need for now
     catInfo.names = podio::utils::sortAlphabeticaly(collsToWrite);
@@ -78,7 +77,7 @@ void RNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& cat
   // Only loop over the collections that were requested in the first Frame of
   // this category
   for (const auto& name : catInfo.names) {
-    auto* coll = frame.getCollectionForWrite(name);
+    const auto* coll = frame.getCollectionForWrite(name);
     if (!coll) {
       // Make sure all collections that we want to write are actually available
       // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
@@ -105,37 +104,37 @@ void RNTupleWriter::writeFrame(const podio::Frame& frame, const std::string& cat
     }
   }
 
-  auto entry = m_categories[category].writer->GetModel().CreateBareEntry();
+  const auto entry = m_categories[category].writer->GetModel().CreateBareEntry();
 
   RNTupleWriteOptions options;
   options.SetCompression(ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
 
   for (const auto& [name, coll] : collections) {
-    auto collBuffers = coll->getBuffers();
+    const auto collBuffers = coll->getBuffers();
     if (collBuffers.vecPtr) {
       entry->BindRawPtr(name, static_cast<void*>(collBuffers.vecPtr));
     }
 
     if (coll->isSubsetCollection()) {
-      auto& refColl = (*collBuffers.references)[0];
+      const auto& refColl = (*collBuffers.references)[0];
       const auto brName = root_utils::subsetBranch(name);
       entry->BindRawPtr(brName, refColl.get());
 
     } else {
 
       const auto relVecNames = podio::DatamodelRegistry::instance().getRelationNames(coll->getValueTypeName());
-      if (auto refColls = collBuffers.references) {
-        int i = 0;
-        for (auto& c : (*refColls)) {
+      if (const auto refColls = collBuffers.references) {
+        size_t i = 0;
+        for (const auto& c : *refColls) {
           const auto brName = root_utils::refBranch(name, relVecNames.relations[i]);
           entry->BindRawPtr(brName, c.get());
           ++i;
         }
       }
 
-      if (auto vmInfo = collBuffers.vectorMembers) {
-        int i = 0;
-        for (auto& [type, vec] : (*vmInfo)) {
+      if (const auto vmInfo = collBuffers.vectorMembers) {
+        size_t i = 0;
+        for (const auto& [type, vec] : *vmInfo) {
           const auto typeName = "vector<" + type + ">";
           const auto brName = root_utils::vecBranch(name, relVecNames.vectorMembers[i]);
           auto ptr = *static_cast<std::vector<int>**>(vec);
@@ -163,7 +162,7 @@ std::unique_ptr<root_compat::RNTupleModel>
 RNTupleWriter::createModels(const std::vector<root_utils::StoreCollection>& collections) {
   auto model = root_compat::RNTupleModel::CreateBare();
 
-  for (auto& [name, coll] : collections) {
+  for (const auto& [name, coll] : collections) {
     // For the first entry in each category we also record the datamodel
     // definition
     m_datamodelCollector.registerDatamodelDefinition(coll, name);
@@ -171,33 +170,33 @@ RNTupleWriter::createModels(const std::vector<root_utils::StoreCollection>& coll
     const auto collBuffers = coll->getBuffers();
 
     if (collBuffers.vecPtr) {
-      auto collClassName = "std::vector<" + std::string(coll->getDataTypeName()) + ">";
+      const auto collClassName = "std::vector<" + std::string(coll->getDataTypeName()) + ">";
       auto field = RFieldBase::Create(name, collClassName).Unwrap();
       model->AddField(std::move(field));
     }
 
     if (coll->isSubsetCollection()) {
       const auto brName = root_utils::subsetBranch(name);
-      auto collClassName = "vector<podio::ObjectID>";
+      const auto collClassName = "vector<podio::ObjectID>";
       auto field = RFieldBase::Create(brName, collClassName).Unwrap();
       model->AddField(std::move(field));
     } else {
 
       const auto relVecNames = podio::DatamodelRegistry::instance().getRelationNames(coll->getValueTypeName());
-      if (auto refColls = collBuffers.references) {
-        int i = 0;
-        for (auto& c [[maybe_unused]] : (*refColls)) {
+      if (const auto refColls = collBuffers.references) {
+        size_t i = 0;
+        for (const auto& c [[maybe_unused]] : *refColls) {
           const auto brName = root_utils::refBranch(name, relVecNames.relations[i]);
-          auto collClassName = "vector<podio::ObjectID>";
+          const auto collClassName = "vector<podio::ObjectID>";
           auto field = RFieldBase::Create(brName, collClassName).Unwrap();
           model->AddField(std::move(field));
           ++i;
         }
       }
 
-      if (auto vminfo = collBuffers.vectorMembers) {
-        int i = 0;
-        for (auto& [type, vec] : (*vminfo)) {
+      if (const auto vminfo = collBuffers.vectorMembers) {
+        size_t i = 0;
+        for (const auto& [type, vec] : *vminfo) {
           const auto typeName = "vector<" + type + ">";
           const auto brName = root_utils::vecBranch(name, relVecNames.vectorMembers[i]);
           auto field = RFieldBase::Create(brName, typeName).Unwrap();
@@ -227,46 +226,46 @@ RNTupleWriter::createModels(const std::vector<root_utils::StoreCollection>& coll
 }
 
 RNTupleWriter::CategoryInfo& RNTupleWriter::getCategoryInfo(const std::string& category) {
-  if (auto it = m_categories.find(category); it != m_categories.end()) {
+  if (const auto it = m_categories.find(category); it != m_categories.end()) {
     return it->second;
   }
 
-  auto [it, _] = m_categories.try_emplace(category, CategoryInfo{});
+  const auto [it, _] = m_categories.try_emplace(category, CategoryInfo{});
   return it->second;
 }
 
 void RNTupleWriter::finish() {
   auto metadata = root_compat::RNTupleModel::Create();
 
-  auto podioVersion = podio::version::build_version;
+  const auto podioVersion = podio::version::build_version;
   auto versionField = metadata->MakeField<std::vector<uint16_t>>(root_utils::versionBranchName);
   *versionField = {podioVersion.major, podioVersion.minor, podioVersion.patch};
 
-  auto edmDefinitions = m_datamodelCollector.getDatamodelDefinitionsToWrite();
+  const auto edmDefinitions = m_datamodelCollector.getDatamodelDefinitionsToWrite();
   for (const auto& [name, _] : edmDefinitions) {
-    auto edmVersion = DatamodelRegistry::instance().getDatamodelVersion(name);
+    const auto edmVersion = DatamodelRegistry::instance().getDatamodelVersion(name);
     if (edmVersion) {
-      auto edmVersionField = metadata->MakeField<std::vector<uint16_t>>(root_utils::edmVersionBranchName(name).c_str());
+      const auto edmVersionField = metadata->MakeField<std::vector<uint16_t>>(root_utils::edmVersionBranchName(name));
       *edmVersionField = {edmVersion->major, edmVersion->minor, edmVersion->patch};
     }
   }
 
-  auto edmField = metadata->MakeField<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
+  const auto edmField = metadata->MakeField<std::vector<std::tuple<std::string, std::string>>>(root_utils::edmDefBranchName);
   *edmField = std::move(edmDefinitions);
 
-  auto availableCategoriesField = metadata->MakeField<std::vector<std::string>>(root_utils::availableCategories);
-  for (auto& [c, _] : m_categories) {
+  const auto availableCategoriesField = metadata->MakeField<std::vector<std::string>>(root_utils::availableCategories);
+  for (const auto& [c, _] : m_categories) {
     availableCategoriesField->push_back(c);
   }
 
-  for (auto& [category, collInfo] : m_categories) {
-    auto collInfoField =
+  for (const auto& [category, collInfo] : m_categories) {
+    const auto collInfoField =
         metadata->MakeField<std::vector<root_utils::CollectionWriteInfo>>({root_utils::collInfoName(category)});
     *collInfoField = collInfo.collInfo;
   }
 
   metadata->Freeze();
-  auto metadataWriter = root_compat::RNTupleWriter::Append(std::move(metadata), root_utils::metaTreeName, *m_file, {});
+  const auto metadataWriter = root_compat::RNTupleWriter::Append(std::move(metadata), root_utils::metaTreeName, *m_file, {});
 
   metadataWriter->Fill();
 
@@ -287,7 +286,7 @@ RNTupleWriter::checkConsistency(const std::vector<std::string>& collsToWrite, co
     return root_utils::getInconsistentColls(it->second.names, collsToWrite);
   }
 
-  return {std::vector<std::string>{}, collsToWrite};
+  return {{}, collsToWrite};
 }
 
 } // namespace podio

--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -286,7 +286,7 @@ RNTupleWriter::checkConsistency(const std::vector<std::string>& collsToWrite, co
     return root_utils::getInconsistentColls(it->second.names, collsToWrite);
   }
 
-  return {{}, collsToWrite};
+  return {std::vector<std::string>{}, collsToWrite};
 }
 
 } // namespace podio

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -187,7 +187,7 @@ void ROOTReader::initCategory(CategoryInfo& catInfo, const std::string& category
   auto* collInfoBranch = root_utils::getBranch(m_metaChain.get(), root_utils::collInfoName(category));
 
   auto collInfo = std::vector<root_utils::CollectionWriteInfo>();
-  auto collInfoPtr = &collInfo;
+  auto* collInfoPtr = &collInfo;
   if (m_fileVersion >= podio::version::Version{1, 2, 99}) {
     collInfoBranch->SetAddress(&collInfoPtr);
     collInfoBranch->GetEntry(0);
@@ -195,7 +195,7 @@ void ROOTReader::initCategory(CategoryInfo& catInfo, const std::string& category
     auto collInfoOld = std::vector<root_utils::CollectionWriteInfoT>();
     if (m_fileVersion < podio::version::Version{0, 16, 4}) {
       auto collInfoReallyOld = std::vector<root_utils::CollectionInfoWithoutSchemaT>();
-      auto tmpPtr = &collInfoReallyOld;
+      auto* tmpPtr = &collInfoReallyOld;
       collInfoBranch->SetAddress(&tmpPtr);
       collInfoBranch->GetEntry(0);
       collInfoOld.reserve(collInfoReallyOld.size());
@@ -204,7 +204,7 @@ void ROOTReader::initCategory(CategoryInfo& catInfo, const std::string& category
         collInfo.emplace_back(collID, std::move(collType), isSubsetColl, 1u);
       }
     } else {
-      auto tmpPtr = &collInfoOld;
+      auto* tmpPtr = &collInfoOld;
       collInfoBranch->SetAddress(&tmpPtr);
       collInfoBranch->GetEntry(0);
     }
@@ -291,16 +291,15 @@ void ROOTReader::openFiles(const std::vector<std::string>& filenames) {
     }
   }
 
-  podio::version::Version* versionPtr{nullptr};
+  auto* versionPtr = &m_fileVersion;
   if (auto* versionBranch = root_utils::getBranch(m_metaChain.get(), root_utils::versionBranchName)) {
     versionBranch->SetAddress(&versionPtr);
     versionBranch->GetEntry(0);
   }
-  m_fileVersion = versionPtr ? *versionPtr : podio::version::Version{0, 0, 0};
 
   if (auto* edmDefBranch = root_utils::getBranch(m_metaChain.get(), root_utils::edmDefBranchName)) {
     auto datamodelDefs = DatamodelDefinitionHolder::MapType{};
-    auto datamodelDefsPtr = &datamodelDefs;
+    auto* datamodelDefsPtr = &datamodelDefs;
     edmDefBranch->SetAddress(&datamodelDefsPtr);
     edmDefBranch->GetEntry(0);
 
@@ -308,7 +307,7 @@ void ROOTReader::openFiles(const std::vector<std::string>& filenames) {
     for (const auto& [name, _] : datamodelDefs) {
       if (auto* edmVersionBranch = root_utils::getBranch(m_metaChain.get(), root_utils::edmVersionBranchName(name))) {
         const auto edmVersion = podio::version::Version{};
-        auto tmpPtr = &edmVersion;
+        auto* tmpPtr = &edmVersion;
         edmVersionBranch->SetAddress(&tmpPtr);
         edmVersionBranch->GetEntry(0);
         edmVersions.emplace_back(name, edmVersion);

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -14,9 +14,13 @@
 #include "TClass.h"
 
 #include <algorithm>
-#include <cstdint>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <tuple>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace podio {
 
@@ -182,41 +186,42 @@ void ROOTReader::initCategory(CategoryInfo& catInfo, const std::string& category
 
   auto* collInfoBranch = root_utils::getBranch(m_metaChain.get(), root_utils::collInfoName(category));
 
-  auto collInfo = new std::vector<root_utils::CollectionWriteInfo>();
+  auto collInfo = std::vector<root_utils::CollectionWriteInfo>();
+  auto collInfoPtr = &collInfo;
   if (m_fileVersion >= podio::version::Version{1, 2, 99}) {
-    collInfoBranch->SetAddress(&collInfo);
+    collInfoBranch->SetAddress(&collInfoPtr);
     collInfoBranch->GetEntry(0);
   } else {
-    auto collInfoOld = new std::vector<root_utils::CollectionWriteInfoT>();
+    auto collInfoOld = std::vector<root_utils::CollectionWriteInfoT>();
     if (m_fileVersion < podio::version::Version{0, 16, 4}) {
-      auto collInfoReallyOld = new std::vector<root_utils::CollectionInfoWithoutSchemaT>();
-      collInfoBranch->SetAddress(&collInfoReallyOld);
+      auto collInfoReallyOld = std::vector<root_utils::CollectionInfoWithoutSchemaT>();
+      auto tmpPtr = &collInfoReallyOld;
+      collInfoBranch->SetAddress(&tmpPtr);
       collInfoBranch->GetEntry(0);
-      collInfoOld->reserve(collInfoReallyOld->size());
-      for (auto& [collID, collType, isSubsetColl] : *collInfoReallyOld) {
+      collInfoOld.reserve(collInfoReallyOld.size());
+      for (const auto& [collID, collType, isSubsetColl] : collInfoReallyOld) {
         // Manually set the schema version to 1
-        collInfo->emplace_back(collID, std::move(collType), isSubsetColl, 1u);
+        collInfo.emplace_back(collID, std::move(collType), isSubsetColl, 1u);
       }
-      delete collInfoReallyOld;
     } else {
-      collInfoBranch->SetAddress(&collInfoOld);
+      auto tmpPtr = &collInfoOld;
+      collInfoBranch->SetAddress(&tmpPtr);
       collInfoBranch->GetEntry(0);
     }
     // "Convert" to new style
-    collInfo->reserve(collInfoOld->size());
-    for (auto& [id, typeName, isSubsetColl, schemaVersion] : *collInfoOld) {
-      collInfo->emplace_back(id, std::move(typeName), isSubsetColl, schemaVersion);
+    collInfo.reserve(collInfoOld.size());
+    for (const auto& [id, typeName, isSubsetColl, schemaVersion] : collInfoOld) {
+      collInfo.emplace_back(id, std::move(typeName), isSubsetColl, schemaVersion);
     }
-    delete collInfoOld;
   }
 
   // Recreate the idTable form the collection info if necessary, otherwise read
   // it directly
   if (m_fileVersion >= podio::version::Version{1, 2, 99}) {
-    catInfo.table = root_utils::makeCollIdTable(*collInfo);
+    catInfo.table = root_utils::makeCollIdTable(collInfo);
   } else {
     catInfo.table = std::make_shared<podio::CollectionIDTable>();
-    auto* table = catInfo.table.get();
+    const auto* table = catInfo.table.get();
     auto* tableBranch = root_utils::getBranch(m_metaChain.get(), root_utils::idTableName(category));
     tableBranch->SetAddress(&table);
     tableBranch->GetEntry(0);
@@ -226,12 +231,11 @@ void ROOTReader::initCategory(CategoryInfo& catInfo, const std::string& category
   // from older versions
   if (m_fileVersion < podio::version::Version{0, 16, 99}) {
     std::tie(catInfo.branches, catInfo.storedClasses) =
-        createCollectionBranchesIndexBased(catInfo.chain.get(), *catInfo.table, *collInfo);
+        createCollectionBranchesIndexBased(catInfo.chain.get(), *catInfo.table, collInfo);
   } else {
     std::tie(catInfo.branches, catInfo.storedClasses) =
-        createCollectionBranches(catInfo.chain.get(), *catInfo.table, *collInfo);
+        createCollectionBranches(catInfo.chain.get(), *catInfo.table, collInfo);
   }
-  delete collInfo;
 
   // Finally set up the branches for the parameters
   if (m_fileVersion < podio::version::Version{0, 99, 99}) {
@@ -253,12 +257,12 @@ void ROOTReader::initCategory(CategoryInfo& catInfo, const std::string& category
 }
 
 std::vector<std::string> getAvailableCategories(TChain* metaChain) {
-  auto* branches = metaChain->GetListOfBranches();
+  const auto* branches = metaChain->GetListOfBranches();
   std::vector<std::string> brNames;
   brNames.reserve(branches->GetEntries());
 
-  for (int i = 0; i < branches->GetEntries(); ++i) {
-    const std::string name = branches->At(i)->GetName();
+  for (const auto branch : *branches) {
+    const std::string name = branch->GetName();
     const auto fUnder = name.find(root_utils::collInfoName(""));
     if (fUnder != std::string::npos) {
       brNames.emplace_back(name.substr(0, fUnder));
@@ -293,26 +297,25 @@ void ROOTReader::openFiles(const std::vector<std::string>& filenames) {
     versionBranch->GetEntry(0);
   }
   m_fileVersion = versionPtr ? *versionPtr : podio::version::Version{0, 0, 0};
-  delete versionPtr;
 
   if (auto* edmDefBranch = root_utils::getBranch(m_metaChain.get(), root_utils::edmDefBranchName)) {
-    auto* datamodelDefs = new DatamodelDefinitionHolder::MapType{};
-    edmDefBranch->SetAddress(&datamodelDefs);
+    auto datamodelDefs = DatamodelDefinitionHolder::MapType{};
+    auto datamodelDefsPtr = &datamodelDefs;
+    edmDefBranch->SetAddress(&datamodelDefsPtr);
     edmDefBranch->GetEntry(0);
 
     DatamodelDefinitionHolder::VersionList edmVersions{};
-    for (const auto& [name, _] : *datamodelDefs) {
+    for (const auto& [name, _] : datamodelDefs) {
       if (auto* edmVersionBranch = root_utils::getBranch(m_metaChain.get(), root_utils::edmVersionBranchName(name))) {
-        auto* edmVersion = new podio::version::Version{};
-        edmVersionBranch->SetAddress(&edmVersion);
+        const auto edmVersion = podio::version::Version{};
+        auto tmpPtr = &edmVersion;
+        edmVersionBranch->SetAddress(&tmpPtr);
         edmVersionBranch->GetEntry(0);
-        edmVersions.emplace_back(name, *edmVersion);
-        delete edmVersion;
+        edmVersions.emplace_back(name, edmVersion);
       }
     }
 
-    m_datamodelHolder = DatamodelDefinitionHolder(std::move(*datamodelDefs), std::move(edmVersions));
-    delete datamodelDefs;
+    m_datamodelHolder = DatamodelDefinitionHolder(std::move(datamodelDefs), std::move(edmVersions));
   }
 
   // Do some work up front for setting up categories and setup all the chains
@@ -320,7 +323,7 @@ void ROOTReader::openFiles(const std::vector<std::string>& filenames) {
   // demand when the category is first read
   m_availCategories = ::podio::getAvailableCategories(m_metaChain.get());
   for (const auto& cat : m_availCategories) {
-    auto [it, _] = m_categories.try_emplace(cat, std::make_unique<TChain>(cat.c_str()));
+    const auto [it, _] = m_categories.try_emplace(cat, std::make_unique<TChain>(cat.c_str()));
     for (const auto& fn : filenames) {
       it->second.chain->Add(fn.c_str());
     }
@@ -328,7 +331,7 @@ void ROOTReader::openFiles(const std::vector<std::string>& filenames) {
 }
 
 unsigned ROOTReader::getEntries(const std::string& name) const {
-  if (auto it = m_categories.find(name); it != m_categories.end()) {
+  if (const auto it = m_categories.find(name); it != m_categories.end()) {
     return it->second.chain->GetEntries();
   }
 
@@ -362,12 +365,12 @@ createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable
     const auto collectionClass = TClass::GetClass(collType.c_str());
     // Need the collection here to setup all the branches. Have to manage the
     // temporary collection ourselves
-    auto collection =
+    const auto collection =
         std::unique_ptr<podio::CollectionBase>(static_cast<podio::CollectionBase*>(collectionClass->New()));
     root_utils::CollectionBranches branches{};
     if (isSubsetColl) {
       // Only one branch will exist and we can trivially get its name
-      auto brName = root_utils::refBranch(name, 0);
+      const auto brName = root_utils::refBranch(name, 0);
       branches.refs.push_back(root_utils::getBranch(chain, brName.c_str()));
       branches.refNames.emplace_back(std::move(brName));
     } else {
@@ -377,13 +380,13 @@ createCollectionBranchesIndexBased(TChain* chain, const podio::CollectionIDTable
 
       const auto buffers = collection->getBuffers();
       for (size_t i = 0; i < buffers.references->size(); ++i) {
-        auto brName = root_utils::refBranch(name, i);
+        const auto brName = root_utils::refBranch(name, i);
         branches.refs.push_back(root_utils::getBranch(chain, brName.c_str()));
         branches.refNames.emplace_back(std::move(brName));
       }
 
       for (size_t i = 0; i < buffers.vectorMembers->size(); ++i) {
-        auto brName = root_utils::vecBranch(name, i);
+        const auto brName = root_utils::vecBranch(name, i);
         branches.vecs.push_back(root_utils::getBranch(chain, brName.c_str()));
         branches.vecNames.emplace_back(std::move(brName));
       }
@@ -414,7 +417,7 @@ createCollectionBranches(TChain* chain, const podio::CollectionIDTable& idTable,
     root_utils::CollectionBranches branches{};
     if (isSubsetColl) {
       // Only one branch will exist and we can trivially get its name
-      auto brName = root_utils::subsetBranch(name);
+      const auto brName = root_utils::subsetBranch(name);
       branches.refs.push_back(root_utils::getBranch(chain, brName.c_str()));
       branches.refNames.emplace_back(std::move(brName));
     } else {
@@ -424,12 +427,12 @@ createCollectionBranches(TChain* chain, const podio::CollectionIDTable& idTable,
 
       const auto relVecNames = podio::DatamodelRegistry::instance().getRelationNames(collType);
       for (const auto& relName : relVecNames.relations) {
-        auto brName = root_utils::refBranch(name, relName);
+        const auto brName = root_utils::refBranch(name, relName);
         branches.refs.push_back(root_utils::getBranch(chain, brName.c_str()));
         branches.refNames.emplace_back(std::move(brName));
       }
       for (const auto& vecName : relVecNames.vectorMembers) {
-        auto brName = root_utils::refBranch(name, vecName);
+        const auto brName = root_utils::refBranch(name, vecName);
         branches.vecs.push_back(root_utils::getBranch(chain, brName.c_str()));
         branches.vecNames.emplace_back(std::move(brName));
       }


### PR DESCRIPTION
BEGINRELEASENOTES
Clean up the ROOT readers and writers
  - Add const where possible
  - Use functions from `std::ranges` when possible
  - Do not use `new` and `delete` when it's not needed (`ROOTReader.cc`)
  - Clean up includes
  - Change some indexes to size_t instead of int to avoid implicit conversions (doesn't change anything)
ENDRELEASENOTES

It's possible I have missed some places where const could be added.
This came up after checking the changes in https://github.com/AIDASoft/podio/pull/711 and noticing at least some of the `new` and `delete`s may not be needed.