### PR TITLE
Add missing override to the destructor of UserDataCollection and LinkCollectionImpl

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,8 +27,6 @@ Checks: -*,
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 CheckOptions:
-  - key:             modernize-use-override.IgnoreDestructors
-    value:           '1'
   - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value:           '1'
   - key:             readability-braces-around-statements.ShortStatementLines

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -87,7 +87,7 @@ class Frame {
   struct FrameModel final : FrameConcept, public ICollectionProvider {
 
     FrameModel(std::unique_ptr<FrameDataT> data);
-    ~FrameModel() = default;
+    ~FrameModel() override = default;
     FrameModel(const FrameModel&) = delete;
     FrameModel& operator=(const FrameModel&) = delete;
     FrameModel(FrameModel&&) = default;

--- a/include/podio/Reader.h
+++ b/include/podio/Reader.h
@@ -42,7 +42,7 @@ private:
     ReaderModel(ReaderModel&&) = default;
     ReaderModel& operator=(ReaderModel&&) = default;
 
-    ~ReaderModel() = default;
+    ~ReaderModel() override = default;
 
     podio::Frame readNextFrame(const std::string& name, const std::vector<std::string>& collsToRead) override {
       auto maybeFrame = m_reader->readNextEntry(name, collsToRead);

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -92,7 +92,7 @@ public:
   UserDataCollection& operator=(const UserDataCollection&) = delete;
   UserDataCollection(UserDataCollection&&) = default;
   UserDataCollection& operator=(UserDataCollection&&) = default;
-  ~UserDataCollection() = default;
+  ~UserDataCollection() override = default;
 
   /// The schema version of UserDataCollections
   static constexpr SchemaVersionT schemaVersion = 1;

--- a/include/podio/Writer.h
+++ b/include/podio/Writer.h
@@ -38,7 +38,7 @@ private:
     WriterModel(WriterModel&&) = default;
     WriterModel& operator=(WriterModel&&) = default;
 
-    ~WriterModel() = default;
+    ~WriterModel() override = default;
 
     void writeFrame(const podio::Frame& frame, const std::string& category,
                     const std::vector<std::string>& collections) override {

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -68,7 +68,7 @@ public:
   LinkCollection(LinkCollection&&) = default;
   LinkCollection& operator=(LinkCollection&&) = default;
 
-  ~LinkCollection() {
+  ~LinkCollection() override {
     // Need to tell the storage how to clean up
     m_storage.clear(m_isSubsetColl);
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Add missing override to the destructor of UserDataCollection and LinkCollectionImpl

ENDRELEASENOTES

It has been appearing everywhere from clangd for a long time