### PR TITLE
Remove the deprecated getter without "get" before the name

### DIFF
--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -34,11 +34,6 @@
 {% endif %}
   /// Get mutable reference to {{ member.docstring }}
   {{ member.full_type }}& {{ member.getter_name(get_syntax) }}();
-{% if get_syntax %}
-  /// Get reference to {{ member.docstring }}
-  [[deprecated("use {{ member.getter_name(get_syntax) }} instead")]]
-  {{ member.full_type }}& {{ member.name }}();
-{% endif %}
 {% if member.sub_members %}
 {% for sub_member in member.sub_members %}
 {% if sub_member.is_builtin %}

--- a/python/templates/macros/implementations.jinja2
+++ b/python/templates/macros/implementations.jinja2
@@ -87,9 +87,6 @@ void {{ class_type }}::{{ member.setter_name(get_syntax) }}({{ member.signature 
 void {{ class_type }}::{{ member.setter_name(get_syntax) }}(size_t i, {{ member.array_type }} value) { m_obj->data.{{ member.name }}.at(i) = value; }
 {% endif %}
 {{ member.full_type }}& {{ class_type }}::{{ member.getter_name(get_syntax) }}() { return m_obj->data.{{ member.name }}; }
-{% if get_syntax %}
-{{ member.full_type }}& {{ class_type }}::{{ member.name }}() {  return m_obj->data.{{ member.name }}; }
-{% endif %}
 {% if member.sub_members %}
 {% for sub_member in member.sub_members %}
 void {{ class_type }}::{{ sub_member.setter_name(get_syntax) }}({{ sub_member.full_type }} value) { m_obj->data.{{ member.name }}.{{ sub_member.name }} = value; }


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the deprecated getter without "get" before the name

ENDRELEASENOTES


Deprecated for two years, since 0.99.