### PR TITLE
Fix the name of the fixture for the read_garbage test

### DIFF
--- a/tests/schema_evolution/code_gen/CMakeLists.txt
+++ b/tests/schema_evolution/code_gen/CMakeLists.txt
@@ -15,7 +15,7 @@ set_tests_properties(schema_evol:code_gen:datatypes_new_member:read_garbage
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/datatypes_new_member
       ENVIRONMENT "${test_env};ROOT_LIBRARY_PATH=${PROJECT_BINARY_DIR}/tests"
       PASS_REGULAR_EXPRESSION "Bad data;Segmentation fault"
-      FIXTURES_REQUIRED datatypes_new_member_w
+      FIXTURES_REQUIRED datatypes_new_member_w_old
 )
 ADD_SCHEMA_EVOLUTION_TEST(implicit_floating_point_change)
 ADD_SCHEMA_EVOLUTION_TEST(components_rename_member WITH_EVOLUTION)


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the name of the fixture for the read_garbage test

ENDRELEASENOTES

I saw this failing, now I've tried a few times and it doesn't seem to fail. This seems to be the right name that is given in https://github.com/AIDASoft/podio/blob/master/tests/schema_evolution/code_gen/test_utilities.cmake#L184.