### PR TITLE
Use python packages from the Key4hep stack in the pre-commit workflow

### DIFF
--- a/.github/scripts/pylint.rc
+++ b/.github/scripts/pylint.rc
@@ -59,6 +59,7 @@ disable=line-too-long,
         useless-suppression,
         trailing-whitespace,
         suppressed-message,
+        too-many-positional-arguments,
 
 
 [REPORTS]

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,17 +18,11 @@ jobs:
         container: el9
         view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
         run: |
-          echo "::group::Setup pre-commit"
+          echo "::group::Setup git"
           # Newer versions of git are more cautious around the github runner
           # environment and without this git rev-parse --show-cdup in pre-commit
           # fails
           git config --global --add safe.directory $(pwd)
-          python -m venv /root/pre-commit-venv
-          source /root/pre-commit-venv/bin/activate
-          pip install pre-commit
-          pip install pylint==2.17.7
-          pip install flake8
-          export PYTHONPATH=$VIRTUAL_ENV/lib/python3.$(python3 -c 'import sys; print(f"{sys.version_info[1]}")')/site-packages:$PYTHONPATH
           echo "::endgroup::"
           echo "::group::Run CMake"
           mkdir build

--- a/python/podio/frame.py
+++ b/python/podio/frame.py
@@ -13,6 +13,10 @@ import ROOT
 # in environments with *ancient* podio versions
 if ROOT.gInterpreter.LoadFile("podio/Frame.h") == 0:  # noqa: E402
     from ROOT import podio  # noqa: E402 # pylint: disable=wrong-import-position
+else:
+    raise ImportError(
+        "Could not load podio/Frame.h. Make sure it is available on ROOT_INCLUDE_PATH."
+    )
 
 
 # This is the list of supported types for the GenericParameters in both c++ and

--- a/python/podio_class_generator.py
+++ b/python/podio_class_generator.py
@@ -5,6 +5,7 @@
 import os
 import subprocess
 import re
+import argparse
 
 from podio_gen.podio_config_reader import PodioConfigReader
 from podio_gen.generator_utils import DefinitionError
@@ -87,8 +88,6 @@ def parse_version(version_str):
 
 
 if __name__ == "__main__":
-    import argparse
-
     # pylint: disable=invalid-name # before 2.5.0 pylint is too strict with the naming here
     parser = argparse.ArgumentParser(
         description="Given a description yaml file this script generates "

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -452,9 +452,14 @@ have resolvable schema evolution incompatibilities:"
                 if isinstance(schema_change, RenamedMember):
                     # find out the type of the renamed member
                     component = self.datamodel.components[type_name]
+                    member_type = None
                     for member in component["Members"]:
                         if member.name == schema_change.member_name_new:
                             member_type = member.full_type
+                    if member_type is None:
+                        raise ValueError(
+                            f"Could not find type for renamed member {schema_change.member_name_new} in {type_name}"
+                        )
 
                     iorule = RootIoRule()
                     iorule.sourceClass = type_name

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -458,7 +458,8 @@ have resolvable schema evolution incompatibilities:"
                             member_type = member.full_type
                     if member_type is None:
                         raise ValueError(
-                            f"Could not find type for renamed member {schema_change.member_name_new} in {type_name}"
+                            "Could not find type for renamed member"
+                            f"{schema_change.member_name_new} in {type_name}"
                         )
 
                     iorule = RootIoRule()

--- a/tests/unittests/std_interoperability.cpp
+++ b/tests/unittests/std_interoperability.cpp
@@ -1014,11 +1014,15 @@ TEST_CASE("Collection iterators", "[collection][container][iterator][std]") {
     // iterator
     STATIC_REQUIRE(traits::has_equality_comparator_v<iterator>);
     STATIC_REQUIRE(std::is_default_constructible_v<iterator>);
-    { REQUIRE(iterator{} == iterator{}); }
+    {
+      REQUIRE(iterator{} == iterator{});
+    }
     // const_iterator
     STATIC_REQUIRE(traits::has_equality_comparator_v<const_iterator>);
     STATIC_REQUIRE(std::is_default_constructible_v<const_iterator>);
-    { REQUIRE(const_iterator{} == const_iterator{}); }
+    {
+      REQUIRE(const_iterator{} == const_iterator{});
+    }
 
     // i++
     // iterator
@@ -1420,8 +1424,9 @@ TEST_CASE("Collection and std ranges algorithms", "[collection][ranges][std]") {
 
 // helper concept for unsupported algorithm compilation test
 template <typename T>
-concept is_range_sortable =
-    requires(T coll) { std::ranges::sort(coll, [](const auto& a, const auto& b) { return a.cellID() < b.cellID(); }); };
+concept is_range_sortable = requires(T coll) {
+  std::ranges::sort(coll, [](const auto & a, const auto & b) { return a.cellID() < b.cellID(); });
+};
 
 // helper concept for unsupported algorithm compilation test
 template <typename T>

--- a/tools/podio-dump-legacy
+++ b/tools/podio-dump-legacy
@@ -5,6 +5,7 @@ NOTE: This is a legacy implementation in python. A newer version implemented in
 c++ is available that is much faster.
 """
 
+import argparse
 import sys
 import json
 import yaml
@@ -167,8 +168,6 @@ def parse_entry_range(ent_string):
 
 
 if __name__ == "__main__":
-    import argparse
-
     _EPILOG = (
         "NOTE: This is a legacy implementation in python. A newer version based on a c++ "
         "implementation is available. That version is much faster, but does not handle pre-release"


### PR DESCRIPTION
The current version of pylint that is installed doesn't work with Python 3.13. Given that this will have to be updated and the packages are in the stack, I propose to just use the ones provided in the stack. 

BEGINRELEASENOTES
- Use python packages from the Key4hep stack in the pre-commit workflow
- Fix pre-commit

ENDRELEASENOTES

This fixes pre-commit in CI, currently broken.