### PR TITLE
Refactor schema evolution detection

### DIFF
--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -132,6 +132,7 @@ function(PODIO_GENERATE_DATAMODEL datamodel YAML_FILE RETURN_HEADERS RETURN_SOUR
     ${YAML_FILE}
     ${PODIO_TEMPLATES}
     ${podio_PYTHON_DIR}/podio_class_generator.py
+    ${podio_PYTHON_DIR}/podio_schema_evolution.py
     ${podio_PYTHON_DIR}/podio_gen/generator_utils.py
     ${podio_PYTHON_DIR}/podio_gen/podio_config_reader.py
     ${podio_PYTHON_DIR}/podio_gen/generator_base.py

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -84,7 +84,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         # information to update the selection.xml
         self.root_schema_component_names = set()
         self.root_schema_datatype_names = set()
-        self.root_schema_iorules = set()
+        self.root_schema_iorules = []
         # a map of datatypes that are used in interfaces populated by pre_process
         self.types_in_interfaces = {}
 
@@ -487,18 +487,22 @@ have resolvable schema evolution incompatibilities:"
                             f"{schema_change.member_name_new} in {type_name}"
                         )
 
-                    iorule = RootIoRule()
-                    iorule.sourceClass = type_name
-                    iorule.targetClass = type_name
+                    sourceClass = type_name
+                    targetClass = type_name
                     if is_datatype:
-                        iorule.sourceClass = f"{type_name}Data"
-                        iorule.targetClass = f"{type_name}Data"
+                        sourceClass = f"{type_name}Data"
+                        targetClass = f"{type_name}Data"
 
-                    iorule.version = self.old_schema_version
-                    iorule.source = f"{member_type} {schema_change.member_name_old}"
-                    iorule.target = schema_change.member_name_new
-                    iorule.code = f"{iorule.target} = onfile.{schema_change.member_name_old};"
-                    self.root_schema_iorules.add(iorule)
+                    target = schema_change.member_name_new
+                    iorule = RootIoRule(
+                        sourceClass=sourceClass,
+                        targetClass=targetClass,
+                        source=f"{member_type} {schema_change.member_name_old}",
+                        version=self.old_schema_version,
+                        target=target,
+                        code=f"{target} = onfile.{schema_change.member_name_old};",
+                    )
+                    self.root_schema_iorules.append(iorule)
                 else:
                     raise NotImplementedError(
                         f"Schema evolution for {schema_change} not yet implemented."

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -344,33 +344,30 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         # which are the ones that changed?
         # have to extend the selection xml file
         if self.old_yamlfile:
-            comparator = DataModelComparator(
-                self.yamlfile, self.old_yamlfile, evolution_file=self.evolution_file
-            )
-            comparator.read()
-            comparator.compare()
-            self.old_schema_version = comparator.datamodel_old.schema_version
+            comparator = DataModelComparator(self.yamlfile, evolution_file=self.evolution_file)
+            comparison_results = comparator.compare(self.old_yamlfile)
+            self.old_schema_version = comparison_results.old_datamodel.schema_version
             # some sanity checks
-            if len(comparator.errors) > 0:
+            if len(comparison_results.errors) > 0:
                 print(
                     f"The given datamodels '{self.yamlfile}' and '{self.old_yamlfile}' \
 have unresolvable schema evolution incompatibilities:"
                 )
-                for error in comparator.errors:
+                for error in comparison_results.errors:
                     print(error)
                 sys.exit(-1)
-            if len(comparator.warnings) > 0:
+            if len(comparison_results.warnings) > 0:
                 print(
                     f"The given datamodels '{self.yamlfile}' and '{self.old_yamlfile}' \
 have resolvable schema evolution incompatibilities:"
                 )
-                for warning in comparator.warnings:
+                for warning in comparison_results.warnings:
                     print(warning)
                 sys.exit(-1)
 
             # now go through all the io_handlers and see what we have to do
             if "ROOT" in self.io_handlers:
-                for item in root_filter(comparator.schema_changes):
+                for item in root_filter(comparison_results.schema_changes):
                     # add whatever is relevant to our ROOT schema evolution
                     self.root_schema_dict.setdefault(item.klassname, []).append(item)
 

--- a/python/podio_schema_evolution.py
+++ b/python/podio_schema_evolution.py
@@ -4,6 +4,7 @@ Provides infrastructure for analyzing schema definitions for schema evolution
 """
 
 import sys
+from dataclasses import dataclass
 import yaml
 
 from podio_gen.podio_config_reader import PodioConfigReader
@@ -173,16 +174,16 @@ class DroppedMultiRelation(SchemaChange):
         )
 
 
+@dataclass
 class RootIoRule:
-    """A placeholder IORule class"""
+    """Class collecting all necessary information to create an I/O rule for ROOT"""
 
-    def __init__(self):
-        self.sourceClass = None
-        self.targetClass = None
-        self.version = None
-        self.source = None
-        self.target = None
-        self.code = None
+    sourceClass: str
+    targetClass: str
+    version: int
+    code: str
+    target: str
+    source: str = ""
 
 
 def sio_filter(schema_changes):

--- a/python/podio_schema_evolution.py
+++ b/python/podio_schema_evolution.py
@@ -5,9 +5,11 @@ Provides infrastructure for analyzing schema definitions for schema evolution
 
 import sys
 from dataclasses import dataclass
+from typing import List
 import yaml
 
 from podio_gen.podio_config_reader import PodioConfigReader
+from podio_gen.generator_utils import DataModel
 
 
 # @TODO: not really a good class model here
@@ -186,6 +188,16 @@ class RootIoRule:
     source: str = ""
 
 
+@dataclass
+class ComparisonResults:
+    """Class grouping the results of a datamodel comparison"""
+
+    old_datamodel: DataModel
+    warnings: List[str]
+    errors: List[str]
+    schema_changes: List[SchemaChange] = None
+
+
 def sio_filter(schema_changes):
     """
     Checks what is required/supported for the SIO backend
@@ -224,101 +236,123 @@ class DataModelComparator:
         DroppedMultiRelation,
     )
 
-    def __init__(self, yamlfile_new, yamlfile_old, evolution_file=None) -> None:
-        self.yamlfile_new = yamlfile_new
-        self.yamlfile_old = yamlfile_old
-        self.evolution_file = evolution_file
+    def __init__(self, yamlfile_new, evolution_file=None) -> None:
         self.reader = PodioConfigReader()
+        self.datamodel_new = self.reader.read(yamlfile_new, package_name="new")
+        self.evolution_file = evolution_file
 
-        self.datamodel_new = None
-        self.datamodel_old = None
-        self.detected_schema_changes = []
-        self.read_schema_changes = []
-        self.schema_changes = []
+    def compare(self, yamlfile_old) -> ComparisonResults:
+        """execute the comparison between the new datamodel and the old one from yamlfile_old"""
 
-        self.warnings = []
-        self.errors = []
+        datamodel_old = self.reader.read(yamlfile_old, package_name="old")
 
-    def compare(self) -> None:
-        """execute the comparison on-preloaded datamodel definitions"""
-        self._compare_components()
-        self._compare_datatypes()
-        self.heuristics()
+        detected_schema_changes = []
+        read_schema_changes = []
+        schema_changes = []
+        warnings = []
+        errors = []
 
-    def _compare_components(self) -> None:
+        if self.evolution_file:
+            read_schema_changes = self._read_evolution_file(datamodel_old)
+
+        detected_schema_changes.extend(self._compare_components(datamodel_old))
+        detected_schema_changes.extend(self._compare_datatypes(datamodel_old))
+        schema_changes, warnings, errors = self._heuristics(
+            datamodel_old, detected_schema_changes, read_schema_changes, warnings, errors
+        )
+
+        return ComparisonResults(
+            old_datamodel=datamodel_old,
+            warnings=warnings,
+            errors=errors,
+            schema_changes=schema_changes,
+        )
+
+    def _compare_components(self, datamodel_old):
         """compare component definitions of old and new datamodel"""
+        detected_schema_changes = []
         # first check for dropped, added and kept components
         added_components, dropped_components, kept_components = self._compare_keys(
-            self.datamodel_new.components.keys(), self.datamodel_old.components.keys()
+            self.datamodel_new.components.keys(), datamodel_old.components.keys()
         )
-        # Make findings known globally
-        self.detected_schema_changes.extend(
+        detected_schema_changes.extend(
             [
                 AddedComponent(self.datamodel_new.components[name], name)
                 for name in added_components
             ]
         )
-        self.detected_schema_changes.extend(
-            [
-                DroppedComponent(self.datamodel_old.components[name], name)
-                for name in dropped_components
-            ]
+        detected_schema_changes.extend(
+            [DroppedComponent(datamodel_old.components[name], name) for name in dropped_components]
         )
 
-        self._compare_members(
-            kept_components,
-            self.datamodel_new.components,
-            self.datamodel_old.components,
-            "Members",
+        detected_schema_changes.extend(
+            self._compare_members(
+                kept_components,
+                self.datamodel_new.components,
+                datamodel_old.components,
+                "Members",
+            )
         )
 
-    def _compare_datatypes(self) -> None:
+        return detected_schema_changes
+
+    def _compare_datatypes(self, datamodel_old):
         """compare datatype definitions of old and new datamodel"""
+        detected_schema_changes = []
         # first check for dropped, added and kept components
         added_types, dropped_types, kept_types = self._compare_keys(
-            self.datamodel_new.datatypes.keys(), self.datamodel_old.datatypes.keys()
+            self.datamodel_new.datatypes.keys(), datamodel_old.datatypes.keys()
         )
-        # Make findings known globally
-        self.detected_schema_changes.extend(
+        detected_schema_changes.extend(
             [AddedDatatype(self.datamodel_new.datatypes[name], name) for name in added_types]
         )
-        self.detected_schema_changes.extend(
-            [DroppedDatatype(self.datamodel_old.datatypes[name], name) for name in dropped_types]
+        detected_schema_changes.extend(
+            [DroppedDatatype(datamodel_old.datatypes[name], name) for name in dropped_types]
         )
 
-        self._compare_members(
-            kept_types,
-            self.datamodel_new.datatypes,
-            self.datamodel_old.datatypes,
-            "Members",
+        detected_schema_changes.extend(
+            self._compare_members(
+                kept_types,
+                self.datamodel_new.datatypes,
+                datamodel_old.datatypes,
+                "Members",
+            )
         )
 
-        self._compare_members(
-            kept_types,
-            self.datamodel_new.datatypes,
-            self.datamodel_old.datatypes,
-            "VectorMembers",
-            AddedVectorMember,
-            DroppedVectorMember,
+        detected_schema_changes.extend(
+            self._compare_members(
+                kept_types,
+                self.datamodel_new.datatypes,
+                datamodel_old.datatypes,
+                "VectorMembers",
+                AddedVectorMember,
+                DroppedVectorMember,
+            )
         )
 
-        self._compare_members(
-            kept_types,
-            self.datamodel_new.datatypes,
-            self.datamodel_old.datatypes,
-            "OneToOneRelations",
-            AddedSingleRelation,
-            DroppedSingleRelation,
+        detected_schema_changes.extend(
+            self._compare_members(
+                kept_types,
+                self.datamodel_new.datatypes,
+                datamodel_old.datatypes,
+                "OneToOneRelations",
+                AddedSingleRelation,
+                DroppedSingleRelation,
+            )
         )
 
-        self._compare_members(
-            kept_types,
-            self.datamodel_new.datatypes,
-            self.datamodel_old.datatypes,
-            "OneToManyRelations",
-            AddedMultiRelation,
-            DroppedMultiRelation,
+        detected_schema_changes.extend(
+            self._compare_members(
+                kept_types,
+                self.datamodel_new.datatypes,
+                datamodel_old.datatypes,
+                "OneToManyRelations",
+                AddedMultiRelation,
+                DroppedMultiRelation,
+            )
         )
+
+        return detected_schema_changes
 
     def _compare_members(
         self,
@@ -328,8 +362,9 @@ class DataModelComparator:
         category,
         added_change=AddedMember,
         dropped_change=DroppedMember,
-    ) -> None:
+    ):
         """compare member definitions in old and new datamodel"""
+        detected_schema_changes = []
         for name in definitions:
             # we are only interested in members not the extracode
             members1 = {member.name: member for member in first[name][category]}
@@ -337,11 +372,10 @@ class DataModelComparator:
             added_members, dropped_members, kept_members = self._compare_keys(
                 members1.keys(), members2.keys()
             )
-            # Make findings known globally
-            self.detected_schema_changes.extend(
+            detected_schema_changes.extend(
                 [added_change(members1[member], name) for member in added_members]
             )
-            self.detected_schema_changes.extend(
+            detected_schema_changes.extend(
                 [dropped_change(members2[member], name) for member in dropped_members]
             )
 
@@ -350,7 +384,9 @@ class DataModelComparator:
                 new = members1[member_name]
                 old = members2[member_name]
                 if old.full_type != new.full_type:
-                    self.detected_schema_changes.append(ChangedMemberType(name, old, new))
+                    detected_schema_changes.append(ChangedMemberType(name, old, new))
+
+        return detected_schema_changes
 
     @staticmethod
     def _compare_keys(keys1, keys2):
@@ -360,26 +396,26 @@ class DataModelComparator:
         kept = set(keys1).intersection(keys2)
         return added, dropped, kept
 
-    def get_changed_schemata(self, schema_filter=None):
+    def get_changed_schemata(self, comparison_results, schema_filter=None):
         """return the schemata which actually changed"""
         if schema_filter:
-            schema_changes = schema_filter(self.schema_changes)
+            schema_changes = schema_filter(comparison_results.schema_changes)
         else:
-            schema_changes = self.schema_changes
+            schema_changes = comparison_results.schema_changes
         changed_klasses = {}
         for schema_change in schema_changes:
             changed_klass = changed_klasses.setdefault(schema_change.klassname, [])
             changed_klass.append(schema_change)
         return changed_klasses
 
-    def check_rename(self, added_member, dropped_member, schema_changes):
+    def check_rename(self, added_member, dropped_member, schema_changes, read_schema_changes):
         """Check whether this pair of addition / removal could be a rename and
         return True if it is found in the renamings and false otherwise"""
         if added_member.member.full_type != dropped_member.member.full_type:
             # Different types cannot be a simple renaming
             return False
 
-        for schema_change in self.read_schema_changes:
+        for schema_change in read_schema_changes:
             if (
                 isinstance(schema_change, RenamedMember)
                 and (schema_change.klassname == dropped_member.klassname)
@@ -406,21 +442,29 @@ class DataModelComparator:
 
         return filtered_list
 
-    def heuristics_members(self, added_members, dropped_members, schema_changes):
+    def heuristics_members(
+        self, added_members, dropped_members, schema_changes, read_schema_changes, warnings
+    ):
         """make analysis of member changes in a given data type"""
         same_type_adds_drops = self.filter_types_with_adds_and_drops(
             added_members, dropped_members
         )
         for added_member, dropped_member in same_type_adds_drops:
-            if not self.check_rename(added_member, dropped_member, schema_changes):
-                self.warnings.append(
+            if not self.check_rename(
+                added_member, dropped_member, schema_changes, read_schema_changes
+            ):
+                warnings.append(
                     f"Definition '{dropped_member.klassname}' has a potential "
                     f"rename: '{dropped_member.member.name}' -> "
                     f"'{added_member.member.name}' of type "
                     f"'{dropped_member.member.full_type}'."
                 )
 
-    def heuristics(self):
+        return warnings
+
+    def _heuristics(
+        self, datamodel_old, detected_schema_changes, read_schema_changes, warnings, errors
+    ):
         """make an analysis of the data model changes:
         - check which can be auto-resolved
         - check which need extra information from the user
@@ -428,16 +472,18 @@ class DataModelComparator:
         """
         # let's analyse the changes in more detail
         # make a copy that can be altered along the way
-        schema_changes = self.detected_schema_changes.copy()
+        schema_changes = detected_schema_changes.copy()
         # are there dropped/added member pairs that could be interpreted as rename?
         dropped_members = [
             change for change in schema_changes if isinstance(change, DroppedMember)
         ]
         added_members = [change for change in schema_changes if isinstance(change, AddedMember)]
-        self.heuristics_members(added_members, dropped_members, schema_changes)
+        warnings = self.heuristics_members(
+            added_members, dropped_members, schema_changes, read_schema_changes, warnings
+        )
 
         for change in (c for c in schema_changes if isinstance(c, self.unsupported_changes)):
-            self.errors.append(f"Unsupported schema change: {change}")
+            errors.append(f"Unsupported schema change: {change}")
 
         # are the member changes actually supported/supportable?
         changed_members = [
@@ -446,14 +492,14 @@ class DataModelComparator:
         for change in changed_members:
             # changes between arrays and basic types are forbidden
             if change.old_member.is_array != change.new_member.is_array:
-                self.errors.append(
+                errors.append(
                     f"Forbidden schema change in '{change.klassname}' for "
                     f"'{change.old_member.name}' from '{change.old_member.full_type}'"
                     f" to '{change.new_member.full_type}'"
                 )
             # changing from one component type to another component type is forbidden
-            elif change.old_member.full_type in self.datamodel_old.components:
-                self.errors.append(
+            elif change.old_member.full_type in datamodel_old.components:
+                errors.append(
                     f"Forbidden schema change in '{change.klassname}' for "
                     f"'{change.old_member.name}' from '{change.old_member.full_type}'"
                     f" to '{change.new_member.full_type}'"
@@ -475,7 +521,7 @@ class DataModelComparator:
             for added in added_datatypes:
                 added_members = {member.name: member for member in added.datatype["Members"]}
                 if set(dropped_members.keys()) == set(added_members.keys()):
-                    for schema_change in self.read_schema_changes:
+                    for schema_change in read_schema_changes:
                         if isinstance(schema_change, RenamedDataType) and (
                             schema_change.name_old == dropped.klassname
                             and schema_change.name_new == added.klassname
@@ -485,7 +531,7 @@ class DataModelComparator:
                             schema_changes.append(schema_change)
                             is_known_evolution = True
                     if not is_known_evolution:
-                        self.warnings.append(
+                        warnings.append(
                             f"Potential rename of '{dropped.klassname}' into '{added.klassname}'."
                         )
 
@@ -502,52 +548,43 @@ class DataModelComparator:
             for added in added_components:
                 added_members = {member.name: member for member in added.component["Members"]}
                 if set(dropped_members.keys()) == set(added_members.keys()):
-                    self.warnings.append(
-                        f"Potential rename of '{dropped.name}' into '{added.name}'."
-                    )
+                    warnings.append(f"Potential rename of '{dropped.name}' into '{added.name}'.")
 
-        # make the results of the heuristics known to the instance
-        self.schema_changes = schema_changes
+        return schema_changes, warnings, errors
 
-    def print_comparison(self):
+    def print_comparison(self, comparison_results):
         """print the result of the datamodel comparison"""
         print(
             f"Comparing datamodel versions {self.datamodel_new.schema_version}"
-            f" and {self.datamodel_old.schema_version}"
+            f" and {comparison_results.old_datamodel.schema_version}"
         )
 
-        print(f"Detected {len(self.schema_changes)} schema changes:")
-        for change in self.schema_changes:
+        print(f"Detected {len(comparison_results.schema_changes)} schema changes:")
+        for change in comparison_results.schema_changes:
             print(f" - {change}")
 
-        if len(self.warnings) > 0:
+        if len(comparison_results.warnings) > 0:
             print("Warnings:")
-            for warning in self.warnings:
+            for warning in comparison_results.warnings:
                 print(f" - {warning}")
 
-        if len(self.errors) > 0:
+        if len(comparison_results.errors) > 0:
             print("ERRORS:")
-            for error in self.errors:
+            for error in comparison_results.errors:
                 print(f" - {error}")
             return False
 
         return True
 
-    def read(self) -> None:
-        """read datamodels from yaml files"""
-        self.datamodel_new = self.reader.read(self.yamlfile_new, package_name="new")
-        self.datamodel_old = self.reader.read(self.yamlfile_old, package_name="old")
-        if self.evolution_file:
-            self.read_evolution_file()
-
-    def read_evolution_file(self) -> None:
+    def _read_evolution_file(self, datamodel_old):
         """read and parse evolution file"""
+        read_schema_changes = []
         supported_operations = ("member_rename", "class_renamed_to")
         with open(self.evolution_file, "r", encoding="utf-8") as stream:
             content = yaml.load(stream, yaml.SafeLoader)
             from_schema_version = content["from_schema_version"]
             to_schema_version = content["to_schema_version"]
-            if (from_schema_version != self.datamodel_old.schema_version) or (
+            if (from_schema_version != datamodel_old.schema_version) or (
                 to_schema_version != self.datamodel_new.schema_version
             ):
                 raise BaseException(
@@ -566,10 +603,12 @@ class DataModelComparator:
                             )
                         if operation == "member_rename":
                             schema_change = RenamedMember(klassname, details[0], details[1])
-                            self.read_schema_changes.append(schema_change)
+                            read_schema_changes.append(schema_change)
                         elif operation == "class_renamed_to":
                             schema_change = RenamedDataType(klassname, details)
-                            self.read_schema_changes.append(schema_change)
+                            read_schema_changes.append(schema_change)
+
+        return read_schema_changes
 
 
 ##########################
@@ -588,9 +627,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    comparator = DataModelComparator(args.new, args.old, evolution_file=args.evo)
-    comparator.read()
-    comparator.compare()
-    if not comparator.print_comparison():
+    comparator = DataModelComparator(args.new, evolution_file=args.evo)
+    comparison_results = comparator.compare(args.old)
+    if not comparator.print_comparison(comparison_results):
         sys.exit(1)
-    # print(comparator.get_changed_schemata(schema_filter=root_filter))
+    # print(comparator.get_changed_schemata(comparison_results, schema_filter=root_filter))


### PR DESCRIPTION
BEGINRELEASENOTES
- Split schema evolution detection into two parts; detecting changes and judging whether they can be handled automatically or not

ENDRELEASENOTES

Partial lift of the changes from #828. The changes here do not yet include the change of grammar / format for the evolution files.

The main changes here are the splitting of the `DatamodelComparator` into two bits, the `DatamodelComparator` that detects differences between two datamodels and the `SchemaEvolutionJudge` that then determines whether these changes need manual intervention or not. It's a better split of responsibilities and should make it easier to adapt this whole functionality in the future. Additionally, it removes enough internal state from the whole machinery to make it possible, to re-use it for multiple schema versions.