### PR TITLE
Update the sanitizer workflow to use the latest available compilers, GCC 16 and Clang 22

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc15, clang19]
+        compiler: [gcc16, clang22]
         # Since Leak is usually part of Address, we do not run it separately in
         # CI. Keeping Address and Undefined separate for easier debugging
         sanitizer: [Thread,
@@ -37,7 +37,7 @@ jobs:
       - uses: key4hep/key4hep-actions/cache-external-data@main
       - uses: aidasoft/run-lcg-view@d8db17c61216548c9192889942d46ff2d7c3a3b6 # v6
         with:
-          release-platform: LCG_108/x86_64-el9-${{ matrix.compiler }}-opt
+          release-platform: LCG_110/x86_64-el9-${{ matrix.compiler }}-opt
           ccache-key: ccache-sanitizers-el9-${{ matrix.compiler }}-${{ matrix.sanitizer }}
           run: |
             echo "::group::Run CMake"
@@ -46,7 +46,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=Debug \
               -DENABLE_ARROW=ON \
               -DUSE_SANITIZER=${{ matrix.sanitizer }} \
-              -DCMAKE_CXX_STANDARD=$([[ ${{ matrix.compiler }} == gcc15 ]] && echo "23" || echo "20")
+              -DCMAKE_CXX_STANDARD=23
             echo "::endgroup::"
             echo "::group::Build"
             cmake --build --preset ci-build


### PR DESCRIPTION
BEGINRELEASENOTES
- Update the sanitizer workflow to use the latest available compilers, GCC 16 and Clang 22

ENDRELEASENOTES