### PR TITLE
Extract common members into a common base

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -155,7 +155,7 @@ ALWAYS_DETAILED_SEC    = NO
 # operators of the base classes will not be shown.
 # The default value is: NO.
 
-INLINE_INHERITED_MEMB  = NO
+INLINE_INHERITED_MEMB  = YES
 
 # If the FULL_PATH_NAMES tag is set to YES, doxygen will prepend the full path
 # before files name in the file list and in the header files. If set to NO the

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -2,8 +2,7 @@
 #define PODIO_RNTUPLEREADER_H
 
 #include "podio/ROOTFrameData.h"
-#include "podio/podioVersion.h"
-#include "podio/utilities/DatamodelRegistryIOHelpers.h"
+#include "podio/utilities/ReaderCommon.h"
 #include "podio/utilities/RootHelpers.h"
 
 #include <string>
@@ -32,7 +31,7 @@ namespace root_compat {
 ///
 /// The RNTupleReader provides the data as ROOTFrameData from which a podio::Frame
 /// can be constructed. It can be used to read files written by the RNTupleWriter.
-class RNTupleReader {
+class RNTupleReader : public ReaderCommon {
 
 public:
   RNTupleReader() = default;
@@ -103,41 +102,6 @@ public:
   /// @returns The number of entries that are available for the category
   unsigned getEntries(std::string_view name) const;
 
-  /// Get the build version of podio that has been used to write the current
-  /// file
-  ///
-  /// @returns The podio build version
-  podio::version::Version currentFileVersion() const {
-    return m_fileVersion;
-  }
-
-  /// Get the (build) version of a datamodel that has been used to write the
-  /// current file
-  ///
-  /// @param name The name of the datamodel
-  ///
-  /// @returns The (build) version of the datamodel if available or an empty
-  ///          optional
-  std::optional<podio::version::Version> currentFileVersion(std::string_view name) const {
-    return m_datamodelHolder.getDatamodelVersion(name);
-  }
-
-  /// Get the datamodel definition for the given name
-  ///
-  /// @param name The name of the datamodel
-  ///
-  /// @returns The high level definition of the datamodel in JSON format
-  const std::string_view getDatamodelDefinition(std::string_view name) const {
-    return m_datamodelHolder.getDatamodelDefinition(name);
-  }
-
-  /// Get all names of the datamodels that are available from this reader
-  ///
-  /// @returns The names of the datamodels
-  std::vector<std::string> getAvailableDatamodels() const {
-    return m_datamodelHolder.getAvailableDatamodels();
-  }
-
 private:
   /**
    * Initialize the given category by filling the maps with metadata information
@@ -151,9 +115,6 @@ private:
   GenericParameters readEventMetaData(root_compat::RNTupleReader* reader, const unsigned localEntry);
 
   std::unique_ptr<root_compat::RNTupleReader> m_metadata{};
-
-  podio::version::Version m_fileVersion{};
-  DatamodelDefinitionHolder m_datamodelHolder{};
 
   std::unordered_map<std::string_view, std::vector<std::unique_ptr<root_compat::RNTupleReader>>> m_readers{};
   std::unordered_map<std::string, std::unique_ptr<root_compat::RNTupleReader>> m_metadata_readers{};

--- a/include/podio/RNTupleReader.h
+++ b/include/podio/RNTupleReader.h
@@ -90,11 +90,6 @@ public:
   std::unique_ptr<podio::ROOTFrameData> readEntry(std::string_view name, const unsigned entry,
                                                   const std::vector<std::string>& collsToRead = {});
 
-  /// Get the names of all the available Frame categories in the current file(s).
-  ///
-  /// @returns The names of the available categores from the file
-  std::vector<std::string_view> getAvailableCategories() const;
-
   /// Get the number of entries for the given name
   ///
   /// @param name The name of the category
@@ -130,8 +125,6 @@ private:
 
   /// Map each category to the collections that have been written and are available
   std::unordered_map<std::string_view, std::vector<podio::root_utils::CollectionWriteInfo>> m_collectionInfo{};
-
-  std::vector<std::string> m_availableCategories{};
 
   std::unordered_map<std::string_view, std::shared_ptr<podio::CollectionIDTable>> m_idTables{};
 };

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -2,8 +2,7 @@
 #define PODIO_ROOTREADER_H
 
 #include "podio/ROOTFrameData.h"
-#include "podio/podioVersion.h"
-#include "podio/utilities/DatamodelRegistryIOHelpers.h"
+#include "podio/utilities/ReaderCommon.h"
 #include "podio/utilities/ReaderUtils.h"
 #include "podio/utilities/RootHelpers.h"
 
@@ -46,7 +45,7 @@ struct CollectionReadBuffers;
 ///
 /// The ROOTReader provides the data as ROOTFrameData from which a podio::Frame
 /// can be constructed. It can be used to read files written by the ROOTWriter.
-class ROOTReader {
+class ROOTReader : public ReaderCommon {
 
 public:
   ROOTReader() = default;
@@ -112,45 +111,11 @@ public:
   /// @returns The number of entries that are available for the category
   unsigned getEntries(std::string_view name) const;
 
-  /// Get the build version of podio that has been used to write the current
-  /// file
-  ///
-  /// @returns The podio build version
-  podio::version::Version currentFileVersion() const {
-    return m_fileVersion;
-  }
-
-  /// Get the (build) version of a datamodel that has been used to write the
-  /// current file
-  ///
-  /// @param name The name of the datamodel
-  ///
-  /// @returns The (build) version of the datamodel if available or an empty
-  ///          optional
-  std::optional<podio::version::Version> currentFileVersion(std::string_view name) const {
-    return m_datamodelHolder.getDatamodelVersion(name);
-  }
-
   /// Get the names of all the available Frame categories in the current file(s).
   ///
   /// @returns The names of the available categories from the file
   std::vector<std::string_view> getAvailableCategories() const;
 
-  /// Get the datamodel definition for the given name
-  ///
-  /// @param name The name of the datamodel
-  ///
-  /// @returns The high level definition of the datamodel in JSON format
-  const std::string_view getDatamodelDefinition(std::string_view name) const {
-    return m_datamodelHolder.getDatamodelDefinition(name);
-  }
-
-  /// Get all names of the datamodels that are available from this reader
-  ///
-  /// @returns The names of the datamodels
-  std::vector<std::string> getAvailableDatamodels() const {
-    return m_datamodelHolder.getAvailableDatamodels();
-  }
   std::optional<std::map<std::string, SizeStats>> getSizeStats(std::string_view category);
 
 private:
@@ -201,9 +166,6 @@ private:
   std::unique_ptr<TChain> m_metaChain{nullptr};                      ///< The metadata tree
   std::unordered_map<std::string_view, CategoryInfo> m_categories{}; ///< All categories
   std::vector<std::string> m_availCategories{};                      ///< All available categories from this file
-
-  podio::version::Version m_fileVersion{0, 0, 0};
-  DatamodelDefinitionHolder m_datamodelHolder{};
 };
 
 } // namespace podio

--- a/include/podio/ROOTReader.h
+++ b/include/podio/ROOTReader.h
@@ -111,11 +111,6 @@ public:
   /// @returns The number of entries that are available for the category
   unsigned getEntries(std::string_view name) const;
 
-  /// Get the names of all the available Frame categories in the current file(s).
-  ///
-  /// @returns The names of the available categories from the file
-  std::vector<std::string_view> getAvailableCategories() const;
-
   std::optional<std::map<std::string, SizeStats>> getSizeStats(std::string_view category);
 
 private:
@@ -165,7 +160,6 @@ private:
 
   std::unique_ptr<TChain> m_metaChain{nullptr};                      ///< The metadata tree
   std::unordered_map<std::string_view, CategoryInfo> m_categories{}; ///< All categories
-  std::vector<std::string> m_availCategories{};                      ///< All available categories from this file
 };
 
 } // namespace podio

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -3,8 +3,7 @@
 
 #include "podio/SIOBlock.h"
 #include "podio/SIOFrameData.h"
-#include "podio/podioVersion.h"
-#include "podio/utilities/DatamodelRegistryIOHelpers.h"
+#include "podio/utilities/ReaderCommon.h"
 
 #include <sio/definitions.h>
 
@@ -22,7 +21,7 @@ class CollectionIDTable;
 ///
 /// The SIOReader provides the data as SIOFrameData from which a podio::Frame
 /// can be constructed. It can be used to read files written by the SIOWriter.
-class SIOReader {
+class SIOReader : public ReaderCommon {
 
 public:
   /// Create an SIOReader
@@ -83,45 +82,10 @@ public:
   /// @param filename The path to the file to read from
   void openFile(const std::string& filename);
 
-  /// Get the build version of podio that has been used to write the current
-  /// file
-  ///
-  /// @returns The podio build version
-  podio::version::Version currentFileVersion() const {
-    return m_fileVersion;
-  }
-
-  /// Get the (build) version of a datamodel that has been used to write the
-  /// current file
-  ///
-  /// @param name The name of the datamodel
-  ///
-  /// @returns The (build) version of the datamodel if available or an empty
-  ///          optional
-  std::optional<podio::version::Version> currentFileVersion(std::string_view name) const {
-    return m_datamodelHolder.getDatamodelVersion(name);
-  }
-
   /// Get the names of all the available Frame categories in the current file.
   ///
   /// @returns The names of the available categores from the file
   std::vector<std::string_view> getAvailableCategories() const;
-
-  /// Get the datamodel definition for the given name
-  ///
-  /// @param name The name of the datamodel
-  ///
-  /// @returns The high level definition of the datamodel in JSON format
-  const std::string_view getDatamodelDefinition(std::string_view name) const {
-    return m_datamodelHolder.getDatamodelDefinition(name);
-  }
-
-  /// Get all names of the datamodels that are available from this reader
-  ///
-  /// @returns The names of the datamodels
-  std::vector<std::string> getAvailableDatamodels() const {
-    return m_datamodelHolder.getAvailableDatamodels();
-  }
 
 private:
   void readPodioHeader();
@@ -138,10 +102,6 @@ private:
 
   /// Table of content record where starting points of named entries can be read from
   SIOFileTOCRecord m_tocRecord{};
-  /// The podio version that has been used to write the file
-  podio::version::Version m_fileVersion{0};
-
-  DatamodelDefinitionHolder m_datamodelHolder{};
 };
 
 } // namespace podio

--- a/include/podio/SIOReader.h
+++ b/include/podio/SIOReader.h
@@ -82,11 +82,6 @@ public:
   /// @param filename The path to the file to read from
   void openFile(const std::string& filename);
 
-  /// Get the names of all the available Frame categories in the current file.
-  ///
-  /// @returns The names of the available categores from the file
-  std::vector<std::string_view> getAvailableCategories() const;
-
 private:
   void readPodioHeader();
 

--- a/include/podio/utilities/ReaderCommon.h
+++ b/include/podio/utilities/ReaderCommon.h
@@ -1,0 +1,62 @@
+#ifndef PODIO_UTILITIES_READERCOMMON_H
+#define PODIO_UTILITIES_READERCOMMON_H
+
+#include "podio/podioVersion.h"
+#include "podio/utilities/DatamodelRegistryIOHelpers.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace podio {
+
+/// Common base class for podio reader classes providing the shared members and
+/// functionality related to the file version and the datamodel definitions.
+///
+/// The population of the members is left to the derived reader classes.
+class ReaderCommon {
+public:
+  /// Get the build version of podio that has been used to write the current
+  /// file
+  ///
+  /// @returns The podio build version
+  podio::version::Version currentFileVersion() const {
+    return m_fileVersion;
+  }
+
+  /// Get the (build) version of a datamodel that has been used to write the
+  /// current file
+  ///
+  /// @param name The name of the datamodel
+  ///
+  /// @returns The (build) version of the datamodel if available or an empty
+  ///          optional
+  std::optional<podio::version::Version> currentFileVersion(std::string_view name) const {
+    return m_datamodelHolder.getDatamodelVersion(name);
+  }
+
+  /// Get the datamodel definition for the given name
+  ///
+  /// @param name The name of the datamodel
+  ///
+  /// @returns The high level definition of the datamodel in JSON format
+  const std::string_view getDatamodelDefinition(std::string_view name) const {
+    return m_datamodelHolder.getDatamodelDefinition(name);
+  }
+
+  /// Get all names of the datamodels that are available from this reader
+  ///
+  /// @returns The names of the datamodels
+  std::vector<std::string> getAvailableDatamodels() const {
+    return m_datamodelHolder.getAvailableDatamodels();
+  }
+
+protected:
+  podio::version::Version m_fileVersion{};
+  DatamodelDefinitionHolder m_datamodelHolder{};
+};
+
+} // namespace podio
+
+#endif // PODIO_UTILITIES_READERCOMMON_H

--- a/include/podio/utilities/ReaderCommon.h
+++ b/include/podio/utilities/ReaderCommon.h
@@ -52,9 +52,22 @@ public:
     return m_datamodelHolder.getAvailableDatamodels();
   }
 
+  /// Get the names of all the available Frame categories in the current file(s).
+  ///
+  /// @returns The names of the available categories from the file
+  std::vector<std::string_view> getAvailableCategories() const {
+    std::vector<std::string_view> categories;
+    categories.reserve(m_availableCategories.size());
+    for (const auto& category : m_availableCategories) {
+      categories.emplace_back(category);
+    }
+    return categories;
+  }
+
 protected:
   podio::version::Version m_fileVersion{};
   DatamodelDefinitionHolder m_datamodelHolder{};
+  std::vector<std::string> m_availableCategories{};
 };
 
 } // namespace podio

--- a/include/podio/utilities/ReaderCommon.h
+++ b/include/podio/utilities/ReaderCommon.h
@@ -56,12 +56,7 @@ public:
   ///
   /// @returns The names of the available categories from the file
   std::vector<std::string_view> getAvailableCategories() const {
-    std::vector<std::string_view> categories;
-    categories.reserve(m_availableCategories.size());
-    for (const auto& category : m_availableCategories) {
-      categories.emplace_back(category);
-    }
-    return categories;
+    return std::vector<std::string_view>(m_availableCategories.cbegin(), m_availableCategories.cend());
   }
 
 protected:

--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -129,15 +129,6 @@ unsigned RNTupleReader::getEntries(std::string_view name) const {
   return 0;
 }
 
-std::vector<std::string_view> RNTupleReader::getAvailableCategories() const {
-  std::vector<std::string_view> cats;
-  cats.reserve(m_availableCategories.size());
-  for (const auto& cat : m_availableCategories) {
-    cats.emplace_back(cat);
-  }
-  return cats;
-}
-
 std::unique_ptr<ROOTFrameData> RNTupleReader::readNextEntry(std::string_view category,
                                                             const std::vector<std::string>& collsToRead) {
   return readEntry(category, m_entries[category], collsToRead);

--- a/src/ROOTReader.cc
+++ b/src/ROOTReader.cc
@@ -331,8 +331,8 @@ void ROOTReader::openFiles(const std::vector<std::string>& filenames) {
   // Do some work up front for setting up categories and setup all the chains
   // and record the available categories. The rest of the setup follows on
   // demand when the category is first read
-  m_availCategories = ::podio::getAvailableCategories(m_metaChain.get());
-  for (const auto& cat : m_availCategories) {
+  m_availableCategories = ::podio::getAvailableCategories(m_metaChain.get());
+  for (const auto& cat : m_availableCategories) {
     const auto [it, _] = m_categories.try_emplace(cat, std::make_unique<TChain>(cat.c_str()));
     for (const auto& fn : filenames) {
       it->second.chain->Add(fn.c_str());
@@ -346,15 +346,6 @@ unsigned ROOTReader::getEntries(std::string_view name) const {
   }
 
   return 0;
-}
-
-std::vector<std::string_view> ROOTReader::getAvailableCategories() const {
-  std::vector<std::string_view> cats;
-  cats.reserve(m_categories.size());
-  for (const auto& [cat, _] : m_categories) {
-    cats.emplace_back(cat);
-  }
-  return cats;
 }
 
 std::tuple<std::vector<root_utils::CollectionBranches>, std::vector<detail::NamedCollInfo>>

--- a/src/SIOReader.cc
+++ b/src/SIOReader.cc
@@ -22,6 +22,16 @@ void SIOReader::openFile(const std::string& filename) {
 
   // NOTE: reading TOC record first because that jumps back to the start of the file!
   readFileTOCRecord();
+  // Filter the available records from the TOC to remove records that are
+  // stored, but use reserved record names for podio meta data
+  const auto recordNames = m_tocRecord.getRecordNames();
+  m_availableCategories.clear();
+  m_availableCategories.reserve(recordNames.size());
+  for (const auto recordName : recordNames) {
+    if (recordName != sio_helpers::SIOEDMDefinitionName) {
+      m_availableCategories.emplace_back(recordName);
+    }
+  }
   readPodioHeader();
   readEDMDefinitions(); // Potentially could do this lazily
 }
@@ -55,16 +65,6 @@ std::unique_ptr<SIOFrameData> SIOReader::readEntry(std::string_view name, const 
   //       All checks are done in the following function
   m_nameCtr[std::string(name)] = entry;
   return readNextEntry(name, collsToRead);
-}
-
-std::vector<std::string_view> SIOReader::getAvailableCategories() const {
-  // Filter the available records from the TOC to remove records that are
-  // stored, but use reserved record names for podio meta data
-  auto recordNames = m_tocRecord.getRecordNames();
-  recordNames.erase(std::remove_if(recordNames.begin(), recordNames.end(),
-                                   [](const auto& elem) { return elem == sio_helpers::SIOEDMDefinitionName; }),
-                    recordNames.end());
-  return recordNames;
 }
 
 unsigned SIOReader::getEntries(std::string_view name) const {


### PR DESCRIPTION
Members related to file version and datamodels contained in files are the same for all readers and some commonly available member functions are also shared across all readers.



BEGINRELEASENOTES
- Extract common functionality related to file versions and datamodels into a `ReaderCommon` utility class.

ENDRELEASENOTES

Somewhat useful output regardless of whether #953 gets merged or not.