### PR TITLE
run cppcheck pre-commit hook only for c++ files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       - id: cppcheck
         name: cppcheck
         entry: cppcheck --project=build/compile_commands.json --enable=all --std=c++20 --cppcheck-build-dir=build --config-exclude="build/src/" --suppressions-list=.cppcheck-suppressions.txt -i "build/_deps/*" --error-exitcode=1 --check-level=exhaustive -j 4
+        types: [c++]
         language: system
         pass_filenames: false
       - id: clang-tidy


### PR DESCRIPTION

BEGINRELEASENOTES
- Run cppcheck pre-commit hook only for c++ files

ENDRELEASENOTES

I think it makes sense to skip running cppcheck if no C++ were modified. For other local hooks we already do this (clang-tidy, clang-format - C++ only;  pylint, flake8 - python only)