### PR TITLE
Remove the deprecated getValue() in Interfaces

### DIFF
--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -159,12 +159,6 @@ public:
     return static_cast<Model<T>*>(m_self.get())->m_value;
   }
 
-  template<typename T>
-  [[deprecated("Use 'as' instead.")]]
-  T getValue() const {
-    return as<T>();
-  }
-
   friend bool operator==(const {{ class.bare_type }}& lhs, const {{ class.bare_type }}& rhs) {
     return lhs.m_self->equal(rhs.m_self.get());
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the deprecated getValue() in Interfaces

ENDRELEASENOTES

Deprecated for about two years now, since version 1.0. I think `getValue` existed in a non-deprecated state for a very short time.