### PR TITLE
Remove the deprecated method isValid for Collections

### DIFF
--- a/include/podio/CollectionBase.h
+++ b/include/podio/CollectionBase.h
@@ -48,8 +48,6 @@ public:
 
   virtual bool hasID() const = 0;
 
-  virtual bool isValid() const = 0;
-
   /// number of elements in the collection
   virtual size_t size() const = 0;
 

--- a/include/podio/UserDataCollection.h
+++ b/include/podio/UserDataCollection.h
@@ -157,12 +157,6 @@ public:
         getID() != static_cast<uint32_t>(podio::ObjectID::invalid);
   }
 
-  [[deprecated("isValid will be removed, use hasID() if you want to check if it has an ID, otherwise assume the "
-               "collection is valid")]]
-  bool isValid() const override {
-    return hasID();
-  }
-
   /// number of elements in the collection
   size_t size() const override {
     return _vec.size();

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -261,12 +261,6 @@ public:
         getID() != static_cast<uint32_t>(podio::ObjectID::invalid);
   }
 
-  [[deprecated("isValid will be removed, use hasID() if you want to check if it has an ID, otherwise assume the "
-               "collection is valid")]]
-  bool isValid() const override {
-    return hasID();
-  }
-
   podio::CollectionWriteBuffers getBuffers() override {
     return m_storage.getCollectionBuffers(m_isSubsetColl);
   }

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -298,12 +298,6 @@ public:
         getID() != static_cast<uint32_t>(podio::ObjectID::invalid);
   }
 
-  [[deprecated("isValid will be removed, use hasID() if you want to check if it has an ID, otherwise assume the "
-               "collection is valid")]]
-  bool isValid() const override {
-    return hasID();
-  }
-
   podio::CollectionWriteBuffers getBuffers() override {
     return m_storage.getCollectionBuffers(m_isSubsetColl);
   }

--- a/python/templates/Collection.h.jinja2
+++ b/python/templates/Collection.h.jinja2
@@ -161,12 +161,6 @@ public:
         getID() != static_cast<uint32_t>(podio::ObjectID::invalid);
   }
 
-  [[deprecated("isValid will be removed, use hasID() if you want to check if it has an ID, otherwise assume the "
-               "collection is valid")]]
-  bool isValid() const final {
-    return hasID();
-  }
-
   size_t getDatamodelRegistryIndex() const final;
 
   // support for the iterator protocol


### PR DESCRIPTION
BEGINRELEASENOTES
- **Remove** the method **`isValid`** for Collections (generated and library provided). **Use `hasID`** if you want to check if a collection has been assigned a collection id, otherwise assume a collection is valid.

ENDRELEASENOTES

Deprecated since 1.06, removed once we get another tag.