### PR TITLE
Add a memory limit to schema evolution tests

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -52,6 +52,7 @@ jobs:
               -DENABLE_JULIA=OFF \
               -DENABLE_RNTUPLE=ON \
               -DENABLE_DATASOURCE=ON \
+              -DPODIO_NO_MEMLIMIT_SCHEMA_EVOL_TESTS=ON \
               -G Ninja ..
             echo "::endgroup::"
             echo "::group::Build"

--- a/tests/schema_evolution/code_gen/CMakeLists.txt
+++ b/tests/schema_evolution/code_gen/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Most sanitizers don't really like to run with limited virtual memory
+option(PODIO_NO_MEMLIMIT_SCHEMA_EVOL_TESTS "Run the schema evolution tests without memory limit" OFF)
+
 include(test_utilities.cmake)
 
 ADD_SCHEMA_EVOLUTION_TEST(components_new_member)


### PR DESCRIPTION
Avoids freezing systems and killing CI when running into issues where ROOT starts to run away with memory



BEGINRELEASENOTES
- Run schema evolution read tests with limited memory to avoid ROOT running away with all the memory.

ENDRELEASENOTES

Triggered by https://github.com/AIDASoft/podio/pull/817#issuecomment-3257539523

@jmcarcell Had the same issue as you, but for me the all tests in #817 ran without issue and only when I started to add failing tests things started to break.

Lifted from #803 