### PR TITLE
feat: change exposed TU-local entities to inline

### DIFF
--- a/include/podio/GenericParameters.h
+++ b/include/podio/GenericParameters.h
@@ -28,7 +28,7 @@ using SupportedGenericDataTypes = std::tuple<int, float, std::string, double>;
 
 /// Static bool for determining if a type T is a supported GenericParameters type
 template <typename T>
-static constexpr bool isSupportedGenericDataType = detail::isAnyOrVectorOf<T, SupportedGenericDataTypes>;
+inline constexpr bool isSupportedGenericDataType = detail::isAnyOrVectorOf<T, SupportedGenericDataTypes>;
 
 /// Concept to be used for templates that should only be present for actually supported data types
 template <typename T>

--- a/include/podio/LinkNavigator.h
+++ b/include/podio/LinkNavigator.h
@@ -35,10 +35,10 @@ namespace detail::links {
 
 /// Tag variable to select the lookup of *From* objects have links with a *To*
 /// object in podio::LinkNavigator::getLinked
-static constexpr detail::links::ReturnFromTag ReturnFrom;
+inline constexpr detail::links::ReturnFromTag ReturnFrom;
 /// Tag variable to select the lookup of *To* objects that have links with a
 /// *From* object in podio::LinkNavigator::getLinked
-static constexpr detail::links::ReturnToTag ReturnTo;
+inline constexpr detail::links::ReturnToTag ReturnTo;
 
 /// A helper class to more easily handle one-to-many links.
 ///

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -46,12 +46,12 @@ class LinkT {
   /// Variable template to for determining whether T is either FromT or ToT.
   /// Mainly defined for convenience
   template <typename T>
-  static constexpr bool isFromOrToT = detail::isInTuple<T, std::tuple<FromT, ToT>>;
+  inline constexpr static bool isFromOrToT = detail::isInTuple<T, std::tuple<FromT, ToT>>;
 
   /// Variable template to for determining whether T is either FromT or ToT or
   /// any of their mutable versions.
   template <typename T>
-  static constexpr bool isMutableFromOrToT =
+  inline constexpr static bool isMutableFromOrToT =
       detail::isInTuple<T,
                         std::tuple<FromT, ToT, detail::GetMutableHandleType<FromT>, detail::GetMutableHandleType<ToT>>>;
 

--- a/include/podio/detail/LinkFwd.h
+++ b/include/podio/detail/LinkFwd.h
@@ -12,10 +12,10 @@
 namespace podio {
 namespace detail {
 
-  constexpr std::string_view link_coll_name_prefix = "podio::LinkCollection<";
-  constexpr std::string_view link_name_prefix = "podio::Link<";
-  constexpr std::string_view link_name_infix = ",";
-  constexpr std::string_view link_name_suffix = ">";
+  inline constexpr std::string_view link_coll_name_prefix = "podio::LinkCollection<";
+  inline constexpr std::string_view link_name_prefix = "podio::Link<";
+  inline constexpr std::string_view link_name_infix = ",";
+  inline constexpr std::string_view link_name_suffix = ">";
 
   /// Get an SIO friendly type name for a LinkCollection (necessary for
   /// registration in the SIOBlockFactory)

--- a/include/podio/utilities/MaybeSharedPtr.h
+++ b/include/podio/utilities/MaybeSharedPtr.h
@@ -12,7 +12,7 @@ namespace detail {
   struct MarkOwnedTag {};
 } // namespace detail
 
-constexpr static auto MarkOwned [[maybe_unused]] = detail::MarkOwnedTag{};
+inline constexpr auto MarkOwned [[maybe_unused]] = detail::MarkOwnedTag{};
 
 /// "Semi-smart" pointer class for pointers that at some point during their
 /// lifetime might hand over management to another entity. E.g. Objects that

--- a/include/podio/utilities/TypeHelpers.h
+++ b/include/podio/utilities/TypeHelpers.h
@@ -59,7 +59,7 @@ namespace detail {
   /// variable template for determining whether type T is in a tuple with types
   /// Ts
   template <typename T, typename Tuple>
-  static constexpr bool isInTuple = TypeInTupleHelper<T, Tuple>::value;
+  inline constexpr bool isInTuple = TypeInTupleHelper<T, Tuple>::value;
 
   /// Helper struct to turn a tuple of types into a tuple of a template of types, e.g.
   ///
@@ -92,7 +92,7 @@ namespace detail {
   /// variable template for determining whether the type T is in the tuple of all
   /// types or in the tuple of all vector of the passed types
   template <typename T, typename Tuple>
-  static constexpr bool isAnyOrVectorOf = isInTuple<T, TupleCatType<Tuple, TupleOfVector<Tuple>>>;
+  inline constexpr bool isAnyOrVectorOf = isInTuple<T, TupleCatType<Tuple, TupleOfVector<Tuple>>>;
 
   /// Helper struct to extract the type from a std::vector or return the
   /// original type if it is not a vector. Works only for "simple" types and does
@@ -119,7 +119,7 @@ namespace detail {
 
   /// Alias template for deciding whether the passed type T is a vector or not
   template <typename T>
-  static constexpr bool isVector = IsVectorHelper<T>::value;
+  inline constexpr bool isVector = IsVectorHelper<T>::value;
 
   /// Helper struct to detect whether a type is a std::map or std::unordered_map
   template <typename T>
@@ -134,7 +134,7 @@ namespace detail {
   /// Alias template for deciding whether the passed type T is a map or
   /// unordered_map
   template <typename T>
-  static constexpr bool isMap = IsMapHelper<T>::value;
+  inline constexpr bool isMap = IsMapHelper<T>::value;
 
   /// Helper struct to homogenize the (type) access for things that behave like
   /// maps, e.g. vectors of pairs (and obviously maps).
@@ -179,12 +179,12 @@ namespace detail {
   /// Variable template for determining whether type T is a podio generated
   /// mutable handle class
   template <typename T>
-  constexpr static bool isMutableHandleType = det::is_detected_v<hasObject_t, std::remove_reference_t<T>>;
+  inline constexpr bool isMutableHandleType = det::is_detected_v<hasObject_t, std::remove_reference_t<T>>;
 
   /// Variable template for determining whether type T is a podio generated
   /// default handle class
   template <typename T>
-  constexpr static bool isDefaultHandleType = det::is_detected_v<hasMutable_t, std::remove_reference_t<T>>;
+  inline constexpr bool isDefaultHandleType = det::is_detected_v<hasMutable_t, std::remove_reference_t<T>>;
 
   /// Variable template for obtaining the default handle type from any podio
   /// generated handle type.
@@ -218,7 +218,7 @@ namespace detail {
   ///
   /// @note: This simply checks whether T has an interfaced_types type member.
   template <typename T>
-  constexpr static bool isInterfaceType = det::is_detected_v<hasInterface_t, std::remove_reference_t<T>>;
+  inline constexpr bool isInterfaceType = det::is_detected_v<hasInterface_t, std::remove_reference_t<T>>;
 
   /// Helper struct to make the detection whether type U can be used to
   /// initialize the interface type T in a SFINAE friendly way
@@ -238,7 +238,7 @@ namespace detail {
   /// Variable template for checking whether the passed type T is an interface
   /// and can be initialized from type U
   template <typename T, typename U>
-  constexpr static bool isInterfaceInitializableFrom = InterfaceInitializerHelper<T, U>::value;
+  inline constexpr bool isInterfaceInitializableFrom = InterfaceInitializerHelper<T, U>::value;
 
 } // namespace detail
 


### PR DESCRIPTION
This PR changes header-exposed [TU-local](https://en.cppreference.com/w/cpp/language/tu_local.html) entities (constexpr variables and variable templates) from static to inline. This allows them to be used in C++20 modules (#907).

BEGINRELEASENOTES
- Move static constexpr to inline constexpr to avoid exposed TU-local entities

ENDRELEASENOTES