### PR TITLE
Make sure a file is closed after opening it

### DIFF
--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -39,7 +39,7 @@ Reader makeReader(const std::vector<std::string>& filenames) {
   }
 
   if (suffix == "root") {
-    TFile* file = TFile::Open(filenames[0].c_str());
+    std::unique_ptr<TFile> file(TFile::Open(filenames[0].c_str()));
     bool hasRNTuple = false;
 
     if (!file) {


### PR DESCRIPTION
when peeking to see if a file is a RNTuple or not, or at least that the TFile is closed.

BEGINRELEASENOTES
- Make sure a file is closed after opening it by using an `std::unique_ptr` to make sure the TFile is deleted.

ENDRELEASENOTES