### PR TITLE
Make it possible to use objects and collections with fmtlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/python/__version__.py.in
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
         DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
+find_package(fmt 9 REQUIRED)
+
 #--- project specific subdirectories -------------------------------------------
 add_subdirectory(src)
 
@@ -187,8 +189,6 @@ if(BUILD_TESTING)
   include(cmake/podioTest.cmake)
   add_subdirectory(tests)
 endif()
-
-find_package(fmt 9 REQUIRED)
 
 add_subdirectory(tools)
 add_subdirectory(python)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/python/__version__.py.in
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
         DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
+find_package(fmt 9 REQUIRED)
+
 #--- project specific subdirectories -------------------------------------------
 add_subdirectory(src)
 
@@ -221,8 +223,6 @@ if(BUILD_TESTING)
   include(cmake/podioTest.cmake)
   add_subdirectory(tests)
 endif()
-
-find_package(fmt 9 REQUIRED)
 
 add_subdirectory(tools)
 add_subdirectory(python)

--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -30,6 +30,7 @@ if(NOT "@REQUIRE_PYTHON_VERSION@" STREQUAL "")
 else()
   find_dependency(Python3 COMPONENTS Interpreter Development)
 endif()
+find_dependency(fmt @fmt_VERSION@)
 
 SET(ENABLE_SIO @ENABLE_SIO@)
 if(ENABLE_SIO)

--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -30,6 +30,7 @@ if(NOT "@REQUIRE_PYTHON_VERSION@" STREQUAL "")
 else()
   find_dependency(Python3 COMPONENTS Interpreter Development)
 endif()
+find_dependency(fmt @fmt_VERSION@)
 
 SET(PODIO_ENABLE_SIO @ENABLE_SIO@)
 if(PODIO_ENABLE_SIO)

--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -1,6 +1,8 @@
 #ifndef PODIO_OBJECTID_H
 #define PODIO_OBJECTID_H
 
+#include <fmt/ostream.h>
+
 #include <cstdint>
 #include <functional>
 #include <iomanip>
@@ -59,5 +61,8 @@ struct std::hash<podio::ObjectID> {
     return hash_collectionID ^ hash_index;
   }
 };
+
+template <>
+struct fmt::formatter<podio::ObjectID> : fmt::ostream_formatter {};
 
 #endif

--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -1,6 +1,8 @@
 #ifndef PODIO_OBJECTID_H
 #define PODIO_OBJECTID_H
 
+#include <fmt/ostream.h>
+
 #include <compare>
 #include <cstdint>
 #include <functional>
@@ -65,5 +67,8 @@ struct std::hash<podio::ObjectID> {
     return hash_collectionID ^ hash_index;
   }
 };
+
+template <>
+struct fmt::formatter<podio::ObjectID> : fmt::ostream_formatter {};
 
 #endif

--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -1,7 +1,11 @@
 #ifndef PODIO_OBJECTID_H
 #define PODIO_OBJECTID_H
 
-#include <fmt/ostream.h>
+// Hide the fmt dependency from cling, so that ROOT does not need to be able to
+// find the fmt headers when it parses the podio headers at runtime
+#if !defined(__CLING__)
+  #include <fmt/ostream.h>
+#endif
 
 #include <compare>
 #include <cstdint>
@@ -68,7 +72,9 @@ struct std::hash<podio::ObjectID> {
   }
 };
 
+#if !defined(__CLING__)
 template <>
 struct fmt::formatter<podio::ObjectID> : fmt::ostream_formatter {};
+#endif
 
 #endif

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -8,6 +8,8 @@
 #include "podio/detail/Pythonizations.h"
 #include "podio/utilities/TypeHelpers.h"
 
+#include <fmt/ostream.h>
+
 #define PODIO_ADD_USER_TYPE(type)                                                                                      \
   template <>                                                                                                          \
   consteval const char* userDataTypeName<type>() {                                                                     \
@@ -353,5 +355,8 @@ constexpr std::string_view UserDataCollection<BasicType, U>::dataTypeName;
 #endif
 
 } // namespace podio
+
+template <typename BasicType>
+struct fmt::formatter<podio::UserDataCollection<BasicType>> : fmt::ostream_formatter {};
 
 #endif

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -8,7 +8,11 @@
 #include "podio/detail/Pythonizations.h"
 #include "podio/utilities/TypeHelpers.h"
 
-#include <fmt/ostream.h>
+// Hide the fmt dependency from cling, so that ROOT does not need to be able to
+// find the fmt headers when it parses the podio headers at runtime
+#if !defined(__CLING__)
+  #include <fmt/ostream.h>
+#endif
 
 #define PODIO_ADD_USER_TYPE(type)                                                                                      \
   template <>                                                                                                          \
@@ -356,7 +360,9 @@ constexpr std::string_view UserDataCollection<BasicType, U>::dataTypeName;
 
 } // namespace podio
 
+#if !defined(__CLING__)
 template <typename BasicType>
 struct fmt::formatter<podio::UserDataCollection<BasicType>> : fmt::ostream_formatter {};
+#endif
 
 #endif

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -12,6 +12,8 @@
   #include "nlohmann/json.hpp"
 #endif
 
+#include <fmt/ostream.h>
+
 #include <functional>
 #include <ostream>
 #include <type_traits>
@@ -348,8 +350,8 @@ private:
   podio::utils::MaybeSharedPtr<LinkObjT> m_obj{nullptr};
 };
 
-template <typename FromT, typename ToT>
-std::ostream& operator<<(std::ostream& os, const Link<FromT, ToT>& link) {
+template <typename FromT, typename ToT, bool Mutable>
+std::ostream& operator<<(std::ostream& os, const LinkT<FromT, ToT, Mutable>& link) {
   if (!link.isAvailable()) {
     return os << "[not available]";
   }
@@ -381,5 +383,8 @@ struct std::hash<podio::LinkT<FromT, ToT, Mutable>> {
     return std::hash<typename podio::LinkT<FromT, ToT, Mutable>::LinkObjT*>{}(obj.m_obj.get());
   }
 };
+
+template <typename FromT, typename ToT, bool Mutable>
+struct fmt::formatter<podio::LinkT<FromT, ToT, Mutable>> : fmt::ostream_formatter {};
 
 #endif // PODIO_DETAIL_LINK_H

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -12,7 +12,11 @@
   #include "nlohmann/json.hpp"
 #endif
 
-#include <fmt/ostream.h>
+// Hide the fmt dependency from cling, so that ROOT does not need to be able to
+// find the fmt headers when it parses the podio headers at runtime
+#if !defined(__CLING__)
+  #include <fmt/ostream.h>
+#endif
 
 #include <functional>
 #include <ostream>
@@ -384,7 +388,9 @@ struct std::hash<podio::LinkT<FromT, ToT, Mutable>> {
   }
 };
 
+#if !defined(__CLING__)
 template <typename FromT, typename ToT, bool Mutable>
 struct fmt::formatter<podio::LinkT<FromT, ToT, Mutable>> : fmt::ostream_formatter {};
+#endif
 
 #endif // PODIO_DETAIL_LINK_H

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -28,6 +28,8 @@
   #include "nlohmann/json.hpp"
 #endif
 
+#include <fmt/ostream.h>
+
 #include <iomanip>
 #include <memory>
 #include <mutex>
@@ -459,5 +461,8 @@ void to_json(nlohmann::json& j, const podio::LinkCollection<FromT, ToT>& collect
 #endif
 
 } // namespace podio
+
+template <typename FromT, typename ToT>
+struct fmt::formatter<podio::LinkCollection<FromT, ToT>> : fmt::ostream_formatter {};
 
 #endif // PODIO_DETAIL_LINKCOLLECTIONIMPL_H

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -28,6 +28,8 @@
   #include "nlohmann/json.hpp"
 #endif
 
+#include <fmt/ostream.h>
+
 #include <iomanip>
 #include <memory>
 #include <mutex>
@@ -462,5 +464,8 @@ void to_json(nlohmann::json& j, const podio::LinkCollection<FromT, ToT>& collect
 #endif
 
 } // namespace podio
+
+template <typename FromT, typename ToT>
+struct fmt::formatter<podio::LinkCollection<FromT, ToT>> : fmt::ostream_formatter {};
 
 #endif // PODIO_DETAIL_LINKCOLLECTIONIMPL_H

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -28,7 +28,11 @@
   #include "nlohmann/json.hpp"
 #endif
 
-#include <fmt/ostream.h>
+// Hide the fmt dependency from cling, so that ROOT does not need to be able to
+// find the fmt headers when it parses the podio headers at runtime
+#if !defined(__CLING__)
+  #include <fmt/ostream.h>
+#endif
 
 #include <iomanip>
 #include <memory>
@@ -465,7 +469,9 @@ void to_json(nlohmann::json& j, const podio::LinkCollection<FromT, ToT>& collect
 
 } // namespace podio
 
+#if !defined(__CLING__)
 template <typename FromT, typename ToT>
 struct fmt::formatter<podio::LinkCollection<FromT, ToT>> : fmt::ostream_formatter {};
+#endif
 
 #endif // PODIO_DETAIL_LINKCOLLECTIONIMPL_H

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -30,6 +30,8 @@
 #include <memory>
 #include <cstddef>
 
+#include <fmt/ostream.h>
+
 namespace podio {
   struct RelationNames;
 }
@@ -279,6 +281,9 @@ void to_json(nlohmann::json& j, const {{ class.bare_type }}Collection& collectio
 #endif
 
 {{ utils.namespace_close(class.namespace) }}
+
+template <>
+struct fmt::formatter<{% if class.namespace %}{{ class.namespace }}::{% endif %}{{ class.bare_type }}Collection> : fmt::ostream_formatter {};
 
 {{ workarounds.ld_library_path(class, "Collection", ["valueTypeName", "dataTypeName"]) }}
 

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -30,7 +30,11 @@
 #include <memory>
 #include <cstddef>
 
+// Hide the fmt dependency from cling, so that ROOT does not need to be able to
+// find the fmt headers when it parses the podio headers at runtime
+#if !defined(__CLING__)
 #include <fmt/ostream.h>
+#endif
 
 namespace podio {
   struct RelationNames;
@@ -282,8 +286,10 @@ void to_json(nlohmann::json& j, const {{ class.bare_type }}Collection& collectio
 
 {{ utils.namespace_close(class.namespace) }}
 
+#if !defined(__CLING__)
 template <>
 struct fmt::formatter<{% if class.namespace %}{{ class.namespace }}::{% endif %}{{ class.bare_type }}Collection> : fmt::ostream_formatter {};
+#endif
 
 {{ workarounds.ld_library_path(class, "Collection", ["valueTypeName", "dataTypeName"]) }}
 

--- a/python/templates/Component.h.jinja2
+++ b/python/templates/Component.h.jinja2
@@ -11,6 +11,8 @@
 {% if generate_current_version %}
 #include <ostream>
 
+#include <fmt/ostream.h>
+
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json_fwd.hpp"
 #endif
@@ -57,5 +59,10 @@ public:
 {% endfor %}
 
 {{ utils.namespace_close(class.namespace) }}
+
+{% if generate_current_version %}
+template <>
+struct fmt::formatter<{{ class.full_type }}> : fmt::ostream_formatter {};
+{% endif %}
 
 #endif

--- a/python/templates/Component.h.jinja2
+++ b/python/templates/Component.h.jinja2
@@ -11,7 +11,11 @@
 {% if generate_current_version %}
 #include <ostream>
 
+// Hide the fmt dependency from cling, so that ROOT does not need to be able to
+// find the fmt headers when it parses the podio headers at runtime
+#if !defined(__CLING__)
 #include <fmt/ostream.h>
+#endif
 
 #if defined(PODIO_JSON_OUTPUT) && !defined(__CLING__)
 #include "nlohmann/json_fwd.hpp"
@@ -61,8 +65,10 @@ public:
 {{ utils.namespace_close(class.namespace) }}
 
 {% if generate_current_version %}
+#if !defined(__CLING__)
 template <>
 struct fmt::formatter<{{ class.full_type }}> : fmt::ostream_formatter {};
+#endif
 {% endif %}
 
 #endif

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -14,6 +14,8 @@
 #include "podio/utilities/TypeHelpers.h"
 #include "podio/detail/OrderKey.h"
 
+#include <fmt/ostream.h>
+
 #include <memory>
 #include <ostream>
 #include <stdexcept>
@@ -195,5 +197,8 @@ struct std::hash<{{ class.full_type }}> {
     return obj.m_self->objHash();
   }
 };
+
+template <>
+struct fmt::formatter<{{ class.full_type }}> : fmt::ostream_formatter {};
 
 #endif

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -14,6 +14,8 @@
 #include "podio/utilities/TypeHelpers.h"
 #include "podio/detail/OrderKey.h"
 
+#include <fmt/ostream.h>
+
 #include <memory>
 #include <ostream>
 #include <stdexcept>
@@ -189,5 +191,8 @@ struct std::hash<{{ class.full_type }}> {
     return obj.m_self->objHash();
   }
 };
+
+template <>
+struct fmt::formatter<{{ class.full_type }}> : fmt::ostream_formatter {};
 
 #endif

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -14,7 +14,11 @@
 #include "podio/utilities/TypeHelpers.h"
 #include "podio/detail/OrderKey.h"
 
+// Hide the fmt dependency from cling, so that ROOT does not need to be able to
+// find the fmt headers when it parses the podio headers at runtime
+#if !defined(__CLING__)
 #include <fmt/ostream.h>
+#endif
 
 #include <memory>
 #include <ostream>
@@ -192,7 +196,9 @@ struct std::hash<{{ class.full_type }}> {
   }
 };
 
+#if !defined(__CLING__)
 template <>
 struct fmt::formatter<{{ class.full_type }}> : fmt::ostream_formatter {};
+#endif
 
 #endif

--- a/python/templates/MutableObject.h.jinja2
+++ b/python/templates/MutableObject.h.jinja2
@@ -62,4 +62,7 @@ private:
 
 {{ macros.std_hash(class, prefix='Mutable') }}
 
+{{ macros.ostream_formatter(class, prefix='Mutable') }}
+
+
 #endif

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -15,6 +15,8 @@
 #include "podio/utilities/MaybeSharedPtr.h"
 #include "podio/detail/OrderKey.h"
 
+#include <fmt/ostream.h>
+
 #include <ostream>
 #include <cstdint>
 
@@ -78,6 +80,8 @@ std::ostream& operator<<(std::ostream& o, const {{ class.bare_type }}& value);
 {{ utils.namespace_close(class.namespace) }}
 
 {{ macros.std_hash(class) }}
+
+{{ macros.ostream_formatter(class) }}
 
 {{ workarounds.ld_library_path(class) }}
 

--- a/python/templates/Object.h.jinja2
+++ b/python/templates/Object.h.jinja2
@@ -15,7 +15,11 @@
 #include "podio/utilities/MaybeSharedPtr.h"
 #include "podio/detail/OrderKey.h"
 
+// Hide the fmt dependency from cling, so that ROOT does not need to be able to
+// find the fmt headers when it parses the podio headers at runtime
+#if !defined(__CLING__)
 #include <fmt/ostream.h>
+#endif
 
 #include <ostream>
 #include <cstdint>

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -158,3 +158,9 @@ struct std::hash<{{ namespace }}{{ prefix }}{{ class.bare_type }}> {
   }
 };
 {% endmacro %}
+
+{% macro ostream_formatter(class, prefix='') %}
+{% set namespace = class.namespace + '::' if class.namespace else '' %}
+template <>
+struct fmt::formatter<{{ namespace }}{{ prefix }}{{ class.bare_type }}> : fmt::ostream_formatter {};
+{% endmacro %}

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -153,3 +153,9 @@ struct std::hash<{{ namespace }}{{ prefix }}{{ class.bare_type }}> {
   }
 };
 {% endmacro %}
+
+{% macro ostream_formatter(class, prefix='') %}
+{% set namespace = class.namespace + '::' if class.namespace else '' %}
+template <>
+struct fmt::formatter<{{ namespace }}{{ prefix }}{{ class.bare_type }}> : fmt::ostream_formatter {};
+{% endmacro %}

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -156,6 +156,8 @@ struct std::hash<{{ namespace }}{{ prefix }}{{ class.bare_type }}> {
 
 {% macro ostream_formatter(class, prefix='') %}
 {% set namespace = class.namespace + '::' if class.namespace else '' %}
+#if !defined(__CLING__)
 template <>
 struct fmt::formatter<{{ namespace }}{{ prefix }}{{ class.bare_type }}> : fmt::ostream_formatter {};
+#endif
 {% endmacro %}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ SET(core_headers
 PODIO_ADD_LIB_AND_DICT(podio "${core_headers}" "${core_sources}" selection.xml)
 target_compile_options(podio PRIVATE -pthread)
 target_link_libraries(podio PRIVATE Python3::Python)
+target_link_libraries(podio PUBLIC fmt::fmt)
 # For Frame.h
 if (ROOT_VERSION VERSION_LESS 6.36)
   target_compile_definitions(podio PUBLIC PODIO_ROOT_OLDER_6_36=1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ SET(core_headers
 PODIO_ADD_LIB_AND_DICT(podio "${core_headers}" "${core_sources}" selection.xml)
 target_compile_options(podio PRIVATE -pthread)
 target_link_libraries(podio PRIVATE Python3::Python)
+target_link_libraries(podio PUBLIC fmt::fmt)
 # For Frame.h
 if (ROOT_VERSION VERSION_LESS 6.36)
   target_compile_definitions(podio PUBLIC PODIO_ROOT_OLDER_6_36=1)

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -195,3 +195,14 @@ TEST_CASE("InterfaceType extension model", "[interface-types][extension]") {
   REQUIRE(wrapper.isA<iextension::AnotherHit>());
   REQUIRE(wrapper.as<iextension::AnotherHit>().energy() == 4.2f);
 }
+
+TEST_CASE("InterfaceType formatting", "[interface-types][basics][formatting]") {
+  auto iface = iextension::EnergyInterface::makeEmpty();
+  auto formatted = fmt::format("{}", iface);
+  REQUIRE(formatted == "[not available]");
+
+  iface = ExampleCluster{};
+  formatted = fmt::format("{}", iface);
+  REQUIRE_FALSE(formatted.empty());
+  REQUIRE(formatted != "[not available]");
+}

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -219,3 +219,14 @@ TEST_CASE("InterfaceType extension model", "[interface-types][extension]") {
   REQUIRE(wrapper.isA<iextension::AnotherHit>());
   REQUIRE(wrapper.as<iextension::AnotherHit>().energy() == 4.2f);
 }
+
+TEST_CASE("InterfaceType formatting", "[interface-types][basics][formatting]") {
+  auto iface = iextension::EnergyInterface::makeEmpty();
+  auto formatted = fmt::format("{}", iface);
+  REQUIRE(formatted == "[not available]");
+
+  iface = ExampleCluster{};
+  formatted = fmt::format("{}", iface);
+  REQUIRE_FALSE(formatted.empty());
+  REQUIRE(formatted != "[not available]");
+}

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -15,6 +15,8 @@
   #include "nlohmann/json.hpp"
 #endif
 
+#include <fmt/format.h>
+
 #include <map>
 #include <set>
 #include <type_traits>
@@ -441,6 +443,19 @@ TEST_CASE("LinkCollection basics", "[links]") {
   for (auto l : links) {
     REQUIRE(l.id().collectionID == 42);
   }
+}
+
+TEST_CASE("LinkCollection formatting", "[links][formatting]") {
+  podio::LinkCollection<ExampleHit, ExampleCluster> links;
+
+  auto formatted = fmt::format("{}", links);
+  REQUIRE_FALSE(formatted.empty());
+
+  links.create();
+  links.create();
+
+  auto formatted2 = fmt::format("{}", links);
+  REQUIRE(formatted2.size() > formatted.size());
 }
 
 auto createLinkCollections(const size_t nElements = 3u) {

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -301,6 +301,22 @@ TEST_CASE("Links templated accessors", "[links]") {
   }
 }
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+TEST_CASE("Link formatting", "[links]") {
+  TestL link;
+  auto formatted = fmt::format("{}", link);
+  REQUIRE_FALSE(formatted.empty());
+  REQUIRE(formatted != "[not available]");
+
+  auto emptyLink = TestL::makeEmpty();
+  auto emptyFmt = fmt::format("{}", emptyLink);
+  REQUIRE(emptyFmt == "[not available]");
+
+  TestMutL mutLink;
+  formatted = fmt::format("{}", mutLink);
+  REQUIRE(formatted != "[not avialable]");
+}
+
 TEST_CASE("LinkCollection collection concept", "[links][concepts]") {
   STATIC_REQUIRE(podio::CollectionType<TestLColl>);
   STATIC_REQUIRE(std::is_same_v<std::ranges::range_value_t<TestLColl>, TestL>);

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -307,6 +307,22 @@ TEST_CASE("Links templated accessors", "[links]") {
   }
 }
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+TEST_CASE("Link formatting", "[links]") {
+  TestL link;
+  auto formatted = fmt::format("{}", link);
+  REQUIRE_FALSE(formatted.empty());
+  REQUIRE(formatted != "[not available]");
+
+  auto emptyLink = TestL::makeEmpty();
+  auto emptyFmt = fmt::format("{}", emptyLink);
+  REQUIRE(emptyFmt == "[not available]");
+
+  TestMutL mutLink;
+  formatted = fmt::format("{}", mutLink);
+  REQUIRE(formatted != "[not avialable]");
+}
+
 TEST_CASE("LinkCollection collection concept", "[links][concepts]") {
   STATIC_REQUIRE(podio::CollectionType<TestLColl>);
   STATIC_REQUIRE(std::is_same_v<std::ranges::range_value_t<TestLColl>, TestL>);

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -15,6 +15,8 @@
   #include "nlohmann/json.hpp"
 #endif
 
+#include <fmt/format.h>
+
 #include <map>
 #include <set>
 #include <type_traits>
@@ -447,6 +449,19 @@ TEST_CASE("LinkCollection basics", "[links]") {
   for (auto l : links) {
     REQUIRE(l.id().collectionID == 42);
   }
+}
+
+TEST_CASE("LinkCollection formatting", "[links][formatting]") {
+  podio::LinkCollection<ExampleHit, ExampleCluster> links;
+
+  auto formatted = fmt::format("{}", links);
+  REQUIRE_FALSE(formatted.empty());
+
+  links.create();
+  links.create();
+
+  auto formatted2 = fmt::format("{}", links);
+  REQUIRE(formatted2.size() > formatted.size());
 }
 
 auto createLinkCollections(const size_t nElements = 3u) {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -66,6 +66,8 @@
 
 #include "podio/UserDataCollection.h"
 
+#include <fmt/format.h>
+
 TEST_CASE("AutoDelete", "[basics][memory-management]") {
   auto coll = EventInfoCollection();
   auto hit1 = MutableEventInfo();
@@ -413,6 +415,9 @@ TEST_CASE("UserDataCollection print", "[basics]") {
   coll.print(sstr);
 
   REQUIRE(sstr.str() == "[1, 2, 3]");
+
+  auto formatted = fmt::format("{}", coll);
+  REQUIRE_FALSE(formatted.empty());
 }
 
 TEST_CASE("UserDataCollection access", "[basics]") {
@@ -635,6 +640,19 @@ TEST_CASE("Equality", "[basics]") {
   REQUIRE(clu == clu2);
   // They never compare equal to a non-empty handle
   REQUIRE(clu != cluster);
+}
+
+TEST_CASE("Collection formatting", "[basics]") {
+  ExampleClusterCollection clusters;
+  auto cluster = clusters.create();
+  cluster.energy(42.5f);
+  auto formatted = fmt::format("{}", clusters);
+  REQUIRE_FALSE(formatted.empty());
+
+  ExampleWithComponentCollection components;
+  auto comp = components.create();
+  formatted = fmt::format("{}", components);
+  REQUIRE_FALSE(formatted.empty());
 }
 
 TEST_CASE("UserInitialization", "[basics][code-gen]") {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -61,6 +61,7 @@
 #include "datamodel/MutableExampleWithArray.h"
 #include "datamodel/MutableExampleWithComponent.h"
 #include "datamodel/MutableExampleWithExternalExtraCode.h"
+#include "datamodel/NamespaceInNamespaceStruct.h"
 #include "datamodel/StructWithExtraCode.h"
 #include "datamodel/datamodel.h"
 #include "extension_model/extension_model.h"
@@ -166,6 +167,14 @@ TEST_CASE("Object formatting", "[basics][formatting]") {
   formatted = fmt::format("{}", mutCluster);
   REQUIRE_FALSE(formatted.empty());
   REQUIRE(formatted != "[not available]");
+
+  auto typeWithComponent = ExampleWithArrayComponent{};
+  formatted = fmt::format("{}", typeWithComponent);
+  REQUIRE_FALSE(formatted.empty());
+
+  auto nspComp = ex2::NamespaceInNamespaceStruct{};
+  formatted = fmt::format("{}", nspComp);
+  REQUIRE_FALSE(formatted.empty());
 }
 
 TEST_CASE("Cyclic", "[basics][relations][memory-management]") {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -152,6 +152,22 @@ TEST_CASE("makeEmpty", "[basics]") {
   REQUIRE(hit.energy() == 0);
 }
 
+TEST_CASE("Object formatting", "[basics][formatting]") {
+  ExampleCluster cluster;
+  auto formatted = fmt::format("{}", cluster);
+  REQUIRE_FALSE(formatted.empty());
+  REQUIRE(formatted != "[not avaialble]");
+
+  cluster = ExampleCluster::makeEmpty();
+  formatted = fmt::format("{}", cluster);
+  REQUIRE(formatted == "[not available]");
+
+  auto mutCluster = MutableExampleCluster{};
+  formatted = fmt::format("{}", mutCluster);
+  REQUIRE_FALSE(formatted.empty());
+  REQUIRE(formatted != "[not available]");
+}
+
 TEST_CASE("Cyclic", "[basics][relations][memory-management]") {
   auto coll1 = ExampleForCyclicDependency1Collection();
   auto start = coll1.create();

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -20,6 +20,7 @@
 // podio specific includes
 #include "podio/Frame.h"
 #include "podio/GenericParameters.h"
+#include "podio/ObjectID.h"
 #include "podio/ROOTLegacyReader.h"
 #include "podio/ROOTReader.h"
 #include "podio/ROOTWriter.h"
@@ -67,6 +68,17 @@
 #include "podio/UserDataCollection.h"
 
 #include <fmt/format.h>
+
+TEST_CASE("ObjectID formatting", "[basics][formatting]") {
+  auto objId = podio::ObjectID{};
+  auto formatted = fmt::format("{}", objId);
+  REQUIRE(formatted == "ffffffff|-1");
+
+  objId.collectionID = 42;
+  objId.index = 123;
+  formatted = fmt::format("{}", objId);
+  REQUIRE(formatted == fmt::format("{:8x}|123", 42));
+}
 
 TEST_CASE("AutoDelete", "[basics][memory-management]") {
   auto coll = EventInfoCollection();

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -152,6 +152,22 @@ TEST_CASE("makeEmpty", "[basics]") {
   REQUIRE(hit.energy() == 0);
 }
 
+TEST_CASE("Object formatting", "[basics][formatting]") {
+  ExampleCluster cluster;
+  auto formatted = fmt::format("{}", cluster);
+  REQUIRE_FALSE(formatted.empty());
+  REQUIRE(formatted != "[not avaialble]");
+
+  cluster = ExampleCluster::makeEmpty();
+  formatted = fmt::format("{}", cluster);
+  REQUIRE(formatted == "[not available]");
+
+  auto mutCluster = MutableExampleCluster{};
+  formatted = fmt::format("{}", mutCluster);
+  REQUIRE_FALSE(formatted.empty());
+  REQUIRE(formatted != "[not available]");
+}
+
 TEST_CASE("Cyclic dependencies", "[LEAK-FAIL][basics][relations][memory-management]") {
   SECTION("with collections") {
     auto coll1 = ExampleForCyclicDependency1Collection();

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -61,6 +61,7 @@
 #include "datamodel/MutableExampleWithArray.h"
 #include "datamodel/MutableExampleWithComponent.h"
 #include "datamodel/MutableExampleWithExternalExtraCode.h"
+#include "datamodel/NamespaceInNamespaceStruct.h"
 #include "datamodel/StructWithExtraCode.h"
 #include "datamodel/datamodel.h"
 #include "extension_model/extension_model.h"
@@ -166,6 +167,14 @@ TEST_CASE("Object formatting", "[basics][formatting]") {
   formatted = fmt::format("{}", mutCluster);
   REQUIRE_FALSE(formatted.empty());
   REQUIRE(formatted != "[not available]");
+
+  auto typeWithComponent = ExampleWithArrayComponent{};
+  formatted = fmt::format("{}", typeWithComponent);
+  REQUIRE_FALSE(formatted.empty());
+
+  auto nspComp = ex2::NamespaceInNamespaceStruct{};
+  formatted = fmt::format("{}", nspComp);
+  REQUIRE_FALSE(formatted.empty());
 }
 
 TEST_CASE("Cyclic dependencies", "[LEAK-FAIL][basics][relations][memory-management]") {

--- a/tests/unittests/unittest.cpp
+++ b/tests/unittests/unittest.cpp
@@ -66,6 +66,8 @@
 
 #include "podio/UserDataCollection.h"
 
+#include <fmt/format.h>
+
 TEST_CASE("AutoDelete", "[basics][memory-management]") {
   auto coll = EventInfoCollection();
   auto hit1 = MutableEventInfo();
@@ -418,6 +420,9 @@ TEST_CASE("UserDataCollection basics", "[basics]") {
     coll.print(sstr);
 
     REQUIRE(sstr.str() == "[1, 2, 3]");
+
+    auto formatted = fmt::format("{}", coll);
+    REQUIRE_FALSE(formatted.empty());
   }
 
   SECTION("access") {
@@ -645,6 +650,19 @@ TEST_CASE("Equality", "[basics]") {
   REQUIRE(clu == clu2);
   // They never compare equal to a non-empty handle
   REQUIRE(clu != cluster);
+}
+
+TEST_CASE("Collection formatting", "[basics]") {
+  ExampleClusterCollection clusters;
+  auto cluster = clusters.create();
+  cluster.energy(42.5f);
+  auto formatted = fmt::format("{}", clusters);
+  REQUIRE_FALSE(formatted.empty());
+
+  ExampleWithComponentCollection components;
+  auto comp = components.create();
+  formatted = fmt::format("{}", components);
+  REQUIRE_FALSE(formatted.empty());
 }
 
 TEST_CASE("UserInitialization", "[basics][code-gen]") {


### PR DESCRIPTION
BEGINRELEASENOTES
- Make it possible to use objects and collections with fmtlib by using the `ostream_formatter` adaptor from fmtlib.
- **`fmtlib` is now a transitive dependency of podio**, i.e. EDMs generated with podio will also depend on it. The necessary propagation of this dependency via CMake is handled here, but build environments might need adjustments.

ENDRELEASENOTES

This is an intermediate step towards better support for using `fmt::format` (and eventually hopefully also `std::format`). Currently this simply re-uses the existing `operator<<`. In a next step I will implement proper formatting via the customization points that `fmtlib` provides. Then `operator<<` will be implemented in terms of `fmt::format`. Ideally, that step would be compatible with `<format>` in which case we might be able do drop the `fmtlib` dependency.

See also the discussion in https://github.com/AIDASoft/podio/issues/920#issuecomment-3777230323