### PR TITLE
Make PODIO_GENERATE_DICTIONARY a thin wrapper around REFLEX_GENERATE_DICTIONARY

### DIFF
--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -13,6 +13,15 @@
 # ---------------------------------------------------------------------------------------------------
 function(PODIO_GENERATE_DICTIONARY dictionary)
   REFLEX_GENERATE_DICTIONARY(${ARGV})
+
+  # Dictionary payloads become very large for our generated EDMs, so we
+  # explicitly silence this warning here.
+  set_source_files_properties(${gensrcdict}
+    PROPERTIES
+    GENERATED TRUE
+    COMPILE_FLAGS "-Wno-overlength-strings"
+  )
+
   # We are not going to be able to fix these in any case, so disable clang-tidy
   # for the generated dictionaries
   set_target_properties(${dictionary} PROPERTIES CXX_CLANG_TIDY "")


### PR DESCRIPTION
BEGINRELEASENOTES
- Make `PODIO_GENERATE_DICTIONARY` a thin wrapper around `REFLEX_GENERATE_DICTIONARY` instead of a re-implementation

ENDRELEASENOTES

We depend on more recent ROOT versions now, so there is no need to keep this re-implementation around. `PODIO_GENERATE_DICTIONARY` becomes a thin wrapper around `REFLEX_GENERATE_DICTIONARY` where we only keep the additional clang-tidy settings on the dictionary target and the disabling of `Woverlength-strings`.