### PR TITLE
Allow calling finish() multiple times, with no effect after the first

### DIFF
--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -28,9 +28,7 @@ RNTupleWriter::RNTupleWriter(const std::string& filename) :
 }
 
 RNTupleWriter::~RNTupleWriter() {
-  if (!m_finished) {
-    finish();
-  }
+  finish();
 }
 
 template <typename T>
@@ -235,6 +233,9 @@ RNTupleWriter::CategoryInfo& RNTupleWriter::getCategoryInfo(const std::string& c
 }
 
 void RNTupleWriter::finish() {
+  if (m_finished) {
+    return;
+  }
   auto metadata = root_compat::RNTupleModel::Create();
 
   const auto podioVersion = podio::version::build_version;

--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -17,9 +17,7 @@ ROOTWriter::ROOTWriter(const std::string& filename) {
 }
 
 ROOTWriter::~ROOTWriter() {
-  if (!m_finished) {
-    finish();
-  }
+  finish();
 }
 
 void ROOTWriter::writeFrame(const podio::Frame& frame, const std::string& category) {
@@ -168,6 +166,9 @@ void ROOTWriter::resetBranches(CategoryInfo& categoryInfo,
 }
 
 void ROOTWriter::finish() {
+  if (m_finished) {
+    return;
+  }
   auto* metaTree = new TTree(root_utils::metaTreeName, "metadata tree for podio I/O functionality");
   metaTree->SetDirectory(m_file.get());
 

--- a/src/SIOWriter.cc
+++ b/src/SIOWriter.cc
@@ -25,9 +25,7 @@ SIOWriter::SIOWriter(const std::string& filename) {
 }
 
 SIOWriter::~SIOWriter() {
-  if (!m_finished) {
-    finish();
-  }
+  finish();
 }
 
 void SIOWriter::writeFrame(const podio::Frame& frame, const std::string& category) {
@@ -55,6 +53,9 @@ void SIOWriter::writeFrame(const podio::Frame& frame, const std::string& categor
 }
 
 void SIOWriter::finish() {
+  if (m_finished) {
+    return;
+  }
   auto edmDefMap = std::make_shared<podio::SIOMapBlock<std::string, std::string>>(
       m_datamodelCollector.getDatamodelDefinitionsToWrite());
 


### PR DESCRIPTION
`finish()` can be called now multiple times for the TTree and RNTuple writers and it will crash after the first one. We check in the destructor but we can check instead inside `finish()` and disallow this behaviour.

BEGINRELEASENOTES
- Allow calling finish() multiple times, with no effect after the first by checking the value of `m_finished`.

ENDRELEASENOTES

The case where this happened (with @fredrikshaw) was trying to write immediately a file in Python which is not trivial. Doing:

``` python
writer = Writer(output_file)
writer.write_frame(frame, 'events')
writer._writer.finish()
```
currently crashes because `finish` will be called later (at the end of the script) again because of https://github.com/AIDASoft/podio/pull/539. Whether `_writer.finish()` should be used is a different question, because `del writer` does not always (in my tests, never) trigger the destructor and sometimes doing `gc.collect()` is not enough. In any case it's probably good not to let this crash happen. Alternatively, some public method could be added and then we could check https://github.com/AIDASoft/podio/blob/master/python/podio/base_writer.py#L19.