### PR TITLE
Make sure to generate Collection headers to beginning

### DIFF
--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -503,9 +503,14 @@ have resolvable schema evolution incompatibilities:"
 
     def _write_cmake_lists_file(self):
         """Write the names of all generated header and src files into cmake lists"""
-        header_files = (f for f in self.generated_files if f.endswith(".h"))
+        header_files = list(f for f in self.generated_files if f.endswith(".h"))
         src_files = (f for f in self.generated_files if f.endswith(".cc"))
         xml_files = (f for f in self.generated_files if f.endswith(".xml"))
+
+        # Sort header files so that Collection headers appear first. This is
+        # necessary for cling to load things in the correct order for some
+        # reason. See https://github.com/AIDASoft/podio/issues/892
+        header_files.sort(key=lambda f: (0 if "Collection.h" in f else 1, f))
 
         def _write_list(name, target_folder, files, comment):
             """Write all files into a cmake variable using the target_folder as path to the


### PR DESCRIPTION
Fixes #892 


BEGINRELEASENOTES
- Make sure to generate the Collection headers to the front of the list of header file that is passed to root dictionary generation.

ENDRELEASENOTES

@wdconinc this fixes things for me. Not sure if this points to a more general "instability" in the code generation (e.g. missing headers, or something along those lines) or if this is just a quirk of ROOTs dictionary generation.

I am not entirely sure how to (or at least where) to add a unittest for this. I could not get the original failure reproduced locally within podio and its tests for some reason. We could add it to the downstream tests of EDM4hep, but that would imply some potentially longish and indirect feedback loop.