### PR TITLE
Fix code generation to make one-to-one relations within a type possible

### DIFF
--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -256,7 +256,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         for relation in datatype["OneToOneRelations"]:
             if relation.full_type != datatype["class"].full_type:
                 fwd_declarations[relation.namespace].append(relation.bare_type)
-                includes_cc.add(self._build_include(relation))
+            includes_cc.add(self._build_include(relation))
 
         if datatype["VectorMembers"] or datatype["OneToManyRelations"]:
             includes.add("#include <vector>")

--- a/tests/datalayout.yaml
+++ b/tests/datalayout.yaml
@@ -208,6 +208,12 @@ datatypes :
       - double d{9.876e5} // double val
       - CompWithInit comp // To make sure that the default initializer of the component does what it should
 
+  ExampleWithSingleSelfRelation:
+    Description: "A datatype that has a one-to-one relation with itself"
+    Author: "Thomas Madlener"
+    OneToOneRelations:
+      - ExampleWithSingleSelfRelation relation // the relation to itself
+
   ExampleWithInterfaceRelation:
     Description: "Datatype that uses an interface type as one of its relations"
     Author: "Thomas Madlener"

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1619,7 +1619,9 @@ TEST_CASE("Add type lists", "[basics][code-gen]") {
                                                         "ExampleWithUserInit",
                                                         "ExampleWithInterfaceRelation",
                                                         "ExampleWithExternalExtraCode",
-                                                        "nsp::EnergyInNamespace"}));
+                                                        "nsp::EnergyInNamespace",
+                                                        "ExampleWithSingleSelfRelation"}));
+
   std::vector<std::string> linkTypes;
   addTypeAll(datamodel::datamodelLinkTypes{}, linkTypes);
   REQUIRE_THAT(linkTypes,


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix code generation to allow for types to have a `OneToOneRelation` to itself. This was previously not possible (but seemingly unused)

ENDRELEASENOTES