### PR TITLE
Add ugly code to trigger an error when reading garbage

### DIFF
--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -38,6 +38,21 @@
   if (!isSubsetColl) {
     m_data.reset(buffers.dataAsVector<{{ class.full_type }}Data>());
 
+  // The following is ugly code for the case when reading garbage data from ROOT
+  // after calling dataAsVector, which can trigger infinite loops that consume
+  // all the available memory and this works at least for GCC 15 and Clang 20 in
+  // {Debug,RelWithDebInfo,Release} modes.
+  // https://github.com/AIDASoft/podio/pull/817#issuecomment-3266748609 and
+  // https://github.com/AIDASoft/podio/pull/842
+  volatile std::uint64_t s = m_data->size();
+  if (s > 1e15) throw std::runtime_error("Bad data after reading: a collection is too big");
+  else
+    if (s == 0)
+      for (const auto& _ : *m_data.get())
+        throw std::runtime_error("Bad data after reading: zero-sized collection with data");
+  // end of ugly
+
+
 {% for member in VectorMembers %}
   m_vec_{{ member.name }}.reset(podio::CollectionReadBuffers::asVector<{{ member.full_type }}>(m_vecmem_info[{{ loop.index0 }}].second));
 {% endfor %}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add ugly code to trigger an error when reading garbage

ENDRELEASENOTES


This prevents an infinite loop from happening and consuming all the memory. Tested on GCC 15 and Clang 20 with all the combinations of {Debug,RelWithDebInfo,Release} builds, in 5 out of 6 it triggers one of the errors and with GCC in Debug it crashes from ROOT.

I think that `s` is a random 64 bit number (or at least it was big one when I checked with gdb), so the probability of not triggering the error should 1e15/2**64=5e-5 if this is true.