### PR TITLE
Create a per ref concurrency group for doc building

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: pages
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Avoids cancelling jobs across different PRs



BEGINRELEASENOTES
- Create a per ref concurrency group for doc building

ENDRELEASENOTES