### PR TITLE
Add I/O tests that run on multiple threads

### DIFF
--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -80,6 +80,11 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
       read_python_with_rdatasource_root
       param_reading_rdataframe
 
+      write_frame_root_multithreaded
+      read_frame_root_multithreaded
+      write_frame_rntuple_multithreaded
+      read_frame_rntuple_multithreaded
+
       read_python_multiple
       write_python_empty_colls_root
       write_python_frame_root

--- a/tests/CTestCustom.cmake
+++ b/tests/CTestCustom.cmake
@@ -82,8 +82,8 @@ if ((NOT "@FORCE_RUN_ALL_TESTS@" STREQUAL "ON") AND (NOT "@USE_SANITIZER@" STREQ
 
       write_frame_root_multithreaded
       read_frame_root_multithreaded
-      write_frame_rntuple_multithreaded
-      read_frame_rntuple_multithreaded
+      write_rntuple_multithreaded
+      read_rntuple_multithreaded
 
       read_python_multiple
       write_python_empty_colls_root

--- a/tests/read_frame_multithreaded.h
+++ b/tests/read_frame_multithreaded.h
@@ -130,11 +130,14 @@ int read_frames_multithreaded(const std::string& filename, int nThreads, unsigne
             break;
           }
 
-          podio::Frame frame;
+          using FrameDataPtrT = decltype(std::declval<ReaderT>().readEntry("", 0));
+          FrameDataPtrT frameData{nullptr};
           {
             std::lock_guard<std::mutex> lock(readerMutex);
-            frame = podio::Frame(reader.readEntry("events", entry));
+            frameData = reader.readEntry("events", entry);
           }
+
+          podio::Frame frame{std::move(frameData)};
           // Verify frame content in parallel (no lock needed)
           const auto& info = frame.get<EventInfoCollection>("info");
           const int frameId = info[0].Number();

--- a/tests/read_frame_multithreaded.h
+++ b/tests/read_frame_multithreaded.h
@@ -1,0 +1,150 @@
+#ifndef PODIO_TESTS_READ_FRAME_MULTITHREADED_H // NOLINT(llvm-header-guard): folder structure not suitable
+#define PODIO_TESTS_READ_FRAME_MULTITHREADED_H // NOLINT(llvm-header-guard): folder structure not suitable
+
+#include "datamodel/EventInfoCollection.h"
+#include "datamodel/ExampleClusterCollection.h"
+#include "datamodel/ExampleHitCollection.h"
+#include "datamodel/ExampleMCCollection.h"
+
+#include "podio/Frame.h"
+#include "podio/UserDataCollection.h"
+
+#include <atomic>
+#include <iostream>
+#include <mutex>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+/// Verify that a Frame's content matches what createRandomFrame would have
+/// produced for the given frameId. Returns 0 on success, 1 on failure.
+int checkRandomFrame(const podio::Frame& frame, int frameId) {
+  std::mt19937 rng(frameId);
+  // Same distributions as in makeMTFrame
+  std::uniform_int_distribution<int> hitCountDist(1, 10);
+  std::uniform_int_distribution<int> clusterCountDist(1, 5);
+  std::uniform_int_distribution<int> mcCountDist(1, 8);
+  std::uniform_int_distribution<int> userDataCountDist(1, 15);
+  std::uniform_real_distribution<double> realDist(-100.0, 100.0);
+  std::uniform_int_distribution<int> intDist(0, 1000);
+
+  const int expectedHits = hitCountDist(rng);
+  const auto& hits = frame.get<ExampleHitCollection>("hits");
+  if (hits.size() != static_cast<size_t>(expectedHits)) {
+    std::cerr << "Frame " << frameId << ": expected " << expectedHits << " hits, got " << hits.size() << std::endl;
+    return 1;
+  }
+  for (int i = 0; i < expectedHits; ++i) {
+    const auto expectedCellID = static_cast<unsigned long long>(intDist(rng));
+    const double expectedX = realDist(rng);
+    const double expectedY = realDist(rng);
+    const double expectedZ = realDist(rng);
+    const double expectedEnergy = realDist(rng);
+    if (hits[i].cellID() != expectedCellID || hits[i].x() != expectedX || hits[i].y() != expectedY ||
+        hits[i].z() != expectedZ || hits[i].energy() != expectedEnergy) {
+      std::cerr << "Frame " << frameId << ": hit " << i << " data mismatch\n"
+                << "  cellID:  expected=" << expectedCellID << " actual=" << hits[i].cellID() << "\n"
+                << "  x:       expected=" << expectedX << " actual=" << hits[i].x() << "\n"
+                << "  y:       expected=" << expectedY << " actual=" << hits[i].y() << "\n"
+                << "  z:       expected=" << expectedZ << " actual=" << hits[i].z() << "\n"
+                << "  energy:  expected=" << expectedEnergy << " actual=" << hits[i].energy() << std::endl;
+      return 1;
+    }
+  }
+
+  const int expectedClusters = clusterCountDist(rng);
+  const auto& clusters = frame.get<ExampleClusterCollection>("clusters");
+  if (clusters.size() != static_cast<size_t>(expectedClusters)) {
+    std::cerr << "Frame " << frameId << ": expected " << expectedClusters << " clusters, got " << clusters.size()
+              << std::endl;
+    return 1;
+  }
+  for (int i = 0; i < expectedClusters; ++i) {
+    const double expectedEnergy = realDist(rng);
+    if (clusters[i].energy() != expectedEnergy) {
+      std::cerr << "Frame " << frameId << ": cluster " << i << " energy mismatch"
+                << " (expected=" << expectedEnergy << " actual=" << clusters[i].energy() << ")" << std::endl;
+      return 1;
+    }
+  }
+
+  const int expectedMCs = mcCountDist(rng);
+  const auto& mcparticles = frame.get<ExampleMCCollection>("mcparticles");
+  if (mcparticles.size() != static_cast<size_t>(expectedMCs)) {
+    std::cerr << "Frame " << frameId << ": expected " << expectedMCs << " mcparticles, got " << mcparticles.size()
+              << std::endl;
+    return 1;
+  }
+  for (int i = 0; i < expectedMCs; ++i) {
+    const double expectedEnergy = realDist(rng);
+    const int expectedPDG = intDist(rng);
+    if (mcparticles[i].energy() != expectedEnergy || mcparticles[i].PDG() != expectedPDG) {
+      std::cerr << "Frame " << frameId << ": mcparticle " << i << " data mismatch\n"
+                << "  energy:  expected=" << expectedEnergy << " actual=" << mcparticles[i].energy() << "\n"
+                << "  PDG:     expected=" << expectedPDG << " actual=" << mcparticles[i].PDG() << std::endl;
+      return 1;
+    }
+  }
+
+  const int expectedUserDoubles = userDataCountDist(rng);
+  const auto& userDoubles = frame.get<podio::UserDataCollection<double>>("userDoubles");
+  if (userDoubles.size() != static_cast<size_t>(expectedUserDoubles)) {
+    std::cerr << "Frame " << frameId << ": expected " << expectedUserDoubles << " userDoubles, got "
+              << userDoubles.size() << std::endl;
+    return 1;
+  }
+  for (int i = 0; i < expectedUserDoubles; ++i) {
+    const double expectedVal = realDist(rng);
+    if (userDoubles[i] != expectedVal) {
+      std::cerr << "Frame " << frameId << ": userDouble " << i << " value mismatch"
+                << " (expected=" << expectedVal << " actual=" << userDoubles[i] << ")" << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+template <typename ReaderT>
+int read_frames_multithreaded(const std::string& filename, int nThreads, unsigned expectedEntries) {
+  ReaderT reader;
+  reader.openFile(filename);
+
+  if (reader.getEntries("events") != expectedEntries) {
+    std::cerr << "Expected " << expectedEntries << " entries, got " << reader.getEntries("events") << std::endl;
+    return 1;
+  }
+
+  std::mutex readerMutex;
+  std::atomic<unsigned> nextEntry{0};
+  std::atomic<int> failures{0};
+
+  {
+    std::vector<std::jthread> threads;
+    for (int t = 0; t < nThreads; ++t) {
+      threads.emplace_back([&]() {
+        while (true) {
+          const unsigned entry = nextEntry.fetch_add(1);
+          if (entry >= expectedEntries) {
+            break;
+          }
+
+          podio::Frame frame;
+          {
+            std::lock_guard<std::mutex> lock(readerMutex);
+            frame = podio::Frame(reader.readEntry("events", entry));
+          }
+          // Verify frame content in parallel (no lock needed)
+          const auto& info = frame.get<EventInfoCollection>("info");
+          const int frameId = info[0].Number();
+          failures += checkRandomFrame(frame, frameId);
+        }
+      });
+    }
+  }
+
+  return failures.load();
+}
+
+#endif // PODIO_TESTS_READ_FRAME_MULTITHREADED_H

--- a/tests/read_frame_multithreaded.h
+++ b/tests/read_frame_multithreaded.h
@@ -15,6 +15,7 @@
 #include <random>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 /// Verify that a Frame's content matches what createRandomFrame would have

--- a/tests/root_io/CMakeLists.txt
+++ b/tests/root_io/CMakeLists.txt
@@ -11,6 +11,8 @@ set(root_dependent_tests
   read_glob.cpp
   selected_colls_roundtrip_root.cpp
   write_empty_collections_root.cpp
+  write_frame_root_multithreaded.cpp
+  read_frame_root_multithreaded.cpp
   )
 if(ENABLE_RNTUPLE)
   set(root_dependent_tests
@@ -21,6 +23,8 @@ if(ENABLE_RNTUPLE)
       write_interface_rntuple.cpp
       read_interface_rntuple.cpp
       selected_colls_roundtrip_rntuple.cpp
+      write_rntuple_multithreaded.cpp
+      read_rntuple_multithreaded.cpp
      )
 endif()
 if(ENABLE_DATASOURCE)
@@ -38,12 +42,15 @@ foreach( sourcefile ${root_dependent_tests} )
 endforeach()
 
 set_tests_properties(write_frame_root PROPERTIES FIXTURES_SETUP podio_write_root_fixture)
+set_tests_properties(write_frame_root_multithreaded PROPERTIES FIXTURES_SETUP podio_write_root_mt_fixture)
 set_tests_properties(write_interface_root PROPERTIES FIXTURES_SETUP podio_write_interface_root_fixture)
 set_tests_properties(read_interface_root PROPERTIES FIXTURES_REQUIRED podio_write_interface_root_fixture)
+set_tests_properties(read_frame_root_multithreaded PROPERTIES FIXTURES_REQUIRED podio_write_root_mt_fixture)
 
 
 if(ENABLE_RNTUPLE)
   set_tests_properties(write_rntuple PROPERTIES FIXTURES_SETUP podio_write_rntuple_fixture)
+  set_tests_properties(write_rntuple_multithreaded PROPERTIES FIXTURES_SETUP podio_write_rntuple_mt_fixture)
   set_tests_properties(write_interface_rntuple PROPERTIES FIXTURES_SETUP podio_write_interface_rntuple_fixture)
 endif()
 
@@ -74,6 +81,7 @@ if(ENABLE_RNTUPLE)
     PROPERTIES
       FIXTURES_REQUIRED podio_write_rntuple_fixture
   )
+  set_tests_properties(read_rntuple_multithreaded PROPERTIES FIXTURES_REQUIRED podio_write_rntuple_mt_fixture)
   set_tests_properties(read_interface_rntuple PROPERTIES FIXTURES_REQUIRED podio_write_interface_rntuple_fixture)
 
   add_test(NAME write_interface_default_rntuple COMMAND write_interface_root example_frame_interface_default_rntuple.root)

--- a/tests/root_io/read_frame_root_multithreaded.cpp
+++ b/tests/root_io/read_frame_root_multithreaded.cpp
@@ -1,0 +1,19 @@
+#include "read_frame_multithreaded.h"
+
+#include "podio/ROOTReader.h"
+
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  int nThreads = 4;
+  int framesPerThread = 10;
+  if (argc >= 2) {
+    nThreads = std::atoi(argv[1]);
+  }
+  if (argc >= 3) {
+    framesPerThread = std::atoi(argv[2]);
+  }
+
+  const unsigned expectedEntries = nThreads * framesPerThread;
+  return read_frames_multithreaded<podio::ROOTReader>("example_frame_multithreaded.root", nThreads, expectedEntries);
+}

--- a/tests/root_io/read_rntuple_multithreaded.cpp
+++ b/tests/root_io/read_rntuple_multithreaded.cpp
@@ -1,0 +1,20 @@
+#include "read_frame_multithreaded.h"
+
+#include "podio/RNTupleReader.h"
+
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  int nThreads = 4;
+  int framesPerThread = 10;
+  if (argc >= 2) {
+    nThreads = std::atoi(argv[1]);
+  }
+  if (argc >= 3) {
+    framesPerThread = std::atoi(argv[2]);
+  }
+
+  const unsigned expectedEntries = nThreads * framesPerThread;
+  return read_frames_multithreaded<podio::RNTupleReader>("example_rntuple_multithreaded.root", nThreads,
+                                                         expectedEntries);
+}

--- a/tests/root_io/write_frame_root_multithreaded.cpp
+++ b/tests/root_io/write_frame_root_multithreaded.cpp
@@ -1,0 +1,18 @@
+#include "write_frame_multithreaded.h"
+
+#include "podio/ROOTWriter.h"
+
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  int nThreads = 4;
+  int framesPerThread = 10;
+  if (argc >= 2) {
+    nThreads = std::atoi(argv[1]);
+  }
+  if (argc >= 3) {
+    framesPerThread = std::atoi(argv[2]);
+  }
+
+  return write_frames_multithreaded<podio::ROOTWriter>("example_frame_multithreaded.root", nThreads, framesPerThread);
+}

--- a/tests/root_io/write_rntuple_multithreaded.cpp
+++ b/tests/root_io/write_rntuple_multithreaded.cpp
@@ -1,0 +1,19 @@
+#include "write_frame_multithreaded.h"
+
+#include "podio/RNTupleWriter.h"
+
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  int nThreads = 4;
+  int framesPerThread = 10;
+  if (argc >= 2) {
+    nThreads = std::atoi(argv[1]);
+  }
+  if (argc >= 3) {
+    framesPerThread = std::atoi(argv[2]);
+  }
+
+  return write_frames_multithreaded<podio::RNTupleWriter>("example_rntuple_multithreaded.root", nThreads,
+                                                          framesPerThread);
+}

--- a/tests/sio_io/CMakeLists.txt
+++ b/tests/sio_io/CMakeLists.txt
@@ -6,6 +6,8 @@ set(sio_dependent_tests
   write_interface_sio.cpp
   read_interface_sio.cpp
   selected_colls_roundtrip_sio.cpp
+  write_frame_sio_multithreaded.cpp
+  read_frame_sio_multithreaded.cpp
 )
 set(sio_libs podio::podioSioIO podio::podioIO)
 foreach( sourcefile ${sio_dependent_tests} )
@@ -13,6 +15,7 @@ foreach( sourcefile ${sio_dependent_tests} )
 endforeach()
 
 set_tests_properties(write_frame_sio PROPERTIES FIXTURES_SETUP podio_write_sio_fixture)
+set_tests_properties(write_frame_sio_multithreaded PROPERTIES FIXTURES_SETUP podio_write_sio_mt_fixture)
 set_tests_properties(write_interface_sio PROPERTIES FIXTURES_SETUP podio_write_interface_sio_fixture)
 
 set_tests_properties(
@@ -25,6 +28,7 @@ set_tests_properties(
 )
 
 set_tests_properties(read_interface_sio PROPERTIES FIXTURES_REQUIRED podio_write_interface_sio_fixture)
+set_tests_properties(read_frame_sio_multithreaded PROPERTIES FIXTURES_REQUIRED podio_write_sio_mt_fixture)
 
 #--- Write via python and the SIO backend and see if we can read it back in in
 #--- c++

--- a/tests/sio_io/read_frame_sio_multithreaded.cpp
+++ b/tests/sio_io/read_frame_sio_multithreaded.cpp
@@ -1,0 +1,19 @@
+#include "read_frame_multithreaded.h"
+
+#include "podio/SIOReader.h"
+
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  int nThreads = 4;
+  int framesPerThread = 10;
+  if (argc >= 2) {
+    nThreads = std::atoi(argv[1]);
+  }
+  if (argc >= 3) {
+    framesPerThread = std::atoi(argv[2]);
+  }
+
+  const unsigned expectedEntries = nThreads * framesPerThread;
+  return read_frames_multithreaded<podio::SIOReader>("example_frame_sio_multithreaded.sio", nThreads, expectedEntries);
+}

--- a/tests/sio_io/write_frame_sio_multithreaded.cpp
+++ b/tests/sio_io/write_frame_sio_multithreaded.cpp
@@ -1,0 +1,18 @@
+#include "write_frame_multithreaded.h"
+
+#include "podio/SIOWriter.h"
+
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  int nThreads = 4;
+  int framesPerThread = 10;
+  if (argc >= 2) {
+    nThreads = std::atoi(argv[1]);
+  }
+  if (argc >= 3) {
+    framesPerThread = std::atoi(argv[2]);
+  }
+
+  return write_frames_multithreaded<podio::SIOWriter>("example_frame_sio_multithreaded.sio", nThreads, framesPerThread);
+}

--- a/tests/write_frame_multithreaded.h
+++ b/tests/write_frame_multithreaded.h
@@ -1,0 +1,105 @@
+#ifndef PODIO_TESTS_WRITE_FRAME_MULTITHREADED_H // NOLINT(llvm-header-guard): folder structure not suitable
+#define PODIO_TESTS_WRITE_FRAME_MULTITHREADED_H // NOLINT(llvm-header-guard): folder structure not suitable
+
+#include "datamodel/EventInfoCollection.h"
+#include "datamodel/ExampleClusterCollection.h"
+#include "datamodel/ExampleHitCollection.h"
+#include "datamodel/ExampleMCCollection.h"
+
+#include "podio/Frame.h"
+#include "podio/UserDataCollection.h"
+
+#include <atomic>
+#include <mutex>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+/// Create a Frame with deterministic but varied content based on frameId. The
+/// frameId is stored in the EventInfo collection so that we can generate the
+/// same random number sequence when reading the frame back for checking
+podio::Frame createRandomFrame(int frameId) {
+  std::mt19937 rng(frameId);
+  // Distributions for collection sizes
+  std::uniform_int_distribution<int> hitCountDist(1, 10);
+  std::uniform_int_distribution<int> clusterCountDist(1, 5);
+  std::uniform_int_distribution<int> mcCountDist(1, 8);
+  std::uniform_int_distribution<int> userDataCountDist(1, 15);
+  // Distributions for data values
+  std::uniform_real_distribution<double> realDist(-100.0, 100.0);
+  std::uniform_int_distribution<int> intDist(0, 1000);
+
+  podio::Frame frame{};
+
+  EventInfoCollection info;
+  auto infoItem = info.create();
+  infoItem.Number(frameId);
+  frame.put(std::move(info), "info");
+
+  const int nHits = hitCountDist(rng);
+  ExampleHitCollection hits;
+  for (int i = 0; i < nHits; ++i) {
+    const auto cellID = static_cast<unsigned long long>(intDist(rng));
+    const double x = realDist(rng);
+    const double y = realDist(rng);
+    const double z = realDist(rng);
+    const double energy = realDist(rng);
+    hits.create(cellID, x, y, z, energy);
+  }
+  frame.put(std::move(hits), "hits");
+
+  const int nClusters = clusterCountDist(rng);
+  ExampleClusterCollection clusters;
+  for (int i = 0; i < nClusters; ++i) {
+    clusters.create(realDist(rng));
+  }
+  frame.put(std::move(clusters), "clusters");
+
+  const int nMCs = mcCountDist(rng);
+  ExampleMCCollection mcparticles;
+  for (int i = 0; i < nMCs; ++i) {
+    const double energy = realDist(rng);
+    const int pdg = intDist(rng);
+    mcparticles.create(energy, pdg);
+  }
+  frame.put(std::move(mcparticles), "mcparticles");
+
+  const int nUserDoubles = userDataCountDist(rng);
+  podio::UserDataCollection<double> userDoubles;
+  userDoubles.resize(nUserDoubles);
+  for (int i = 0; i < nUserDoubles; ++i) {
+    userDoubles[i] = realDist(rng);
+  }
+  frame.put(std::move(userDoubles), "userDoubles");
+
+  return frame;
+}
+
+template <typename WriterT>
+int write_frames_multithreaded(const std::string& filename, int nThreads, int framesPerThread) {
+  WriterT writer(filename);
+  std::mutex writerMutex;
+  std::atomic<int> frameCounter{0};
+  {
+    std::vector<std::jthread> threads;
+    for (int t = 0; t < nThreads; ++t) {
+      threads.emplace_back([&]() {
+        for (int f = 0; f < framesPerThread; ++f) {
+          const int frameId = frameCounter.fetch_add(1);
+          auto frame = createRandomFrame(frameId);
+
+          {
+            std::lock_guard<std::mutex> lock(writerMutex);
+            writer.writeFrame(frame, "events");
+          }
+        }
+      });
+    }
+  }
+
+  writer.finish();
+  return 0;
+}
+
+#endif // PODIO_TESTS_WRITE_FRAME_MULTITHREADED_H


### PR DESCRIPTION
BEGINRELEASENOTES
- Add tests that run I/O on multiple threads

ENDRELEASENOTES

These tests build / read Frames on multiple threads serializing the I/O part (as per design). They effectively check whether the Frame construction as well as the retrival of buffers from the `FrameData` is done properly when running under TSan. They do not check whether accessing a single Frame from multiple threads is thread safe that is covered by unit tests.

This was something that I would have liked to do for quite some time, and due to https://github.com/AIDASoft/podio/pull/940 it has become possible to actually run these under the sanitizers so that there is some actual checks behind it as well.