### PR TITLE
Remove unnecessary hasID check in DataSource

### DIFF
--- a/src/DataSource.cc
+++ b/src/DataSource.cc
@@ -59,7 +59,7 @@ void DataSource::SetupInput(int nEvents, const std::vector<std::string>& collsTo
   std::vector<std::string> collNames = frame.getAvailableCollections();
   for (auto&& collName : collNames) {
     const podio::CollectionBase* coll = frame.get(collName);
-    if (coll->hasID()) {
+    if (coll) {
       m_columnNames.emplace_back(std::move(collName));
       m_columnTypes.emplace_back(coll->getTypeName());
     }


### PR DESCRIPTION
Frame::get will return a nullptr if the collection does not exist so checking whether it has an ID is not necessary. Instead we should check whether it's a nullptr (as otherwise the hasID check will lead to a segfault in any case)



BEGINRELEASENOTES
- Remove an unnecessary (and wrong) `hasID` check in the `podio::DataSource`.

ENDRELEASENOTES