### PR TITLE
Remove value for a header guard not to confuse `clang-format`

### DIFF
--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -1,6 +1,5 @@
-// -*- C++ -*-
 #ifndef PODIO_GENERICPARAMETERS_H
-#define PODIO_GENERICPARAMETERS_H 1
+#define PODIO_GENERICPARAMETERS_H
 
 #include "podio/utilities/TypeHelpers.h"
 


### PR DESCRIPTION
With Clang 21 `clang-format` will add indenting if the header guard is given a value

BEGINRELEASENOTES
- Remove value for a header guard not to confuse `clang-format`

ENDRELEASENOTES