### PR TITLE
Add the Python headers to the system includes to avoid warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,8 @@ FUNCTION(PODIO_ADD_LIB_AND_DICT libname headers sources selection )
   target_include_directories(${libname} PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+  target_include_directories(${libname} SYSTEM PUBLIC
     ${Python3_INCLUDE_DIRS}
   )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the Python headers to the system includes to avoid warnings

ENDRELEASENOTES

See https://github.com/AIDASoft/podio/pull/810#issuecomment-3248092637