### PR TITLE
Fix compilation with fmt 12.2.0 by including a missing fmt/ranges.h

### DIFF
--- a/tools/src/tabulate.h
+++ b/tools/src/tabulate.h
@@ -2,9 +2,9 @@
 #define PODIO_TOOLS_TABULATE_H // NOLINT(llvm-header-guard): folder structure not suitable
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <algorithm>
-#include <iostream>
 #include <iterator>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix compilation with fmt 12.2.0 by including a missing fmt/ranges.h

ENDRELEASENOTES

With GCC 16:
``` cpp
/podio/tools/src/tabulate.h:27:66: error: ‘format’ is not a member of ‘fmt’ [-Wtemplate-body]
   27 |     std::apply([&strs](auto&&... args) { (strs.emplace_back(fmt::format("{}", args)), ...); }, elem);
      |                                                                  ^~~~~~
/podio/tools/src/tabulate.h:27:87: error: operand of fold expression has no unexpanded parameter packs [-Wtemplate-body]
   27 |     std::apply([&strs](auto&&... args) { (strs.emplace_back(fmt::format("{}", args)), ...); }, elem);
      |                                                                                       ^~~
ninja: build stopped: subcommand failed.
```

With Clang 22:

``` cpp
/podio/tools/src/tabulate.h:27:66: error: no member named 'format' in namespace 'fmt'
   27 |     std::apply([&strs](auto&&... args) { (strs.emplace_back(fmt::format("{}", args)), ...); }, elem);
      |                                                                  ^~~~~~
/podio/tools/src/tabulate.h:27:87: error: pack expansion does not contain any unexpanded parameter packs
   27 |     std::apply([&strs](auto&&... args) { (strs.emplace_back(fmt::format("{}", args)), ...); }, elem);
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^
/podio/tools/src/tabulate.h:27:18: warning: lambda capture 'strs' is not used [-Wunused-lambda-capture]
   27 |     std::apply([&strs](auto&&... args) { (strs.emplace_back(fmt::format("{}", args)), ...); }, elem);
      |                  ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2890:7: note: in instantiation of function template specialization 'printTable(const std::vector<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::basic_string_view<char, std::char_traits<char>>, unsigned long, std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::basic_string<char, std::char_traits<char>, std::allocator<char>>>> &, const std::vector<std::string> &)::(lambda)::operator()<std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long, std::basic_string<char>, std::basic_string<char>>>' requested here
 2890 |       std::declval<_Fn>()(std::declval<_Args>()...)
      |       ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2901:29: note: while substituting deduced template arguments into function template '_S_test' [with _Fn = (lambda at /podio/tools/src/tabulate.h:24:64) &, _Args = (no value)]
 2901 |       using type = decltype(_S_test<_Functor, _ArgTypes...>(0));
      |                             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2907:14: note: in instantiation of template class 'std::__result_of_impl<false, false, (lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long, std::basic_string<char>, std::basic_string<char>> &>' requested here
 2907 |     : public __result_of_impl<
      |              ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3270:29: note: in instantiation of template class 'std::__invoke_result<(lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long, std::basic_string<char>, std::basic_string<char>> &>' requested here
 3270 |                                __void_t<typename _Result::type>>
      |                                                  ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3421:7: note: during template argument deduction for class template partial specialization '__is_invocable_impl<_Result, _Ret, true, __void_t<typename _Result::type>>' [with _Result = std::__invoke_result<(lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long, std::basic_string<char>, std::basic_string<char>> &>, _Ret = void]
 3421 |     : __is_invocable_impl<__invoke_result<_Fn, _ArgTypes...>, void>::type
      |       ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3421:7: note: (skipping 6 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/iterator_concepts.h:585:35: note: while substituting template arguments into constraint expression here
  585 |     concept indirectly_writable = requires(_Out&& __o, _Tp&& __t)
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  586 |       {
      |       ~
  587 |         *__o = std::forward<_Tp>(__t);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  588 |         *std::forward<_Out>(__o) = std::forward<_Tp>(__t);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  589 |         const_cast<const iter_reference_t<_Out>&&>(*__o)
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  590 |           = std::forward<_Tp>(__t);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
  591 |         const_cast<const iter_reference_t<_Out>&&>(*std::forward<_Out>(__o))
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  592 |           = std::forward<_Tp>(__t);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
  593 |       };
      |       ~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/ranges_algo.h:1017:16: note: while checking the satisfaction of concept 'indirectly_writable<const std::vector<std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long, std::basic_string<char>, std::basic_string<char>>> &, std::back_insert_iterator<std::vector<std::vector<std::basic_string<char>>>>, (lambda at /podio/tools/src/tabulate.h:24:64), std::identity>' requested here
 1017 |       requires indirectly_writable<_Out,
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~
 1018 |                                    indirect_result_t<_Fp&,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~
 1019 |                                      projected<iterator_t<_Range>, _Proj>>>
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/podio/tools/src/tabulate.h:24:3: note: while checking constraint satisfaction for template 'operator()<const std::vector<std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long, std::basic_string<char>, std::basic_string<char>>> &, std::back_insert_iterator<std::vector<std::vector<std::basic_string<char>>>>, (lambda at /podio/tools/src/tabulate.h:24:64), std::identity>' required here
   24 |   std::ranges::transform(rows, std::back_inserter(stringRows), [&nCols](const auto& elem) {
      |   ^~~
/podio/tools/src/tabulate.h:24:3: note: while substituting deduced template arguments into function template 'operator()' [with _Range = const std::vector<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::basic_string_view<char, std::char_traits<char>>, unsigned long, std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::basic_string<char, std::char_traits<char>, std::allocator<char>>>> &, _Out = back_insert_iterator<std::vector<std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char>>>>, std::allocator<std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>>>, _Fp = (lambda at /podio/tools/src/tabulate.h:24:64), _Proj = (no value)]
/podio/tools/src/podio-dump-tool.cpp:209:3: note: in instantiation of function template specialization 'printTable<std::basic_string<char>, std::basic_string_view<char>, unsigned long, std::basic_string<char>, std::basic_string<char>>' requested here
  209 |   printTable(
      |   ^
In file included from /build/podio/tools/CMakeFiles/podio-dump-tool.dir/Unity/unity_0_cxx.cxx:4:
In file included from /podio/tools/src/podio-dump-tool.cpp:2:
/podio/tools/src/tabulate.h:27:18: warning: lambda capture 'strs' is not used [-Wunused-lambda-capture]
   27 |     std::apply([&strs](auto&&... args) { (strs.emplace_back(fmt::format("{}", args)), ...); }, elem);
      |                  ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2890:7: note: in instantiation of function template specialization 'printTable(const std::vector<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::basic_string_view<char, std::char_traits<char>>, unsigned long>> &, const std::vector<std::string> &)::(lambda)::operator()<std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long>>' requested here
 2890 |       std::declval<_Fn>()(std::declval<_Args>()...)
      |       ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2901:29: note: while substituting deduced template arguments into function template '_S_test' [with _Fn = (lambda at /podio/tools/src/tabulate.h:24:64) &, _Args = (no value)]
 2901 |       using type = decltype(_S_test<_Functor, _ArgTypes...>(0));
      |                             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2907:14: note: in instantiation of template class 'std::__result_of_impl<false, false, (lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long> &>' requested here
 2907 |     : public __result_of_impl<
      |              ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3270:29: note: in instantiation of template class 'std::__invoke_result<(lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long> &>' requested here
 3270 |                                __void_t<typename _Result::type>>
      |                                                  ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3421:7: note: during template argument deduction for class template partial specialization '__is_invocable_impl<_Result, _Ret, true, __void_t<typename _Result::type>>' [with _Result = std::__invoke_result<(lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long> &>, _Ret = void]
 3421 |     : __is_invocable_impl<__invoke_result<_Fn, _ArgTypes...>, void>::type
      |       ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3421:7: note: (skipping 6 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/iterator_concepts.h:585:35: note: while substituting template arguments into constraint expression here
  585 |     concept indirectly_writable = requires(_Out&& __o, _Tp&& __t)
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  586 |       {
      |       ~
  587 |         *__o = std::forward<_Tp>(__t);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  588 |         *std::forward<_Out>(__o) = std::forward<_Tp>(__t);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  589 |         const_cast<const iter_reference_t<_Out>&&>(*__o)
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  590 |           = std::forward<_Tp>(__t);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
  591 |         const_cast<const iter_reference_t<_Out>&&>(*std::forward<_Out>(__o))
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  592 |           = std::forward<_Tp>(__t);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
  593 |       };
      |       ~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/ranges_algo.h:1017:16: note: while checking the satisfaction of concept 'indirectly_writable<const std::vector<std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long>> &, std::back_insert_iterator<std::vector<std::vector<std::basic_string<char>>>>, (lambda at /podio/tools/src/tabulate.h:24:64), std::identity>' requested here
 1017 |       requires indirectly_writable<_Out,
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~
 1018 |                                    indirect_result_t<_Fp&,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~
 1019 |                                      projected<iterator_t<_Range>, _Proj>>>
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/podio/tools/src/tabulate.h:24:3: note: while checking constraint satisfaction for template 'operator()<const std::vector<std::tuple<std::basic_string<char>, std::basic_string_view<char>, unsigned long>> &, std::back_insert_iterator<std::vector<std::vector<std::basic_string<char>>>>, (lambda at /podio/tools/src/tabulate.h:24:64), std::identity>' required here
   24 |   std::ranges::transform(rows, std::back_inserter(stringRows), [&nCols](const auto& elem) {
      |   ^~~
/podio/tools/src/tabulate.h:24:3: note: while substituting deduced template arguments into function template 'operator()' [with _Range = const std::vector<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::basic_string_view<char, std::char_traits<char>>, unsigned long>> &, _Out = back_insert_iterator<std::vector<std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char>>>>, std::allocator<std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>>>, _Fp = (lambda at /podio/tools/src/tabulate.h:24:64), _Proj = (no value)]
/podio/tools/src/podio-dump-tool.cpp:220:3: note: in instantiation of function template specialization 'printTable<std::basic_string<char>, std::basic_string_view<char>, unsigned long>' requested here
  220 |   printTable(paramRows, {"Name", "Type", "Elements"});
      |   ^
In file included from /build/podio/tools/CMakeFiles/podio-dump-tool.dir/Unity/unity_0_cxx.cxx:4:
In file included from /podio/tools/src/podio-dump-tool.cpp:2:
/podio/tools/src/tabulate.h:27:18: warning: lambda capture 'strs' is not used [-Wunused-lambda-capture]
   27 |     std::apply([&strs](auto&&... args) { (strs.emplace_back(fmt::format("{}", args)), ...); }, elem);
      |                  ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2890:7: note: in instantiation of function template specialization 'printTable(const std::vector<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, unsigned long>> &, const std::vector<std::string> &)::(lambda)::operator()<std::tuple<std::basic_string<char>, unsigned long>>' requested here
 2890 |       std::declval<_Fn>()(std::declval<_Args>()...)
      |       ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2901:29: note: while substituting deduced template arguments into function template '_S_test' [with _Fn = (lambda at /podio/tools/src/tabulate.h:24:64) &, _Args = (no value)]
 2901 |       using type = decltype(_S_test<_Functor, _ArgTypes...>(0));
      |                             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:2907:14: note: in instantiation of template class 'std::__result_of_impl<false, false, (lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, unsigned long> &>' requested here
 2907 |     : public __result_of_impl<
      |              ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3270:29: note: in instantiation of template class 'std::__invoke_result<(lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, unsigned long> &>' requested here
 3270 |                                __void_t<typename _Result::type>>
      |                                                  ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3421:7: note: during template argument deduction for class template partial specialization '__is_invocable_impl<_Result, _Ret, true, __void_t<typename _Result::type>>' [with _Result = std::__invoke_result<(lambda at /podio/tools/src/tabulate.h:24:64) &, const std::tuple<std::basic_string<char>, unsigned long> &>, _Ret = void]
 3421 |     : __is_invocable_impl<__invoke_result<_Fn, _ArgTypes...>, void>::type
      |       ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/type_traits:3421:7: note: (skipping 6 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/iterator_concepts.h:585:35: note: while substituting template arguments into constraint expression here
  585 |     concept indirectly_writable = requires(_Out&& __o, _Tp&& __t)
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  586 |       {
      |       ~
  587 |         *__o = std::forward<_Tp>(__t);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  588 |         *std::forward<_Out>(__o) = std::forward<_Tp>(__t);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  589 |         const_cast<const iter_reference_t<_Out>&&>(*__o)
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  590 |           = std::forward<_Tp>(__t);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
  591 |         const_cast<const iter_reference_t<_Out>&&>(*std::forward<_Out>(__o))
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  592 |           = std::forward<_Tp>(__t);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
  593 |       };
      |       ~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../include/c++/16.1.1/bits/ranges_algo.h:1017:16: note: while checking the satisfaction of concept 'indirectly_writable<const std::vector<std::tuple<std::basic_string<char>, unsigned long>> &, std::back_insert_iterator<std::vector<std::vector<std::basic_string<char>>>>, (lambda at /podio/tools/src/tabulate.h:24:64), std::identity>' requested here
 1017 |       requires indirectly_writable<_Out,
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~
 1018 |                                    indirect_result_t<_Fp&,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~
 1019 |                                      projected<iterator_t<_Range>, _Proj>>>
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/podio/tools/src/tabulate.h:24:3: note: while checking constraint satisfaction for template 'operator()<const std::vector<std::tuple<std::basic_string<char>, unsigned long>> &, std::back_insert_iterator<std::vector<std::vector<std::basic_string<char>>>>, (lambda at /podio/tools/src/tabulate.h:24:64), std::identity>' required here
   24 |   std::ranges::transform(rows, std::back_inserter(stringRows), [&nCols](const auto& elem) {
      |   ^~~
/podio/tools/src/tabulate.h:24:3: note: while substituting deduced template arguments into function template 'operator()' [with _Range = const std::vector<std::tuple<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, unsigned long>> &, _Out = back_insert_iterator<std::vector<std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char>>>>, std::allocator<std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>>>, _Fp = (lambda at /podio/tools/src/tabulate.h:24:64), _Proj = (no value)]
/podio/tools/src/podio-dump-tool.cpp:256:3: note: in instantiation of function template specialization 'printTable<std::basic_string<char>, unsigned long>' requested here
  256 |   printTable(rows, {"Name", "Entries"});
      |   ^
3 warnings and 2 errors generated.
ninja: build stopped: subcommand failed.
```