### PR TITLE
Ignore the datasource tests when using the address sanitizer

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -52,6 +52,7 @@ jobs:
               -DENABLE_SIO=ON \
               -DENABLE_JULIA=ON \
               -DENABLE_RNTUPLE=ON \
+              -DENABLE_DATASOURCE=ON \
               -G Ninja ..
             echo "::endgroup::"
             echo "::group::Build"

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -53,6 +53,9 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
 
     write_old_data_root
     read_new_data_root
+
+    read_with_rdatasource_root
+    read_python_with_rdatasource_root
   )
 
   foreach(version in @root_legacy_test_versions@)


### PR DESCRIPTION
BEGINRELEASENOTES
- Ignore the datasource tests when using the address sanitizer since the tests that create their input files are also ignored
- Enable `-DENABLE_DATASOURCE` when building with sanitizer (although all the related tests will be ignored)

ENDRELEASENOTES