### PR TITLE
[WIP] Add a `podio-filter-frames` tool 

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,7 +6,16 @@ install(TARGETS podio-test-hashes EXPORT podioTargets DESTINATION "${CMAKE_INSTA
 add_executable(podio-dump-tool src/podio-dump-tool.cpp)
 target_link_libraries(podio-dump-tool PRIVATE podio::podio podio::podioIO fmt::fmt)
 
-install(TARGETS podio-dump-tool EXPORT podioTargets DESTINATION ${CMAKE_INSTALL_BINDIR})
+add_executable(podio-filter-frames src/podio-filter-frames.cpp)
+target_link_libraries(podio-filter-frames PRIVATE podio::podioIO fmt::fmt)
+
+install(
+  TARGETS
+    podio-dump-tool
+    podio-filter-frames
+  EXPORT podioTargets
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
 install(PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/podio-dump DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/podio-dump-legacy DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/src/argparseUtils.h
+++ b/tools/src/argparseUtils.h
@@ -1,6 +1,8 @@
 #ifndef PODIO_TOOLS_ARGPARSEUTILS_H // NOLINT(llvm-header-guard): folder structure not suitable
 #define PODIO_TOOLS_ARGPARSEUTILS_H // NOLINT(llvm-header-guard): folder structure not suitable
 
+#include <fmt/core.h>
+
 #include <algorithm>
 #include <charconv>
 #include <iostream>
@@ -21,6 +23,30 @@ inline size_t parseSizeOrExit(std::string_view str) {
     std::exit(1);
   }
   return number;
+}
+
+void printUsageAndExit(const char* usageMsg) {
+  fmt::println(stderr, "{}", usageMsg);
+  std::exit(1);
+}
+
+auto getArgumentValueOrExit(const std::vector<std::string>& argv, std::vector<std::string>::const_iterator it,
+                            const char* usageMsg) {
+  const int argc = argv.size();
+  const auto index = std::distance(argv.begin(), it);
+  if (index > argc - 2) {
+    printUsageAndExit(usageMsg);
+  }
+  return argv[index + 1];
+}
+
+/// Check if -h or --help is in the flags and exit in case it is after printing
+/// the help message
+void printHelpAndExit(const std::vector<std::string>& argv, const char* usageMsg, const char* helpMsg) {
+  if (const auto it = findFlags(argv, "-h", "--help"); it != argv.end()) {
+    fmt::print("{}\n{}", usageMsg, helpMsg);
+    std::exit(0);
+  }
 }
 
 #endif // PODIO_TOOLS_ARGPARSEUTILS_H

--- a/tools/src/podio-dump-tool.cpp
+++ b/tools/src/podio-dump-tool.cpp
@@ -50,20 +50,6 @@ options:
   --version             Show the program's version number and exit
 )";
 
-void printUsageAndExit() {
-  fmt::println(stderr, "{}", usageMsg);
-  std::exit(1);
-}
-
-auto getArgumentValueOrExit(const std::vector<std::string>& argv, std::vector<std::string>::const_iterator it) {
-  const int argc = argv.size();
-  const auto index = std::distance(argv.begin(), it);
-  if (index > argc - 2) {
-    printUsageAndExit();
-  }
-  return argv[index + 1];
-}
-
 std::vector<size_t> parseEventRange(const std::string_view evtRange) {
   auto parseError = [evtRange]() {
     fmt::println(stderr, "error: argument -e/--entries: '{}' cannot be parsed into a list of entries", evtRange);
@@ -120,12 +106,9 @@ std::vector<size_t> fullEntryList(const ParsedArgs& args, const podio::Reader& r
 
 ParsedArgs parseArgs(std::vector<std::string> argv) {
   // find help or version
-  if (const auto it = findFlags(argv, "-h", "--help", "--version"); it != argv.end()) {
-    if (*it == "--version") {
-      fmt::println("podio {}", podio::version::build_version);
-    } else {
-      fmt::print("{}\n{}", usageMsg, helpMsg);
-    }
+  printHelpAndExit(argv, usageMsg, helpMsg);
+  if (const auto it = findFlags(argv, "--version"); it != argv.end()) {
+    fmt::println("podio {}", podio::version::build_version);
     std::exit(0);
   }
 
@@ -137,7 +120,7 @@ ParsedArgs parseArgs(std::vector<std::string> argv) {
   }
   // category
   if (const auto it = findFlags(argv, "-c", "--category"); it != argv.end()) {
-    args.category = getArgumentValueOrExit(argv, it);
+    args.category = getArgumentValueOrExit(argv, it, usageMsg);
     argv.erase(it, it + 2);
   }
   // event range
@@ -147,7 +130,7 @@ ParsedArgs parseArgs(std::vector<std::string> argv) {
   }
   // dump-edm
   if (const auto it = findFlags(argv, "--dump-edm"); it != argv.end()) {
-    args.dumpEDM = getArgumentValueOrExit(argv, it);
+    args.dumpEDM = getArgumentValueOrExit(argv, it, usageMsg);
     argv.erase(it, it + 2);
   }
   if (const auto it = findFlags(argv, "-s", "--size-stats"); it != argv.end()) {
@@ -156,7 +139,7 @@ ParsedArgs parseArgs(std::vector<std::string> argv) {
   }
 
   if (argv.size() != 1) {
-    printUsageAndExit();
+    printUsageAndExit(usageMsg);
   }
   args.inputFile = argv[0];
 

--- a/tools/src/podio-filter-frames.cpp
+++ b/tools/src/podio-filter-frames.cpp
@@ -1,0 +1,117 @@
+#include "argparseUtils.h"
+
+#include "podio/Frame.h"
+#include "podio/Reader.h"
+#include "podio/Writer.h"
+
+#include "TInterpreter.h"
+
+#include <fmt/core.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+constexpr auto usageMsg = R"(usage: podio-filter-events [-o outputfile] [-c CATEGORY] filter-def inputfile)";
+constexpr auto helpMsg = R"(
+Filter events according to the definition in filter-def
+
+filter-def needs to be a c++ file that contains a filter function with the following signature
+
+bool keepFrame(const podio::Frame&)
+
+If it returns true the Frame will be stored to the output file otherwise it will be discarded.
+
+positional arguments 
+  filter-def            Name of the file that contains the definition of the filter function
+  inputfile             Name of the input file to filter
+
+options:
+  -h, --help            Show this help message and exit
+  -c CATEGORY, --category CATEGORY
+                        Which Frame category to filter (all others will remain unchanged!).
+                        Defaults to "events".
+  -o outputfile, --output outputfile
+                        The name of the output file that is created. Defaults to filtered.root
+)";
+
+struct ParsedArgs {
+  std::string inputFile{};
+  std::string filterDef{};
+  std::string outputFile{"filtered.root"};
+  std::string category{"events"};
+  bool verbose{false};
+};
+
+ParsedArgs parseArgs(std::vector<std::string> argv) {
+  printHelpAndExit(argv, usageMsg, helpMsg);
+
+  ParsedArgs args;
+  if (const auto it = findFlags(argv, "-c", "--category"); it != argv.end()) {
+    args.category = getArgumentValueOrExit(argv, it, usageMsg);
+    argv.erase(it, it + 2);
+  }
+  if (const auto it = findFlags(argv, "-o", "--output"); it != argv.end()) {
+    args.outputFile = getArgumentValueOrExit(argv, it, usageMsg);
+    argv.erase(it, it + 2);
+  }
+  if (const auto it = findFlags(argv, "-v", "--verbose"); it != argv.end()) {
+    args.verbose = true;
+    argv.erase(it);
+  }
+  if (argv.size() != 2) {
+    printUsageAndExit(usageMsg);
+  }
+  args.filterDef = argv[0];
+  args.inputFile = argv[1];
+
+  return args;
+}
+
+using FilterFunc = bool(const podio::Frame&);
+
+FilterFunc* jitFilterFunc(const std::string& filterDefFile) {
+
+  if (gInterpreter->LoadFile(filterDefFile.c_str()) != 0) {
+    fmt::println(stderr, "Cannot JIT compile file {}", filterDefFile);
+    std::exit(1);
+  }
+
+  if (const auto filterFunc = gInterpreter->FindSym("_Z9keepFrameRKN5podio5FrameE")) {
+    return reinterpret_cast<FilterFunc*>(filterFunc);
+  }
+
+  fmt::println(stderr, "Could not find a 'keepFrame' function in {}", filterDefFile);
+  std::exit(1);
+}
+
+int main(int argc, char* argv[]) {
+  const auto args = parseArgs({argv + 1, argv + argc});
+
+  auto reader = podio::makeReader(args.inputFile);
+  auto writer = podio::makeWriter(args.outputFile);
+
+  const auto filterFunc = jitFilterFunc(args.filterDef);
+
+  const auto nEntries = reader.getEntries(args.category);
+  fmt::println("Filtering file '{}' with '{}' entries using filter definition from '{}' applying it to category: {}",
+               args.inputFile, nEntries, args.filterDef, args.category);
+
+  for (size_t i = 0; i < nEntries; ++i) {
+    if (args.verbose) {
+      fmt::println("Processing event {}", i);
+    }
+    try {
+      const auto& frame = reader.readFrame(args.category, i);
+      if (filterFunc(frame)) {
+        fmt::println("Filter decision passed");
+        writer.writeFrame(frame, args.category);
+      }
+    } catch (std::runtime_error& err) {
+      fmt::println(stderr, "{}", err.what());
+      return 1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a `podio-filter-frames` tool that allows to filter whole Frames from files via a user defined `keepFrame` function that is JIT compiled on the fly.

ENDRELEASENOTES

This might simplify things a bit in some cases, e.g. when you want to select files that only contain a certain set of decays and takes off the boiler plate of setting up a reader / writer and an event loop.

- [ ] Documentation
- [ ] Tests