### PR TITLE
Fix rpaths in podio, not set correctly because ${LIBDIR} is empty

### DIFF
--- a/cmake/podioBuild.cmake
+++ b/cmake/podioBuild.cmake
@@ -23,7 +23,7 @@ macro(podio_set_rpath)
   elseif(PODIO_SET_RPATH)
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
     # the RPATH to be used when installing, but only if it's not a system directory
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
     if("${isSystemDir}" STREQUAL "-1")
       set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
     endif("${isSystemDir}" STREQUAL "-1")


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix rpaths in podio, not set correctly because ${LIBDIR} is empty
- Remove the linker flags that force to use `RPATH` instead of the more modern and recommended `RUNPATH` (the difference being `RPATH` is searched before `LD_LIBRARY_PATH` and `RUNPATH` is searched after `LD_LIBRARY_PATH`).

ENDRELEASENOTES

I have one build where I don't have podio in LD_LIBRARY_PATH and what I get from the library folder (before this PR) is:

```
$ ldd libpodioIO.so
...
	libpodioRootIO.so => not found
	libpodio.so => not found
...

```
and

```
readelf -d libpodio.so | grep RPATH
 0x000000000000000f (RPATH)              Library rpath: [/podio/install/]
```
which is pointing to the installation prefix, and not to the library folder.

This is probably not noticed because everyone has podio under LD_LIBRARY_PATH. I don't change the MacOS stuff since I have not tested it, if everything is installed to /lib it should probably work.

- This says `RPATH` is deprecated: https://libc-help.sourceware.narkive.com/n4inVNdm/deprecated-status-of-rpath (written 14 years ago) but I can't find that in `man ld`.
- See the source of truth of RPATH handling: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling#always-full-rpath