### PR TITLE
Use a cache for compiled jinja templates

### DIFF
--- a/python/podio_gen/generator_base.py
+++ b/python/podio_gen/generator_base.py
@@ -15,7 +15,7 @@ from podio_gen.generator_utils import DataType
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 PYTHONBASE_DIR = os.path.abspath(THIS_DIR + "/../")
 TEMPLATE_DIR = os.path.join(PYTHONBASE_DIR, "templates")
-CACHE_DIR = os.path.join(os.environ.get("TMPDIR, "/tmp"), "podio", "jinja2_cache")
+CACHE_DIR = os.path.join(os.environ.get("TMPDIR", "/tmp"), "podio", "jinja2_cache")
 
 
 def _get_bytecode_cache():


### PR DESCRIPTION
BEGINRELEASENOTES
- Use a cache for compiled jinja templates to reduce template compilation time.

ENDRELEASENOTES
  
Compiled templates are saved in `/tmp`, in files that contain their hash and this is useful for generating with the same configuration multiple times. They don't take much space. Modifying templates or macros applies to new runs. CMake configuration time is halved for me when having the schema evolution tests enabled.