### PR TITLE
Remove old schema components from selection.xml

### DIFF
--- a/python/templates/selection.xml.jinja2
+++ b/python/templates/selection.xml.jinja2
@@ -35,11 +35,6 @@
 {{ class_selection(class, postfix='Collection') }}
 {% endfor %}
 
-        <!-- previous schema components and pods -->
-{% for class in old_schema_components %}
-{{ class_selection(class) }}
-{% endfor %}
-
     </selection>
 
 {% for iorule in iorules %}


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove old schema components from the selection.xml

ENDRELEASENOTES

I think they shouldn't be needed since they are not accessible anymore from Python.

Fix https://github.com/AIDASoft/podio/issues/581.