### PR TITLE
Refactor schema evolution related code generation

### DIFF
--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -215,7 +215,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         for rel in ("From", "To"):
             rel_type = link[rel]
             include_header = f"{rel_type.bare_type}Collection"
-            if self._is_interface(rel_type.full_type):
+            if self._is_in(rel_type.full_type, "interfaces"):
                 # Interfaces do not have a Collection header
                 include_header = rel_type.bare_type
             link["include_types"].append(
@@ -253,7 +253,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
                 member.sub_members = self.datamodel.components[member.full_type]["Members"]
 
         for relation in datatype["OneToOneRelations"]:
-            if self._is_interface(relation.full_type):
+            if self._is_in(relation.full_type, "interfaces"):
                 relation.interface_types = self.datamodel.interfaces[relation.full_type]["Types"]
             if self._needs_include(relation.full_type):
                 fwd_declarations[relation.namespace].append(relation.bare_type)
@@ -265,7 +265,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
             includes.add('#include "podio/RelationRange.h"')
 
         for relation in datatype["OneToManyRelations"]:
-            if self._is_interface(relation.full_type):
+            if self._is_in(relation.full_type, "interfaces"):
                 relation.interface_types = self.datamodel.interfaces[relation.full_type]["Types"]
             if self._needs_include(relation.full_type):
                 includes.add(self._build_include(relation))
@@ -335,7 +335,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         for relation in datatype["OneToManyRelations"] + datatype["OneToOneRelations"]:
             if datatype["class"].bare_type != relation.bare_type:
                 include_from = self._needs_include(relation.full_type)
-                if self._is_interface(relation.full_type):
+                if self._is_in(relation.full_type, "interfaces"):
                     includes_cc.add(
                         self._build_include_for_class(relation.bare_type, include_from)
                     )

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -410,7 +410,7 @@ have resolvable schema evolution incompatibilities:"
             print(f"  Preparing explicit schema evolution for {name}")
             schema_evolution_datatype["class"].bare_type = _versioned(
                 schema_evolution_datatype["class"].bare_type, self.old_schema_version
-            )  # noqa
+            )
             self._fill_templates("Data", schema_evolution_datatype)
             self.root_schema_datatype_names.add(_versioned(name, self.old_schema_version))
 
@@ -603,7 +603,7 @@ have resolvable schema evolution incompatibilities:"
             "old_schema_components": [
                 DataType(d)
                 for d in self.root_schema_datatype_names | self.root_schema_component_names
-            ],  # noqa
+            ],
             "iorules": self.root_schema_iorules,
         }
 

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -389,28 +389,20 @@ have resolvable schema evolution incompatibilities:"
         schema_evolution_datatype = deepcopy(datatype)
         needs_schema_evolution = False
         for member in schema_evolution_datatype["Members"]:
-            if member.is_array:
-                if member.array_type in self.root_schema_dict:
-                    needs_schema_evolution = True
-                    replace_component_in_paths(
-                        member.array_type,
-                        _versioned(member.array_type, self.old_schema_version),
-                        schema_evolution_datatype["includes_data"],
-                    )
+            member_type = member.array_type if member.is_array else member.full_type
+            if member_type in self.root_schema_dict:
+                needs_schema_evolution = True
+                replace_component_in_paths(
+                    member_type,
+                    _versioned(member_type, self.old_schema_version),
+                    schema_evolution_datatype["includes_data"],
+                )
+                if member.is_array:
                     member.full_type = member.full_type.replace(
                         member.array_type, _versioned(member.array_type, self.old_schema_version)
                     )
                     member.array_type = _versioned(member.array_type, self.old_schema_version)
-
-            else:
-                if member.full_type in self.root_schema_dict:
-                    needs_schema_evolution = True
-                    # prepare the ROOT I/O rule
-                    replace_component_in_paths(
-                        member.full_type,
-                        _versioned(member.full_type, self.old_schema_version),
-                        schema_evolution_datatype["includes_data"],
-                    )
+                else:
                     member.full_type = _versioned(member.full_type, self.old_schema_version)
                     member.bare_type = _versioned(member.bare_type, self.old_schema_version)
 

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -436,6 +436,7 @@ have resolvable schema evolution incompatibilities:"
             self.root_schema_component_names.add(_versioned(name, self.old_schema_version))
 
         except KeyError:
+            # We didn't find any schema evolution for this component
             pass
 
     def _invert_interfaces(self):

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -415,7 +415,7 @@ have resolvable schema evolution incompatibilities:"
             self.root_schema_datatype_names.add(_versioned(name, self.old_schema_version))
 
     def _preprocess_schema_evolution_component(self, name, component):
-        """Preprocess this component (and generaty the necessary code) in case
+        """Preprocess this component (and generate the necessary code) in case
         schema evolution is necessary
 
         NOTE: currently limited to support only ROOT schema evolution needs

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -411,7 +411,6 @@ have resolvable schema evolution incompatibilities:"
             schema_evolution_datatype["class"].bare_type = _versioned(
                 schema_evolution_datatype["class"].bare_type, self.old_schema_version
             )  # noqa
-            schema_evolution_datatype["old_schema_version"] = self.old_schema_version
             self._fill_templates("Data", schema_evolution_datatype)
             self.root_schema_datatype_names.add(_versioned(name, self.old_schema_version))
 

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -414,8 +414,6 @@ have resolvable schema evolution incompatibilities:"
             schema_evolution_datatype["old_schema_version"] = self.old_schema_version
             self._fill_templates("Data", schema_evolution_datatype)
             self.root_schema_datatype_names.add(_versioned(name, self.old_schema_version))
-        else:
-            self._fill_templates("Collection", datatype)
 
     def _preprocess_schema_evolution_component(self, name, component):
         """Preprocess this component (and generaty the necessary code) in case

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -422,7 +422,6 @@ have resolvable schema evolution incompatibilities:"
             schema_evolution_datatype["old_schema_version"] = self.old_schema_version
             self._fill_templates("Data", schema_evolution_datatype)
             self.root_schema_datatype_names.add(_versioned(name, self.old_schema_version))
-            self._fill_templates("Collection", datatype, schema_evolution_datatype)
         else:
             self._fill_templates("Collection", datatype)
 

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -439,7 +439,7 @@ have resolvable schema evolution incompatibilities:"
             self.root_schema_component_names.add(_versioned(name, self.old_schema_version))
 
         except KeyError:
-            return
+            pass
 
     def _invert_interfaces(self):
         """'Invert' the interfaces to have a mapping of types and their usage in

--- a/python/podio_gen/generator_base.py
+++ b/python/podio_gen/generator_base.py
@@ -259,14 +259,8 @@ class ClassGeneratorBaseMixin:
 
         return fn_templates
 
-    def _eval_template(self, template, data, old_schema_data=None):
+    def _eval_template(self, template, data):
         """Fill the specified template"""
-        # merge the info of data and the old schema into a single dict
-        if old_schema_data:
-            data["OneToOneRelations_old"] = old_schema_data["OneToOneRelations"]
-            data["OneToManyRelations_old"] = old_schema_data["OneToManyRelations"]
-            data["VectorMembers_old"] = old_schema_data["VectorMembers"]
-
         return self.env.get_template(template).render(data)
 
     def _write_file(self, name, content):
@@ -284,7 +278,7 @@ class ClassGeneratorBaseMixin:
             changed = write_file_if_changed(fullname, content)
             self.any_changes = changed or self.any_changes
 
-    def _fill_templates(self, template_base, data, old_schema_data=None):
+    def _fill_templates(self, template_base, data):
         """Fill the template and write the results to file"""
         # Update the passed data with some global things that are the same for all
         # files
@@ -294,7 +288,7 @@ class ClassGeneratorBaseMixin:
         for filename, template in self._get_filenames_templates(
             template_base, data["class"].bare_type
         ):
-            self._write_file(filename, self._eval_template(template, data, old_schema_data))
+            self._write_file(filename, self._eval_template(template, data))
 
     def _is_in(self, classname, category):
         """Check whether classname is a member of the category (components,

--- a/python/podio_gen/generator_base.py
+++ b/python/podio_gen/generator_base.py
@@ -296,9 +296,15 @@ class ClassGeneratorBaseMixin:
         ):
             self._write_file(filename, self._eval_template(template, data, old_schema_data))
 
-    def _is_interface(self, classname):
-        """Check whether this is an interface type or a regular datatype"""
-        all_interfaces = self.datamodel.interfaces
+    def _is_in(self, classname, category):
+        """Check whether classname is a member of the category (components,
+        datatypes, interfaces)"""
+        if category not in ("datatypes", "components", "interfaces"):
+            raise ValueError(f"{category=} is not a valid category")
+
+        all_classes = getattr(self.datamodel, category)
         if self.upstream_edm:
-            all_interfaces = list(self.datamodel.interfaces) + list(self.upstream_edm.interfaces)
-        return classname in all_interfaces
+            all_classes = list(getattr(self.datamodel, category)) + list(
+                getattr(self.upstream_edm, category)
+            )
+        return classname in all_classes

--- a/python/podio_gen/julia_generator.py
+++ b/python/podio_gen/julia_generator.py
@@ -56,7 +56,7 @@ class JuliaClassGenerator(ClassGeneratorBaseMixin):
     def do_process_datatype(self, _, datatype):
         """Do the julia specific processing for a datatype"""
         if any(
-            self._is_interface(r.full_type)
+            self._is_in(r.full_type, "interfaces")
             for r in datatype["OneToOneRelations"] + datatype["OneToManyRelations"]
         ):
             # Julia doesn't support any interfaces yet, so we have to also sort out

--- a/python/podio_schema_evolution.py
+++ b/python/podio_schema_evolution.py
@@ -31,8 +31,8 @@ class AddedComponent(SchemaChange):
 
     def __init__(self, component, name):
         self.component = component
-        self.name = name
-        super().__init__(f"'{self.name}' has been added")
+        self.klassname = name
+        super().__init__(f"'{self.klassname}' has been added")
 
 
 class DroppedComponent(SchemaChange):
@@ -40,9 +40,8 @@ class DroppedComponent(SchemaChange):
 
     def __init__(self, component, name):
         self.component = component
-        self.name = name
         self.klassname = name
-        super().__init__(f"'{self.name}' has been dropped")
+        super().__init__(f"'{self.klassname}' has been dropped")
 
 
 class AddedDatatype(SchemaChange):
@@ -50,9 +49,8 @@ class AddedDatatype(SchemaChange):
 
     def __init__(self, datatype, name):
         self.datatype = datatype
-        self.name = name
         self.klassname = name
-        super().__init__(f"'{self.name}' has been added")
+        super().__init__(f"'{self.klassname}' has been added")
 
 
 class DroppedDatatype(SchemaChange):
@@ -60,9 +58,8 @@ class DroppedDatatype(SchemaChange):
 
     def __init__(self, datatype, name):
         self.datatype = datatype
-        self.name = name
         self.klassname = name
-        super().__init__(f"'{self.name}' has been dropped")
+        super().__init__(f"'{self.klassname}' has been dropped")
 
 
 class RenamedDataType(SchemaChange):
@@ -81,9 +78,8 @@ class AddedMember(SchemaChange):
 
     def __init__(self, member, definition_name):
         self.member = member
-        self.definition_name = definition_name
         self.klassname = definition_name
-        super().__init__(f"'{self.definition_name}' has an added member '{self.member.name}'")
+        super().__init__(f"'{self.klassname}' has an added member '{self.member.name}'")
 
 
 class DroppedMember(SchemaChange):
@@ -91,22 +87,20 @@ class DroppedMember(SchemaChange):
 
     def __init__(self, member, definition_name):
         self.member = member
-        self.definition_name = definition_name
         self.klassname = definition_name
-        super().__init__(f"'{self.definition_name}' has a dropped member '{self.member.name}")
+        super().__init__(f"'{self.klassname}' has a dropped member '{self.member.name}")
 
 
 class ChangedMember(SchemaChange):
     """Class representing a type change in a member"""
 
     def __init__(self, name, member_name, old_member, new_member):
-        self.name = name
         self.member_name = member_name
         self.old_member = old_member
         self.new_member = new_member
         self.klassname = name
         super().__init__(
-            f"'{self.name}.{self.member_name}' changed type from "
+            f"'{self.klassname}.{self.member_name}' changed type from "
             + f"{self.old_member.full_type} to {self.new_member.full_type}"
         )
 
@@ -115,12 +109,11 @@ class RenamedMember(SchemaChange):
     """Class representing a renamed member"""
 
     def __init__(self, name, member_name_old, member_name_new):
-        self.name = name
         self.member_name_old = member_name_old
         self.member_name_new = member_name_new
         self.klassname = name
         super().__init__(
-            f"'{self.name}': member '{self.member_name_old}' renamed to '{self.member_name_new}'."
+            f"'{self.klassname}': member '{self.member_name_old}' renamed to '{self.member_name_new}'."
         )
 
 
@@ -388,7 +381,7 @@ class DataModelComparator:
         for schema_change in self.read_schema_changes:
             if (
                 isinstance(schema_change, RenamedMember)
-                and (schema_change.name == dropped_member.definition_name)
+                and (schema_change.klassname == dropped_member.klassname)
                 and (schema_change.member_name_old == dropped_member.member.name)
                 and (schema_change.member_name_new == added_member.member.name)
             ):
@@ -407,7 +400,7 @@ class DataModelComparator:
         filtered_list = []
         for dropped_member in dropped_members:
             for added_member in added_members:
-                if dropped_member.definition_name == added_member.definition_name:
+                if dropped_member.klassname == added_member.klassname:
                     filtered_list.append((added_member, dropped_member))
 
         return filtered_list
@@ -420,7 +413,7 @@ class DataModelComparator:
         for added_member, dropped_member in same_type_adds_drops:
             if not self.check_rename(added_member, dropped_member, schema_changes):
                 self.warnings.append(
-                    f"Definition '{dropped_member.definition_name}' has a potential "
+                    f"Definition '{dropped_member.klassname}' has a potential "
                     f"rename: '{dropped_member.member.name}' -> "
                     f"'{added_member.member.name}' of type "
                     f"'{dropped_member.member.full_type}'."
@@ -481,8 +474,8 @@ class DataModelComparator:
                 if set(dropped_members.keys()) == set(added_members.keys()):
                     for schema_change in self.read_schema_changes:
                         if isinstance(schema_change, RenamedDataType) and (
-                            schema_change.name_old == dropped.name
-                            and schema_change.name_new == added.name
+                            schema_change.name_old == dropped.klassname
+                            and schema_change.name_new == added.klassname
                         ):
                             schema_changes.remove(dropped)
                             schema_changes.remove(added)
@@ -490,7 +483,7 @@ class DataModelComparator:
                             is_known_evolution = True
                     if not is_known_evolution:
                         self.warnings.append(
-                            f"Potential rename of '{dropped.name}' into '{added.name}'."
+                            f"Potential rename of '{dropped.klassname}' into '{added.klassname}'."
                         )
 
         # are there dropped/added component pairs that could be interpreted as rename?

--- a/python/podio_schema_evolution.py
+++ b/python/podio_schema_evolution.py
@@ -94,7 +94,7 @@ class DroppedMember(SchemaChange):
 class ChangedMemberType(SchemaChange):
     """Class representing a type change in a member"""
 
-    def __init__(self, name, member_name, old_member, new_member):
+    def __init__(self, name, old_member, new_member):
         self.old_member = old_member
         self.new_member = new_member
         self.klassname = name
@@ -112,7 +112,8 @@ class RenamedMember(SchemaChange):
         self.member_name_new = member_name_new
         self.klassname = name
         super().__init__(
-            f"'{self.klassname}': member '{self.member_name_old}' renamed to '{self.member_name_new}'."
+            f"'{self.klassname}': member '{self.member_name_old}' renamed to "
+            f"'{self.member_name_new}'."
         )
 
 
@@ -348,9 +349,7 @@ class DataModelComparator:
                 new = members1[member_name]
                 old = members2[member_name]
                 if old.full_type != new.full_type:
-                    self.detected_schema_changes.append(
-                        ChangedMemberType(name, member_name, old, new)
-                    )
+                    self.detected_schema_changes.append(ChangedMemberType(name, old, new))
 
     @staticmethod
     def _compare_keys(keys1, keys2):

--- a/python/podio_schema_evolution.py
+++ b/python/podio_schema_evolution.py
@@ -91,16 +91,15 @@ class DroppedMember(SchemaChange):
         super().__init__(f"'{self.klassname}' has a dropped member '{self.member.name}")
 
 
-class ChangedMember(SchemaChange):
+class ChangedMemberType(SchemaChange):
     """Class representing a type change in a member"""
 
     def __init__(self, name, member_name, old_member, new_member):
-        self.member_name = member_name
         self.old_member = old_member
         self.new_member = new_member
         self.klassname = name
         super().__init__(
-            f"'{self.klassname}.{self.member_name}' changed type from "
+            f"'{self.klassname}.{self.old_member.name}' changed type from "
             + f"{self.old_member.full_type} to {self.new_member.full_type}"
         )
 
@@ -349,7 +348,9 @@ class DataModelComparator:
                 new = members1[member_name]
                 old = members2[member_name]
                 if old.full_type != new.full_type:
-                    self.detected_schema_changes.append(ChangedMember(name, member_name, old, new))
+                    self.detected_schema_changes.append(
+                        ChangedMemberType(name, member_name, old, new)
+                    )
 
     @staticmethod
     def _compare_keys(keys1, keys2):
@@ -440,7 +441,7 @@ class DataModelComparator:
 
         # are the member changes actually supported/supportable?
         changed_members = [
-            change for change in schema_changes if isinstance(change, ChangedMember)
+            change for change in schema_changes if isinstance(change, ChangedMemberType)
         ]
         for change in changed_members:
             # changes between arrays and basic types are forbidden

--- a/python/templates/Collection.cc.jinja2
+++ b/python/templates/Collection.cc.jinja2
@@ -185,13 +185,6 @@ podio::SchemaVersionT {{ collection_type }}::getSchemaVersion() const {
 namespace {
  {{ macros.create_buffers(class, package_name, collection_type, OneToManyRelations, OneToOneRelations, VectorMembers, -1) }}
 
-{#
-// SCHEMA EVOLUTION: Not yet required with only ROOT backend
-// {% if old_schema_version is defined %}
-// {{ macros.create_buffers(class, package_name, collection_type, OneToManyRelations_old, OneToOneRelations_old, VectorMembers_old, old_schema_version) }}
-// {% endif %}
-#}
-
 // The usual trick with an IIFE and a static variable inside a function and then
 // making sure to call that function during shared library loading
 bool register{{ class.bare_type }}Collection() {

--- a/tests/schema_evolution/read_new_data.h
+++ b/tests/schema_evolution/read_new_data.h
@@ -3,7 +3,6 @@
 
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/ExampleWithARelationCollection.h"
-#include "datamodel/ExampleWithArrayComponentCollection.h"
 #include "datamodel/ExampleWithNamespaceCollection.h"
 
 #include "podio/Frame.h"
@@ -16,18 +15,6 @@
     std::cerr << __PRETTY_FUNCTION__ << ": " << msg << " (expected: " << expected << ", actual: " << actual << ")";    \
     return 1;                                                                                                          \
   }
-
-int readSimpleStruct(const podio::Frame& event) {
-  const auto& coll = event.get<ExampleWithArrayComponentCollection>("simpleStructTest");
-  auto elem = coll[0];
-  const auto sstruct = elem.s();
-
-  ASSERT_EQUAL(sstruct.y, 0, "New component member not 0 initialized")
-  ASSERT_EQUAL(sstruct.x, 42, "Existing component member changed")
-  ASSERT_EQUAL(sstruct.z, 123, "Existing component member changed")
-
-  return 0;
-}
 
 int readExampleHit(const podio::Frame& event) {
   const auto& coll = event.get<ExampleHitCollection>("datatypeMemberAdditionTest");
@@ -71,7 +58,6 @@ int read_new_data(const std::string& filename) {
   const auto event = podio::Frame(reader.readEntry("events", 0));
 
   int result = 0;
-  result += readSimpleStruct(event);
   result += readExampleHit(event);
   result += readExampleWithNamespace(event);
   result += readExampleWithARelation(event);

--- a/tests/schema_evolution/write_old_data.h
+++ b/tests/schema_evolution/write_old_data.h
@@ -3,24 +3,11 @@
 
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/ExampleWithARelationCollection.h"
-#include "datamodel/ExampleWithArrayComponentCollection.h"
 #include "datamodel/ExampleWithNamespaceCollection.h"
 
 #include "podio/Frame.h"
 
 #include <string>
-
-/// This is a datatype that holds a SimpleStruct component
-auto writeSimpleStruct() {
-  ExampleWithArrayComponentCollection coll;
-  auto elem = coll.create();
-  auto sstruct = SimpleStruct();
-  sstruct.x = 42;
-  sstruct.z = 123;
-  elem.s(sstruct);
-
-  return coll;
-}
 
 auto writeExampleHit() {
   ExampleHitCollection coll;
@@ -53,7 +40,6 @@ auto writeExampleWithARelation() {
 podio::Frame createFrame() {
   podio::Frame event;
 
-  event.put(writeSimpleStruct(), "simpleStructTest");
   event.put(writeExampleHit(), "datatypeMemberAdditionTest");
   event.put(writeExampleWithNamespace(), "componentMemberRenameTest");
   event.put(writeExampleWithARelation(), "floatToDoubleMemberTest");


### PR DESCRIPTION
BEGINRELEASENOTES
- Refactor parts of the code generation that are related to schema evolution
- Remove some duplication and homogenize information from schema changes detection system

ENDRELEASENOTES

This is probably still somewhat ongoing work that falls out of trying to fix some short comings of the whole system on the short run. This PR will collect the changes that are purely function preserving. Other PRs will build on top of this. Parts of the changes here already introduce new / generalized functionality that will be required for those.