### PR TITLE
Allow subprocess aborted in the read_garbage test

### DIFF
--- a/tests/schema_evolution/code_gen/CMakeLists.txt
+++ b/tests/schema_evolution/code_gen/CMakeLists.txt
@@ -13,9 +13,9 @@ add_test(NAME schema_evol:code_gen:datatypes_new_member:read_garbage COMMAND ${C
 # Under the thread sanitizer, the message "signal-unsafe call inside of a
 # signal" may appear
 if(USE_SANITIZER MATCHES "Thread")
-  set(_read_garbage_pass_re "Bad data;signal-unsafe call inside of a signal|Bad data;Segmentation fault")
+  set(_read_garbage_pass_re "Bad data;signal-unsafe call inside of a signal;Segmentation fault;Subprocess aborted;malloc")
 else()
-  set(_read_garbage_pass_re "Bad data;Segmentation fault")
+  set(_read_garbage_pass_re "Bad data;Segmentation fault;Subprocess aborted;malloc")
 endif()
 set_tests_properties(schema_evol:code_gen:datatypes_new_member:read_garbage
       PROPERTIES

--- a/tests/schema_evolution/code_gen/CMakeLists.txt
+++ b/tests/schema_evolution/code_gen/CMakeLists.txt
@@ -13,9 +13,9 @@ add_test(NAME schema_evol:code_gen:datatypes_new_member:read_garbage COMMAND ${C
 # Under the thread sanitizer, the message "signal-unsafe call inside of a
 # signal" may appear
 if(USE_SANITIZER MATCHES "Thread")
-  set(_read_garbage_pass_re "Bad data;signal-unsafe call inside of a signal;Segmentation fault;Subprocess aborted;malloc")
+  set(_read_garbage_pass_re "Bad data;signal-unsafe call inside of a signal|Bad data;Segmentation fault")
 else()
-  set(_read_garbage_pass_re "Bad data;Segmentation fault;Subprocess aborted;malloc")
+  set(_read_garbage_pass_re "Bad data;Segmentation fault;Subprocess aborted")
 endif()
 set_tests_properties(schema_evol:code_gen:datatypes_new_member:read_garbage
       PROPERTIES


### PR DESCRIPTION
BEGINRELEASENOTES
- Allow subprocess aborted in the read_garbage test

ENDRELEASENOTES

I have seen also this failure in the past and happens consistently in https://github.com/AIDASoft/podio/pull/979