### PR TITLE
Add move constructor and assignment to the ROOT and RNTuple reader and writer

### DIFF
--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -35,14 +35,13 @@ namespace root_compat {
 class RNTupleReader {
 
 public:
-  /// Create a RNTupleReader
   RNTupleReader() = default;
-  /// Destructor
   ~RNTupleReader() = default;
-  /// The RNTupleReader is not copy-able
+
   RNTupleReader(const RNTupleReader&) = delete;
-  /// The RNTupleReader is not copy-able
   RNTupleReader& operator=(const RNTupleReader&) = delete;
+  RNTupleReader(RNTupleReader&&) = default;
+  RNTupleReader& operator=(RNTupleReader&&) = default;
 
   /// Open a single file for reading.
   ///

--- a/include/podio/RNTupleWriter.h
+++ b/include/podio/RNTupleWriter.h
@@ -52,10 +52,10 @@ public:
   /// able to read files back again.
   ~RNTupleWriter();
 
-  /// The RNTupleWriter is not copy-able
   RNTupleWriter(const RNTupleWriter&) = delete;
-  /// The RNTupleWriter is not copy-able
   RNTupleWriter& operator=(const RNTupleWriter&) = delete;
+  RNTupleWriter(RNTupleWriter&&) = default;
+  RNTupleWriter& operator=(RNTupleWriter&&) = default;
 
   /// Store the given frame with the given category.
   ///

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -49,15 +49,13 @@ struct CollectionReadBuffers;
 class ROOTReader {
 
 public:
-  /// Create a ROOTReader
   ROOTReader() = default;
-  /// Destructor
   ~ROOTReader() = default;
 
-  /// The ROOTReader is not copy-able
   ROOTReader(const ROOTReader&) = delete;
-  /// The ROOTReader is not copy-able
   ROOTReader& operator=(const ROOTReader&) = delete;
+  ROOTReader(ROOTReader&&) = default;
+  ROOTReader& operator=(ROOTReader&&) = default;
 
   /// Open a single file for reading.
   ///

--- a/include/podio/ROOTWriter.h
+++ b/include/podio/ROOTWriter.h
@@ -40,10 +40,10 @@ public:
   /// This also takes care of writing all the necessary metadata to read files back again.
   ~ROOTWriter();
 
-  /// The ROOTWriter is not copy-able
   ROOTWriter(const ROOTWriter&) = delete;
-  /// The ROOTWriter is not copy-able
   ROOTWriter& operator=(const ROOTWriter&) = delete;
+  ROOTWriter(ROOTWriter&&) = delete;
+  ROOTWriter& operator=(ROOTWriter&&) = delete;
 
   /// Store the given frame with the given category.
   ///


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the defifinitions for the move constructor and assignment operator.
  `ROOTWriter` can not be movable because it has a `TFile` that is not movable.
- Remove a few useless comments

ENDRELEASENOTES

This doesn't change anything, it's just adding the existing definitions.