### PR TITLE
Remove the deprecated operator-> in collections

### DIFF
--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -73,10 +73,6 @@ public:
   /// Print this collection to the passed stream
   void print(std::ostream& os=std::cout, bool flush=true) const final;
 
-  /// operator to allow pointer like calling of members a la LCIO
-  [[deprecated("Use of operator->() is deprecated. Use . instead.")]]
-  {{ class.bare_type }}Collection* operator->() { return static_cast<{{ class.bare_type }}Collection*>(this); }
-
   /// Append a new object to the collection, and return this object.
   Mutable{{ class.bare_type }} create();
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the deprecated operator-> in collections

ENDRELEASENOTES

Contains https://github.com/AIDASoft/podio/pull/811 and will serve as reminder. In addition, I won't fix the `RecursionError` (https://github.com/wlav/cppyy/issues/312) that would require adding another pythonization since it's not a big issue and it will disappear once this PR is merged.