### PR TITLE
Move black to earlier in the pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
         exclude: (doc/ReleaseNotes.md)
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
   - repo: local
     hooks:
       - id: clang-format
@@ -35,7 +39,3 @@ repos:
         types: [c++]
         exclude: (tests/(datamodel|src|extra_code)/.*(h|cc)|podioVersion.in.h)
         language: system
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
-    hooks:
-      - id: black


### PR DESCRIPTION
Makes it easier to see formatting issues during the CI run without having to wait for clang-tidy



BEGINRELEASENOTES
- Move black to earlier in the pre-commit config

ENDRELEASENOTES