### PR TITLE
Do not load the deprecated pythonization collection_subscript

### DIFF
--- a/python/podio/pythonizations/__init__.py
+++ b/python/podio/pythonizations/__init__.py
@@ -11,7 +11,7 @@ def load_pythonizations(namespace):
     pythonizations_dir = path.dirname(__file__)
     # find only direct submodules of the current module
     module_names = [name for _, name, _ in iter_modules([pythonizations_dir])]
-    for module_name in module_names:
+    for module_name in (name for name in module_names if name != "collection_subscript"):
         import_module(__name__ + "." + module_name)
     pythonizers = sorted(Pythonizer.__subclasses__(), key=lambda x: x.priority())
     for i in pythonizers:


### PR DESCRIPTION
BEGINRELEASENOTES
- Do not load the deprecated pythonization collection_subscript

ENDRELEASENOTES

It was deprecated in https://github.com/AIDASoft/podio/pull/810, but it is still being loaded.