### PR TITLE
Fix Unity builds with SIO enabled by giving a variable different names

### DIFF
--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -86,7 +86,7 @@ namespace {
   // library actually needs linking to the core library. Otherwise it is
   // possible that the registry is not populated when the SioBlock library is
   // loaded, e.g. when using the python bindings.
-  const auto elem = {{ class.full_type }}{};
+  const auto elem{{ class.bare_type }} = {{ class.full_type }}{};
 }
 
 {% endwith %}


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix Unity builds with SIO enabled by giving a variable different names

ENDRELEASENOTES

I was building without SIO in https://github.com/AIDASoft/podio/pull/746, so when I tried out to use unity builds with SIO it failed. With this I was able to build podio and EDM4hep with SIO enabled.