### PR TITLE
Introduce a FrameDataType concept

### DIFF
--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -31,11 +31,18 @@ concept RValueType = !std::is_lvalue_reference_v<T>;
 template <typename T>
 concept CollectionRValueType = CollectionType<T> && RValueType<T>;
 
+/// Concept encoding the minimal interface a type has to provide to usable as
+/// raw data from which a Frame can be constructed.
+///
+/// Since the Frame either locks on raw data access, or is guaranteed to only
+/// run on a single thread when doing so (e.g. constructors) none of these have
+/// to be thread-safe either, even though implementations might be able to
+/// provide reasonable guarantees anyway.
 template <typename T>
-concept FrameDataType = requires(T t, const T ct) {
-  { ct.getIDTable() } -> std::same_as<podio::CollectionIDTable>;
+concept FrameDataType = requires(T t) {
+  { t.getIDTable() } -> std::same_as<podio::CollectionIDTable>;
   { t.getCollectionBuffers(std::string{}) } -> std::same_as<std::optional<podio::CollectionReadBuffers>>;
-  { ct.getAvailableCollections() } -> std::same_as<std::vector<std::string>>;
+  { t.getAvailableCollections() } -> std::same_as<std::vector<std::string>>;
   { t.getParameters() } -> std::same_as<std::unique_ptr<podio::GenericParameters>>;
 };
 

--- a/include/podio/Frame.h
+++ b/include/podio/Frame.h
@@ -163,10 +163,10 @@ public:
 
   /// Frame constructor from (almost) arbitrary raw data.
   ///
-  /// @tparam FrameDataT Arbitrary data container that provides access to the
-  ///                    collection buffers as well as the metadata, when
-  ///                    requested by the Frame. The unique_ptr has to be checked
-  ///                    for validity before calling this constructor.
+  /// @tparam FrameData Arbitrary data container that provides access to the
+  ///                   collection buffers as well as the metadata, when
+  ///                   requested by the Frame. The unique_ptr has to be checked
+  ///                   for validity before calling this constructor.
   ///
   /// @throws std::invalid_argument if the passed pointer is a nullptr.
   template <FrameDataType FrameData>
@@ -177,9 +177,9 @@ public:
   /// This r-value overload is mainly present for enabling the python bindings,
   /// where cppyy seems to strip the std::unique_ptr somewhere in the process
   ///
-  /// @tparam FrameDataT Arbitrary data container that provides access to the
-  ///                    collection buffers as well as the metadata, when
-  ///                    requested by the Frame.
+  /// @tparam FrameData Arbitrary data container that provides access to the
+  ///                   collection buffers as well as the metadata, when
+  ///                   requested by the Frame.
   template <RValueFrameDataType FrameData>
   Frame(FrameData&&);
 

--- a/include/podio/SIOFrameData.h
+++ b/include/podio/SIOFrameData.h
@@ -40,7 +40,7 @@ public:
 
   std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
 
-  podio::CollectionIDTable getIDTable() {
+  podio::CollectionIDTable getIDTable() const {
     return {m_idTable.ids(), m_idTable.names()};
   }
 


### PR DESCRIPTION
Make the interface of the EmptyFrameData into a concept and replace the unconstrained constructors with it.



BEGINRELEASENOTES
- Introduce a `FrameDataType` concept and constrain the `Frame` constructors with it

ENDRELEASENOTES