### PR TITLE
[WIP] Make sure to not consume all available memory on garbage data

### DIFF
--- a/include/podio/CollectionBuffers.h
+++ b/include/podio/CollectionBuffers.h
@@ -91,11 +91,16 @@ struct CollectionReadBuffers {
     // an infinite loop that eats all memory. Almost certainly ROOT has emitted
     // some warnings prior to this.
     const auto* tmp = static_cast<std::vector<T>*>(raw);
-    for (const auto& _ [[maybe_unused]] : *tmp) {
+    // NOTE: We deliberatly make this a copy, as that at least leads to a crash
+    // in Debug builds
+    for (const auto _ [[maybe_unused]] : *tmp) {
       // The "garbageness" of the vector is indicated by the fact that it
       // reports a size of 0 (implying begin() == end() in at least GCCs
       // implementation), but still entering this loop. Hence, we use that to
       // assert here.
+      //
+      // NOTE: It looks like this is not necessarily true nor sufficient to
+      // detect problems.
       assert(tmp->size() != 0);
       break; // Only need to do this once
     }

--- a/include/podio/CollectionBuffers.h
+++ b/include/podio/CollectionBuffers.h
@@ -4,6 +4,9 @@
 #include "podio/ObjectID.h"
 #include "podio/SchemaEvolution.h"
 
+#ifndef NDEBUG
+  #include <cassert>
+#endif
 #include <functional>
 #include <memory>
 #include <string>
@@ -82,6 +85,24 @@ struct CollectionReadBuffers {
   template <typename T>
   static std::vector<T>* asVector(void* raw) {
     // Are we at a beach? I can almost smell the C...
+#ifndef NDEBUG
+    // It is possible that we get a garbage vector pointer back from ROOT in
+    // some cases. These can be triggered, e.g. by not providing the correct
+    // dictionaries when reading back data. This can happen via a faulty
+    // environment or in cases where the on-disk version of the data can no
+    // longer be read back properly into the in-memory representation of the
+    // current datamodel. This really is just a stop-gap to avoid running into
+    // an infinite loop that eats all memory. Almost certainly ROOT has emitted
+    // some warnings prior to this.
+    const auto* tmp = static_cast<std::vector<T>*>(raw);
+    for (auto elem [[maybe_unused]] : *tmp) {
+      // The "garbageness" of the vector is indicated by the fact that it
+      // reports a size of 0 (implying begin() == end() in at least GCCs
+      // implementation), but still entering this loop. Hence, we use that to
+      // assert here.
+      assert(tmp->size() != 0);
+    }
+#endif
     return static_cast<std::vector<T>*>(raw);
   }
 

--- a/include/podio/CollectionBuffers.h
+++ b/include/podio/CollectionBuffers.h
@@ -4,9 +4,7 @@
 #include "podio/ObjectID.h"
 #include "podio/SchemaEvolution.h"
 
-#ifndef NDEBUG
-  #include <cassert>
-#endif
+#include <cassert>
 #include <functional>
 #include <memory>
 #include <string>
@@ -84,8 +82,6 @@ struct CollectionReadBuffers {
 
   template <typename T>
   static std::vector<T>* asVector(void* raw) {
-    // Are we at a beach? I can almost smell the C...
-#ifndef NDEBUG
     // It is possible that we get a garbage vector pointer back from ROOT in
     // some cases. These can be triggered, e.g. by not providing the correct
     // dictionaries when reading back data. This can happen via a faulty
@@ -95,14 +91,15 @@ struct CollectionReadBuffers {
     // an infinite loop that eats all memory. Almost certainly ROOT has emitted
     // some warnings prior to this.
     const auto* tmp = static_cast<std::vector<T>*>(raw);
-    for (auto elem [[maybe_unused]] : *tmp) {
+    for (const auto& _ [[maybe_unused]] : *tmp) {
       // The "garbageness" of the vector is indicated by the fact that it
       // reports a size of 0 (implying begin() == end() in at least GCCs
       // implementation), but still entering this loop. Hence, we use that to
       // assert here.
       assert(tmp->size() != 0);
+      break; // Only need to do this once
     }
-#endif
+    // Are we at a beach? I can almost smell the C...
     return static_cast<std::vector<T>*>(raw);
   }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Put in an assertion to avoid eating all available memory in case there are problems when reading back data.

ENDRELEASENOTES

Following: https://github.com/AIDASoft/podio/pull/817#issuecomment-3266748609