### PR TITLE
Make it possible to get the collection for an object

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -208,7 +208,7 @@ public:
   /// @returns       A const reference to the collection if it is available or to
   ///                an empty (static) collection
   template <CollectionType CollT>
-  const CollT& get(const CollT::value_type& object) const;
+  const CollT& get(const typename CollT::value_type& object) const;
 
   /// Get the collection pointer to which the passed object belongs from the
   /// Frame.
@@ -406,7 +406,7 @@ const CollT& Frame::get(const std::string& name) const {
 }
 
 template <CollectionType CollT>
-const CollT& Frame::get(const CollT::value_type& object) const {
+const CollT& Frame::get(const typename CollT::value_type& object) const {
   const auto name = m_self->getIDTable().name(object.id().collectionID);
   return get<CollT>(name.value_or(""));
 }

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -220,7 +220,7 @@ public:
   /// @returns A const pointer to a collection if it is available or a nullptr
   ///          if it is not
   template <ObjectType O>
-  inline const podio::CollectionBase* get(const O& object) const;
+  inline const typename O::collection_type* get(const O& object) const;
 
   /// (Destructively) move a collection into the Frame and get a reference to
   /// the inserted collection back for further use.
@@ -416,9 +416,9 @@ inline const podio::CollectionBase* Frame::get(const std::string& name) const {
 }
 
 template <ObjectType O>
-inline const podio::CollectionBase* Frame::get(const O& object) const {
+inline const typename O::collection_type* Frame::get(const O& object) const {
   const auto name = m_self->getIDTable().name(object.id().collectionID);
-  return get(name.value_or(""));
+  return dynamic_cast<const typename O::collection_type*>(get(name.value_or("")));
 }
 
 inline void Frame::put(std::unique_ptr<podio::CollectionBase> coll, const std::string& name) {

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -199,6 +199,29 @@ public:
   ///          if it is not
   const podio::CollectionBase* get(const std::string& name) const;
 
+  /// Get the collection to which the passed object belongs from the Frame.
+  ///
+  /// @tparam CollT  The type of the desired collection
+  /// @param  object The object for which the collection it belongs to should
+  ///                be retrieved
+  ///
+  /// @returns       A const reference to the collection if it is available or to
+  ///                an empty (static) collection
+  template <CollectionType CollT>
+  const CollT& get(const CollT::value_type& object) const;
+
+  /// Get the collection pointer to which the passed object belongs from the
+  /// Frame.
+  ///
+  /// @tparam O      The type of the object
+  /// @param  object The object for which the collection it belongs to should
+  ///                be retrieved
+  ///
+  /// @returns A const pointer to a collection if it is available or a nullptr
+  ///          if it is not
+  template <ObjectType O>
+  inline const podio::CollectionBase* get(const O& object) const;
+
   /// (Destructively) move a collection into the Frame and get a reference to
   /// the inserted collection back for further use.
   ///
@@ -382,8 +405,20 @@ const CollT& Frame::get(const std::string& name) const {
   return emptyColl;
 }
 
+template <CollectionType CollT>
+const CollT& Frame::get(const CollT::value_type& object) const {
+  const auto name = m_self->getIDTable().name(object.id().collectionID);
+  return get<CollT>(name.value_or(""));
+}
+
 inline const podio::CollectionBase* Frame::get(const std::string& name) const {
   return m_self->get(name);
+}
+
+template <ObjectType O>
+inline const podio::CollectionBase* Frame::get(const O& object) const {
+  const auto name = m_self->getIDTable().name(object.id().collectionID);
+  return get(name.value_or(""));
 }
 
 inline void Frame::put(std::unique_ptr<podio::CollectionBase> coll, const std::string& name) {

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -57,7 +57,7 @@ class LinkT {
 
 public:
   using mutable_type = podio::MutableLink<FromT, ToT>;
-  using value_type = podio::Link<FromT, ToT>;
+  using object_type = podio::Link<FromT, ToT>;
   using collection_type = podio::LinkCollection<FromT, ToT>;
 
   static constexpr std::string_view typeName =

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -245,6 +245,11 @@ namespace detail {
 // forward declaration to be able to use it below
 class CollectionBase;
 
+/// Concept for checking whether a passed type T is (or can be) a podio
+/// generated handle class
+template <typename T>
+concept ObjectType = detail::isMutableHandleType<T> || detail::isDefaultHandleType<T>;
+
 /// Concept for checking whether a passed type T is a collection
 template <typename T>
 concept CollectionType = !std::is_abstract_v<T> && std::derived_from<T, CollectionBase> &&

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -176,6 +176,12 @@ namespace detail {
   template <typename T>
   using hasObject_t = typename T::object_type;
 
+  /// Detector for checking the existence of a value_type member. Necessary to
+  /// avoid false positives for default handle types from collections, since
+  /// collections also specify a mutable_type member.
+  template <typename T>
+  using hasValue_t = typename T::value_type;
+
   /// Variable template for determining whether type T is a podio generated
   /// mutable handle class
   template <typename T>
@@ -184,7 +190,8 @@ namespace detail {
   /// Variable template for determining whether type T is a podio generated
   /// default handle class
   template <typename T>
-  constexpr static bool isDefaultHandleType = det::is_detected_v<hasMutable_t, std::remove_reference_t<T>>;
+  constexpr static bool isDefaultHandleType = det::is_detected_v<hasMutable_t, std::remove_reference_t<T>> &&
+      !det::is_detected_v<hasValue_t, std::remove_reference_t<T>>;
 
   /// Variable template for obtaining the default handle type from any podio
   /// generated handle type.

--- a/python/podio/test_Frame.py
+++ b/python/podio/test_Frame.py
@@ -152,6 +152,20 @@ class FrameTest(unittest.TestCase):
         vals = frame.get_parameter("empty_param")
         self.assertEqual(len(vals), 0)
 
+    def test_frame_get_collection_from_object(self):
+        """Check that using an object (handle) to get a collection works"""
+        frame = Frame()
+        hits = ExampleHitCollection()
+        hit = hits.create()
+
+        with self.assertRaises(ReferenceError):
+            invalidHits = frame.get(hit)
+            _ = invalidHits[0]
+
+        hits = frame.put(hits, "hits")
+        hitsFromHit = frame.get(hit)
+        self.assertEqual(hit, hitsFromHit[0])
+
 
 class FrameReadTest(unittest.TestCase):
     """Unit tests for the Frame python bindings for Frames read from file.

--- a/tests/unittests/frame.cpp
+++ b/tests/unittests/frame.cpp
@@ -428,6 +428,28 @@ TEST_CASE("Frame getName", "[frame][basics]") {
   REQUIRE_FALSE(frame.getName(0xfffffff).has_value());
 }
 
+TEST_CASE("Frame get from object", "[frame][basics]") {
+  auto event = podio::Frame{};
+
+  auto clusters = ExampleClusterCollection{};
+  auto cluster = clusters.create(3.14f);
+
+  REQUIRE(event.get(cluster) == nullptr);
+
+  const auto& invalidClusters = event.get<ExampleClusterCollection>(cluster);
+  REQUIRE_FALSE(invalidClusters.isValid());
+
+  const auto& frameClusters = event.put(std::move(clusters), "clusters");
+  const auto& objectClusters = event.get<ExampleClusterCollection>(cluster);
+  REQUIRE(frameClusters[0] == objectClusters[0]);
+
+  const auto* collPtr = event.get(cluster);
+  REQUIRE(collPtr != nullptr);
+  const auto* clusterCollPtr = dynamic_cast<const ExampleClusterCollection*>(collPtr);
+  REQUIRE(clusterCollPtr != nullptr);
+  REQUIRE((*clusterCollPtr)[0] == cluster);
+}
+
 TEST_CASE("EIC-Jana2 cleanup use case", "[memory-management][492][174]") {
   // Test case that only triggers in ASan builds if memory-management / cleanup
   // has a bug

--- a/tests/unittests/frame.cpp
+++ b/tests/unittests/frame.cpp
@@ -444,10 +444,9 @@ TEST_CASE("Frame get from object", "[frame][basics]") {
   REQUIRE(frameClusters[0] == objectClusters[0]);
 
   const auto* collPtr = event.get(cluster);
+  STATIC_REQUIRE(std::is_same_v<decltype(collPtr), const ExampleClusterCollection*>);
   REQUIRE(collPtr != nullptr);
-  const auto* clusterCollPtr = dynamic_cast<const ExampleClusterCollection*>(collPtr);
-  REQUIRE(clusterCollPtr != nullptr);
-  REQUIRE((*clusterCollPtr)[0] == cluster);
+  REQUIRE((*collPtr)[0] == cluster);
 }
 
 TEST_CASE("EIC-Jana2 cleanup use case", "[memory-management][492][174]") {

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -298,8 +298,12 @@ TEST_CASE("Links templated accessors", "[links]") {
   }
 }
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
-TEST_CASE("LinkCollection collection concept", "[links][concepts]") {
+
+TEST_CASE("Link concept checks", "[links][concepts]") {
   STATIC_REQUIRE(podio::CollectionType<TestLColl>);
+  STATIC_REQUIRE(podio::ObjectType<TestL>);
+  STATIC_REQUIRE(podio::ObjectType<TestMutL>);
+  STATIC_REQUIRE_FALSE(podio::ObjectType<TestLColl>);
 }
 
 TEST_CASE("LinkCollection constness", "[links][static-checks][const-correctness]") {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -63,6 +63,7 @@
 #include "extension_model/extension_model.h"
 
 #include "podio/UserDataCollection.h"
+#include "podio/utilities/TypeHelpers.h"
 
 TEST_CASE("AutoDelete", "[basics][memory-management]") {
   auto coll = EventInfoCollection();
@@ -124,6 +125,11 @@ TEST_CASE("Component", "[basics]") {
   auto info = MutableExampleWithComponent();
   info.component().data.x = 3;
   REQUIRE(3 == info.component().data.x);
+}
+
+TEST_CASE("ObjectType concept", "[concepts]") {
+  STATIC_REQUIRE(podio::ObjectType<ExampleHit>);
+  STATIC_REQUIRE_FALSE(podio::ObjectType<ExampleHitCollection>);
 }
 
 TEST_CASE("makeEmpty", "[basics]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `Frame::get` overloads that take a podio generated object handle as argument and return the collection this object belongs to *if the collection is known to the Frame*.

ENDRELEASENOTES

See the discussion in https://github.com/key4hep/k4FWCore/issues/311 for a rationale of this functionality

The main question at this point is whether the existing `getName` functionality that takes a `collectionID` should be deprecated and removed eventually.