### PR TITLE
add subscript pythonization to podio collections

### DIFF
--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -5,6 +5,7 @@
 #include "podio/CollectionBuffers.h"
 #include "podio/DatamodelRegistry.h"
 #include "podio/SchemaEvolution.h"
+#include "podio/detail/Pythonizations.h"
 #include "podio/utilities/TypeHelpers.h"
 
 #define PODIO_ADD_USER_TYPE(type)                                                                                      \
@@ -163,6 +164,11 @@ public:
   /// fully qualified type name of stored POD elements - with namespace
   const std::string_view getDataTypeName() const override {
     return dataTypeName;
+  }
+
+  /// Cppyy protocol to setup the pythonizations for this class. Not to be called directly.
+  static void __cppyy_pythonize__(PyObject* klass, const std::string& name) {
+    podio::detail::pythonizations::pythonize_subscript(klass, name);
   }
 
   /// clear the collection and all internal states

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -14,6 +14,7 @@
 #include "podio/DatamodelRegistry.h"
 #include "podio/ICollectionProvider.h"
 #include "podio/SchemaEvolution.h"
+#include "podio/detail/Pythonizations.h"
 #include "podio/utilities/MaybeSharedPtr.h"
 #include "podio/utilities/StaticConcatenate.h"
 #include "podio/utilities/TypeHelpers.h"
@@ -230,6 +231,11 @@ public:
 
   const std::string_view getDataTypeName() const override {
     return dataTypeName;
+  }
+
+  /// Cppyy protocol to setup the pythonizations for this class. Not to be called directly.
+  static void __cppyy_pythonize__(PyObject* klass, const std::string& name) {
+    podio::detail::pythonizations::pythonize_subscript(klass, name);
   }
 
   bool isSubsetCollection() const override {

--- a/python/podio/test_CodeGen.py
+++ b/python/podio/test_CodeGen.py
@@ -4,8 +4,15 @@
 import unittest
 import ROOT
 import cppyy
-from ROOT import ExampleMCCollection, MutableExampleMC
+from ROOT import (
+    ExampleMCCollection,
+    MutableExampleMC,
+    TestLinkCollection,
+    MutableTestLink,
+    TestLink,
+)
 from ROOT import nsp
+import podio
 
 
 class ObjectConversionsTest(unittest.TestCase):
@@ -53,6 +60,38 @@ class CollectionSubscriptTest(unittest.TestCase):
         obj = collection.create()
         self.assertIsInstance(obj, nsp.MutableEnergyInNamespace)
         self.assertIsInstance(collection[0], nsp.EnergyInNamespace)
+
+    def test_link_collection_check(self):
+        """Test that bound checking for link collection subscript is enabled"""
+        collection = TestLinkCollection()
+        _ = collection.create()
+        self.assertEqual(len(collection), 1)
+        with self.assertRaises(IndexError):
+            _ = collection[20]
+        _ = collection[0]
+
+    def test_link_collection_getitem_type(self):
+        """Test that link collection subscript returns an instance of podio immutable datatype"""
+        collection = TestLinkCollection()
+        obj = collection.create()
+        self.assertIsInstance(obj, MutableTestLink)
+        self.assertIsInstance(collection[0], TestLink)
+
+    def test_user_data_collection_check(self):
+        """Test that bound checking for podio.UserDataCollection subscript is enabled"""
+        collection = podio.podio.UserDataCollection["float"]()
+        _ = collection.create()
+        self.assertEqual(len(collection), 1)
+        with self.assertRaises(IndexError):
+            _ = collection[20]
+        _ = collection[0]
+
+    def test_user_data_collection_getitem_type(self):
+        """Test that link collection subscript returns parameterized type"""
+        collection = podio.podio.UserDataCollection["float"]()
+        obj = collection.create()
+        self.assertIsInstance(obj, float)
+        self.assertIsInstance(collection[0], float)
 
 
 class HashTest(unittest.TestCase):


### PR DESCRIPTION
BEGINRELEASENOTES
- Add automatic collection subscript pythonization to `UserDataCollection` and `LinkCollection`

ENDRELEASENOTES

Follow up to #810,  which missed the C++ pythonization callback for `podio::UserDataCollection` and `podio::LinkCollection`.

Requires #826 