### PR TITLE
Sort categories in getAvailableCategories for RNTuples and in podio-dump

### DIFF
--- a/src/RNTupleReader.cc
+++ b/src/RNTupleReader.cc
@@ -94,6 +94,7 @@ void RNTupleReader::openFiles(const std::vector<std::string>& filenames) {
 
   auto availableCategoriesField = m_metadata->GetView<std::vector<std::string>>(root_utils::availableCategories);
   m_availableCategories = availableCategoriesField(0);
+  std::ranges::sort(m_availableCategories);
 
   // Pre-fill the entries map
   for (const auto& category : m_availableCategories) {

--- a/tools/src/podio-dump-tool.cpp
+++ b/tools/src/podio-dump-tool.cpp
@@ -249,7 +249,9 @@ void printGeneralInfo(const podio::Reader& reader, const std::string& filename) 
   }
 
   std::vector<std::tuple<std::string, size_t>> rows{};
-  for (const auto& cat : reader.getAvailableCategories()) {
+  const auto availCats = reader.getAvailableCategories();
+  for (const auto& cat : podio::utils::sortAlphabeticaly(
+           std::vector<std::string>(availCats.begin(), availCats.end()))) {
     rows.emplace_back(cat, reader.getEntries(cat));
   }
   fmt::println("\nFrame categories in this file:");

--- a/tools/src/podio-dump-tool.cpp
+++ b/tools/src/podio-dump-tool.cpp
@@ -250,8 +250,8 @@ void printGeneralInfo(const podio::Reader& reader, const std::string& filename) 
 
   std::vector<std::tuple<std::string, size_t>> rows{};
   const auto availCats = reader.getAvailableCategories();
-  for (const auto& cat : podio::utils::sortAlphabeticaly(
-           std::vector<std::string>(availCats.begin(), availCats.end()))) {
+  for (const auto& cat :
+       podio::utils::sortAlphabeticaly(std::vector<std::string>(availCats.begin(), availCats.end()))) {
     rows.emplace_back(cat, reader.getEntries(cat));
   }
   fmt::println("\nFrame categories in this file:");


### PR DESCRIPTION
BEGINRELEASENOTES
- Sort categories in getAvailableCategories for RNTuples
- Sort categories (alphabetically, ignoring case) in `podio-dump`

ENDRELEASENOTES

Do it the same way as the `ROOTReader` (see https://github.com/AIDASoft/podio/blob/master/src/ROOTReader.cc#L283). I noticed because `podio-dump` does not sort its output for categories, after this change it will as it does sort collection names. It makes it easier to compare similar files since the order will be the same if the categories are the same.