### PR TITLE
Add string representations for better logging to generator utils

### DIFF
--- a/python/podio_gen/generator_utils.py
+++ b/python/podio_gen/generator_utils.py
@@ -336,7 +336,7 @@ class DataModel:  # pylint: disable=too-few-public-methods
     def __repr__(self):
         return (
             f"DataModel: {self.schema_version=} | {len(self.datatypes)} datatypes,"
-            f" {len(self.components)} components {len(self.interfaces)} interfaces "
+            f" {len(self.components)} components, {len(self.interfaces)} interfaces, "
             f"{len(self.links)} links"
         )
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a `__repr__` method to some of the classes in the generator python utils for improved printouts

ENDRELEASENOTES

Small atomic change that was quite useful for #828 