### PR TITLE
Update the sanitizer workflows to use newer compilers

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc13, clang16]
+        compiler: [gcc15, clang19]
         # Since Leak is usually part of Address, we do not run it separately in
         # CI. Keeping Address and Undefined separate for easier debugging
         sanitizer: [Thread,
@@ -33,11 +33,11 @@ jobs:
         #     sanitizer: MemoryWithOrigin
     steps:
       - uses: actions/checkout@v4
-      - uses: cvmfs-contrib/github-action-cvmfs@v4
+      - uses: cvmfs-contrib/github-action-cvmfs@v5
       - uses: key4hep/key4hep-actions/cache-external-data@main
       - uses: aidasoft/run-lcg-view@v5
         with:
-          release-platform: LCG_107/x86_64-el9-${{ matrix.compiler }}-opt
+          release-platform: LCG_108/x86_64-el9-${{ matrix.compiler }}-opt
           ccache-key: ccache-sanitizers-el9-${{ matrix.compiler }}-${{ matrix.sanitizer }}
           run: |
             echo "::group::Run CMake"
@@ -45,7 +45,7 @@ jobs:
             cd build
             cmake -DCMAKE_BUILD_TYPE=Debug \
               -DUSE_SANITIZER=${{ matrix.sanitizer }} \
-              -DCMAKE_CXX_STANDARD=20 \
+              -DCMAKE_CXX_STANDARD=$([[ ${{ matrix.compiler }} == gcc15 ]] && echo "23" || echo "20") \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
               -DUSE_EXTERNAL_CATCH2=OFF \

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -48,7 +48,6 @@ jobs:
               -DCMAKE_CXX_STANDARD=$([[ ${{ matrix.compiler }} == gcc15 ]] && echo "23" || echo "20") \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " \
-              -DUSE_EXTERNAL_CATCH2=OFF \
               -DENABLE_SIO=ON \
               -DENABLE_JULIA=OFF \
               -DENABLE_RNTUPLE=ON \

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -846,17 +846,6 @@ auto createCollections(const size_t nElements = 3u) {
     userDataColl.push_back(3.14f * i);
   }
 
-  vecMemColl.prepareForWrite();
-  auto buffers = vecMemColl.getBuffers();
-  auto vecBuffers = buffers.vectorMembers;
-  auto thisVec = (*vecBuffers)[0].second;
-
-  // const auto floatVec = podio::CollectionWriteBuffers::asVector<float>(thisVec);
-  const auto floatVec2 = podio::CollectionReadBuffers::asVector<float>(thisVec);
-
-  // std::cout << floatVec->size() << '\n';
-  std::cout << "** " << floatVec2->size() << " vs " << vecMemColl.size() << '\n';
-
   return colls;
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to newer LCG release and compilers for sanitizer CI workflows
- Remove some unnecessary debug output from the unittests that trips UBSan on gcc15

ENDRELEASENOTES