### PR TITLE
Make test for renaming member variables more comprehensive

### DIFF
--- a/tests/schema_evolution/code_gen/datatypes_rename_member/check.cpp
+++ b/tests/schema_evolution/code_gen/datatypes_rename_member/check.cpp
@@ -3,7 +3,14 @@
 #include "check_base.h"
 
 int main() {
-  WRITE_AS(nsp::TestTypeCollection, { elem.oldEnergy(3.14); });
-  READ_AS(nsp::TestTypeCollection,
-          { ASSERT_EQUAL(elem.energy(), 3.14, "Renamed datatype member does not have the expected value"); })
+  WRITE_AS(nsp::TestTypeCollection, {
+    elem.oldEnergy(3.14);
+    elem.unchangedMember(123);
+    elem.anotherNonChange(4.3f);
+  });
+  READ_AS(nsp::TestTypeCollection, {
+    ASSERT_EQUAL(elem.energy(), 3.14, "Renamed datatype member does not have the expected value");
+    ASSERT_EQUAL(elem.unchangedMember(), 123, "Non renamed member should not change");
+    ASSERT_EQUAL(elem.anotherNonChange(), 4.3f, "Non renamed member should not change");
+  })
 }

--- a/tests/schema_evolution/code_gen/datatypes_rename_member/new.yaml
+++ b/tests/schema_evolution/code_gen/datatypes_rename_member/new.yaml
@@ -7,4 +7,6 @@ datatypes:
     Description: "A datatype to test member renaming"
     Author: "Thomas Madlener"
     Members:
+      - int unchangedMember // a member that doesn't change
       - double energy // the old name
+      - float anotherNonChange // another member that doesn't change

--- a/tests/schema_evolution/code_gen/datatypes_rename_member/old.yaml
+++ b/tests/schema_evolution/code_gen/datatypes_rename_member/old.yaml
@@ -7,4 +7,6 @@ datatypes:
     Description: "A datatype to test member renaming"
     Author: "Thomas Madlener"
     Members:
+      - int unchangedMember // a member that doesn't change
       - double oldEnergy // the old name
+      - float anotherNonChange // another member that doesn't change


### PR DESCRIPTION

BEGINRELEASENOTES
- Make the test that checks if renaming members works more comprehensive

ENDRELEASENOTES

This should ensure that things work even if the `Data` struct is a bit more complicated and doesn't simply have one member.