### PR TITLE
Add a workflow that builds all the way to EDM4eic

### DIFF
--- a/.github/workflows/edm4eic.yml
+++ b/.github/workflows/edm4eic.yml
@@ -2,6 +2,8 @@ name: edm4eic
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a CI workflow that builds all the way to EDM4eic

ENDRELEASENOTES

@wdconinc this looks like the minimal effort thing to check on our side. For the rest (Jana2 and EICrecon) we would still need to build quite a bit of additional bits and pieces on top of the default Key4hep stack. Do you have nightlies at the moment that build off of the head version of podio?

- [x] Needs https://github.com/eic/EDM4eic/pull/131 (upstream fixes to build on top of podio and EDM4hep HEAD versions)