### PR TITLE
Remove potentially confusing "Data" from generated type list name

### DIFF
--- a/python/templates/datamodel.h.jinja2
+++ b/python/templates/datamodel.h.jinja2
@@ -15,7 +15,7 @@ using {{ package_name }}DataTypes = podio::utils::TypeList<
   {{ datatypes | join(', ')}}
 >;
 
-using {{ package_name }}DataCollectionTypes = podio::utils::TypeList<
+using {{ package_name }}CollectionTypes = podio::utils::TypeList<
 {%  if datatypes %}
   {{ datatypes | join('Collection, ') ~ 'Collection' }}
 {% endif %}

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -1611,7 +1611,7 @@ TEST_CASE("Add type lists", "[basics][code-gen]") {
                                                         "nsp::EnergyInNamespace",
                                                         "ExampleWithSingleSelfRelation"}));
   std::vector<std::string> dataCollectionTypes;
-  addTypeAll(datamodel::datamodelDataCollectionTypes{}, dataCollectionTypes);
+  addTypeAll(datamodel::datamodelCollectionTypes{}, dataCollectionTypes);
   REQUIRE_THAT(dataCollectionTypes,
                UnorderedEquals(std::vector<std::string>{"EventInfoCollection",
                                                         "ExampleHitCollection",
@@ -1659,9 +1659,9 @@ TEST_CASE("Add type lists", "[basics][code-gen]") {
                UnorderedEquals(std::vector<std::string>{"extension::ContainedType", "extension::ExternalComponentType",
                                                         "extension::ExternalRelationType"}));
 
-  std::vector<std::string> extensionDataCollectionTypes;
-  addTypeAll(extension_model::extension_modelDataCollectionTypes{}, extensionDataCollectionTypes);
-  REQUIRE_THAT(extensionDataCollectionTypes,
+  std::vector<std::string> extensionCollectionTypes;
+  addTypeAll(extension_model::extension_modelCollectionTypes{}, extensionCollectionTypes);
+  REQUIRE_THAT(extensionCollectionTypes,
                UnorderedEquals(std::vector<std::string>{"extension::ContainedTypeCollection",
                                                         "extension::ExternalComponentTypeCollection",
                                                         "extension::ExternalRelationTypeCollection"}));


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the `Data` from the generated type list containing all generated datatype collection names

ENDRELEASENOTES

As mentioned here: https://github.com/AIDASoft/podio/pull/832/files#r2333176757

Originally introduced in #832 