### PR TITLE
Choose existing function for showing useless state

### DIFF
--- a/doc/datamodel_syntax.md
+++ b/doc/datamodel_syntax.md
@@ -196,7 +196,7 @@ is currently being held internally.
 
 ```cpp
 auto energyType = TypeWithEnergy{}; // An empty interface is possible but useless
-bool hasID = energyType.hasID();  // <-- false
+bool hasID = energyType.isAvailable();  // <-- false
 
 auto hit = ExampleHit{};
 energyType = hit;     // assigning a hit to the interface type


### PR DESCRIPTION
hasID does the same thing in this case, but isAvailable is the more appropriate choice, since a default constructed (non-interface) datatype will be available while it will also not have an ID.



BEGINRELEASENOTES
- Use an actually existing member function in documentation of interfaces

ENDRELEASENOTES