### PR TITLE
Switch back to docker runtime for CI

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cvmfs-contrib/github-action-cvmfs@v4
       - uses: key4hep/key4hep-actions/cache-external-data@main
-      - uses: tmadlener/run-lcg-view@podman
+      - uses: aidasoft/run-lcg-view@v5
         with:
           release-platform: LCG_107/x86_64-el9-${{ matrix.compiler }}-opt
           ccache-key: ccache-sanitizers-el9-${{ matrix.compiler }}-${{ matrix.sanitizer }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: tmadlener/run-lcg-view@podman
+    - uses: aidasoft/run-lcg-view@v5
       with:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-el9-${{ matrix.LCG }}
-        container-runtime: podman
         run: |
           echo "::group::Run CMake"
           # export JULIA_DEPOT_PATH="$(mktemp -d -p /tmp -t julia_depot_XXXXX):"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,11 +24,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: key4hep/key4hep-actions/cache-external-data@main
-    - uses: tmadlener/run-lcg-view@podman
+    - uses: aidasoft/run-lcg-view@v5
       with:
         release-platform: ${{ matrix.LCG }}
         ccache-key: ccache-ubuntu-${{ matrix.LCG }}
-        container-runtime: podman
         run: |
           echo "::group::Run CMake"
           mkdir -p build install


### PR DESCRIPTION
Upstream issue should be fixed with cvmfs



BEGINRELEASENOTES
- Switch back to the standard version of the run-lcg-view action, using docker as container runtime, since the upstream issue with cvmfs has been fixed.

ENDRELEASENOTES

See #791 for some more details