### PR TITLE
[Draft] Prototype TransportFrameData backend 

### DIFF
--- a/include/podio/TransportFrameData.h
+++ b/include/podio/TransportFrameData.h
@@ -1,0 +1,48 @@
+#ifndef PODIO_TRANSPORTFRAMEDATA_H
+#define PODIO_TRANSPORTFRAMEDATA_H
+
+#include "podio/CollectionBuffers.h"
+#include "podio/CollectionIDTable.h"
+#include "podio/GenericParameters.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace podio {
+
+/// Minimal draft backend for exploring frame-level transport at FrameData layer.
+///
+/// This intentionally provides read-side stubs only and does not perform any
+/// serialization or deserialization.
+class TransportFrameData {
+public:
+  TransportFrameData() = default;
+  ~TransportFrameData() = default;
+
+  TransportFrameData(const TransportFrameData&) = delete;
+  TransportFrameData& operator=(const TransportFrameData&) = delete;
+  TransportFrameData(TransportFrameData&&) = default;
+  TransportFrameData& operator=(TransportFrameData&&) = default;
+
+  TransportFrameData(podio::CollectionIDTable idTable, std::vector<std::string> availableCollections,
+                     podio::GenericParameters parameters);
+
+  std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
+
+  podio::CollectionIDTable getIDTable() const;
+
+  std::vector<std::string> getAvailableCollections() const;
+
+  std::unique_ptr<podio::GenericParameters> getParameters();
+
+private:
+  podio::CollectionIDTable m_idTable{};
+  std::vector<std::string> m_availableCollections{};
+  podio::GenericParameters m_parameters{};
+};
+
+} // namespace podio
+
+#endif // PODIO_TRANSPORTFRAMEDATA_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ SET(core_sources
   SchemaEvolution.cc
   Glob.cc
   Pythonizations.cc
+  TransportFrameData.cc
   )
 
 SET(core_headers

--- a/src/TransportFrameData.cc
+++ b/src/TransportFrameData.cc
@@ -1,0 +1,30 @@
+#include "podio/TransportFrameData.h"
+
+#include <utility>
+
+namespace podio {
+
+TransportFrameData::TransportFrameData(podio::CollectionIDTable idTable, std::vector<std::string> availableCollections,
+                                       podio::GenericParameters parameters) :
+    m_idTable(std::move(idTable)),
+    m_availableCollections(std::move(availableCollections)),
+    m_parameters(std::move(parameters)) {
+}
+
+std::optional<podio::CollectionReadBuffers> TransportFrameData::getCollectionBuffers(const std::string& /*name*/) {
+  return std::nullopt;
+}
+
+podio::CollectionIDTable TransportFrameData::getIDTable() const {
+  return {m_idTable.ids(), m_idTable.names()};
+}
+
+std::vector<std::string> TransportFrameData::getAvailableCollections() const {
+  return m_availableCollections;
+}
+
+std::unique_ptr<podio::GenericParameters> TransportFrameData::getParameters() {
+  return std::make_unique<podio::GenericParameters>(m_parameters);
+}
+
+} // namespace podio


### PR DESCRIPTION
## Summary

This draft PR explores implementing a minimal `FrameData` backend to 
validate whether frame-level transport can live at the `FrameData` layer 
without modifying `Frame` or existing writers.

## Scope

- Minimal `TransportFrameData` class implementing the required interface
- `getIDTable()`, `getCollectionBuffers()`, `getAvailableCollections()`, `getParameters()`
- Compiles cleanly against core podio
- Verified that a podio::Frame can be constructed from this backend without modifying Frame

## Out of scope

- Writer side (intentionally excluded — writers currently assume fully 
  materialized collections as noted in #565)
- Actual serialization format
- Network transport implementation

## Relation to #565

This prototype is motivated by the discussion in #565 and the recent 
suggestion that the reading side may already be solvable via arbitrary 
`FrameData` construction. This is an attempt to validate that boundary.

## Open question

Should `getCollectionBuffers()` eventually own the Arrow/transport buffers 
directly, or should a separate buffer ownership layer sit between the 
transport and `CollectionReadBuffers`?

Feedback welcome on the architectural direction before going further.