### PR TITLE
Fix deprecation warning but updating hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v5.0.0
     hooks:
       - id: mixed-line-ending
       - id: trailing-whitespace


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix deprecation warning in pre-commit by updating hook version to latest one (v5.0.0)

ENDRELEASENOTES