### PR TITLE
Change CI to use Clang22 instead of Clang19, soon unsupported

### DIFF
--- a/.github/workflows/edm4hep.yaml
+++ b/.github/workflows/edm4hep.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         LCG: ["LCG_107/x86_64-el9-gcc13-opt",
               "dev4/x86_64-el9-gcc15-opt",
-              "dev3/x86_64-el9-clang19-opt"]
+              "dev3/x86_64-el9-clang22-opt"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc15, clang19]
+        compiler: [gcc15, clang22]
         # Since Leak is usually part of Address, we do not run it separately in
         # CI. Keeping Address and Undefined separate for easier debugging
         sanitizer: [Thread,

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc15, clang22]
+        compiler: [gcc15, clang19]
         # Since Leak is usually part of Address, we do not run it separately in
         # CI. Keeping Address and Undefined separate for easier debugging
         sanitizer: [Thread,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         LCG: ["dev3/x86_64-el9-gcc15-opt",
-              "dev4/x86_64-el9-clang19-opt",
+              "dev4/x86_64-el9-clang22-opt",
               "dev4/x86_64-el9-gcc15-opt",
               "LCG_108/x86_64-el9-gcc15-opt",  # root 6.36.02 with c++23
               "LCG_107/x86_64-el9-gcc13-opt",  # root 6.34.02 !minimal root version for RNTuple


### PR DESCRIPTION
BEGINRELEASENOTES
- Change CI to use Clang22 instead of Clang19, soon unsupported

ENDRELEASENOTES