### PR TITLE
Fix typo causing error in non-const overload of `LinkCollection::at(size_t)`

### DIFF
--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -98,7 +98,7 @@ public:
   }
   /// Returns the mutable object of given index
   mutable_type at(std::size_t index) {
-    return mutable_type(podio::utils::MaybeSharedPtr(m_storage.at(index)));
+    return mutable_type(podio::utils::MaybeSharedPtr(m_storage.entries.at(index)));
   }
 
   void push_back(mutable_type object) {

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -319,11 +319,11 @@ TEST_CASE("LinkCollection constness", "[links][static-checks][const-correctness]
 
     // check the individual steps again from above, to see where things fail if they fail
     STATIC_REQUIRE(std::is_same_v<decltype(std::declval<const TestLColl>().begin()),
-                                  TestLColl::const_iterator>); // const collectionb begin() should return a
+                                  TestLColl::const_iterator>); // const collection begin() should return a
                                                                // LinkCollectionIterator
 
     STATIC_REQUIRE(std::is_same_v<decltype(std::declval<const TestLColl>().end()),
-                                  TestLColl::const_iterator>); // const collectionb end() should return a
+                                  TestLColl::const_iterator>); // const collection end() should return a
                                                                // LinkCollectionIterator
 
     STATIC_REQUIRE(std::is_same_v<decltype(*std::declval<const TestLColl>().begin()),
@@ -350,7 +350,7 @@ TEST_CASE("LinkCollection constness", "[links][static-checks][const-correctness]
                                                          // MutableCollectionIterator
 
     STATIC_REQUIRE(std::is_same_v<decltype(std::declval<TestLColl>().end()),
-                                  TestLColl::iterator>); // collectionb end() should return a
+                                  TestLColl::iterator>); // collection end() should return a
                                                          // MutableCollectionIterator
 
     STATIC_REQUIRE(std::is_same_v<decltype(*std::declval<TestLColl>().begin()),

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -9,6 +9,7 @@
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/TestInterfaceLinkCollection.h"
 #include "datamodel/TypeWithEnergy.h"
+#include <utility>
 
 #ifdef PODIO_JSON_OUTPUT
   #include "nlohmann/json.hpp"
@@ -475,6 +476,20 @@ void checkCollections(const TestLColl& links, const ExampleHitCollection& hits,
 
     index++;
   }
+}
+
+TEST_CASE("LinkCollection element access", "[links][basics]") {
+  auto [linkColl, hitColl, clusterColl] = createLinkCollections();
+
+  for (size_t i = 0; i < linkColl.size(); ++i) {
+    REQUIRE(linkColl[i].getWeight() == i);
+    REQUIRE(std::as_const(linkColl)[i].getWeight() == i);
+    REQUIRE(linkColl.at(i).getWeight() == i);
+    REQUIRE(std::as_const(linkColl).at(i).getWeight() == i);
+  }
+
+  REQUIRE_THROWS_AS(linkColl.at(linkColl.size()), std::out_of_range);
+  REQUIRE_THROWS_AS(std::as_const(linkColl).at(linkColl.size()), std::out_of_range);
 }
 
 TEST_CASE("LinkCollection looping", "[links][basics]") {


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix typo causing error in non-const overload of `LinkCollection::at(size_t)`

ENDRELEASENOTES

Discovered in #824, there was a typo in non-const overload of `LinkCollection::at(size_t)`. `LinkCollectionData` (`m_storage`) doesn't have `at` method
I'm not sure how it was able to pass this far
