### PR TITLE
Make sure to read only necessary collections

### DIFF
--- a/src/DataSource.cc
+++ b/src/DataSource.cc
@@ -118,7 +118,8 @@ void DataSource::InitSlot(unsigned int, ULong64_t) {
 }
 
 bool DataSource::SetEntry(unsigned int slot, ULong64_t entry) {
-  m_frames[slot] = std::make_unique<podio::Frame>(m_podioReaders[slot]->readFrame(podio::Category::Event, entry));
+  m_frames[slot] =
+      std::make_unique<podio::Frame>(m_podioReaders[slot]->readFrame(podio::Category::Event, entry, m_columnNames));
 
   for (auto& collectionIndex : m_activeCollections) {
     m_Collections[collectionIndex][slot] = m_frames[slot]->get(m_columnNames.at(collectionIndex));


### PR DESCRIPTION
Without this we set the available collections properly, but we still read full frames for filling the data in.



BEGINRELEASENOTES
- Make sure that the `DataSource` does not read unnecessary collections if the collections have been limited.

ENDRELEASENOTES

@kjvbrt looks like I forgot this in #504. IIUC, this should be possible because in `m_columnNames` we only ever store collection names and we make sure to only populate it with collections that are actually available (done in `SetupInputs`).