### PR TITLE
Use `TFileMerger` to speed up `podio-merge-files`

### DIFF
--- a/python/podio/base_writer.py
+++ b/python/podio/base_writer.py
@@ -20,7 +20,7 @@ class AllWriters:
         """Finish all managed writers"""
         for writer in self.writers:
             try:
-                writer._writer.finish()  # pylint: disable=protected-access
+                writer.finish()
             except AttributeError:
                 pass
 
@@ -57,3 +57,7 @@ class BaseWriterMixin:
         if collections is not None:
             args.append(collections)
         self._writer.writeFrame(*args)
+
+    def finish(self):
+        """Finish writing and flush all data to the output file."""
+        self._writer.finish()  # pylint: disable=protected-access

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Utilities for merging podio ROOT files (TTree and RNTuple)."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+import ROOT
+
+from podio.frame import Frame
+from podio.utils import convert_to_str_paths
+from podio.root_io import Reader, RNTupleReader, RNTupleWriter, Writer
+
+
+def _get_tree_names(filename):
+    """Return the names of all TTrees in a ROOT file"""
+    f = ROOT.TFile.Open(filename)
+    if not f or f.IsZombie():
+        raise RuntimeError(f"Cannot open file: {filename}")
+    names = {elem.GetName() for elem in f.GetListOfKeys() if elem.GetClassName() == "TTree"}
+    f.Close()
+    return names
+
+
+def _get_rntuple_names(filename):
+    """Return the names of all RNTuples in a ROOT file"""
+    f = ROOT.TFile.Open(filename)
+    if not f or f.IsZombie():
+        raise RuntimeError(f"Cannot open file: {filename}")
+    names = {elem.GetName() for elem in f.GetListOfKeys() if elem.GetClassName() == "ROOT::RNTuple"}
+    f.Close()
+    return names
+
+
+def _hadd_path():
+    """Return the path to the hadd executable, or raise if not found"""
+    path = shutil.which("hadd")
+    if path is None:
+        raise RuntimeError(
+            "hadd not found on PATH. hadd is required by podio.root_merge.merge_files "
+            "and is distributed with ROOT."
+        )
+    return path
+
+
+def _merge_files_impl(output_file, input_files, metadata, get_names_fn, reader_cls, writer_cls, fmt_name):
+    """Common implementation for merge_files and merge_files_rntuple.
+
+    Args:
+        output_file (str): Path of the output file to create.
+        input_files (list[str]): Ordered list of input files (already str).
+        metadata (str): ``"first"``, ``"all"``, or ``"none"``.
+        get_names_fn: Callable returning the set of object names in a file.
+        reader_cls: Reader class to use (Reader or RNTupleReader).
+        writer_cls: Writer class to use (Writer or RNTupleWriter).
+        fmt_name (str): Format label used in error messages (e.g. "TTree").
+    """
+    has_metadata_cat = "metadata" in get_names_fn(input_files[0])
+
+    hadd = _hadd_path()
+    result = subprocess.run([hadd, "-f", "-k", output_file] + input_files, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"hadd failed (exit {result.returncode}):\n{result.stderr}")
+
+    # Delete the incorrectly merged metadata category (rewritten below)
+    out_f = ROOT.TFile.Open(output_file, "UPDATE")
+    if not out_f or out_f.IsZombie():
+        raise RuntimeError(f"Cannot open for UPDATE: {output_file}")
+    try:
+        if has_metadata_cat:
+            out_f.Delete("metadata;*")
+        out_f.Write("", ROOT.TObject.kOverwrite)
+    finally:
+        out_f.Close()
+
+    if metadata == "none":
+        return
+
+    # Write the corrected metadata category via a temp file, then copy only
+    # the metadata object into the output using TFileMerger
+    if has_metadata_cat:
+        src_reader = reader_cls([input_files[0]] if metadata == "first" else input_files)
+        frames = list(src_reader.get("metadata"))
+    else:
+        frames = [Frame()]
+
+    for frame in frames:
+        frame.put_parameter("MergedInputFiles", list(input_files))
+
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".root")
+    os.close(tmp_fd)
+    try:
+        tmp_writer = writer_cls(tmp_path)
+        for frame in frames:
+            tmp_writer.write_frame(frame, "metadata")
+        tmp_writer._writer.finish()
+
+        m = ROOT.TFileMerger(ROOT.kFALSE)
+        m.OutputFile(output_file, "UPDATE")
+        m.AddFile(tmp_path)
+        m.SetFastMethod(ROOT.kTRUE)
+        m.AddObjectNames("metadata")
+        if not m.PartialMerge(ROOT.TFileMerger.kAll | ROOT.TFileMerger.kOnlyListed | ROOT.TFileMerger.kIncremental):
+            raise RuntimeError(f"TFileMerger failed adding metadata {fmt_name} to {output_file}")
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def merge_files(output_file, input_files, metadata="first"):
+    """Merge podio TTree files.
+
+    Uses hadd for the event data, then rewrites the ``metadata`` category
+    (with the ``MergedInputFiles`` parameter set) via a temp file
+    and TFileMerger.
+
+    All input files must have been written with the same category and
+    collection layout.
+
+    Args:
+        output_file (str or Path): Path of the output file to create.
+        input_files (list[str] or list[Path]): Ordered list of input files.
+        metadata (str): How to handle the ``metadata`` Frame category.
+            ``"first"``  – copy only the first file's entry (default).
+            ``"all"``    – copy entries from every file.
+            ``"none"``   – omit the metadata category entirely.
+
+    Raises:
+        ValueError: If *input_files* is empty or *metadata* is not one of the
+            accepted values.
+        RuntimeError: If a file cannot be opened, hadd is not found, or
+            trees are inconsistent.
+    """
+    if not input_files:
+        raise ValueError("input_files must not be empty")
+    if metadata not in ("first", "all", "none"):
+        raise ValueError(f"metadata must be 'first', 'all', or 'none', got {metadata!r}")
+
+    input_files = [str(p) for p in convert_to_str_paths(input_files)]
+    output_file = str(convert_to_str_paths(output_file)[0])
+
+    _merge_files_impl(output_file, input_files, metadata, _get_tree_names, Reader, Writer, "TTree")
+
+
+def merge_files_rntuple(output_file, input_files, metadata="first"):
+    """Merge podio RNTuple files.
+
+    Uses hadd for the event data, then rewrites the ``metadata`` category
+    (with the ``MergedInputFiles`` parameter set) via a temp file
+    and TFileMerger.
+
+    All input files must have been written with the same category and
+    collection layout.
+
+    Args:
+        output_file (str or Path): Path of the output file to create.
+        input_files (list[str] or list[Path]): Ordered list of input files.
+        metadata (str): How to handle the ``metadata`` Frame category.
+            ``"first"``  – copy only the first file's entry (default).
+            ``"all"``    – copy entries from every file.
+            ``"none"``   – omit the metadata category entirely.
+
+    Raises:
+        ValueError: If *input_files* is empty or *metadata* is not one of the
+            accepted values.
+        RuntimeError: If a file cannot be opened, hadd is not found, or
+            ntuples are inconsistent.
+    """
+    if not input_files:
+        raise ValueError("input_files must not be empty")
+    if metadata not in ("first", "all", "none"):
+        raise ValueError(f"metadata must be 'first', 'all', or 'none', got {metadata!r}")
+
+    input_files = [str(p) for p in convert_to_str_paths(input_files)]
+    output_file = str(convert_to_str_paths(output_file)[0])
+
+    _merge_files_impl(output_file, input_files, metadata, _get_rntuple_names, RNTupleReader, RNTupleWriter, "RNTuple")

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -93,7 +93,8 @@ def merge_files(output_file, input_files, metadata="first"):
         frame.put_parameter("MergedInputFiles", list(input_files))
 
     with tempfile.NamedTemporaryFile(suffix=".root") as tmp_file:
-        tmp_file.close()  # release the handle so Writer can open the file below
+        # NamedTemporaryFile opens on creation, close so Writer can reopen
+        tmp_file.close()
         tmp_path = tmp_file.name
 
         tmp_writer = Writer(tmp_path)

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Utilities for merging podio ROOT files (TTree and RNTuple)."""
 
-import os
 import shutil
 import subprocess
 import tempfile
@@ -93,9 +92,10 @@ def merge_files(output_file, input_files, metadata="first"):
     for frame in frames:
         frame.put_parameter("MergedInputFiles", list(input_files))
 
-    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".root")
-    os.close(tmp_fd)
-    try:
+    with tempfile.NamedTemporaryFile(suffix=".root") as tmp_file:
+        tmp_file.close()
+        tmp_path = tmp_file.name
+
         tmp_writer = Writer(tmp_path)
         for frame in frames:
             tmp_writer.write_frame(frame, "metadata")
@@ -110,9 +110,6 @@ def merge_files(output_file, input_files, metadata="first"):
             ROOT.TFileMerger.kAll | ROOT.TFileMerger.kOnlyListed | ROOT.TFileMerger.kIncremental
         ):
             raise RuntimeError(f"TFileMerger failed adding metadata category to {output_file}")
-    finally:
-        if os.path.exists(tmp_path):
-            os.unlink(tmp_path)
 
 
 def _detect_metadata(filename):

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -1,34 +1,22 @@
 #!/usr/bin/env python3
 """Utilities for merging podio ROOT files (TTree and RNTuple)."""
 
-import shutil
-import subprocess
+import os
 import tempfile
 
 import ROOT
 
 from podio.frame import Frame
 from podio.utils import convert_to_str_paths
-from podio.root_io import Reader, RNTupleReader, Writer
+from podio.root_io import Reader, RNTupleReader, RNTupleWriter, Writer
 
 
-def _hadd_path():
-    """Return the path to the hadd executable, or raise if not found"""
-    path = shutil.which("hadd")
-    if path is None:
-        raise RuntimeError(
-            "hadd not found on PATH. hadd is required by podio.root_merge.merge_files "
-            "and is distributed with ROOT."
-        )
-    return path
-
-
-def merge_files(output_file, input_files, metadata="first"):
+def merge_files(output_file, input_files, metadata="first", compression=101):
     """Merge podio ROOT files.
 
-    Uses hadd for the event data (both TTree and RNTuple), then rewrites the
-    ``metadata`` category (with the ``MergedInputFiles`` parameter set) via
-    a temp file and TFileMerger.
+    Uses ROOT's TFileMerger directly for the event data (both TTree and
+    RNTuple), then rewrites the ``metadata`` category correctly
+    (with the ``MergedInputFiles`` parameter set) via an incremental merge.
 
     All input files must have been written with the same category and
     collection layout.
@@ -40,12 +28,16 @@ def merge_files(output_file, input_files, metadata="first"):
             ``"first"``  -- copy only the first file's entry (default).
             ``"all"``    -- copy entries from every file.
             ``"none"``   -- omit the metadata category entirely.
+        compression (int): ROOT compression settings for the output file.
+            The format is ``<algorithm>*100 + <level>``, where algorithm is
+            1 (ZLIB), 2 (LZMA), 4 (LZ4) or 5 (ZSTD), and level is 1-9.
+            Defaults to 101 (ZLIB level 1).  Pass 0 to use the compression
+            of the first input file.
 
     Raises:
         ValueError: If *input_files* is empty or *metadata* is not one of the
             accepted values.
-        RuntimeError: If a file cannot be opened, hadd is not found, or
-            trees are inconsistent.
+        RuntimeError: If a file cannot be opened or the merge fails.
     """
     if not input_files:
         raise ValueError("input_files must not be empty")
@@ -55,61 +47,137 @@ def merge_files(output_file, input_files, metadata="first"):
     input_files = [str(p) for p in convert_to_str_paths(input_files)]
     output_file = str(convert_to_str_paths(output_file)[0])
 
+    if compression == 0:
+        compression = _first_file_compression(input_files[0])
+
     metadata_info = _detect_metadata(input_files[0])
-
-    hadd = _hadd_path()
-    result = subprocess.run(
-        [hadd, "-f", "-k", output_file] + input_files,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"hadd failed (exit {result.returncode}):\n{result.stderr}")
-
-    # Delete the incorrectly merged metadata category (rewritten below)
-    out_f = ROOT.TFile.Open(output_file, "UPDATE")
-    if not out_f or out_f.IsZombie():
-        raise RuntimeError(f"Cannot open for UPDATE: {output_file}")
-    try:
-        out_f.Delete("metadata;*")
-        out_f.Write("", ROOT.TObject.kOverwrite)
-    finally:
-        out_f.Close()
+    _main_merge(output_file, input_files, compression, metadata_info)
 
     if metadata == "none":
         return
 
-    # Write the corrected metadata category via a temp file, then copy only
-    # the metadata object into the output using TFileMerger
+    # Prepare the corrected metadata frames
     if metadata_info is not None:
-        reader_cls = metadata_info[0]
+        reader_cls, writer_cls = metadata_info
         src_reader = reader_cls([input_files[0]] if metadata == "first" else input_files)
         frames = list(src_reader.get("metadata"))
     else:
+        writer_cls = _detect_writer(input_files[0])
         frames = [Frame()]
 
     for frame in frames:
         frame.put_parameter("MergedInputFiles", list(input_files))
 
-    with tempfile.NamedTemporaryFile(suffix=".root") as tmp_file:
-        # NamedTemporaryFile opens on creation, close so Writer can reopen
-        tmp_file.close()
-        tmp_path = tmp_file.name
-
-        tmp_writer = Writer(tmp_path)
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".root")
+    os.close(tmp_fd)
+    try:
+        tmp_writer = writer_cls(tmp_path)
         for frame in frames:
             tmp_writer.write_frame(frame, "metadata")
-        tmp_writer._writer.finish()
+        tmp_writer.finish()
 
-        m = ROOT.TFileMerger(ROOT.kFALSE)
-        m.OutputFile(output_file, "UPDATE")
-        m.AddFile(tmp_path)
-        m.SetFastMethod(ROOT.kTRUE)
-        m.AddObjectNames("metadata")
-        if not m.PartialMerge(
-            ROOT.TFileMerger.kAll | ROOT.TFileMerger.kOnlyListed | ROOT.TFileMerger.kIncremental
-        ):
-            raise RuntimeError(f"TFileMerger failed adding metadata category to {output_file}")
+        if metadata_info is not None:
+            # Metadata already exists in inputs: podio_metadata from the main
+            # merge already has the right entries. Only merge the metadata
+            # category data tree.
+            merger = ROOT.TFileMerger(ROOT.kFALSE)
+            merger.OutputFile(output_file, "UPDATE")
+            merger.AddFile(tmp_path)
+            merger.SetFastMethod(ROOT.kTRUE)
+            merger.AddObjectNames("metadata")
+            if not merger.PartialMerge(
+                ROOT.TFileMerger.kAll
+                | ROOT.TFileMerger.kOnlyListed
+                | ROOT.TFileMerger.kIncremental
+            ):
+                raise RuntimeError(f"TFileMerger failed adding metadata to {output_file}")
+        else:
+            # Metadata does not exist in inputs. We need to replace
+            # podio_metadata too so the Reader discovers the new category.
+            # The temp file only contains the metadata category, so its
+            # podio_metadata lacks the fields from the output. Rebuild the
+            # temp file with all categories to make the schemas match, then
+            # delete the old podio_metadata and merge the new one.
+            _rebuild_metadata(output_file, tmp_path, writer_cls, frames)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def _first_file_compression(filename):
+    """Return the compression settings of *filename* (like hadd -ff)."""
+    first_file = ROOT.TFile.Open(filename)
+    if first_file and not first_file.IsZombie():
+        compression = first_file.GetCompressionSettings()
+        first_file.Close()
+        return compression
+    return 0
+
+
+def _main_merge(output_file, input_files, compression, metadata_info):
+    """Merge all objects from all input files into *output_file*.
+
+    When metadata already exists in the inputs, skip it during the main
+    merge and write it correctly afterwards, to avoid duplicates.
+    """
+    merger = ROOT.TFileMerger(ROOT.kFALSE)
+    merger.OutputFile(output_file, ROOT.kTRUE, compression)
+    merger.SetFastMethod(ROOT.kTRUE)
+    for fp in input_files:
+        merger.AddFile(fp)
+    flags = ROOT.TFileMerger.kAll
+    if metadata_info is not None:
+        merger.AddObjectNames("metadata")
+        flags |= ROOT.TFileMerger.kSkipListed
+    if not merger.PartialMerge(flags):
+        raise RuntimeError(f"TFileMerger failed merging into {output_file}")
+
+
+def _rebuild_metadata(output_file, tmp_path, writer_cls, frames):
+    """Rebuild temp file with all categories so podio_metadata schemas match.
+
+    The RNTuple merger (and TTree merger for podio_metadata) require
+    matching field/branch structures between source and target.  Writing
+    one frame for each category from the merged output into the temp file
+    ensures the temp file's podio_metadata has all the same fields.
+    """
+    reader_cls = Reader if writer_cls is Writer else RNTupleReader
+    src_reader = reader_cls([output_file])
+
+    # Reopen the temp file with a writer that includes all categories
+    tmp_writer = writer_cls(tmp_path)
+    for frame in frames:
+        tmp_writer.write_frame(frame, "metadata")
+    for cat in src_reader.categories:
+        it = iter(src_reader.get(cat))
+        try:
+            tmp_writer.write_frame(next(it), cat)
+        except StopIteration:
+            pass
+    tmp_writer.finish()
+    del src_reader
+
+    # Delete old podio_metadata so it can be replaced
+    out_f = ROOT.TFile.Open(output_file, "UPDATE")
+    if not out_f or out_f.IsZombie():
+        raise RuntimeError(f"Cannot open for UPDATE: {output_file}")
+    try:
+        out_f.Delete("podio_metadata;*")
+        out_f.Write("", ROOT.TObject.kOverwrite)
+    finally:
+        out_f.Close()
+
+    # Merge metadata + podio_metadata from the rebuilt temp file
+    merger = ROOT.TFileMerger(ROOT.kFALSE)
+    merger.OutputFile(output_file, "UPDATE")
+    merger.AddFile(tmp_path)
+    merger.SetFastMethod(ROOT.kTRUE)
+    merger.AddObjectNames("metadata")
+    merger.AddObjectNames("podio_metadata")
+    if not merger.PartialMerge(
+        ROOT.TFileMerger.kAll | ROOT.TFileMerger.kOnlyListed | ROOT.TFileMerger.kIncremental
+    ):
+        raise RuntimeError(f"TFileMerger failed adding metadata to {output_file}")
 
 
 def _detect_metadata(filename):
@@ -118,18 +186,32 @@ def _detect_metadata(filename):
     Checks both TTrees and RNTuples since metadata may be stored in either
     format depending on how the file was written.
     """
-    f = ROOT.TFile.Open(filename)
-    if not f or f.IsZombie():
+    root_file = ROOT.TFile.Open(filename)
+    if not root_file or root_file.IsZombie():
         raise RuntimeError(f"Cannot open file: {filename}")
     try:
-        for elem in f.GetListOfKeys():
+        for elem in root_file.GetListOfKeys():
             if elem.GetName() != "metadata":
                 continue
             cls = elem.GetClassName()
             if "TTree" in cls:
                 return (Reader, Writer)
             if "RNTuple" in cls:
-                return (RNTupleReader, Writer)
+                return (RNTupleReader, RNTupleWriter)
     finally:
-        f.Close()
+        root_file.Close()
     return None
+
+
+def _detect_writer(filename):
+    """Return the writer class (Writer or RNTupleWriter) for the file backend."""
+    root_file = ROOT.TFile.Open(filename)
+    if not root_file or root_file.IsZombie():
+        raise RuntimeError(f"Cannot open file: {filename}")
+    try:
+        for elem in root_file.GetListOfKeys():
+            if "RNTuple" in elem.GetClassName():
+                return RNTupleWriter
+    finally:
+        root_file.Close()
+    return Writer

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -93,7 +93,7 @@ def merge_files(output_file, input_files, metadata="first"):
         frame.put_parameter("MergedInputFiles", list(input_files))
 
     with tempfile.NamedTemporaryFile(suffix=".root") as tmp_file:
-        tmp_file.close()
+        tmp_file.close()  # release the handle so Writer can open the file below
         tmp_path = tmp_file.name
 
         tmp_writer = Writer(tmp_path)

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -8,12 +8,7 @@ import ROOT
 from podio.frame import Frame
 from podio.utils import convert_to_str_paths
 from podio.reading import get_reader
-from podio.root_io import Reader, RNTupleReader, RNTupleWriter, Writer
-
-_WRITER_FOR_READER = {
-    Reader: Writer,
-    RNTupleReader: RNTupleWriter,
-}
+from podio.root_io import Reader, RNTupleWriter, Writer
 
 
 def merge_files(input_files, output_file, metadata="first", compression=101):
@@ -54,7 +49,7 @@ def merge_files(input_files, output_file, metadata="first", compression=101):
         compression = _first_file_compression(input_files[0])
 
     has_metadata = _has_metadata(input_files[0])
-    _main_merge(output_file, input_files, compression, has_metadata)
+    _main_merge(input_files, output_file, compression, has_metadata)
 
     if metadata == "none":
         return
@@ -62,7 +57,7 @@ def merge_files(input_files, output_file, metadata="first", compression=101):
     # Prepare the corrected metadata frames. get_reader auto-detects the
     # backend, and the matching writer is derived from the reader type.
     src_reader = get_reader(input_files if metadata == "all" else input_files[0])
-    writer_cls = _WRITER_FOR_READER[type(src_reader)]
+    writer_cls = Writer if isinstance(src_reader, Reader) else RNTupleWriter
     if has_metadata:
         frames = list(src_reader.get("metadata"))
     else:
@@ -96,17 +91,7 @@ def merge_files(input_files, output_file, metadata="first", compression=101):
             _rebuild_metadata(output_file, tmp_path, writer_cls, frames)
 
 
-def _first_file_compression(filename):
-    """Return the compression settings of *filename* (like hadd -ff)."""
-    first_file = ROOT.TFile.Open(filename)
-    if first_file and not first_file.IsZombie():
-        compression = first_file.GetCompressionSettings()
-        first_file.Close()
-        return compression
-    return 0
-
-
-def _main_merge(output_file, input_files, compression, has_metadata):
+def _main_merge(input_files, output_file, compression, has_metadata):
     """Merge all objects from all input files into *output_file*.
 
     When metadata already exists in the inputs, skip it during the main
@@ -125,11 +110,21 @@ def _main_merge(output_file, input_files, compression, has_metadata):
         raise RuntimeError(f"TFileMerger failed merging into {output_file}")
 
 
+def _first_file_compression(filename):
+    """Return the compression settings of *filename* (like hadd -ff)."""
+    first_file = ROOT.TFile.Open(filename)
+    if first_file and not first_file.IsZombie():
+        compression = first_file.GetCompressionSettings()
+        first_file.Close()
+        return compression
+    return 0
+
+
 def _rebuild_metadata(output_file, tmp_path, writer_cls, frames):
     """Rebuild temp file with all categories so podio_metadata schemas match.
 
     The RNTuple merger (and TTree merger for podio_metadata) require
-    matching field/branch structures between source and target.  Writing
+    matching field/branch structures between source and target. Writing
     one frame for each category from the merged output into the temp file
     ensures the temp file's podio_metadata has all the same fields.
     """

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -41,8 +41,6 @@ def merge_files(output_file, input_files, metadata="first", compression=101):
     """
     if not input_files:
         raise ValueError("input_files must not be empty")
-    if metadata not in ("first", "all", "none"):
-        raise ValueError(f"metadata must be 'first', 'all', or 'none', got {metadata!r}")
 
     input_files = [str(p) for p in convert_to_str_paths(input_files)]
     output_file = str(convert_to_str_paths(output_file)[0])

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -44,7 +44,7 @@ def _hadd_path():
     return path
 
 
-def _merge_files_impl(output_file, input_files, metadata, get_names_fn, reader_cls, writer_cls, fmt_name):
+def _merge_files_impl(output_file, input_files, metadata, get_names_fn, reader_cls, writer_cls):
     """Common implementation for merge_files and merge_files_rntuple.
 
     Args:
@@ -54,7 +54,6 @@ def _merge_files_impl(output_file, input_files, metadata, get_names_fn, reader_c
         get_names_fn: Callable returning the set of object names in a file.
         reader_cls: Reader class to use (Reader or RNTupleReader).
         writer_cls: Writer class to use (Writer or RNTupleWriter).
-        fmt_name (str): Format label used in error messages (e.g. "TTree").
     """
     has_metadata_cat = "metadata" in get_names_fn(input_files[0])
 
@@ -102,7 +101,7 @@ def _merge_files_impl(output_file, input_files, metadata, get_names_fn, reader_c
         m.SetFastMethod(ROOT.kTRUE)
         m.AddObjectNames("metadata")
         if not m.PartialMerge(ROOT.TFileMerger.kAll | ROOT.TFileMerger.kOnlyListed | ROOT.TFileMerger.kIncremental):
-            raise RuntimeError(f"TFileMerger failed adding metadata {fmt_name} to {output_file}")
+            raise RuntimeError(f"TFileMerger failed adding metadata category to {output_file}")
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
@@ -140,7 +139,7 @@ def merge_files(output_file, input_files, metadata="first"):
     input_files = [str(p) for p in convert_to_str_paths(input_files)]
     output_file = str(convert_to_str_paths(output_file)[0])
 
-    _merge_files_impl(output_file, input_files, metadata, _get_tree_names, Reader, Writer, "TTree")
+    _merge_files_impl(output_file, input_files, metadata, _get_tree_names, Reader, Writer)
 
 
 def merge_files_rntuple(output_file, input_files, metadata="first"):
@@ -175,4 +174,4 @@ def merge_files_rntuple(output_file, input_files, metadata="first"):
     input_files = [str(p) for p in convert_to_str_paths(input_files)]
     output_file = str(convert_to_str_paths(output_file)[0])
 
-    _merge_files_impl(output_file, input_files, metadata, _get_rntuple_names, RNTupleReader, RNTupleWriter, "RNTuple")
+    _merge_files_impl(output_file, input_files, metadata, _get_rntuple_names, RNTupleReader, RNTupleWriter)

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -42,8 +42,8 @@ def merge_files(input_files, output_file, metadata="first", compression=101):
     if not input_files:
         raise ValueError("input_files must not be empty")
 
-    input_files = [str(p) for p in convert_to_str_paths(input_files)]
-    output_file = str(convert_to_str_paths(output_file)[0])
+    input_files = convert_to_str_paths(input_files)
+    output_file = convert_to_str_paths(output_file)[0]
 
     if compression == 0:
         compression = _first_file_compression(input_files[0])

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -67,7 +67,6 @@ def merge_files(output_file, input_files, metadata="first"):
         raise RuntimeError(f"hadd failed (exit {result.returncode}):\n{result.stderr}")
 
     # Delete the incorrectly merged metadata category (rewritten below)
-    # Always delete — hadd merges metadata regardless of TTree/RNTuple format
     out_f = ROOT.TFile.Open(output_file, "UPDATE")
     if not out_f or out_f.IsZombie():
         raise RuntimeError(f"Cannot open for UPDATE: {output_file}")

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -15,27 +15,27 @@ def merge_files(input_files, output_file, metadata="first", compression=101):
     """Merge podio ROOT files.
 
     Uses ROOT's TFileMerger directly for the event data (both TTree and
-    RNTuple), then rewrites the ``metadata`` category correctly
-    (with the ``MergedInputFiles`` parameter set) via an incremental merge.
+    RNTuple), then rewrites the metadata category correctly (with the
+    MergedInputFiles parameter set) via an incremental merge.
 
     All input files must have been written with the same category and
     collection layout.
 
     Args:
-        output_file (str or Path): Path of the output file to create.
         input_files (list[str] or list[Path]): Ordered list of input files.
-        metadata (str): How to handle the ``metadata`` Frame category.
-            ``"first"``  -- copy only the first file's entry (default).
-            ``"all"``    -- copy entries from every file.
-            ``"none"``   -- omit the metadata category entirely.
+        output_file (str or Path): Path of the output file to create.
+        metadata (str): How to handle the metadata Frame category.
+            "first" copies only the first file's entry (default), "all"
+            copies entries from every file, "none" omits the metadata
+            category entirely.
         compression (int): ROOT compression settings for the output file.
-            The format is ``<algorithm>*100 + <level>``, where algorithm is
+            The format is algorithm*100 + level, where algorithm is
             1 (ZLIB), 2 (LZMA), 4 (LZ4) or 5 (ZSTD), and level is 1-9.
-            Defaults to 101 (ZLIB level 1).  Pass 0 to use the compression
+            Defaults to 101 (ZLIB level 1). Pass 0 to use the compression
             of the first input file.
 
     Raises:
-        ValueError: If *input_files* is empty or *metadata* is not one of the
+        ValueError: If input_files is empty or metadata is not one of the
             accepted values.
         RuntimeError: If a file cannot be opened or the merge fails.
     """
@@ -92,7 +92,7 @@ def merge_files(input_files, output_file, metadata="first", compression=101):
 
 
 def _main_merge(input_files, output_file, compression, has_metadata):
-    """Merge all objects from all input files into *output_file*.
+    """Merge all objects from all input files into the output file.
 
     When metadata already exists in the inputs, skip it during the main
     merge and write it correctly afterwards, to avoid duplicates.
@@ -111,7 +111,7 @@ def _main_merge(input_files, output_file, compression, has_metadata):
 
 
 def _first_file_compression(filename):
-    """Return the compression settings of *filename* (like hadd -ff)."""
+    """Return the compression settings of the file (like hadd -ff)."""
     first_file = ROOT.TFile.Open(filename)
     if first_file and not first_file.IsZombie():
         compression = first_file.GetCompressionSettings()
@@ -167,7 +167,7 @@ def _rebuild_metadata(output_file, tmp_path, writer_cls, frames):
 
 
 def _has_metadata(filename):
-    """Return True if a 'metadata' category is present in *filename*."""
+    """Return True if a 'metadata' category is present in the file."""
     root_file = ROOT.TFile.Open(filename)
     if not root_file or root_file.IsZombie():
         raise RuntimeError(f"Cannot open file: {filename}")

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
 """Utilities for merging podio ROOT files (TTree and RNTuple)."""
 
-import os
 import tempfile
 
 import ROOT
 
 from podio.frame import Frame
 from podio.utils import convert_to_str_paths
+from podio.reading import get_reader
 from podio.root_io import Reader, RNTupleReader, RNTupleWriter, Writer
 
+_WRITER_FOR_READER = {
+    Reader: Writer,
+    RNTupleReader: RNTupleWriter,
+}
 
-def merge_files(output_file, input_files, metadata="first", compression=101):
+
+def merge_files(input_files, output_file, metadata="first", compression=101):
     """Merge podio ROOT files.
 
     Uses ROOT's TFileMerger directly for the event data (both TTree and
@@ -48,36 +53,34 @@ def merge_files(output_file, input_files, metadata="first", compression=101):
     if compression == 0:
         compression = _first_file_compression(input_files[0])
 
-    metadata_info = _detect_metadata(input_files[0])
-    _main_merge(output_file, input_files, compression, metadata_info)
+    has_metadata = _has_metadata(input_files[0])
+    _main_merge(output_file, input_files, compression, has_metadata)
 
     if metadata == "none":
         return
 
-    # Prepare the corrected metadata frames
-    if metadata_info is not None:
-        reader_cls, writer_cls = metadata_info
-        src_reader = reader_cls([input_files[0]] if metadata == "first" else input_files)
+    # Prepare the corrected metadata frames. get_reader auto-detects the
+    # backend, and the matching writer is derived from the reader type.
+    src_reader = get_reader(input_files if metadata == "all" else input_files[0])
+    writer_cls = _WRITER_FOR_READER[type(src_reader)]
+    if has_metadata:
         frames = list(src_reader.get("metadata"))
     else:
-        writer_cls = _detect_writer(input_files[0])
         frames = [Frame()]
 
     for frame in frames:
         frame.put_parameter("MergedInputFiles", list(input_files))
 
-    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".root")
-    os.close(tmp_fd)
-    try:
+    with tempfile.NamedTemporaryFile(suffix=".root") as tmp_file:
+        tmp_file.close()
+        tmp_path = tmp_file.name
+
         tmp_writer = writer_cls(tmp_path)
         for frame in frames:
             tmp_writer.write_frame(frame, "metadata")
         tmp_writer.finish()
 
-        if metadata_info is not None:
-            # Metadata already exists in inputs: podio_metadata from the main
-            # merge already has the right entries. Only merge the metadata
-            # category data tree.
+        if has_metadata:
             merger = ROOT.TFileMerger(ROOT.kFALSE)
             merger.OutputFile(output_file, "UPDATE")
             merger.AddFile(tmp_path)
@@ -90,16 +93,7 @@ def merge_files(output_file, input_files, metadata="first", compression=101):
             ):
                 raise RuntimeError(f"TFileMerger failed adding metadata to {output_file}")
         else:
-            # Metadata does not exist in inputs. We need to replace
-            # podio_metadata too so the Reader discovers the new category.
-            # The temp file only contains the metadata category, so its
-            # podio_metadata lacks the fields from the output. Rebuild the
-            # temp file with all categories to make the schemas match, then
-            # delete the old podio_metadata and merge the new one.
             _rebuild_metadata(output_file, tmp_path, writer_cls, frames)
-    finally:
-        if os.path.exists(tmp_path):
-            os.unlink(tmp_path)
 
 
 def _first_file_compression(filename):
@@ -112,7 +106,7 @@ def _first_file_compression(filename):
     return 0
 
 
-def _main_merge(output_file, input_files, compression, metadata_info):
+def _main_merge(output_file, input_files, compression, has_metadata):
     """Merge all objects from all input files into *output_file*.
 
     When metadata already exists in the inputs, skip it during the main
@@ -124,7 +118,7 @@ def _main_merge(output_file, input_files, compression, metadata_info):
     for fp in input_files:
         merger.AddFile(fp)
     flags = ROOT.TFileMerger.kAll
-    if metadata_info is not None:
+    if has_metadata:
         merger.AddObjectNames("metadata")
         flags |= ROOT.TFileMerger.kSkipListed
     if not merger.PartialMerge(flags):
@@ -139,8 +133,7 @@ def _rebuild_metadata(output_file, tmp_path, writer_cls, frames):
     one frame for each category from the merged output into the temp file
     ensures the temp file's podio_metadata has all the same fields.
     """
-    reader_cls = Reader if writer_cls is Writer else RNTupleReader
-    src_reader = reader_cls([output_file])
+    src_reader = get_reader(output_file)
 
     # Reopen the temp file with a writer that includes all categories
     tmp_writer = writer_cls(tmp_path)
@@ -178,38 +171,11 @@ def _rebuild_metadata(output_file, tmp_path, writer_cls, frames):
         raise RuntimeError(f"TFileMerger failed adding metadata to {output_file}")
 
 
-def _detect_metadata(filename):
-    """Return (reader_cls, writer_cls) if 'metadata' exists, or None.
-
-    Checks both TTrees and RNTuples since metadata may be stored in either
-    format depending on how the file was written.
-    """
+def _has_metadata(filename):
+    """Return True if a 'metadata' category is present in *filename*."""
     root_file = ROOT.TFile.Open(filename)
     if not root_file or root_file.IsZombie():
         raise RuntimeError(f"Cannot open file: {filename}")
-    try:
-        for elem in root_file.GetListOfKeys():
-            if elem.GetName() != "metadata":
-                continue
-            cls = elem.GetClassName()
-            if "TTree" in cls:
-                return (Reader, Writer)
-            if "RNTuple" in cls:
-                return (RNTupleReader, RNTupleWriter)
-    finally:
-        root_file.Close()
-    return None
-
-
-def _detect_writer(filename):
-    """Return the writer class (Writer or RNTupleWriter) for the file backend."""
-    root_file = ROOT.TFile.Open(filename)
-    if not root_file or root_file.IsZombie():
-        raise RuntimeError(f"Cannot open file: {filename}")
-    try:
-        for elem in root_file.GetListOfKeys():
-            if "RNTuple" in elem.GetClassName():
-                return RNTupleWriter
-    finally:
-        root_file.Close()
-    return Writer
+    has_metadata = any(elem.GetName() == "metadata" for elem in root_file.GetListOfKeys())
+    root_file.Close()
+    return has_metadata

--- a/python/podio/root_merge.py
+++ b/python/podio/root_merge.py
@@ -10,27 +10,7 @@ import ROOT
 
 from podio.frame import Frame
 from podio.utils import convert_to_str_paths
-from podio.root_io import Reader, RNTupleReader, RNTupleWriter, Writer
-
-
-def _get_tree_names(filename):
-    """Return the names of all TTrees in a ROOT file"""
-    f = ROOT.TFile.Open(filename)
-    if not f or f.IsZombie():
-        raise RuntimeError(f"Cannot open file: {filename}")
-    names = {elem.GetName() for elem in f.GetListOfKeys() if elem.GetClassName() == "TTree"}
-    f.Close()
-    return names
-
-
-def _get_rntuple_names(filename):
-    """Return the names of all RNTuples in a ROOT file"""
-    f = ROOT.TFile.Open(filename)
-    if not f or f.IsZombie():
-        raise RuntimeError(f"Cannot open file: {filename}")
-    names = {elem.GetName() for elem in f.GetListOfKeys() if elem.GetClassName() == "ROOT::RNTuple"}
-    f.Close()
-    return names
+from podio.root_io import Reader, RNTupleReader, Writer
 
 
 def _hadd_path():
@@ -44,75 +24,12 @@ def _hadd_path():
     return path
 
 
-def _merge_files_impl(output_file, input_files, metadata, get_names_fn, reader_cls, writer_cls):
-    """Common implementation for merge_files and merge_files_rntuple.
-
-    Args:
-        output_file (str): Path of the output file to create.
-        input_files (list[str]): Ordered list of input files (already str).
-        metadata (str): ``"first"``, ``"all"``, or ``"none"``.
-        get_names_fn: Callable returning the set of object names in a file.
-        reader_cls: Reader class to use (Reader or RNTupleReader).
-        writer_cls: Writer class to use (Writer or RNTupleWriter).
-    """
-    has_metadata_cat = "metadata" in get_names_fn(input_files[0])
-
-    hadd = _hadd_path()
-    result = subprocess.run([hadd, "-f", "-k", output_file] + input_files, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(f"hadd failed (exit {result.returncode}):\n{result.stderr}")
-
-    # Delete the incorrectly merged metadata category (rewritten below)
-    out_f = ROOT.TFile.Open(output_file, "UPDATE")
-    if not out_f or out_f.IsZombie():
-        raise RuntimeError(f"Cannot open for UPDATE: {output_file}")
-    try:
-        if has_metadata_cat:
-            out_f.Delete("metadata;*")
-        out_f.Write("", ROOT.TObject.kOverwrite)
-    finally:
-        out_f.Close()
-
-    if metadata == "none":
-        return
-
-    # Write the corrected metadata category via a temp file, then copy only
-    # the metadata object into the output using TFileMerger
-    if has_metadata_cat:
-        src_reader = reader_cls([input_files[0]] if metadata == "first" else input_files)
-        frames = list(src_reader.get("metadata"))
-    else:
-        frames = [Frame()]
-
-    for frame in frames:
-        frame.put_parameter("MergedInputFiles", list(input_files))
-
-    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".root")
-    os.close(tmp_fd)
-    try:
-        tmp_writer = writer_cls(tmp_path)
-        for frame in frames:
-            tmp_writer.write_frame(frame, "metadata")
-        tmp_writer._writer.finish()
-
-        m = ROOT.TFileMerger(ROOT.kFALSE)
-        m.OutputFile(output_file, "UPDATE")
-        m.AddFile(tmp_path)
-        m.SetFastMethod(ROOT.kTRUE)
-        m.AddObjectNames("metadata")
-        if not m.PartialMerge(ROOT.TFileMerger.kAll | ROOT.TFileMerger.kOnlyListed | ROOT.TFileMerger.kIncremental):
-            raise RuntimeError(f"TFileMerger failed adding metadata category to {output_file}")
-    finally:
-        if os.path.exists(tmp_path):
-            os.unlink(tmp_path)
-
-
 def merge_files(output_file, input_files, metadata="first"):
-    """Merge podio TTree files.
+    """Merge podio ROOT files.
 
-    Uses hadd for the event data, then rewrites the ``metadata`` category
-    (with the ``MergedInputFiles`` parameter set) via a temp file
-    and TFileMerger.
+    Uses hadd for the event data (both TTree and RNTuple), then rewrites the
+    ``metadata`` category (with the ``MergedInputFiles`` parameter set) via
+    a temp file and TFileMerger.
 
     All input files must have been written with the same category and
     collection layout.
@@ -121,9 +38,9 @@ def merge_files(output_file, input_files, metadata="first"):
         output_file (str or Path): Path of the output file to create.
         input_files (list[str] or list[Path]): Ordered list of input files.
         metadata (str): How to handle the ``metadata`` Frame category.
-            ``"first"``  – copy only the first file's entry (default).
-            ``"all"``    – copy entries from every file.
-            ``"none"``   – omit the metadata category entirely.
+            ``"first"``  -- copy only the first file's entry (default).
+            ``"all"``    -- copy entries from every file.
+            ``"none"``   -- omit the metadata category entirely.
 
     Raises:
         ValueError: If *input_files* is empty or *metadata* is not one of the
@@ -139,39 +56,83 @@ def merge_files(output_file, input_files, metadata="first"):
     input_files = [str(p) for p in convert_to_str_paths(input_files)]
     output_file = str(convert_to_str_paths(output_file)[0])
 
-    _merge_files_impl(output_file, input_files, metadata, _get_tree_names, Reader, Writer)
+    metadata_info = _detect_metadata(input_files[0])
+
+    hadd = _hadd_path()
+    result = subprocess.run(
+        [hadd, "-f", "-k", output_file] + input_files,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"hadd failed (exit {result.returncode}):\n{result.stderr}")
+
+    # Delete the incorrectly merged metadata category (rewritten below)
+    # Always delete — hadd merges metadata regardless of TTree/RNTuple format
+    out_f = ROOT.TFile.Open(output_file, "UPDATE")
+    if not out_f or out_f.IsZombie():
+        raise RuntimeError(f"Cannot open for UPDATE: {output_file}")
+    try:
+        out_f.Delete("metadata;*")
+        out_f.Write("", ROOT.TObject.kOverwrite)
+    finally:
+        out_f.Close()
+
+    if metadata == "none":
+        return
+
+    # Write the corrected metadata category via a temp file, then copy only
+    # the metadata object into the output using TFileMerger
+    if metadata_info is not None:
+        reader_cls = metadata_info[0]
+        src_reader = reader_cls([input_files[0]] if metadata == "first" else input_files)
+        frames = list(src_reader.get("metadata"))
+    else:
+        frames = [Frame()]
+
+    for frame in frames:
+        frame.put_parameter("MergedInputFiles", list(input_files))
+
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".root")
+    os.close(tmp_fd)
+    try:
+        tmp_writer = Writer(tmp_path)
+        for frame in frames:
+            tmp_writer.write_frame(frame, "metadata")
+        tmp_writer._writer.finish()
+
+        m = ROOT.TFileMerger(ROOT.kFALSE)
+        m.OutputFile(output_file, "UPDATE")
+        m.AddFile(tmp_path)
+        m.SetFastMethod(ROOT.kTRUE)
+        m.AddObjectNames("metadata")
+        if not m.PartialMerge(
+            ROOT.TFileMerger.kAll | ROOT.TFileMerger.kOnlyListed | ROOT.TFileMerger.kIncremental
+        ):
+            raise RuntimeError(f"TFileMerger failed adding metadata category to {output_file}")
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
-def merge_files_rntuple(output_file, input_files, metadata="first"):
-    """Merge podio RNTuple files.
+def _detect_metadata(filename):
+    """Return (reader_cls, writer_cls) if 'metadata' exists, or None.
 
-    Uses hadd for the event data, then rewrites the ``metadata`` category
-    (with the ``MergedInputFiles`` parameter set) via a temp file
-    and TFileMerger.
-
-    All input files must have been written with the same category and
-    collection layout.
-
-    Args:
-        output_file (str or Path): Path of the output file to create.
-        input_files (list[str] or list[Path]): Ordered list of input files.
-        metadata (str): How to handle the ``metadata`` Frame category.
-            ``"first"``  – copy only the first file's entry (default).
-            ``"all"``    – copy entries from every file.
-            ``"none"``   – omit the metadata category entirely.
-
-    Raises:
-        ValueError: If *input_files* is empty or *metadata* is not one of the
-            accepted values.
-        RuntimeError: If a file cannot be opened, hadd is not found, or
-            ntuples are inconsistent.
+    Checks both TTrees and RNTuples since metadata may be stored in either
+    format depending on how the file was written.
     """
-    if not input_files:
-        raise ValueError("input_files must not be empty")
-    if metadata not in ("first", "all", "none"):
-        raise ValueError(f"metadata must be 'first', 'all', or 'none', got {metadata!r}")
-
-    input_files = [str(p) for p in convert_to_str_paths(input_files)]
-    output_file = str(convert_to_str_paths(output_file)[0])
-
-    _merge_files_impl(output_file, input_files, metadata, _get_rntuple_names, RNTupleReader, RNTupleWriter)
+    f = ROOT.TFile.Open(filename)
+    if not f or f.IsZombie():
+        raise RuntimeError(f"Cannot open file: {filename}")
+    try:
+        for elem in f.GetListOfKeys():
+            if elem.GetName() != "metadata":
+                continue
+            cls = elem.GetClassName()
+            if "TTree" in cls:
+                return (Reader, Writer)
+            if "RNTuple" in cls:
+                return (RNTupleReader, Writer)
+    finally:
+        f.Close()
+    return None

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -22,8 +22,9 @@ args = parser.parse_args()
 
 # Import podio later for quick help messages
 import podio  # pylint: disable=wrong-import-position # noqa: E402
-import podio.root_io  # pylint: disable=wrong-import-position # noqa: E402
 from podio import reading  # pylint: disable=wrong-import-position # noqa: E402
+from podio.root_io import Reader, RNTupleReader  # pylint: disable=wrong-import-position # noqa: E402
+from podio.root_merge import merge_files, merge_files_rntuple  # pylint: disable=wrong-import-position # noqa: E402
 
 all_files = set()
 for f in args.files:
@@ -32,37 +33,40 @@ for f in args.files:
     all_files.add(f)
 
 reader = reading.get_reader(args.files)
-if isinstance(reader, podio.root_io.Reader):
-    writer = podio.root_io.Writer(args.output_file)
-elif isinstance(reader, podio.root_io.RNTupleReader):
-    writer = podio.root_io.RNTupleWriter(args.output_file)
+
+if isinstance(reader, Reader):
+    merge_files(args.output_file, args.files, metadata=args.metadata)
+elif isinstance(reader, RNTupleReader):
+    merge_files_rntuple(args.output_file, args.files, metadata=args.metadata)
 else:
-    raise ValueError(f"Input file {args.files[0]} is not a TTree or RNTuple file")
+    # Slow path: frame-by-frame copy
+    from podio import sio_io  # pylint: disable=wrong-import-position # noqa: E402
+    writer = sio_io.Writer(args.output_file)
 
-categories = list(reader.categories)
-is_metadata_available = True  # pylint: disable=invalid-name
-try:
-    # All frames will be copied as they are except the metadata ones
-    categories.remove("metadata")
-except ValueError:
-    is_metadata_available = False  # pylint: disable=invalid-name
+    categories = list(reader.categories)
+    is_metadata_available = True  # pylint: disable=invalid-name
+    try:
+        # All frames will be copied as they are except the metadata ones
+        categories.remove("metadata")
+    except ValueError:
+        is_metadata_available = False  # pylint: disable=invalid-name
 
-for category in tqdm(categories):
-    all_frames = reader.get(category)
-    for frame in tqdm(all_frames, desc=f"Merging category '{category}'"):
-        writer.write_frame(frame, category)
+    for category in tqdm(categories):
+        all_frames = reader.get(category)
+        for frame in tqdm(all_frames, desc=f"Merging category '{category}'"):
+            writer.write_frame(frame, category)
 
-if args.metadata == "none":
-    sys.exit(0)
+    if args.metadata == "none":
+        sys.exit(0)
 
-if not is_metadata_available:
-    print("Warning: metadata category 'metadata' not found in the input files, it will be created")
-    all_frames = [podio.Frame()]
-else:
-    if args.metadata == "first":
-        all_frames = [reader.get("metadata")[0]]
+    if not is_metadata_available:
+        print("Warning: metadata category 'metadata' not found in the input files, it will be created")
+        all_frames = [podio.Frame()]
     else:
-        all_frames = reader.get("metadata")
-for frame in all_frames:
-    frame.put_parameter("MergedInputFiles", args.files)
-    writer.write_frame(frame, "metadata")
+        if args.metadata == "first":
+            all_frames = [reader.get("metadata")[0]]
+        else:
+            all_frames = reader.get("metadata")
+    for frame in all_frames:
+        frame.put_parameter("MergedInputFiles", args.files)
+        writer.write_frame(frame, "metadata")

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -42,7 +42,7 @@ for f in args.files:
 first = args.files[0]
 
 if first.endswith(".root"):
-    merge_files(args.output_file, args.files, metadata=args.metadata, compression=args.compression)
+    merge_files(args.files, args.output_file, metadata=args.metadata, compression=args.compression)
 elif first.endswith(".sio"):
     # Slow path: frame-by-frame copy
     from podio import reading  # pylint: disable=wrong-import-position # noqa: E402

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -22,15 +22,7 @@ args = parser.parse_args()
 
 # Import podio later for quick help messages
 import podio  # pylint: disable=wrong-import-position # noqa: E402
-from podio import reading  # pylint: disable=wrong-import-position # noqa: E402
-from podio.root_io import (
-    Reader,
-    RNTupleReader,
-)  # pylint: disable=wrong-import-position # noqa: E402
-from podio.root_merge import (
-    merge_files,
-    merge_files_rntuple,
-)  # pylint: disable=wrong-import-position # noqa: E402
+from podio.root_merge import merge_files  # pylint: disable=wrong-import-position # noqa: E402
 
 all_files = set()
 for f in args.files:
@@ -38,16 +30,16 @@ for f in args.files:
         raise ValueError(f"File {f} is present more than once in the input list")
     all_files.add(f)
 
-reader = reading.get_reader(args.files)
+first = args.files[0]
 
-if isinstance(reader, Reader):
+if first.endswith(".root"):
     merge_files(args.output_file, args.files, metadata=args.metadata)
-elif isinstance(reader, RNTupleReader):
-    merge_files_rntuple(args.output_file, args.files, metadata=args.metadata)
-else:
+elif first.endswith(".sio"):
     # Slow path: frame-by-frame copy
+    from podio import reading  # pylint: disable=wrong-import-position # noqa: E402
     from podio import sio_io  # pylint: disable=wrong-import-position # noqa: E402
 
+    reader = reading.get_reader(args.files)
     writer = sio_io.Writer(args.output_file)
 
     categories = list(reader.categories)
@@ -68,7 +60,8 @@ else:
 
     if not is_metadata_available:
         print(
-            "Warning: metadata category 'metadata' not found in the input files, it will be created"
+            "Warning: metadata category 'metadata' not found in the input files,"
+            " it will be created"
         )
         all_frames = [podio.Frame()]
     else:
@@ -79,3 +72,5 @@ else:
     for frame in all_frames:
         frame.put_parameter("MergedInputFiles", args.files)
         writer.write_frame(frame, "metadata")
+else:
+    raise ValueError(f"Unsupported file type: {first}. Supported types: .root, .sio")

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -18,6 +18,15 @@ parser.add_argument(
     help="metadata to include in the output file, default: "
     "only the one from the first file, other options: all files, none",
 )
+parser.add_argument(
+    "-c",
+    "--compression",
+    type=int,
+    default=101,
+    help="ROOT compression settings for the output file "
+    "(<algorithm>*100 + <level>). 1=ZLIB, 2=LZMA, 4=LZ4, 5=ZSTD. "
+    "Default: 101 (ZLIB level 1). Pass 0 to use the first input file's compression.",
+)
 args = parser.parse_args()
 
 # Import podio later for quick help messages
@@ -33,7 +42,7 @@ for f in args.files:
 first = args.files[0]
 
 if first.endswith(".root"):
-    merge_files(args.output_file, args.files, metadata=args.metadata)
+    merge_files(args.output_file, args.files, metadata=args.metadata, compression=args.compression)
 elif first.endswith(".sio"):
     # Slow path: frame-by-frame copy
     from podio import reading  # pylint: disable=wrong-import-position # noqa: E402

--- a/tools/podio-merge-files
+++ b/tools/podio-merge-files
@@ -23,8 +23,14 @@ args = parser.parse_args()
 # Import podio later for quick help messages
 import podio  # pylint: disable=wrong-import-position # noqa: E402
 from podio import reading  # pylint: disable=wrong-import-position # noqa: E402
-from podio.root_io import Reader, RNTupleReader  # pylint: disable=wrong-import-position # noqa: E402
-from podio.root_merge import merge_files, merge_files_rntuple  # pylint: disable=wrong-import-position # noqa: E402
+from podio.root_io import (
+    Reader,
+    RNTupleReader,
+)  # pylint: disable=wrong-import-position # noqa: E402
+from podio.root_merge import (
+    merge_files,
+    merge_files_rntuple,
+)  # pylint: disable=wrong-import-position # noqa: E402
 
 all_files = set()
 for f in args.files:
@@ -41,6 +47,7 @@ elif isinstance(reader, RNTupleReader):
 else:
     # Slow path: frame-by-frame copy
     from podio import sio_io  # pylint: disable=wrong-import-position # noqa: E402
+
     writer = sio_io.Writer(args.output_file)
 
     categories = list(reader.categories)
@@ -60,7 +67,9 @@ else:
         sys.exit(0)
 
     if not is_metadata_available:
-        print("Warning: metadata category 'metadata' not found in the input files, it will be created")
+        print(
+            "Warning: metadata category 'metadata' not found in the input files, it will be created"
+        )
         all_frames = [podio.Frame()]
     else:
         if args.metadata == "first":


### PR DESCRIPTION
Currently `podio-merge-files` reads every Frame and writes it back. This is very slow (between 10x and 100x) compared to using `hadd`; I would say unusable. For TTrees and RNTuples, our files can be merged with `hadd`, producing readable files with the only caveat that there are some categories that may be repeated a few times, like metadata. The new implementation is equivalent to what we had before, but much faster.

BEGINRELEASENOTES
- Use `TFileMerger` with ROOT files in `podio-merge-files` to speed it up and add code to make sure the metadata is set correctly. Keep the old behaviour for the other backends (SIO only).

ENDRELEASENOTES

@meleneemil