### PR TITLE
Remove the three star cast and make changes in the SIO code

### DIFF
--- a/include/podio/CollectionBuffers.h
+++ b/include/podio/CollectionBuffers.h
@@ -21,23 +21,19 @@ using UVecPtr = std::unique_ptr<std::vector<T>>;
 using CollRefCollection = std::vector<UVecPtr<podio::ObjectID>>;
 using VectorMembersInfo = std::vector<std::pair<std::string, void*>>;
 
-/// Simple helper struct that bundles all the potentially necessary buffers that
-/// are necessary to represent a collection for I/O purposes.
+/// Struct bundling the buffers that represent a collection for writing.
+///
+/// data is used by ROOT and holds the address of a unique_ptr.
+/// vecPtr holds the raw vector pointer, used by SIO and RNTuple.
 struct CollectionWriteBuffers {
   void* data{nullptr};
   void* vecPtr{nullptr};
   CollRefCollection* references{nullptr};
   VectorMembersInfo* vectorMembers{nullptr};
 
-  template <typename DataT>
-  std::vector<DataT>* dataAsVector() {
-    return asVector<DataT>(data);
-  }
-
   template <typename T>
-  static std::vector<T>* asVector(void* raw) {
-    // Are we at a beach? I can almost smell the C...
-    return *static_cast<std::vector<T>**>(raw);
+  std::vector<T>* dataAsVector() {
+    return static_cast<std::vector<T>*>(vecPtr);
   }
 };
 
@@ -124,7 +120,6 @@ struct CollectionReadBuffers {
 
   template <typename T>
   static std::vector<T>* asVector(void* raw) {
-    // Are we at a beach? I can almost smell the C...
     return static_cast<std::vector<T>*>(raw);
   }
 

--- a/include/podio/SIOBlock.h
+++ b/include/podio/SIOBlock.h
@@ -2,6 +2,7 @@
 #define PODIO_SIOBLOCK_H
 
 #include <podio/CollectionBase.h>
+#include <podio/CollectionBuffers.h>
 #include <podio/CollectionIDTable.h>
 #include <podio/GenericParameters.h>
 #include <podio/podioVersion.h>
@@ -72,7 +73,7 @@ public:
   SIOBlock& operator=(const SIOBlock&) = delete;
 
   podio::CollectionReadBuffers getBuffers() {
-    return std::move(m_buffers);
+    return std::move(m_readBuffers);
   }
 
   std::string name() {
@@ -85,14 +86,15 @@ public:
 
   void setCollection(podio::CollectionBase* col) {
     m_subsetColl = col->isSubsetCollection();
-    m_buffers = col->getBuffers();
+    m_writeBuffers = col->getBuffers();
   }
 
   virtual SIOBlock* create(const std::string& name) const = 0;
 
 protected:
   bool m_subsetColl{false};
-  podio::CollectionReadBuffers m_buffers{};
+  podio::CollectionWriteBuffers m_writeBuffers{};
+  podio::CollectionReadBuffers m_readBuffers{};
 };
 
 /// A dedicated block for handling the I/O of the CollectionIDTable

--- a/include/podio/SIOBlockUserData.h
+++ b/include/podio/SIOBlockUserData.h
@@ -41,12 +41,12 @@ public:
 
   void read(sio::read_device& device, sio::version_type version) override {
     const auto& bufferFactory = podio::CollectionBufferFactory::instance();
-    m_buffers =
+    m_readBuffers =
         bufferFactory
             .createBuffers(podio::userDataCollTypeName<BasicType>(), sio::version::major_version(version), false)
             .value();
 
-    auto* dataVec = m_buffers.dataAsVector<BasicType>();
+    auto* dataVec = m_readBuffers.template dataAsVector<BasicType>();
     unsigned size(0);
     device.data(size);
     dataVec->resize(size);
@@ -54,7 +54,7 @@ public:
   }
 
   void write(sio::write_device& device) override {
-    auto* dataVec = podio::CollectionWriteBuffers::asVector<BasicType>(m_buffers.data);
+    auto* dataVec = m_writeBuffers.template dataAsVector<BasicType>();
     unsigned size = dataVec->size();
     device.data(size);
     podio::handlePODDataSIO(device, &(*dataVec)[0], size);

--- a/include/podio/detail/LinkSIOBlock.h
+++ b/include/podio/detail/LinkSIOBlock.h
@@ -34,18 +34,18 @@ public:
     // - Error handling of empty optional
     auto maybeBuffers = bufferFactory.createBuffers(std::string(podio::LinkCollection<FromT, ToT>::typeName),
                                                     sio::version::major_version(version), m_subsetColl);
-    m_buffers = std::move(maybeBuffers.value());
+    m_readBuffers = std::move(maybeBuffers.value());
 
     if (!m_subsetColl) {
       unsigned size{0};
       device.data(size);
-      auto* dataVec = m_buffers.dataAsVector<float>();
+      auto* dataVec = m_readBuffers.template dataAsVector<float>();
       dataVec->resize(size);
       podio::handlePODDataSIO(device, dataVec->data(), size);
     }
 
     // ---- read ref collections
-    auto* refColls = m_buffers.references;
+    const auto* refColls = m_readBuffers.references;
     for (auto& refC : *refColls) {
       unsigned size{0};
       device.data(size);
@@ -56,14 +56,14 @@ public:
 
   void write(sio::write_device& device) override {
     if (!m_subsetColl) {
-      auto* dataVec = podio::CollectionWriteBuffers::asVector<float>(m_buffers.data);
+      const auto* dataVec = m_writeBuffers.template dataAsVector<float>();
       unsigned size = dataVec->size();
       device.data(size);
       podio::handlePODDataSIO(device, dataVec->data(), size);
     }
 
     // ---- write ref collections ------
-    auto* refColls = m_buffers.references;
+    const auto* refColls = m_writeBuffers.references;
     for (auto& refC : *refColls) {
       unsigned size = refC->size();
       device.data(size);

--- a/python/templates/SIOBlock.cc.jinja2
+++ b/python/templates/SIOBlock.cc.jinja2
@@ -20,18 +20,18 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type version
   // TODO:
   // - Error handling of empty optional
   auto maybeBuffers = bufferFactory.createBuffers("{{ class.full_type }}Collection", sio::version::major_version(version), m_subsetColl);
-  m_buffers = std::move(maybeBuffers).value_or(podio::CollectionReadBuffers{});
+  m_readBuffers = std::move(maybeBuffers).value_or(podio::CollectionReadBuffers{});
 
   if (not m_subsetColl) {
     unsigned size(0);
     device.data( size );
-    auto* dataVec = m_buffers.dataAsVector<{{ class.full_type }}Data>();
+    auto* dataVec = m_readBuffers.dataAsVector<{{ class.full_type }}Data>();
     dataVec->resize(size);
     podio::handlePODDataSIO(device, dataVec->data(), size);
   }
 
   //---- read ref collections -----
-  auto* refCols = m_buffers.references;
+  const auto* refCols = m_readBuffers.references;
   for( auto& refC : *refCols ){
     unsigned size{0};
     device.data( size ) ;
@@ -42,7 +42,7 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type version
 {% if VectorMembers %}
   if (not m_subsetColl) {
     //---- read vector members
-    auto* vecMemInfo = m_buffers.vectorMembers;
+    const auto* vecMemInfo = m_readBuffers.vectorMembers;
     unsigned size{0};
 
 {% for member in VectorMembers %}
@@ -54,14 +54,14 @@ void {{ block_class }}::read(sio::read_device& device, sio::version_type version
 
 void {{ block_class }}::write(sio::write_device& device) {
   if (not m_subsetColl) {
-    auto* dataVec = podio::CollectionWriteBuffers::asVector<{{ class.full_type }}Data>(m_buffers.data);
+    auto* dataVec = m_writeBuffers.dataAsVector<{{ class.full_type }}Data>();
     unsigned size = dataVec->size() ;
     device.data( size ) ;
     podio::handlePODDataSIO( device ,  dataVec->data(), size ) ;
   }
 
   //---- write ref collections -----
-  auto* refCols = m_buffers.references;
+  const auto* refCols = m_writeBuffers.references;
   for( auto& refC : *refCols ){
     unsigned size = refC->size() ;
     device.data( size ) ;
@@ -71,7 +71,7 @@ void {{ block_class }}::write(sio::write_device& device) {
 {% if VectorMembers %}
   if (not m_subsetColl) {
     //---- write vector members
-    auto* vecMemInfo = m_buffers.vectorMembers;
+    const auto* vecMemInfo = m_writeBuffers.vectorMembers;
     unsigned size{0};
 
 {% for member in VectorMembers %}


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the "three star cast" `*static_cast<std::vector<T>**>(raw)`. To do that:
  - Remove `CollectionWriteBuffers::asVector()`, the method that had the cast
  - Do the necessary modifications in SIO code that was using it in several places: now hold a `CollectionReadBuffers` for reading and a `CollectionWriteBuffers` for writing

ENDRELEASENOTES

Fix https://github.com/AIDASoft/podio/issues/393.