### PR TITLE
Workaround the Julia isues that we observe in CI

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cvmfs-contrib/github-action-cvmfs@v4
       - uses: key4hep/key4hep-actions/cache-external-data@main
-      - uses: aidasoft/run-lcg-view@v5
+      - uses: tmadlener/run-lcg-view@podman
         with:
           release-platform: LCG_107/x86_64-el9-${{ matrix.compiler }}-opt
           ccache-key: ccache-sanitizers-el9-${{ matrix.compiler }}-${{ matrix.sanitizer }}

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -50,7 +50,7 @@ jobs:
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
               -DUSE_EXTERNAL_CATCH2=OFF \
               -DENABLE_SIO=ON \
-              -DENABLE_JULIA=ON \
+              -DENABLE_JULIA=OFF \
               -DENABLE_RNTUPLE=ON \
               -DENABLE_DATASOURCE=ON \
               -G Ninja ..
@@ -58,9 +58,6 @@ jobs:
             echo "::group::Build"
             ninja -k0
             echo "::endgroup::"
-            echo "::group::Julia StaticArrays Package Install"
-            julia -e 'import Pkg; Pkg.add("StaticArrays")'
-            echo "::endgroup"
             echo "::group::Run tests"
             ctest --output-on-failure
             echo "::endgroup::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-el9-${{ matrix.LCG }}
+        container-runtime: podman
         run: |
           echo "::group::Run CMake"
           # export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
           ninja -k0
           echo "::endgroup::"
           echo "::group::Julia StaticArrays Package Install"
+          # Temporary workaround for https://its.cern.ch/jira/browse/SPI-2838
+          JULIA_DEPOT_PATH=$(pwd)/.julia julia -e 'import Pkg'
           julia -e 'import Pkg; Pkg.add("StaticArrays")'
           echo "::endgroup"
           echo "::group::Run tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: aidasoft/run-lcg-view@v5
+    - uses: tmadlener/run-lcg-view@podman
       with:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-el9-${{ matrix.LCG }}
         run: |
           echo "::group::Run CMake"
-          export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"
+          # export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"
           mkdir -p build install
           cd build
           cmake -DENABLE_SIO=ON \
@@ -52,8 +52,8 @@ jobs:
           ninja -k0
           echo "::endgroup::"
           echo "::group::Julia StaticArrays Package Install"
-          # Temporary workaround for https://its.cern.ch/jira/browse/SPI-2838
-          JULIA_DEPOT_PATH=$(pwd)/.julia julia -e 'import Pkg'
+          # # Temporary workaround for https://its.cern.ch/jira/browse/SPI-2838
+          # JULIA_DEPOT_PATH=$(pwd)/.julia julia -e 'import Pkg'
           julia -e 'import Pkg; Pkg.add("StaticArrays")'
           echo "::endgroup"
           echo "::group::Run tests"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,13 +24,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: aidasoft/run-lcg-view@v5
+    - uses: tmadlener/run-lcg-view@podman
       with:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-ubuntu-${{ matrix.LCG }}
+        container-runtime: podman
         run: |
           echo "::group::Run CMake"
-          export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"
           mkdir -p build install
           cd build
           cmake -DENABLE_SIO=ON \
@@ -49,8 +49,6 @@ jobs:
           ninja -k0
           echo "::endgroup"
           echo "::group::Julia StaticArrays Package Install"
-          # Temporary workaround for https://its.cern.ch/jira/browse/SPI-2838
-          JULIA_DEPOT_PATH=$(pwd)/.julia julia -e 'import Pkg'
           julia -e 'import Pkg; Pkg.add("StaticArrays")'
           echo "::endgroup"
           echo "::group::Run tests"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,6 +49,8 @@ jobs:
           ninja -k0
           echo "::endgroup"
           echo "::group::Julia StaticArrays Package Install"
+          # Temporary workaround for https://its.cern.ch/jira/browse/SPI-2838
+          JULIA_DEPOT_PATH=$(pwd)/.julia julia -e 'import Pkg'
           julia -e 'import Pkg; Pkg.add("StaticArrays")'
           echo "::endgroup"
           echo "::group::Run tests"


### PR DESCRIPTION
BEGINRELEASENOTES
- Disable the julia tests in the sanitizers workflows as they do not test anything meaningful there
- Use podman for now to run the CI that requires Julia

ENDRELEASENOTES

Workaround from: https://its.cern.ch/jira/browse/SPI-2838

Once https://github.com/AIDASoft/run-lcg-view/pull/10 is merged, we can switch back to the `aidasoft` version of that action