### PR TITLE
Do not construct the full path up-front

### DIFF
--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -566,7 +566,7 @@ have resolvable schema evolution incompatibilities:"
             for x in list(self.datamodel.datatypes.keys()) + list(self.datamodel.links.keys())
         )
         self._write_file(
-            os.path.join(self.install_dir, self.package_name, f"{self.package_name}.h"),
+            f"{self.package_name}.h",
             self._eval_template(
                 "datamodel.h.jinja2",
                 {


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix a minor bug in generation of all collections header file

ENDRELEASENOTES

I am not entirely sure if this simply worked because we always passed full paths to the generator, but in principle the construction of the full path is done by `GeneratorBase._write_file`. This does not work when passing relative paths to `PODIO_GENERATE_DATAMODEL`.