### PR TITLE
Use Clang 19 instead of 16 in CI

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         LCG: ["LCG_107/x86_64-el9-gcc13-opt",
               "dev4/x86_64-el9-gcc15-opt",
-              "dev3/x86_64-el9-clang16-opt"]
+              "dev3/x86_64-el9-clang19-opt"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
BEGINRELEASENOTES
- Use Clang 19 instead of 16 in CI, since these builds are going to be revomed

ENDRELEASENOTES

Clang 16 builds seem not to work and are going to be removed, see
https://its.cern.ch/jira/projects/SPI/issues/SPI-2955.