### PR TITLE
Remove an unnecessary datatype from the test datamodel

### DIFF
--- a/python/podio/test_CodeGen.py
+++ b/python/podio/test_CodeGen.py
@@ -5,11 +5,12 @@ import unittest
 import ROOT
 import cppyy
 from ROOT import ExampleMCCollection, MutableExampleMC
-from ROOT import nsp
+from ROOT import ex2, nsp
 from pythonizations import load_pythonizations  # pylint: disable=import-error
 
 # load all available pythonizations to the classes in a namespace
 # loading pythonizations changes the state of cppyy backend shared by all the tests in a process
+load_pythonizations("ex2")
 load_pythonizations("nsp")
 
 
@@ -64,7 +65,7 @@ class AttributeCreationTest(unittest.TestCase):
     """Setting new attributes test"""
 
     def test_disable_new_attribute_creation(self):
-        component = nsp.AnotherNamespaceStruct()
+        component = ex2.NamespaceStruct()
         self.assertEqual(component.x, 0)
         component.x = 1
         self.assertEqual(component.x, 1)

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -42,11 +42,6 @@ components :
     Members:
       - ex2::NamespaceStruct data
 
-  nsp::AnotherNamespaceStruct:
-    Members:
-      - int x
-      - int y
-
   StructWithFixedWithTypes:
     Members:
       - uint16_t fixedUnsigned16 // unsigned int with exactly 16 bits


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove unused datatype from the original model and re-use another one to do the same test

ENDRELEASENOTES

Removed datatype has been introduced in #663 but is actually not necessary.