### PR TITLE
Link against `Python3::Module`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,7 @@ SET(core_headers
 
 PODIO_ADD_LIB_AND_DICT(podio "${core_headers}" "${core_sources}" selection.xml)
 target_compile_options(podio PRIVATE -pthread)
-target_link_libraries(podio PRIVATE Python3::Python)
+target_link_libraries(podio PRIVATE Python3::Module)
 # For Frame.h
 if (ROOT_VERSION VERSION_LESS 6.36)
   target_compile_definitions(podio PUBLIC PODIO_ROOT_OLDER_6_36=1)


### PR DESCRIPTION
instead of `Python3::Python`, which according to the documentation is meant for embedding the python interpreter.



BEGINRELEASENOTES
- Thank you for writing the text to appear in the release notes. It will show up
  exactly as it appears between the two bold lines
- ...

ENDRELEASENOTES