### PR TITLE
Add types with all the collection types of a datamodel in datamodel.h

### DIFF
--- a/python/templates/datamodel.h.jinja2
+++ b/python/templates/datamodel.h.jinja2
@@ -12,27 +12,27 @@
 namespace {{ package_name }} {
 
 using {{ package_name }}DataTypes = podio::utils::TypeList<
-  {{ datatypes | map('string') | join(', ')}}
+  {{ datatypes | join(', ')}}
 >;
 
 using {{ package_name }}DataCollectionTypes = podio::utils::TypeList<
 {%  if datatypes %}
-  {{ datatypes | map('string') | join('Collection, ') ~ 'Collection' }}
+  {{ datatypes | join('Collection, ') ~ 'Collection' }}
 {% endif %}
 >;
 
 using {{ package_name }}LinkTypes = podio::utils::TypeList<
-  {{ links | map('string') | join(', ')}}
+  {{ links  | join(', ')}}
 >;
 
 using {{ package_name }}LinkCollectionTypes = podio::utils::TypeList<
 {% if links %}
-  {{ links | map('string') | join('Collection, ') ~ 'Collection' }}
+  {{ links | join('Collection, ') ~ 'Collection' }}
 {% endif %}
 >;
 
 using {{ package_name }}InterfaceTypes = podio::utils::TypeList<
-  {{ interfaces | map('string') | join(', ')}}
+  {{ interfaces | join(', ')}}
 >;
 
 }

--- a/python/templates/datamodel.h.jinja2
+++ b/python/templates/datamodel.h.jinja2
@@ -13,13 +13,25 @@ namespace {{ package_name }} {
 
 using {{ package_name }}DataTypes = podio::utils::TypeList<
 {% for name in datatypes %}
-  {{ name }}{% if not loop.last %},{% endif %}
+{% if loop.first %}  {% else %} {% endif %}{{ name }}{% if not loop.last %},{% endif %}
+{% endfor %}
+>;
+
+using {{ package_name }}DataCollectionTypes = podio::utils::TypeList<
+{% for name in datatypes %}
+{% if loop.first %}  {% else %} {% endif %}{{ name }}Collection{% if not loop.last %},{% endif %}
 {% endfor %}
 >;
 
 using {{ package_name }}LinkTypes = podio::utils::TypeList<
 {% for name in links %}
-  {{ name }}{% if not loop.last %},{% endif %}
+{% if loop.first %}  {% else %} {% endif %}{{ name }}{% if not loop.last %},{% endif %}
+{% endfor %}
+>;
+
+using {{ package_name }}LinkCollectionTypes = podio::utils::TypeList<
+{% for name in links %}
+{% if loop.first %}  {% else %} {% endif %}{{ name }}Collection{% if not loop.last %},{% endif %}
 {% endfor %}
 >;
 

--- a/python/templates/datamodel.h.jinja2
+++ b/python/templates/datamodel.h.jinja2
@@ -12,33 +12,27 @@
 namespace {{ package_name }} {
 
 using {{ package_name }}DataTypes = podio::utils::TypeList<
-{% for name in datatypes %}
-{% if loop.first %}  {% else %} {% endif %}{{ name }}{% if not loop.last %},{% endif %}
-{% endfor %}
+  {{ datatypes | map('string') | join(', ')}}
 >;
 
 using {{ package_name }}DataCollectionTypes = podio::utils::TypeList<
-{% for name in datatypes %}
-{% if loop.first %}  {% else %} {% endif %}{{ name }}Collection{% if not loop.last %},{% endif %}
-{% endfor %}
+{%  if datatypes %}
+  {{ datatypes | map('string') | join('Collection, ') ~ 'Collection' }}
+{% endif %}
 >;
 
 using {{ package_name }}LinkTypes = podio::utils::TypeList<
-{% for name in links %}
-{% if loop.first %}  {% else %} {% endif %}{{ name }}{% if not loop.last %},{% endif %}
-{% endfor %}
+  {{ links | map('string') | join(', ')}}
 >;
 
 using {{ package_name }}LinkCollectionTypes = podio::utils::TypeList<
-{% for name in links %}
-{% if loop.first %}  {% else %} {% endif %}{{ name }}Collection{% if not loop.last %},{% endif %}
-{% endfor %}
+{% if links %}
+  {{ links | map('string') | join('Collection, ') ~ 'Collection' }}
+{% endif %}
 >;
 
 using {{ package_name }}InterfaceTypes = podio::utils::TypeList<
-{% for name in interfaces %}
-  {{ name }}{% if not loop.last %},{% endif %}
-{% endfor %}
+  {{ interfaces | map('string') | join(', ')}}
 >;
 
 }

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1659,7 +1659,7 @@ TEST_CASE("Add type lists", "[basics][code-gen]") {
                UnorderedEquals(std::vector<std::string>{"extension::ContainedType", "extension::ExternalComponentType",
                                                         "extension::ExternalRelationType"}));
 
-  std::vector<std::string> extensionDataCollectionTypes;  
+  std::vector<std::string> extensionDataCollectionTypes;
   addTypeAll(extension_model::extension_modelDataCollectionTypes{}, extensionDataCollectionTypes);
   REQUIRE_THAT(extensionDataCollectionTypes,
                UnorderedEquals(std::vector<std::string>{"extension::ContainedTypeCollection",
@@ -1670,7 +1670,7 @@ TEST_CASE("Add type lists", "[basics][code-gen]") {
   addTypeAll(extension_model::extension_modelLinkTypes{}, extensionLinkTypes);
   REQUIRE_THAT(extensionLinkTypes, UnorderedEquals(std::vector<std::string>{}));
 
-  std::vector<std::string> extensionLinkCollectionTypes;  
+  std::vector<std::string> extensionLinkCollectionTypes;
   addTypeAll(extension_model::extension_modelLinkCollectionTypes{}, extensionLinkCollectionTypes);
   REQUIRE_THAT(extensionLinkCollectionTypes, UnorderedEquals(std::vector<std::string>{}));
 

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1586,9 +1586,9 @@ void addTypeAll(podio::utils::TypeList<T...>&&, std::vector<std::string>& collec
 TEST_CASE("Add type lists", "[basics][code-gen]") {
   using Catch::Matchers::UnorderedEquals;
 
-  std::vector<std::string> collectionTypes;
-  addTypeAll(datamodel::datamodelDataTypes{}, collectionTypes);
-  REQUIRE_THAT(collectionTypes,
+  std::vector<std::string> dataTypes;
+  addTypeAll(datamodel::datamodelDataTypes{}, dataTypes);
+  REQUIRE_THAT(dataTypes,
                UnorderedEquals(std::vector<std::string>{"EventInfo",
                                                         "ExampleHit",
                                                         "ExampleMC",
@@ -1610,12 +1610,42 @@ TEST_CASE("Add type lists", "[basics][code-gen]") {
                                                         "ExampleWithExternalExtraCode",
                                                         "nsp::EnergyInNamespace",
                                                         "ExampleWithSingleSelfRelation"}));
+  std::vector<std::string> dataCollectionTypes;
+  addTypeAll(datamodel::datamodelDataCollectionTypes{}, dataCollectionTypes);
+  REQUIRE_THAT(dataCollectionTypes,
+               UnorderedEquals(std::vector<std::string>{"EventInfoCollection",
+                                                        "ExampleHitCollection",
+                                                        "ExampleMCCollection",
+                                                        "ExampleClusterCollection",
+                                                        "ExampleReferencingTypeCollection",
+                                                        "ExampleWithVectorMemberCollection",
+                                                        "ExampleWithOneRelationCollection",
+                                                        "ExampleWithArrayComponentCollection",
+                                                        "ExampleWithComponentCollection",
+                                                        "ExampleForCyclicDependency1Collection",
+                                                        "ExampleForCyclicDependency2Collection",
+                                                        "ex42::ExampleWithNamespaceCollection",
+                                                        "ex42::ExampleWithARelationCollection",
+                                                        "ExampleWithDifferentNamespaceRelationsCollection",
+                                                        "ExampleWithArrayCollection",
+                                                        "ExampleWithFixedWidthIntegersCollection",
+                                                        "ExampleWithUserInitCollection",
+                                                        "ExampleWithInterfaceRelationCollection",
+                                                        "ExampleWithExternalExtraCodeCollection",
+                                                        "nsp::EnergyInNamespaceCollection",
+                                                        "ExampleWithSingleSelfRelationCollection"}));
 
   std::vector<std::string> linkTypes;
   addTypeAll(datamodel::datamodelLinkTypes{}, linkTypes);
   REQUIRE_THAT(linkTypes,
                UnorderedEquals(std::vector<std::string>{"podio::Link<ExampleHit,ExampleCluster>",
                                                         "podio::Link<ExampleCluster,TypeWithEnergy>"}));
+
+  std::vector<std::string> linkCollectionTypes;
+  addTypeAll(datamodel::datamodelLinkCollectionTypes{}, linkCollectionTypes);
+  REQUIRE_THAT(linkCollectionTypes,
+               UnorderedEquals(std::vector<std::string>{"podio::LinkCollection<ExampleHit,ExampleCluster>",
+                                                        "podio::LinkCollection<ExampleCluster,TypeWithEnergy>"}));
 
   std::vector<std::string> interfaceTypes;
   addTypeAll(datamodel::datamodelInterfaceTypes{}, interfaceTypes);
@@ -1628,9 +1658,21 @@ TEST_CASE("Add type lists", "[basics][code-gen]") {
   REQUIRE_THAT(extensionDataTypes,
                UnorderedEquals(std::vector<std::string>{"extension::ContainedType", "extension::ExternalComponentType",
                                                         "extension::ExternalRelationType"}));
+
+  std::vector<std::string> extensionDataCollectionTypes;  
+  addTypeAll(extension_model::extension_modelDataCollectionTypes{}, extensionDataCollectionTypes);
+  REQUIRE_THAT(extensionDataCollectionTypes,
+               UnorderedEquals(std::vector<std::string>{"extension::ContainedTypeCollection",
+                                                        "extension::ExternalComponentTypeCollection",
+                                                        "extension::ExternalRelationTypeCollection"}));
+
   std::vector<std::string> extensionLinkTypes;
   addTypeAll(extension_model::extension_modelLinkTypes{}, extensionLinkTypes);
   REQUIRE_THAT(extensionLinkTypes, UnorderedEquals(std::vector<std::string>{}));
+
+  std::vector<std::string> extensionLinkCollectionTypes;  
+  addTypeAll(extension_model::extension_modelLinkCollectionTypes{}, extensionLinkCollectionTypes);
+  REQUIRE_THAT(extensionLinkCollectionTypes, UnorderedEquals(std::vector<std::string>{}));
 
   std::vector<std::string> userDataCollectionTypes;
   addTypeAll(podio::UserDataCollectionTypes{}, userDataCollectionTypes);


### PR DESCRIPTION
BEGINRELEASENOTES
- Add types with all the collection types of a datamodel in datamodel.h
- Add tests for the new types
- Use single spaces instead of two spaces between types in the list

ENDRELEASENOTES

See https://github.com/AIDASoft/podio/pull/829 and the original PR https://github.com/AIDASoft/podio/pull/761