### PR TITLE
include `Python.h` before standard headers

### DIFF
--- a/include/podio/detail/Pythonizations.h
+++ b/include/podio/detail/Pythonizations.h
@@ -1,7 +1,6 @@
 #ifndef PODIO_DETAIL_PYTHONIZATIONS_H
 #define PODIO_DETAIL_PYTHONIZATIONS_H
 
-#define PY_SSIZE_T_CLEAN
 #include <string>
 
 typedef struct _object PyObject;

--- a/src/Pythonizations.cc
+++ b/src/Pythonizations.cc
@@ -1,10 +1,11 @@
+// NOTE: Python.h must be included before any standard headers and should be preceded by PY_SSIZE_T_CLEAN definition
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "podio/detail/Pythonizations.h"
 
 #include <cstring>
 #include <stdexcept>
-
-#include <Python.h>
-
 namespace podio::detail::pythonizations {
 
 // Callback function for the subscript pythonization


### PR DESCRIPTION

BEGINRELEASENOTES
- Include `Python.h` before standard headers

ENDRELEASENOTES

According to the [docs](https://docs.python.org/3/c-api/intro.html#include-files) `Python.h` should be included before the standard headers and also be preceded by `PY_SSIZE_T_CLEAN` macro definition. We strayed from this in #910

