### PR TITLE
Deprecate the usage of -> instead of . for objects that are not pointers

### DIFF
--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -74,6 +74,7 @@ public:
   void print(std::ostream& os=std::cout, bool flush=true) const final;
 
   /// operator to allow pointer like calling of members a la LCIO
+  [[deprecated("Use of operator->() is deprecated. Use . instead.")]]
   {{ class.bare_type }}Collection* operator->() { return static_cast<{{ class.bare_type }}Collection*>(this); }
 
   /// Append a new object to the collection, and return this object.


### PR DESCRIPTION
An issue in python (https://github.com/wlav/cppyy/issues/312) where a `RecursionError` is thrown seems to happen because we have an `operator->` for collections. Regardless of that, I think it doesn't fit with the rest of podio and should be removed. I have made a few PRs not to use this:
- https://github.com/key4hep/k4geo/pull/500
- https://github.com/key4hep/k4Reco/pull/39
- https://github.com/AIDASoft/DD4hep/pull/1480

BEGINRELEASENOTES
- Deprecate the usage of -> instead of . for objects that are not pointers

ENDRELEASENOTES