### PR TITLE
Implement Arrow-to-Frame Conversion (Deserialization) for Arrow Backend

### DIFF
--- a/.cppcheck-suppressions.txt
+++ b/.cppcheck-suppressions.txt
@@ -15,3 +15,6 @@ useStlAlgorithm:LinkCollectionImpl.h
 useStlAlgorithm:podio-dump-tool.cpp
 useStlAlgorithm:SIOFrameData.cc
 useStlAlgorithm:rootUtils.h
+
+# getAvailableCollections must return by value to satisfy C++20 FrameDataType concept (std::same_as)
+returnByReference:*ArrowFrameData*

--- a/include/podio/utilities/ArrowConverterRegistry.h
+++ b/include/podio/utilities/ArrowConverterRegistry.h
@@ -1,6 +1,8 @@
 #ifndef PODIO_ARROWCONVERTERREGISTRY_H
 #define PODIO_ARROWCONVERTERREGISTRY_H
 
+#include "podio/CollectionBuffers.h"
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -20,6 +22,7 @@ class CollectionBase;
 class ArrowConverterRegistry {
 public:
   using CreatorFunc = std::function<std::shared_ptr<arrow::Array>(const podio::CollectionBase*)>;
+  using BufferReaderFunc = std::function<podio::CollectionReadBuffers(std::shared_ptr<arrow::Array>, int64_t, bool)>;
 
   ArrowConverterRegistry(const ArrowConverterRegistry&) = delete;
   ArrowConverterRegistry& operator=(const ArrowConverterRegistry&) = delete;
@@ -44,11 +47,23 @@ public:
    */
   CreatorFunc getConverter(const std::string& typeName) const;
 
+  /**
+   * @brief Register an Arrow array reader callback for a specific type name.
+   */
+  void registerReader(const std::string& typeName, BufferReaderFunc reader);
+
+  /**
+   * @brief Retrieve the Arrow collection reader registered for a specific type name.
+   * @return The registered BufferReaderFunc, or nullptr if not registered.
+   */
+  BufferReaderFunc getReader(const std::string& typeName) const;
+
 private:
   ArrowConverterRegistry() : m_registry() {
   }
 
   std::unordered_map<std::string, CreatorFunc> m_registry;
+  std::unordered_map<std::string, BufferReaderFunc> m_readerRegistry;
 };
 
 } // namespace podio

--- a/include/podio/utilities/ArrowConverterRegistry.h
+++ b/include/podio/utilities/ArrowConverterRegistry.h
@@ -59,7 +59,7 @@ public:
   BufferReaderFunc getReader(const std::string& typeName) const;
 
 private:
-  ArrowConverterRegistry() : m_registry() {
+  ArrowConverterRegistry() : m_registry(), m_readerRegistry() {
   }
 
   std::unordered_map<std::string, CreatorFunc> m_registry;

--- a/include/podio/utilities/ArrowConverterRegistry.h
+++ b/include/podio/utilities/ArrowConverterRegistry.h
@@ -2,9 +2,11 @@
 #define PODIO_ARROWCONVERTERREGISTRY_H
 
 #include "podio/CollectionBuffers.h"
+#include "podio/SchemaEvolution.h"
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -22,7 +24,8 @@ class CollectionBase;
 class ArrowConverterRegistry {
 public:
   using CreatorFunc = std::function<std::shared_ptr<arrow::Array>(const podio::CollectionBase*)>;
-  using BufferReaderFunc = std::function<podio::CollectionReadBuffers(std::shared_ptr<arrow::Array>, int64_t, bool)>;
+  using BufferReaderFunc = std::function<std::optional<podio::CollectionReadBuffers>(std::shared_ptr<arrow::Array>,
+                                                                                     int64_t, bool, SchemaVersionT)>;
 
   ArrowConverterRegistry(const ArrowConverterRegistry&) = delete;
   ArrowConverterRegistry& operator=(const ArrowConverterRegistry&) = delete;

--- a/include/podio/utilities/ArrowConverterRegistry.h
+++ b/include/podio/utilities/ArrowConverterRegistry.h
@@ -5,10 +5,10 @@
 #include "podio/SchemaEvolution.h"
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 namespace arrow {
 class Array;
@@ -53,7 +53,7 @@ public:
   /**
    * @brief Register an Arrow array reader callback for a specific type name.
    */
-  void registerReader(const std::string& typeName, BufferReaderFunc reader);
+  void registerReader(const std::string& typeName, BufferReaderFunc&& reader);
 
   /**
    * @brief Retrieve the Arrow collection reader registered for a specific type name.
@@ -65,8 +65,8 @@ private:
   ArrowConverterRegistry() : m_registry(), m_readerRegistry() {
   }
 
-  std::unordered_map<std::string, CreatorFunc> m_registry;
-  std::unordered_map<std::string, BufferReaderFunc> m_readerRegistry;
+  std::map<std::string, CreatorFunc> m_registry;
+  std::map<std::string, BufferReaderFunc> m_readerRegistry;
 };
 
 } // namespace podio

--- a/include/podio/utilities/ArrowFrameConverter.h
+++ b/include/podio/utilities/ArrowFrameConverter.h
@@ -42,9 +42,9 @@ std::shared_ptr<arrow::Table> convertFrameToTable(const podio::Frame& frame,
  *
  * @param table The Arrow Table containing the frame data.
  * @param rowIndex The index of the row to read.
- * @return A unique pointer to the reconstructed Frame.
+ * @return The reconstructed Frame.
  */
-std::unique_ptr<podio::Frame> convertTableToFrame(const std::shared_ptr<arrow::Table>& table, int rowIndex = 0);
+podio::Frame convertTableToFrame(const std::shared_ptr<arrow::Table>& table, int rowIndex = 0);
 
 } // namespace podio
 

--- a/include/podio/utilities/ArrowFrameConverter.h
+++ b/include/podio/utilities/ArrowFrameConverter.h
@@ -35,6 +35,18 @@ std::shared_ptr<arrow::DataType> objectRefType();
 std::shared_ptr<arrow::Table> convertFrameToTable(const podio::Frame& frame,
                                                   const std::vector<std::string>& collsToWrite);
 
+/**
+ * @brief Convert a 1-row slice of an Arrow Table to a PODIO Frame.
+ *
+ * Reconstructs the frame parameters and all collection buffers using registered BufferReaderFuncs.
+ * 
+ * @param table The Arrow Table containing the frame data.
+ * @param rowIndex The index of the row to read.
+ * @return A unique pointer to the reconstructed Frame.
+ */
+std::unique_ptr<podio::Frame> convertTableToFrame(const std::shared_ptr<arrow::Table>& table, int rowIndex = 0);
+
+
 } // namespace podio
 
 #endif // PODIO_ARROWFRAMECONVERTER_H

--- a/include/podio/utilities/ArrowFrameConverter.h
+++ b/include/podio/utilities/ArrowFrameConverter.h
@@ -39,13 +39,12 @@ std::shared_ptr<arrow::Table> convertFrameToTable(const podio::Frame& frame,
  * @brief Convert a 1-row slice of an Arrow Table to a PODIO Frame.
  *
  * Reconstructs the frame parameters and all collection buffers using registered BufferReaderFuncs.
- * 
+ *
  * @param table The Arrow Table containing the frame data.
  * @param rowIndex The index of the row to read.
  * @return A unique pointer to the reconstructed Frame.
  */
 std::unique_ptr<podio::Frame> convertTableToFrame(const std::shared_ptr<arrow::Table>& table, int rowIndex = 0);
-
 
 } // namespace podio
 

--- a/include/podio/utilities/ArrowFrameData.h
+++ b/include/podio/utilities/ArrowFrameData.h
@@ -22,7 +22,7 @@ public:
 
   podio::CollectionIDTable getIDTable() const;
   std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
-  // cppcheck-suppress returnByReference
+  // Must return by value to satisfy the C++20 FrameDataType concept (as other backends construct it dynamically)
   std::vector<std::string> getAvailableCollections() const;
   std::unique_ptr<podio::GenericParameters> getParameters();
 

--- a/include/podio/utilities/ArrowFrameData.h
+++ b/include/podio/utilities/ArrowFrameData.h
@@ -1,0 +1,37 @@
+#ifndef PODIO_ARROWFRAMEDATA_H
+#define PODIO_ARROWFRAMEDATA_H
+
+#include "podio/CollectionBuffers.h"
+#include "podio/CollectionIDTable.h"
+#include "podio/GenericParameters.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace arrow {
+class Table;
+} // namespace arrow
+
+namespace podio {
+
+class ArrowFrameData {
+public:
+  ArrowFrameData(std::shared_ptr<arrow::Table> table, int64_t rowIndex);
+
+  podio::CollectionIDTable getIDTable() const;
+  std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
+  std::vector<std::string> getAvailableCollections() const;
+  std::unique_ptr<podio::GenericParameters> getParameters();
+
+private:
+  std::shared_ptr<arrow::Table> m_table;
+  int64_t m_rowIndex;
+  std::vector<std::string> m_availableCollections;
+  podio::CollectionIDTable m_idTable;
+};
+
+} // namespace podio
+
+#endif // PODIO_ARROWFRAMEDATA_H

--- a/include/podio/utilities/ArrowFrameData.h
+++ b/include/podio/utilities/ArrowFrameData.h
@@ -22,6 +22,7 @@ public:
 
   podio::CollectionIDTable getIDTable() const;
   std::optional<podio::CollectionReadBuffers> getCollectionBuffers(const std::string& name);
+  // cppcheck-suppress returnByReference
   std::vector<std::string> getAvailableCollections() const;
   std::unique_ptr<podio::GenericParameters> getParameters();
 

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -194,6 +194,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
             "package_name": self.package_name,
             "schema_version": self.datamodel.schema_version,
             "datatypes": datatypes,
+            "links": datamodel.get("links", []),
             "incfolder": self.incfolder,
         }
         self._write_file(

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -81,6 +81,34 @@ ARROW_BUILDERS = {
     "std::string": "arrow::StringBuilder",
 }
 
+ARROW_ARRAYS = {
+    "bool": "arrow::BooleanArray",
+    "char": "arrow::Int8Array",
+    "short": "arrow::Int16Array",
+    "int": "arrow::Int32Array",
+    "long": "arrow::Int64Array",
+    "long long": "arrow::Int64Array",
+    "unsigned": "arrow::UInt32Array",
+    "unsigned int": "arrow::UInt32Array",
+    "unsigned long": "arrow::UInt64Array",
+    "unsigned long long": "arrow::UInt64Array",
+    "float": "arrow::FloatArray",
+    "double": "arrow::DoubleArray",
+    "int16_t": "arrow::Int16Array",
+    "int32_t": "arrow::Int32Array",
+    "int64_t": "arrow::Int64Array",
+    "uint16_t": "arrow::UInt16Array",
+    "uint32_t": "arrow::UInt32Array",
+    "uint64_t": "arrow::UInt64Array",
+    "std::int16_t": "arrow::Int16Array",
+    "std::int32_t": "arrow::Int32Array",
+    "std::int64_t": "arrow::Int64Array",
+    "std::uint16_t": "arrow::UInt16Array",
+    "std::uint32_t": "arrow::UInt32Array",
+    "std::uint64_t": "arrow::UInt64Array",
+    "std::string": "arrow::StringArray",
+}
+
 
 class IncludeFrom(IntEnum):
     """Enum to signify if an include is needed and from where it should come"""
@@ -244,6 +272,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
             "name": member.name,
             "getter": member.getter_name(self.get_syntax),
             "is_array": member.is_array,
+            "full_type": member.full_type,
         }
         if member.is_array:
             meta["array_size"] = member.array_size
@@ -251,7 +280,9 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
             if member.array_type in ARROW_PRIMITIVE_TYPES:
                 meta["value_builder"] = {
                     "builder_type": ARROW_BUILDERS[member.array_type],
+                    "arrow_array_type": ARROW_ARRAYS[member.array_type],
                     "is_primitive": True,
+                    "full_type": member.array_type,
                 }
             else:
                 comp_name = member.array_type.removeprefix("::")
@@ -260,10 +291,12 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
                 )
                 meta["value_builder"] = {
                     "builder_type": "arrow::StructBuilder",
+                    "arrow_array_type": "arrow::StructArray",
                     "is_struct": True,
                     "children": [
                         self._get_member_metadata(sub_mem) for sub_mem in comp["Members"]
                     ],
+                    "full_type": member.array_type,
                 }
             return meta
 
@@ -273,10 +306,12 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         )
         if comp:
             meta["builder_type"] = "arrow::StructBuilder"
+            meta["arrow_array_type"] = "arrow::StructArray"
             meta["is_struct"] = True
             meta["children"] = [self._get_member_metadata(sub_mem) for sub_mem in comp["Members"]]
         else:
             meta["builder_type"] = ARROW_BUILDERS.get(member.full_type)
+            meta["arrow_array_type"] = ARROW_ARRAYS.get(member.full_type)
             meta["is_primitive"] = True
         return meta
 
@@ -290,7 +325,9 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         if member.full_type in ARROW_PRIMITIVE_TYPES:
             meta["value_builder"] = {
                 "builder_type": ARROW_BUILDERS[member.full_type],
+                "arrow_array_type": ARROW_ARRAYS[member.full_type],
                 "is_primitive": True,
+                "full_type": member.full_type,
             }
         else:
             comp_name = member.full_type.removeprefix("::")
@@ -299,8 +336,10 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
             )
             meta["value_builder"] = {
                 "builder_type": "arrow::StructBuilder",
+                "arrow_array_type": "arrow::StructArray",
                 "is_struct": True,
                 "children": [self._get_member_metadata(sub_mem) for sub_mem in comp["Members"]],
+                "full_type": member.full_type,
             }
         return meta
 

--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -284,6 +284,7 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         meta = {
             "name": member.name,
             "getter": member.getter_name(self.get_syntax),
+            "full_type": member.full_type,
         }
         if member.full_type in ARROW_PRIMITIVE_TYPES:
             meta["value_builder"] = {

--- a/python/templates/ArrowMapper.cc.jinja2
+++ b/python/templates/ArrowMapper.cc.jinja2
@@ -163,16 +163,16 @@ bool registerBufferReaders() {
   convRegistry.registerReader("{{ datatype.class.full_type }}", [](std::shared_ptr<arrow::Array> array, int64_t rowIndex, bool isSubset) {
     auto buffers = podio::CollectionBufferFactory::instance().createBuffers("{{ datatype.class.full_type }}Collection", 1, isSubset);
     if (!buffers->data) {
-      auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
-      auto obj_array = list_array->value_slice(rowIndex);
-      auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
-      auto collId_arr = std::static_pointer_cast<arrow::UInt32Array>(struct_array->field(0));
-      auto index_arr = std::static_pointer_cast<arrow::Int32Array>(struct_array->field(1));
+      auto collection_frames_list = std::static_pointer_cast<arrow::ListArray>(array);
+      auto frame_collection_slice = collection_frames_list->value_slice(rowIndex);
+      auto raw_data_struct_array = std::static_pointer_cast<arrow::StructArray>(frame_collection_slice);
+      auto collId_arr = std::static_pointer_cast<arrow::UInt32Array>(raw_data_struct_array->field(0));
+      auto index_arr = std::static_pointer_cast<arrow::Int32Array>(raw_data_struct_array->field(1));
       auto* refVec = buffers->references->at(0).get();
-      size_t num_objs = struct_array->length();
-      refVec->reserve(num_objs);
-      for (size_t i = 0; i < num_objs; ++i) {
-        if (struct_array->IsNull(i)) {
+      size_t collection_size = raw_data_struct_array->length();
+      refVec->reserve(collection_size);
+      for (size_t i = 0; i < collection_size; ++i) {
+        if (raw_data_struct_array->IsNull(i)) {
           refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
         } else {
           refVec->push_back(podio::ObjectID{index_arr->Value(i), collId_arr->Value(i)});
@@ -182,16 +182,16 @@ bool registerBufferReaders() {
     }
     
     auto* dataVec = buffers->dataAsVector<{{ datatype.class.full_type }}Data>();
-    auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
-    auto obj_array = list_array->value_slice(rowIndex);
-    auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
-    size_t num_objs = struct_array->length();
-    dataVec->resize(num_objs);
+    auto collection_frames_list = std::static_pointer_cast<arrow::ListArray>(array);
+    auto frame_collection_slice = collection_frames_list->value_slice(rowIndex);
+    auto raw_data_struct_array = std::static_pointer_cast<arrow::StructArray>(frame_collection_slice);
+    size_t collection_size = raw_data_struct_array->length();
+    dataVec->resize(collection_size);
     {%- for member in datatype.arrow_metadata.members %}
-    {{ declare_arrays(member, 'struct_array', '') | indent(4) }}
+    {{ declare_arrays(member, 'raw_data_struct_array', '') | indent(4) }}
     {%- endfor %}
     {%- for member in datatype.arrow_metadata.vector_members %}
-    auto arr_{{ member.name }} = std::static_pointer_cast<arrow::ListArray>(struct_array->GetFieldByName("{{ member.name }}"));
+    auto arr_{{ member.name }} = std::static_pointer_cast<arrow::ListArray>(raw_data_struct_array->GetFieldByName("{{ member.name }}"));
     {%- set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') %}
     {%- if member.value_builder.is_primitive %}
     auto arr_{{ member.name }}_val = std::static_pointer_cast<{{ val_array_type }}>(arr_{{ member.name }}->values());
@@ -203,7 +203,7 @@ bool registerBufferReaders() {
     {%- endif %}
     {%- endfor %}
 
-    for (size_t i = 0; i < num_objs; ++i) {
+    for (size_t i = 0; i < collection_size; ++i) {
       {%- for member in datatype.arrow_metadata.members %}
       {{ read_member(member, '(*dataVec)[i]', '') | indent(6) }}
       {%- endfor %}
@@ -234,7 +234,7 @@ bool registerBufferReaders() {
       {%- endfor %}
       {%- for relation in datatype.arrow_metadata.one_to_many_relations %}
       {
-        auto rel_arr = std::static_pointer_cast<arrow::ListArray>(struct_array->GetFieldByName("{{ relation.name }}"));
+        auto rel_arr = std::static_pointer_cast<arrow::ListArray>(raw_data_struct_array->GetFieldByName("{{ relation.name }}"));
         auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(rel_arr->values());
         auto rel_collId_arr = std::static_pointer_cast<arrow::UInt32Array>(rel_struct_arr->field(0));
         auto rel_index_arr = std::static_pointer_cast<arrow::Int32Array>(rel_struct_arr->field(1));
@@ -256,7 +256,7 @@ bool registerBufferReaders() {
       {%- endfor %}
       {%- for relation in datatype.arrow_metadata.one_to_one_relations %}
       {
-        auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(struct_array->GetFieldByName("{{ relation.name }}"));
+        auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(raw_data_struct_array->GetFieldByName("{{ relation.name }}"));
         auto rel_collId_arr = std::static_pointer_cast<arrow::UInt32Array>(rel_struct_arr->field(0));
         auto rel_index_arr = std::static_pointer_cast<arrow::Int32Array>(rel_struct_arr->field(1));
         

--- a/python/templates/ArrowMapper.cc.jinja2
+++ b/python/templates/ArrowMapper.cc.jinja2
@@ -184,8 +184,7 @@ bool registerConverters() {
     };
 
     checkStatus(collectionBuilder->Append(), "Failed to append to collectionBuilder");
-    for (size_t i = 0; i < concreteColl->size(); ++i) {
-      auto obj = (*concreteColl)[i];
+    for (const auto& obj: *concreteColl) {
       checkStatus(objectBuilder->Append(), "Failed to append to objectBuilder");
       checkStatus(weightBuilder->Append(obj.getWeight()), "Failed to append weight");
       appendRelationRef(fromBuilder, obj.getFrom().getObjectID());

--- a/python/templates/ArrowMapper.cc.jinja2
+++ b/python/templates/ArrowMapper.cc.jinja2
@@ -15,8 +15,13 @@
 #include <stdexcept>
 #include <string>
 
+#include "podio/LinkCollection.h"
+
 {% for datatype in datatypes %}
 #include "{{ incfolder }}{{ datatype.class.bare_type }}Collection.h"
+{% endfor %}
+{% for link in links %}
+#include "{{ incfolder }}{{ link['class'].bare_type }}Collection.h"
 {% endfor %}
 
 namespace {{ package_name }}::arrow_io {
@@ -91,6 +96,16 @@ static const std::map<std::string, std::shared_ptr<arrow::DataType>>& typeMap() 
       }))
     },
 {% endfor %}
+{% for link in links %}
+    {
+      "podio::Link<{{ link.From.full_type }},{{ link.To.full_type }}>",
+      arrow::list(arrow::struct_({
+          arrow::field("weight", arrow::float32()),
+          arrow::field("from", podio::objectRefType()),
+          arrow::field("to", podio::objectRefType()),
+      }))
+    },
+{% endfor %}
   };
   return instance;
 }
@@ -118,7 +133,6 @@ bool registerConverters() {
     }
     auto* collectionBuilder = static_cast<arrow::ListBuilder*>(builder.get());
     auto* objectBuilder = static_cast<arrow::StructBuilder*>(collectionBuilder->value_builder());
-
     {% for member in datatype.arrow_metadata.members %}
     {{ arrow_macros.declare_builder(member, 'objectBuilder', loop.index0, '') | indent(4) }}
     {%- endfor %}
@@ -146,6 +160,40 @@ bool registerConverters() {
       {{ arrow_macros.append_relation(relation) | indent(6) }}
       {%- endfor %}
       checkStatus(objectBuilder->Append(), "Failed to append to objectBuilder");
+    }
+    std::shared_ptr<arrow::Array> array;
+    checkStatus(collectionBuilder->Finish(&array), "Failed to finish collectionBuilder");
+    return array;
+  });
+{% endfor %}
+{% for link in links %}
+  convRegistry.registerConverter("podio::Link<{{ link.From.full_type }},{{ link.To.full_type }}>", [](const podio::CollectionBase* coll) {
+    const auto* concreteColl = static_cast<const podio::LinkCollection<{{ link.From.full_type }},{{ link.To.full_type }}>*>(coll);
+    auto type = podio::ArrowTypeRegistry::instance().getType("podio::Link<{{ link.From.full_type }},{{ link.To.full_type }}>");
+    std::unique_ptr<arrow::ArrayBuilder> builder;
+    auto status = arrow::MakeBuilder(arrow::default_memory_pool(), type, &builder);
+    if (!status.ok()) {
+      throw std::runtime_error("Failed to create builder for Link: " + status.ToString());
+    }
+    auto* collectionBuilder = static_cast<arrow::ListBuilder*>(builder.get());
+    auto* objectBuilder = static_cast<arrow::StructBuilder*>(collectionBuilder->value_builder());
+    auto* weightBuilder = static_cast<arrow::FloatBuilder*>(objectBuilder->child(0));
+    auto* fromBuilder = static_cast<arrow::StructBuilder*>(objectBuilder->child(1));
+    auto* toBuilder = static_cast<arrow::StructBuilder*>(objectBuilder->child(2));
+
+    auto appendRelationRef = [](arrow::StructBuilder* structBuilder, const podio::ObjectID& objId) {
+      checkStatus(structBuilder->Append(), "Failed to append relation struct");
+      checkStatus(static_cast<arrow::UInt32Builder*>(structBuilder->child(0))->Append(objId.collectionID), "Failed to append collectionID");
+      checkStatus(static_cast<arrow::Int32Builder*>(structBuilder->child(1))->Append(objId.index), "Failed to append index");
+    };
+
+    checkStatus(collectionBuilder->Append(), "Failed to append to collectionBuilder");
+    for (size_t i = 0; i < concreteColl->size(); ++i) {
+      auto obj = (*concreteColl)[i];
+      checkStatus(objectBuilder->Append(), "Failed to append to objectBuilder");
+      checkStatus(weightBuilder->Append(obj.getWeight()), "Failed to append weight");
+      appendRelationRef(fromBuilder, obj.getFrom().getObjectID());
+      appendRelationRef(toBuilder, obj.getTo().getObjectID());
     }
     std::shared_ptr<arrow::Array> array;
     checkStatus(collectionBuilder->Finish(&array), "Failed to finish collectionBuilder");
@@ -180,7 +228,7 @@ bool registerBufferReaders() {
       }
       return std::move(buffers).value();
     }
-    
+
     auto* dataVec = buffers->dataAsVector<{{ datatype.class.full_type }}Data>();
     auto collection_frames_list = std::static_pointer_cast<arrow::ListArray>(array);
     auto frame_collection_slice = collection_frames_list->value_slice(rowIndex);
@@ -238,7 +286,7 @@ bool registerBufferReaders() {
         auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(rel_arr->values());
         auto rel_collId_arr = std::static_pointer_cast<arrow::UInt32Array>(rel_struct_arr->field(0));
         auto rel_index_arr = std::static_pointer_cast<arrow::Int32Array>(rel_struct_arr->field(1));
-        
+
         auto* refVec = buffers->references->at({{ loop.index0 }}).get();
         size_t count_begin = refVec->size();
         int32_t start_offset = rel_arr->value_offset(i);
@@ -259,7 +307,7 @@ bool registerBufferReaders() {
         auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(raw_data_struct_array->GetFieldByName("{{ relation.name }}"));
         auto rel_collId_arr = std::static_pointer_cast<arrow::UInt32Array>(rel_struct_arr->field(0));
         auto rel_index_arr = std::static_pointer_cast<arrow::Int32Array>(rel_struct_arr->field(1));
-        
+
         auto* refVec = buffers->references->at({{ loop.index0 + datatype.arrow_metadata.one_to_many_relations|length }}).get();
         if (rel_struct_arr->IsNull(i)) {
           refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
@@ -268,6 +316,62 @@ bool registerBufferReaders() {
         }
       }
       {%- endfor %}
+    }
+    return std::move(buffers).value();
+  });
+{% endfor %}
+{% for link in links %}
+  convRegistry.registerReader("podio::Link<{{ link.From.full_type }},{{ link.To.full_type }}>", [](std::shared_ptr<arrow::Array> array, int64_t rowIndex, bool isSubset) {
+    auto buffers = podio::CollectionBufferFactory::instance().createBuffers("podio::LinkCollection<{{ link.From.full_type }},{{ link.To.full_type }}>", 1, isSubset);
+    if (!buffers->data) {
+      auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
+      auto obj_array = list_array->value_slice(rowIndex);
+      auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
+      auto collId_arr = std::static_pointer_cast<arrow::UInt32Array>(struct_array->field(0));
+      auto index_arr = std::static_pointer_cast<arrow::Int32Array>(struct_array->field(1));
+      auto* refVec = buffers->references->at(0).get();
+      size_t num_objs = struct_array->length();
+      refVec->reserve(num_objs);
+      for (size_t i = 0; i < num_objs; ++i) {
+        if (struct_array->IsNull(i)) {
+          refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
+        } else {
+          refVec->push_back(podio::ObjectID{index_arr->Value(i), collId_arr->Value(i)});
+        }
+      }
+      return std::move(buffers).value();
+    }
+
+    auto* dataVec = buffers->dataAsVector<podio::LinkData>();
+    auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
+    auto obj_array = list_array->value_slice(rowIndex);
+    auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
+    size_t num_objs = struct_array->length();
+    dataVec->resize(num_objs);
+
+    auto weight_arr = std::static_pointer_cast<arrow::FloatArray>(struct_array->GetFieldByName("weight"));
+    auto from_struct_arr = std::static_pointer_cast<arrow::StructArray>(struct_array->GetFieldByName("from"));
+    auto to_struct_arr = std::static_pointer_cast<arrow::StructArray>(struct_array->GetFieldByName("to"));
+
+    auto* fromRefVec = buffers->references->at(0).get();
+    auto* toRefVec = buffers->references->at(1).get();
+    fromRefVec->reserve(num_objs);
+    toRefVec->reserve(num_objs);
+
+    auto readRelationRef = [](arrow::StructArray* structArr, size_t idx, std::vector<podio::ObjectID>* refVec) {
+      if (structArr->IsNull(idx)) {
+        refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
+      } else {
+        auto collId = std::static_pointer_cast<arrow::UInt32Array>(structArr->field(0))->Value(idx);
+        auto index = std::static_pointer_cast<arrow::Int32Array>(structArr->field(1))->Value(idx);
+        refVec->push_back(podio::ObjectID{index, collId});
+      }
+    };
+
+    for (size_t i = 0; i < num_objs; ++i) {
+      (*dataVec)[i].weight = weight_arr->Value(i);
+      readRelationRef(from_struct_arr.get(), i, fromRefVec);
+      readRelationRef(to_struct_arr.get(), i, toRefVec);
     }
     return std::move(buffers).value();
   });

--- a/python/templates/ArrowMapper.cc.jinja2
+++ b/python/templates/ArrowMapper.cc.jinja2
@@ -32,7 +32,7 @@ using podio::arrow_utils::checkStatus;
 {% macro declare_arrays(member, parent_array, path_prefix) -%}
 {% if member.is_array -%}
 auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<arrow::FixedSizeListArray>({{ parent_array }}->GetFieldByName("{{ member.name }}"));
-{% set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') -%}
+{% set val_array_type = member.value_builder.arrow_array_type -%}
 {% if member.value_builder.is_primitive -%}
 auto arr_{{ path_prefix }}{{ member.name }}_val = std::static_pointer_cast<{{ val_array_type }}>(arr_{{ path_prefix }}{{ member.name }}->values());
 {% else -%}
@@ -47,7 +47,7 @@ auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<arrow::St
 {{ declare_arrays(child, 'arr_' + path_prefix + member.name, path_prefix + member.name + '_') }}
 {% endfor -%}
 {% else -%}
-{% set array_type = member.builder_type | replace('Builder', 'Array') -%}
+{% set array_type = member.arrow_array_type -%}
 auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<{{ array_type }}>({{ parent_array }}->GetFieldByName("{{ member.name }}"));
 {% endif -%}
 {%- endmacro %}
@@ -72,14 +72,10 @@ for (size_t arr_i = 0; arr_i < {{ member.array_size }}; ++arr_i) {
 {% endfor -%}
 {% else -%}
 {% set value = (obj_expr + '.' + member.name) -%}
-{% if member.builder_type == 'arrow::BooleanBuilder' -%}
-  {{ value }} = arr_{{ path_prefix }}{{ member.name }}->Value({{ index_var }});
-{% else -%}
-{% if member.builder_type == 'arrow::StringBuilder' -%}
+{% if member.full_type == 'std::string' -%}
   {{ value }} = arr_{{ path_prefix }}{{ member.name }}->GetString({{ index_var }});
 {% else -%}
   {{ value }} = arr_{{ path_prefix }}{{ member.name }}->Value({{ index_var }});
-{% endif -%}
 {% endif -%}
 {% endif -%}
 {%- endmacro %}
@@ -208,31 +204,29 @@ static const bool convertersRegistered = registerConverters();
 bool registerBufferReaders() {
   auto& convRegistry = podio::ArrowConverterRegistry::mutInstance();
 {% for datatype in datatypes %}
-  convRegistry.registerReader("{{ datatype.class.full_type }}", [](std::shared_ptr<arrow::Array> array, int64_t rowIndex, bool isSubset) {
-    auto buffers = podio::CollectionBufferFactory::instance().createBuffers("{{ datatype.class.full_type }}Collection", 1, isSubset);
+  convRegistry.registerReader("{{ datatype.class.full_type }}", [](std::shared_ptr<arrow::Array> array, int64_t rowIndex, bool isSubset, podio::SchemaVersionT version) -> std::optional<podio::CollectionReadBuffers> {
+    auto buffers = podio::CollectionBufferFactory::instance().createBuffers("{{ datatype.class.full_type }}Collection", version, isSubset);
+    if (!buffers) {
+      return std::nullopt;
+    }
+
+    auto collection_frames_list = std::static_pointer_cast<arrow::ListArray>(array);
+    auto frame_collection_slice = collection_frames_list->value_slice(rowIndex);
+    auto raw_data_struct_array = std::static_pointer_cast<arrow::StructArray>(frame_collection_slice);
+
     if (!buffers->data) {
-      auto collection_frames_list = std::static_pointer_cast<arrow::ListArray>(array);
-      auto frame_collection_slice = collection_frames_list->value_slice(rowIndex);
-      auto raw_data_struct_array = std::static_pointer_cast<arrow::StructArray>(frame_collection_slice);
       auto collId_arr = std::static_pointer_cast<arrow::UInt32Array>(raw_data_struct_array->field(0));
       auto index_arr = std::static_pointer_cast<arrow::Int32Array>(raw_data_struct_array->field(1));
       auto* refVec = buffers->references->at(0).get();
       size_t collection_size = raw_data_struct_array->length();
       refVec->reserve(collection_size);
       for (size_t i = 0; i < collection_size; ++i) {
-        if (raw_data_struct_array->IsNull(i)) {
-          refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
-        } else {
-          refVec->push_back(podio::ObjectID{index_arr->Value(i), collId_arr->Value(i)});
-        }
+        refVec->push_back(podio::ObjectID{index_arr->Value(i), collId_arr->Value(i)});
       }
-      return std::move(buffers).value();
+      return buffers;
     }
 
     auto* dataVec = buffers->dataAsVector<{{ datatype.class.full_type }}Data>();
-    auto collection_frames_list = std::static_pointer_cast<arrow::ListArray>(array);
-    auto frame_collection_slice = collection_frames_list->value_slice(rowIndex);
-    auto raw_data_struct_array = std::static_pointer_cast<arrow::StructArray>(frame_collection_slice);
     size_t collection_size = raw_data_struct_array->length();
     dataVec->resize(collection_size);
     {%- for member in datatype.arrow_metadata.members %}
@@ -240,7 +234,7 @@ bool registerBufferReaders() {
     {%- endfor %}
     {%- for member in datatype.arrow_metadata.vector_members %}
     auto arr_{{ member.name }} = std::static_pointer_cast<arrow::ListArray>(raw_data_struct_array->GetFieldByName("{{ member.name }}"));
-    {%- set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') %}
+    {%- set val_array_type = member.value_builder.arrow_array_type %}
     {%- if member.value_builder.is_primitive %}
     auto arr_{{ member.name }}_val = std::static_pointer_cast<{{ val_array_type }}>(arr_{{ member.name }}->values());
     {%- else %}
@@ -259,11 +253,12 @@ bool registerBufferReaders() {
       {
         auto* vecMemberBuffer = podio::CollectionReadBuffers::asVector<{{ member.full_type }}>(buffers->vectorMembers->at({{ loop.index0 }}).second);
         size_t count_begin = vecMemberBuffer->size();
+        // Get start and end offsets of the vector/list element in the flat values array
         int32_t start_offset = arr_{{ member.name }}->value_offset(i);
         int32_t end_offset = arr_{{ member.name }}->value_offset(i + 1);
         for (int32_t j = start_offset; j < end_offset; ++j) {
         {% if member.value_builder.is_primitive -%}
-        {% if member.value_builder.builder_type == 'arrow::StringBuilder' -%}
+        {% if member.value_builder.full_type == 'std::string' -%}
           vecMemberBuffer->push_back(arr_{{ member.name }}_val->GetString(j));
         {% else -%}
           vecMemberBuffer->push_back(arr_{{ member.name }}_val->Value(j));
@@ -289,14 +284,11 @@ bool registerBufferReaders() {
 
         auto* refVec = buffers->references->at({{ loop.index0 }}).get();
         size_t count_begin = refVec->size();
+        // Get start and end offsets of the relation list in the flat values array
         int32_t start_offset = rel_arr->value_offset(i);
         int32_t end_offset = rel_arr->value_offset(i + 1);
         for (int32_t j = start_offset; j < end_offset; ++j) {
-          if (rel_struct_arr->IsNull(j)) {
-            refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
-          } else {
-            refVec->push_back(podio::ObjectID{rel_index_arr->Value(j), rel_collId_arr->Value(j)});
-          }
+          refVec->push_back(podio::ObjectID{rel_index_arr->Value(j), rel_collId_arr->Value(j)});
         }
         (*dataVec)[i].{{ relation.name }}_begin = count_begin;
         (*dataVec)[i].{{ relation.name }}_end = refVec->size();
@@ -309,44 +301,36 @@ bool registerBufferReaders() {
         auto rel_index_arr = std::static_pointer_cast<arrow::Int32Array>(rel_struct_arr->field(1));
 
         auto* refVec = buffers->references->at({{ loop.index0 + datatype.arrow_metadata.one_to_many_relations|length }}).get();
-        if (rel_struct_arr->IsNull(i)) {
-          refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
-        } else {
-          refVec->push_back(podio::ObjectID{rel_index_arr->Value(i), rel_collId_arr->Value(i)});
-        }
+        refVec->push_back(podio::ObjectID{rel_index_arr->Value(i), rel_collId_arr->Value(i)});
       }
       {%- endfor %}
     }
-    return std::move(buffers).value();
+    return buffers;
   });
 {% endfor %}
 {% for link in links %}
-  convRegistry.registerReader("podio::Link<{{ link.From.full_type }},{{ link.To.full_type }}>", [](std::shared_ptr<arrow::Array> array, int64_t rowIndex, bool isSubset) {
-    auto buffers = podio::CollectionBufferFactory::instance().createBuffers("podio::LinkCollection<{{ link.From.full_type }},{{ link.To.full_type }}>", 1, isSubset);
-    if (!buffers->data) {
-      auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
-      auto obj_array = list_array->value_slice(rowIndex);
-      auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
-      auto collId_arr = std::static_pointer_cast<arrow::UInt32Array>(struct_array->field(0));
-      auto index_arr = std::static_pointer_cast<arrow::Int32Array>(struct_array->field(1));
-      auto* refVec = buffers->references->at(0).get();
-      size_t num_objs = struct_array->length();
-      refVec->reserve(num_objs);
-      for (size_t i = 0; i < num_objs; ++i) {
-        if (struct_array->IsNull(i)) {
-          refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
-        } else {
-          refVec->push_back(podio::ObjectID{index_arr->Value(i), collId_arr->Value(i)});
-        }
-      }
-      return std::move(buffers).value();
+  convRegistry.registerReader("podio::Link<{{ link.From.full_type }},{{ link.To.full_type }}>", [](std::shared_ptr<arrow::Array> array, int64_t rowIndex, bool isSubset, podio::SchemaVersionT version) -> std::optional<podio::CollectionReadBuffers> {
+    auto buffers = podio::CollectionBufferFactory::instance().createBuffers("podio::LinkCollection<{{ link.From.full_type }},{{ link.To.full_type }}>", version, isSubset);
+    if (!buffers) {
+      return std::nullopt;
     }
-
-    auto* dataVec = buffers->dataAsVector<podio::LinkData>();
     auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
     auto obj_array = list_array->value_slice(rowIndex);
     auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
     size_t num_objs = struct_array->length();
+
+    if (!buffers->data) {
+      auto collId_arr = std::static_pointer_cast<arrow::UInt32Array>(struct_array->field(0));
+      auto index_arr = std::static_pointer_cast<arrow::Int32Array>(struct_array->field(1));
+      auto* refVec = buffers->references->at(0).get();
+      refVec->reserve(num_objs);
+      for (size_t i = 0; i < num_objs; ++i) {
+        refVec->push_back(podio::ObjectID{index_arr->Value(i), collId_arr->Value(i)});
+      }
+      return buffers;
+    }
+
+    auto* dataVec = buffers->dataAsVector<podio::LinkData>();
     dataVec->resize(num_objs);
 
     auto weight_arr = std::static_pointer_cast<arrow::FloatArray>(struct_array->GetFieldByName("weight"));
@@ -359,13 +343,9 @@ bool registerBufferReaders() {
     toRefVec->reserve(num_objs);
 
     auto readRelationRef = [](arrow::StructArray* structArr, size_t idx, std::vector<podio::ObjectID>* refVec) {
-      if (structArr->IsNull(idx)) {
-        refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
-      } else {
-        auto collId = std::static_pointer_cast<arrow::UInt32Array>(structArr->field(0))->Value(idx);
-        auto index = std::static_pointer_cast<arrow::Int32Array>(structArr->field(1))->Value(idx);
-        refVec->push_back(podio::ObjectID{index, collId});
-      }
+      auto collId = std::static_pointer_cast<arrow::UInt32Array>(structArr->field(0))->Value(idx);
+      auto index = std::static_pointer_cast<arrow::Int32Array>(structArr->field(1))->Value(idx);
+      refVec->push_back(podio::ObjectID{index, collId});
     };
 
     for (size_t i = 0; i < num_objs; ++i) {
@@ -373,7 +353,7 @@ bool registerBufferReaders() {
       readRelationRef(from_struct_arr.get(), i, fromRefVec);
       readRelationRef(to_struct_arr.get(), i, toRefVec);
     }
-    return std::move(buffers).value();
+    return buffers;
   });
 {% endfor %}
   return true;

--- a/python/templates/ArrowMapper.cc.jinja2
+++ b/python/templates/ArrowMapper.cc.jinja2
@@ -27,7 +27,7 @@ using podio::arrow_utils::checkStatus;
 {% macro declare_arrays(member, parent_array, path_prefix) -%}
 {% if member.is_array -%}
 auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<arrow::FixedSizeListArray>({{ parent_array }}->GetFieldByName("{{ member.name }}"));
-{% set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') %}
+{% set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') -%}
 {% if member.value_builder.is_primitive -%}
 auto arr_{{ path_prefix }}{{ member.name }}_val = std::static_pointer_cast<{{ val_array_type }}>(arr_{{ path_prefix }}{{ member.name }}->values());
 {% else -%}
@@ -42,7 +42,7 @@ auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<arrow::St
 {{ declare_arrays(child, 'arr_' + path_prefix + member.name, path_prefix + member.name + '_') }}
 {% endfor -%}
 {% else -%}
-{% set array_type = member.builder_type | replace('Builder', 'Array') %}
+{% set array_type = member.builder_type | replace('Builder', 'Array') -%}
 auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<{{ array_type }}>({{ parent_array }}->GetFieldByName("{{ member.name }}"));
 {% endif -%}
 {%- endmacro %}
@@ -187,30 +187,27 @@ bool registerBufferReaders() {
     auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
     size_t num_objs = struct_array->length();
     dataVec->resize(num_objs);
-    
-    {% for member in datatype.arrow_metadata.members %}
+    {%- for member in datatype.arrow_metadata.members %}
     {{ declare_arrays(member, 'struct_array', '') | indent(4) }}
-    {% endfor %}
-    
-    {% for member in datatype.arrow_metadata.vector_members %}
+    {%- endfor %}
+    {%- for member in datatype.arrow_metadata.vector_members %}
     auto arr_{{ member.name }} = std::static_pointer_cast<arrow::ListArray>(struct_array->GetFieldByName("{{ member.name }}"));
-    {% set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') %}
-    {% if member.value_builder.is_primitive -%}
+    {%- set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') %}
+    {%- if member.value_builder.is_primitive %}
     auto arr_{{ member.name }}_val = std::static_pointer_cast<{{ val_array_type }}>(arr_{{ member.name }}->values());
-    {% else -%}
+    {%- else %}
     auto arr_{{ member.name }}_val = std::static_pointer_cast<arrow::StructArray>(arr_{{ member.name }}->values());
-    {% for child in member.value_builder.children -%}
+    {%- for child in member.value_builder.children %}
     {{ declare_arrays(child, 'arr_' + member.name + '_val', member.name + '_val_') | indent(4) }}
-    {% endfor -%}
-    {% endif -%}
-    {% endfor %}
+    {%- endfor %}
+    {%- endif %}
+    {%- endfor %}
 
     for (size_t i = 0; i < num_objs; ++i) {
-      {% for member in datatype.arrow_metadata.members %}
+      {%- for member in datatype.arrow_metadata.members %}
       {{ read_member(member, '(*dataVec)[i]', '') | indent(6) }}
-      {% endfor %}
-      
-      {% for member in datatype.arrow_metadata.vector_members %}
+      {%- endfor %}
+      {%- for member in datatype.arrow_metadata.vector_members %}
       {
         auto* vecMemberBuffer = podio::CollectionReadBuffers::asVector<{{ member.full_type }}>(buffers->vectorMembers->at({{ loop.index0 }}).second);
         size_t count_begin = vecMemberBuffer->size();
@@ -234,9 +231,8 @@ bool registerBufferReaders() {
         (*dataVec)[i].{{ member.name }}_begin = count_begin;
         (*dataVec)[i].{{ member.name }}_end = vecMemberBuffer->size();
       }
-      {% endfor %}
-      
-      {% for relation in datatype.arrow_metadata.one_to_many_relations %}
+      {%- endfor %}
+      {%- for relation in datatype.arrow_metadata.one_to_many_relations %}
       {
         auto rel_arr = std::static_pointer_cast<arrow::ListArray>(struct_array->GetFieldByName("{{ relation.name }}"));
         auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(rel_arr->values());
@@ -257,9 +253,8 @@ bool registerBufferReaders() {
         (*dataVec)[i].{{ relation.name }}_begin = count_begin;
         (*dataVec)[i].{{ relation.name }}_end = refVec->size();
       }
-      {% endfor %}
-      
-      {% for relation in datatype.arrow_metadata.one_to_one_relations %}
+      {%- endfor %}
+      {%- for relation in datatype.arrow_metadata.one_to_one_relations %}
       {
         auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(struct_array->GetFieldByName("{{ relation.name }}"));
         auto rel_collId_arr = std::static_pointer_cast<arrow::UInt32Array>(rel_struct_arr->field(0));
@@ -272,7 +267,7 @@ bool registerBufferReaders() {
           refVec->push_back(podio::ObjectID{rel_index_arr->Value(i), rel_collId_arr->Value(i)});
         }
       }
-      {% endfor %}
+      {%- endfor %}
     }
     return std::move(buffers).value();
   });

--- a/python/templates/ArrowMapper.cc.jinja2
+++ b/python/templates/ArrowMapper.cc.jinja2
@@ -4,6 +4,7 @@
 #include "podio/utilities/ArrowFrameConverter.h"
 #include "podio/utilities/ArrowTypeRegistry.h"
 #include "podio/utilities/ArrowConverterRegistry.h"
+#include "podio/CollectionBufferFactory.h"
 #include <arrow/type.h>
 #include <arrow/api.h>
 
@@ -22,6 +23,61 @@ namespace {{ package_name }}::arrow_io {
 
 namespace {
 using podio::arrow_utils::checkStatus;
+
+{% macro declare_arrays(member, parent_array, path_prefix) -%}
+{% if member.is_array -%}
+auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<arrow::FixedSizeListArray>({{ parent_array }}->GetFieldByName("{{ member.name }}"));
+{% set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') %}
+{% if member.value_builder.is_primitive -%}
+auto arr_{{ path_prefix }}{{ member.name }}_val = std::static_pointer_cast<{{ val_array_type }}>(arr_{{ path_prefix }}{{ member.name }}->values());
+{% else -%}
+auto arr_{{ path_prefix }}{{ member.name }}_val = std::static_pointer_cast<arrow::StructArray>(arr_{{ path_prefix }}{{ member.name }}->values());
+{% for child in member.value_builder.children -%}
+{{ declare_arrays(child, 'arr_' + path_prefix + member.name + '_val', path_prefix + member.name + '_val_') }}
+{% endfor -%}
+{% endif -%}
+{% elif member.is_struct -%}
+auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<arrow::StructArray>({{ parent_array }}->GetFieldByName("{{ member.name }}"));
+{% for child in member.children -%}
+{{ declare_arrays(child, 'arr_' + path_prefix + member.name, path_prefix + member.name + '_') }}
+{% endfor -%}
+{% else -%}
+{% set array_type = member.builder_type | replace('Builder', 'Array') %}
+auto arr_{{ path_prefix }}{{ member.name }} = std::static_pointer_cast<{{ array_type }}>({{ parent_array }}->GetFieldByName("{{ member.name }}"));
+{% endif -%}
+{%- endmacro %}
+
+{% macro read_member(member, obj_expr, path_prefix, index_var='i') -%}
+{% if member.is_array -%}
+for (size_t arr_i = 0; arr_i < {{ member.array_size }}; ++arr_i) {
+{% if member.value_builder.is_primitive -%}
+{% set value = (obj_expr + '.' + member.name + '[arr_i]') -%}
+  {{ value }} = arr_{{ path_prefix }}{{ member.name }}_val->Value({{ index_var }} * {{ member.array_size }} + arr_i);
+{% else -%}
+{% set sub_obj = (obj_expr + '.' + member.name + '[arr_i]') -%}
+{% for child in member.value_builder.children -%}
+{{ read_member(child, sub_obj, path_prefix + member.name + '_val_', index_var) | indent(2, first=True) }}
+{% endfor -%}
+{% endif -%}
+}
+{% elif member.is_struct -%}
+{% set sub_obj = (obj_expr + '.' + member.name) -%}
+{% for child in member.children -%}
+{{ read_member(child, sub_obj, path_prefix + member.name + '_', index_var) }}
+{% endfor -%}
+{% else -%}
+{% set value = (obj_expr + '.' + member.name) -%}
+{% if member.builder_type == 'arrow::BooleanBuilder' -%}
+  {{ value }} = arr_{{ path_prefix }}{{ member.name }}->Value({{ index_var }});
+{% else -%}
+{% if member.builder_type == 'arrow::StringBuilder' -%}
+  {{ value }} = arr_{{ path_prefix }}{{ member.name }}->GetString({{ index_var }});
+{% else -%}
+  {{ value }} = arr_{{ path_prefix }}{{ member.name }}->Value({{ index_var }});
+{% endif -%}
+{% endif -%}
+{% endif -%}
+{%- endmacro %}
 
 static const std::map<std::string, std::shared_ptr<arrow::DataType>>& typeMap() {
   static const std::map<std::string, std::shared_ptr<arrow::DataType>> instance = {
@@ -100,6 +156,131 @@ bool registerConverters() {
 }
 
 static const bool convertersRegistered = registerConverters();
+
+bool registerBufferReaders() {
+  auto& convRegistry = podio::ArrowConverterRegistry::mutInstance();
+{% for datatype in datatypes %}
+  convRegistry.registerReader("{{ datatype.class.full_type }}", [](std::shared_ptr<arrow::Array> array, int64_t rowIndex, bool isSubset) {
+    auto buffers = podio::CollectionBufferFactory::instance().createBuffers("{{ datatype.class.full_type }}Collection", 1, isSubset);
+    if (!buffers->data) {
+      auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
+      auto obj_array = list_array->value_slice(rowIndex);
+      auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
+      auto collId_arr = std::static_pointer_cast<arrow::UInt32Array>(struct_array->field(0));
+      auto index_arr = std::static_pointer_cast<arrow::Int32Array>(struct_array->field(1));
+      auto* refVec = buffers->references->at(0).get();
+      size_t num_objs = struct_array->length();
+      refVec->reserve(num_objs);
+      for (size_t i = 0; i < num_objs; ++i) {
+        if (struct_array->IsNull(i)) {
+          refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
+        } else {
+          refVec->push_back(podio::ObjectID{index_arr->Value(i), collId_arr->Value(i)});
+        }
+      }
+      return std::move(buffers).value();
+    }
+    
+    auto* dataVec = buffers->dataAsVector<{{ datatype.class.full_type }}Data>();
+    auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
+    auto obj_array = list_array->value_slice(rowIndex);
+    auto struct_array = std::static_pointer_cast<arrow::StructArray>(obj_array);
+    size_t num_objs = struct_array->length();
+    dataVec->resize(num_objs);
+    
+    {% for member in datatype.arrow_metadata.members %}
+    {{ declare_arrays(member, 'struct_array', '') | indent(4) }}
+    {% endfor %}
+    
+    {% for member in datatype.arrow_metadata.vector_members %}
+    auto arr_{{ member.name }} = std::static_pointer_cast<arrow::ListArray>(struct_array->GetFieldByName("{{ member.name }}"));
+    {% set val_array_type = member.value_builder.builder_type | replace('Builder', 'Array') %}
+    {% if member.value_builder.is_primitive -%}
+    auto arr_{{ member.name }}_val = std::static_pointer_cast<{{ val_array_type }}>(arr_{{ member.name }}->values());
+    {% else -%}
+    auto arr_{{ member.name }}_val = std::static_pointer_cast<arrow::StructArray>(arr_{{ member.name }}->values());
+    {% for child in member.value_builder.children -%}
+    {{ declare_arrays(child, 'arr_' + member.name + '_val', member.name + '_val_') | indent(4) }}
+    {% endfor -%}
+    {% endif -%}
+    {% endfor %}
+
+    for (size_t i = 0; i < num_objs; ++i) {
+      {% for member in datatype.arrow_metadata.members %}
+      {{ read_member(member, '(*dataVec)[i]', '') | indent(6) }}
+      {% endfor %}
+      
+      {% for member in datatype.arrow_metadata.vector_members %}
+      {
+        auto* vecMemberBuffer = podio::CollectionReadBuffers::asVector<{{ member.full_type }}>(buffers->vectorMembers->at({{ loop.index0 }}).second);
+        size_t count_begin = vecMemberBuffer->size();
+        int32_t start_offset = arr_{{ member.name }}->value_offset(i);
+        int32_t end_offset = arr_{{ member.name }}->value_offset(i + 1);
+        for (int32_t j = start_offset; j < end_offset; ++j) {
+        {% if member.value_builder.is_primitive -%}
+        {% if member.value_builder.builder_type == 'arrow::StringBuilder' -%}
+          vecMemberBuffer->push_back(arr_{{ member.name }}_val->GetString(j));
+        {% else -%}
+          vecMemberBuffer->push_back(arr_{{ member.name }}_val->Value(j));
+        {% endif -%}
+        {% else -%}
+          {{ member.full_type }} val;
+        {% for child in member.value_builder.children -%}
+          {{ read_member(child, 'val', member.name + '_val_', 'j') | indent(10) }}
+        {% endfor -%}
+          vecMemberBuffer->push_back(val);
+        {% endif -%}
+        }
+        (*dataVec)[i].{{ member.name }}_begin = count_begin;
+        (*dataVec)[i].{{ member.name }}_end = vecMemberBuffer->size();
+      }
+      {% endfor %}
+      
+      {% for relation in datatype.arrow_metadata.one_to_many_relations %}
+      {
+        auto rel_arr = std::static_pointer_cast<arrow::ListArray>(struct_array->GetFieldByName("{{ relation.name }}"));
+        auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(rel_arr->values());
+        auto rel_collId_arr = std::static_pointer_cast<arrow::UInt32Array>(rel_struct_arr->field(0));
+        auto rel_index_arr = std::static_pointer_cast<arrow::Int32Array>(rel_struct_arr->field(1));
+        
+        auto* refVec = buffers->references->at({{ loop.index0 }}).get();
+        size_t count_begin = refVec->size();
+        int32_t start_offset = rel_arr->value_offset(i);
+        int32_t end_offset = rel_arr->value_offset(i + 1);
+        for (int32_t j = start_offset; j < end_offset; ++j) {
+          if (rel_struct_arr->IsNull(j)) {
+            refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
+          } else {
+            refVec->push_back(podio::ObjectID{rel_index_arr->Value(j), rel_collId_arr->Value(j)});
+          }
+        }
+        (*dataVec)[i].{{ relation.name }}_begin = count_begin;
+        (*dataVec)[i].{{ relation.name }}_end = refVec->size();
+      }
+      {% endfor %}
+      
+      {% for relation in datatype.arrow_metadata.one_to_one_relations %}
+      {
+        auto rel_struct_arr = std::static_pointer_cast<arrow::StructArray>(struct_array->GetFieldByName("{{ relation.name }}"));
+        auto rel_collId_arr = std::static_pointer_cast<arrow::UInt32Array>(rel_struct_arr->field(0));
+        auto rel_index_arr = std::static_pointer_cast<arrow::Int32Array>(rel_struct_arr->field(1));
+        
+        auto* refVec = buffers->references->at({{ loop.index0 + datatype.arrow_metadata.one_to_many_relations|length }}).get();
+        if (rel_struct_arr->IsNull(i)) {
+          refVec->push_back(podio::ObjectID{podio::ObjectID::invalid, static_cast<uint32_t>(podio::ObjectID::untracked)});
+        } else {
+          refVec->push_back(podio::ObjectID{rel_index_arr->Value(i), rel_collId_arr->Value(i)});
+        }
+      }
+      {% endfor %}
+    }
+    return std::move(buffers).value();
+  });
+{% endfor %}
+  return true;
+}
+
+static const bool readersRegistered = registerBufferReaders();
 
 } // namespace
 

--- a/src/ArrowConverterRegistry.cc
+++ b/src/ArrowConverterRegistry.cc
@@ -23,4 +23,16 @@ ArrowConverterRegistry::CreatorFunc ArrowConverterRegistry::getConverter(const s
   return nullptr;
 }
 
+void ArrowConverterRegistry::registerReader(const std::string& typeName, BufferReaderFunc reader) {
+  m_readerRegistry[typeName] = std::move(reader);
+}
+
+ArrowConverterRegistry::BufferReaderFunc ArrowConverterRegistry::getReader(const std::string& typeName) const {
+  auto it = m_readerRegistry.find(typeName);
+  if (it != m_readerRegistry.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
 } // namespace podio

--- a/src/ArrowConverterRegistry.cc
+++ b/src/ArrowConverterRegistry.cc
@@ -23,7 +23,7 @@ ArrowConverterRegistry::CreatorFunc ArrowConverterRegistry::getConverter(const s
   return nullptr;
 }
 
-void ArrowConverterRegistry::registerReader(const std::string& typeName, BufferReaderFunc reader) {
+void ArrowConverterRegistry::registerReader(const std::string& typeName, BufferReaderFunc&& reader) {
   m_readerRegistry[typeName] = std::move(reader);
 }
 

--- a/src/ArrowFrameConverter.cc
+++ b/src/ArrowFrameConverter.cc
@@ -179,8 +179,8 @@ std::shared_ptr<arrow::Table> convertFrameToTable(const podio::Frame& frame,
   return tableResult.ValueOrDie();
 }
 
-std::unique_ptr<podio::Frame> convertTableToFrame(const std::shared_ptr<arrow::Table>& table, int rowIndex) {
-  return std::make_unique<podio::Frame>(std::make_unique<ArrowFrameData>(table, rowIndex));
+podio::Frame convertTableToFrame(const std::shared_ptr<arrow::Table>& table, int rowIndex) {
+  return podio::Frame(std::make_unique<ArrowFrameData>(table, rowIndex));
 }
 
 } // namespace podio

--- a/src/ArrowFrameConverter.cc
+++ b/src/ArrowFrameConverter.cc
@@ -1,9 +1,9 @@
 #include "podio/utilities/ArrowFrameConverter.h"
 #include "podio/Frame.h"
 #include "podio/utilities/ArrowConverterRegistry.h"
+#include "podio/utilities/ArrowFrameData.h"
 #include "podio/utilities/ArrowTypeRegistry.h"
 #include "podio/utilities/ArrowUtils.h"
-#include "podio/utilities/ArrowFrameData.h"
 
 #include <algorithm>
 #include <arrow/api.h>

--- a/src/ArrowFrameConverter.cc
+++ b/src/ArrowFrameConverter.cc
@@ -3,7 +3,9 @@
 #include "podio/utilities/ArrowConverterRegistry.h"
 #include "podio/utilities/ArrowTypeRegistry.h"
 #include "podio/utilities/ArrowUtils.h"
+#include "podio/utilities/ArrowFrameData.h"
 
+#include <algorithm>
 #include <arrow/api.h>
 #include <stdexcept>
 
@@ -52,10 +54,10 @@ namespace {
     auto stringMap = buildParamMap<std::string, arrow::StringBuilder>(params);
 
     std::vector<std::shared_ptr<arrow::Field>> fields = {
-        arrow::field("int_params", arrow::map(arrow::utf8(), arrow::list(arrow::int32())), true),
-        arrow::field("float_params", arrow::map(arrow::utf8(), arrow::list(arrow::float32())), true),
-        arrow::field("double_params", arrow::map(arrow::utf8(), arrow::list(arrow::float64())), true),
-        arrow::field("string_params", arrow::map(arrow::utf8(), arrow::list(arrow::utf8())), true),
+        arrow::field("int_params", arrow::map(arrow::utf8(), arrow::list(arrow::int32()))),
+        arrow::field("float_params", arrow::map(arrow::utf8(), arrow::list(arrow::float32()))),
+        arrow::field("double_params", arrow::map(arrow::utf8(), arrow::list(arrow::float64()))),
+        arrow::field("string_params", arrow::map(arrow::utf8(), arrow::list(arrow::utf8()))),
     };
 
     auto structResult = arrow::StructArray::Make({intMap, floatMap, doubleMap, stringMap}, fields);
@@ -174,6 +176,10 @@ std::shared_ptr<arrow::Table> convertFrameToTable(const podio::Frame& frame,
   }
 
   return tableResult.ValueOrDie();
+}
+
+std::unique_ptr<podio::Frame> convertTableToFrame(const std::shared_ptr<arrow::Table>& table, int rowIndex) {
+  return std::make_unique<podio::Frame>(std::make_unique<ArrowFrameData>(table, rowIndex));
 }
 
 } // namespace podio

--- a/src/ArrowFrameConverter.cc
+++ b/src/ArrowFrameConverter.cc
@@ -146,10 +146,11 @@ std::shared_ptr<arrow::Table> convertFrameToTable(const podio::Frame& frame,
                                std::to_string(array->length()) + ", expected 1");
     }
 
-    // Attach "value_type", "is_subset", and "coll_id" metadata to the field
-    auto metadata = arrow::KeyValueMetadata::Make(
-        {"value_type", "is_subset", "coll_id"},
-        {typeName, coll->isSubsetCollection() ? "1" : "0", std::to_string(coll->getID())});
+    // Attach "value_type", "is_subset", "coll_id", and "schema_version" metadata to the field
+    auto metadata =
+        arrow::KeyValueMetadata::Make({"value_type", "is_subset", "coll_id", "schema_version"},
+                                      {typeName, coll->isSubsetCollection() ? "1" : "0", std::to_string(coll->getID()),
+                                       std::to_string(coll->getSchemaVersion())});
     auto field = arrow::field(collName, arrowType, /*nullable=*/true, std::move(metadata));
 
     fields.push_back(std::move(field));

--- a/src/ArrowFrameData.cc
+++ b/src/ArrowFrameData.cc
@@ -1,0 +1,202 @@
+#include "podio/utilities/ArrowFrameData.h"
+#include "podio/utilities/ArrowConverterRegistry.h"
+
+#include <algorithm>
+#include <arrow/api.h>
+#include <stdexcept>
+#include <type_traits>
+
+namespace podio {
+
+namespace {
+
+  struct IntSetter {
+    using ArrayType = arrow::Int32Array;
+    using ValueType = int32_t;
+    static ValueType getValue(const ArrayType* arr, int32_t idx) {
+      return arr->Value(idx);
+    }
+    static void set(podio::GenericParameters* p, const std::string& k, const std::vector<int32_t>& v) {
+      p->set(k, v);
+    }
+  };
+  struct FloatSetter {
+    using ArrayType = arrow::FloatArray;
+    using ValueType = float;
+    static ValueType getValue(const ArrayType* arr, int32_t idx) {
+      return arr->Value(idx);
+    }
+    static void set(podio::GenericParameters* p, const std::string& k, const std::vector<float>& v) {
+      p->set(k, v);
+    }
+  };
+  struct DoubleSetter {
+    using ArrayType = arrow::DoubleArray;
+    using ValueType = double;
+    static ValueType getValue(const ArrayType* arr, int32_t idx) {
+      return arr->Value(idx);
+    }
+    static void set(podio::GenericParameters* p, const std::string& k, const std::vector<double>& v) {
+      p->set(k, v);
+    }
+  };
+  struct StringSetter {
+    using ArrayType = arrow::StringArray;
+    using ValueType = std::string;
+    static ValueType getValue(const ArrayType* arr, int32_t idx) {
+      return arr->GetString(idx);
+    }
+    static void set(podio::GenericParameters* p, const std::string& k, const std::vector<std::string>& v) {
+      p->set(k, v);
+    }
+  };
+
+  template <typename Setter>
+  void extractMap(const arrow::StructArray* struct_array, const std::string& fieldName, int64_t rowIndex, podio::GenericParameters* params) {
+    auto map_array = std::static_pointer_cast<arrow::MapArray>(struct_array->GetFieldByName(fieldName));
+    if (!map_array)
+      return;
+    auto keys_array = std::static_pointer_cast<arrow::StringArray>(map_array->keys());
+    auto items_array = map_array->items();
+    auto list_items = std::static_pointer_cast<arrow::ListArray>(items_array);
+
+    int32_t start = map_array->value_offset(rowIndex);
+    int32_t end = map_array->value_offset(rowIndex + 1);
+
+    using ArrayType = typename Setter::ArrayType;
+    using ValueType = typename Setter::ValueType;
+    auto val_array = std::static_pointer_cast<ArrayType>(list_items->values());
+
+    for (int32_t i = start; i < end; ++i) {
+      std::string key = keys_array->GetString(i);
+
+      int32_t list_start = list_items->value_offset(i);
+      int32_t list_end = list_items->value_offset(i + 1);
+
+      std::vector<ValueType> vals;
+      vals.reserve(list_end - list_start);
+      for (int32_t j = list_start; j < list_end; ++j) {
+        vals.push_back(Setter::getValue(val_array.get(), j));
+      }
+      Setter::set(params, key, vals);
+    }
+  }
+
+} // namespace
+
+ArrowFrameData::ArrowFrameData(std::shared_ptr<arrow::Table> table, int64_t rowIndex) :
+    m_table(std::move(table)), m_rowIndex(rowIndex) {
+  if (!m_table) {
+    throw std::runtime_error("ArrowTable is null");
+  }
+  if (m_rowIndex < 0 || m_rowIndex >= m_table->num_rows()) {
+    throw std::runtime_error("ArrowTable row index out of bounds");
+  }
+
+  std::vector<uint32_t> ids;
+  std::vector<std::string> names;
+
+  auto schema = m_table->schema();
+  for (int i = 0; i < schema->num_fields(); ++i) {
+    auto field = schema->field(i);
+    if (field->name() == "frame_parameters") {
+      continue;
+    }
+    m_availableCollections.push_back(field->name());
+
+    auto metadata = field->metadata();
+    if (!metadata) {
+      throw std::runtime_error("Missing metadata for collection column: " + field->name());
+    }
+    auto collIdIdx = metadata->FindKey("coll_id");
+    if (collIdIdx == -1) {
+      throw std::runtime_error("Missing coll_id in metadata for collection: " + field->name());
+    }
+
+    uint32_t collId = std::stoul(metadata->value(collIdIdx));
+    if (std::find(ids.begin(), ids.end(), collId) != ids.end() ||
+        std::find(names.begin(), names.end(), field->name()) != names.end()) {
+      throw std::runtime_error("Duplicate collection ID or name: " + field->name());
+    }
+    ids.push_back(collId);
+    names.push_back(field->name());
+  }
+  m_idTable = podio::CollectionIDTable(std::move(ids), std::move(names));
+}
+
+std::optional<podio::CollectionReadBuffers> ArrowFrameData::getCollectionBuffers(const std::string& name) {
+  auto chunked_array = m_table->GetColumnByName(name);
+  if (!chunked_array)
+    return std::nullopt;
+
+  auto field = m_table->schema()->GetFieldByName(name);
+  auto metadata = field->metadata();
+
+  auto typeNameIdx = metadata->FindKey("value_type");
+  auto isSubsetIdx = metadata->FindKey("is_subset");
+
+  if (typeNameIdx == -1 || isSubsetIdx == -1) {
+    throw std::runtime_error("Missing value_type or is_subset in metadata for: " + name);
+  }
+
+  std::string typeName = metadata->value(typeNameIdx);
+  bool isSubset = (metadata->value(isSubsetIdx) == "1");
+
+  int64_t remaining_idx = m_rowIndex;
+  std::shared_ptr<arrow::Array> chunk;
+  for (const auto& c : chunked_array->chunks()) {
+    if (remaining_idx < c->length()) {
+      chunk = c;
+      break;
+    }
+    remaining_idx -= c->length();
+  }
+  if (!chunk) {
+    throw std::runtime_error("Row index out of bounds in chunked array");
+  }
+
+  auto reader = podio::ArrowConverterRegistry::instance().getReader(typeName);
+  if (!reader) {
+    throw std::runtime_error("No Arrow reader registered for type: " + typeName);
+  }
+
+  return reader(chunk, remaining_idx, isSubset);
+}
+
+std::unique_ptr<podio::GenericParameters> ArrowFrameData::getParameters() {
+  auto chunked_array = m_table->GetColumnByName("frame_parameters");
+  if (!chunked_array) {
+    return std::make_unique<podio::GenericParameters>();
+  }
+  int64_t remaining_idx = m_rowIndex;
+  std::shared_ptr<arrow::Array> chunk;
+  for (const auto& c : chunked_array->chunks()) {
+    if (remaining_idx < c->length()) {
+      chunk = c;
+      break;
+    }
+    remaining_idx -= c->length();
+  }
+  if (!chunk)
+    return std::make_unique<podio::GenericParameters>();
+
+  auto struct_array = std::static_pointer_cast<arrow::StructArray>(chunk);
+  auto params = std::make_unique<podio::GenericParameters>();
+
+  extractMap<IntSetter>(struct_array.get(), "int_params", remaining_idx, params.get());
+  extractMap<FloatSetter>(struct_array.get(), "float_params", remaining_idx, params.get());
+  extractMap<DoubleSetter>(struct_array.get(), "double_params", remaining_idx, params.get());
+  extractMap<StringSetter>(struct_array.get(), "string_params", remaining_idx, params.get());
+
+  return params;
+}
+
+std::vector<std::string> ArrowFrameData::getAvailableCollections() const {
+  return m_availableCollections;
+}
+
+podio::CollectionIDTable ArrowFrameData::getIDTable() const {
+  return {m_idTable.ids(), m_idTable.names()};
+}
+
+} // namespace podio

--- a/src/ArrowFrameData.cc
+++ b/src/ArrowFrameData.cc
@@ -193,7 +193,6 @@ std::unique_ptr<podio::GenericParameters> ArrowFrameData::getParameters() {
   return params;
 }
 
-// cppcheck-suppress returnByReference
 std::vector<std::string> ArrowFrameData::getAvailableCollections() const {
   return m_availableCollections;
 }

--- a/src/ArrowFrameData.cc
+++ b/src/ArrowFrameData.cc
@@ -52,10 +52,12 @@ namespace {
   };
 
   template <typename Setter>
-  void extractMap(const arrow::StructArray* struct_array, const std::string& fieldName, int64_t rowIndex, podio::GenericParameters* params) {
+  void extractMap(const arrow::StructArray* struct_array, const std::string& fieldName, int64_t rowIndex,
+                  podio::GenericParameters* params) {
     auto map_array = std::static_pointer_cast<arrow::MapArray>(struct_array->GetFieldByName(fieldName));
-    if (!map_array)
+    if (!map_array) {
       return;
+    }
     auto keys_array = std::static_pointer_cast<arrow::StringArray>(map_array->keys());
     auto items_array = map_array->items();
     auto list_items = std::static_pointer_cast<arrow::ListArray>(items_array);
@@ -85,7 +87,7 @@ namespace {
 } // namespace
 
 ArrowFrameData::ArrowFrameData(std::shared_ptr<arrow::Table> table, int64_t rowIndex) :
-    m_table(std::move(table)), m_rowIndex(rowIndex) {
+    m_table(std::move(table)), m_rowIndex(rowIndex), m_availableCollections(), m_idTable() {
   if (!m_table) {
     throw std::runtime_error("ArrowTable is null");
   }
@@ -126,8 +128,9 @@ ArrowFrameData::ArrowFrameData(std::shared_ptr<arrow::Table> table, int64_t rowI
 
 std::optional<podio::CollectionReadBuffers> ArrowFrameData::getCollectionBuffers(const std::string& name) {
   auto chunked_array = m_table->GetColumnByName(name);
-  if (!chunked_array)
+  if (!chunked_array) {
     return std::nullopt;
+  }
 
   auto field = m_table->schema()->GetFieldByName(name);
   auto metadata = field->metadata();
@@ -177,8 +180,9 @@ std::unique_ptr<podio::GenericParameters> ArrowFrameData::getParameters() {
     }
     remaining_idx -= c->length();
   }
-  if (!chunk)
+  if (!chunk) {
     return std::make_unique<podio::GenericParameters>();
+  }
 
   auto struct_array = std::static_pointer_cast<arrow::StructArray>(chunk);
   auto params = std::make_unique<podio::GenericParameters>();

--- a/src/ArrowFrameData.cc
+++ b/src/ArrowFrameData.cc
@@ -193,6 +193,7 @@ std::unique_ptr<podio::GenericParameters> ArrowFrameData::getParameters() {
   return params;
 }
 
+// cppcheck-suppress returnByReference
 std::vector<std::string> ArrowFrameData::getAvailableCollections() const {
   return m_availableCollections;
 }

--- a/src/ArrowFrameData.cc
+++ b/src/ArrowFrameData.cc
@@ -10,48 +10,7 @@ namespace podio {
 
 namespace {
 
-  struct IntSetter {
-    using ArrayType = arrow::Int32Array;
-    using ValueType = int32_t;
-    static ValueType getValue(const ArrayType* arr, int32_t idx) {
-      return arr->Value(idx);
-    }
-    static void set(podio::GenericParameters* p, const std::string& k, const std::vector<int32_t>& v) {
-      p->set(k, v);
-    }
-  };
-  struct FloatSetter {
-    using ArrayType = arrow::FloatArray;
-    using ValueType = float;
-    static ValueType getValue(const ArrayType* arr, int32_t idx) {
-      return arr->Value(idx);
-    }
-    static void set(podio::GenericParameters* p, const std::string& k, const std::vector<float>& v) {
-      p->set(k, v);
-    }
-  };
-  struct DoubleSetter {
-    using ArrayType = arrow::DoubleArray;
-    using ValueType = double;
-    static ValueType getValue(const ArrayType* arr, int32_t idx) {
-      return arr->Value(idx);
-    }
-    static void set(podio::GenericParameters* p, const std::string& k, const std::vector<double>& v) {
-      p->set(k, v);
-    }
-  };
-  struct StringSetter {
-    using ArrayType = arrow::StringArray;
-    using ValueType = std::string;
-    static ValueType getValue(const ArrayType* arr, int32_t idx) {
-      return arr->GetString(idx);
-    }
-    static void set(podio::GenericParameters* p, const std::string& k, const std::vector<std::string>& v) {
-      p->set(k, v);
-    }
-  };
-
-  template <typename Setter>
+  template <typename ArrayType, typename ValueType>
   void extractMap(const arrow::StructArray* struct_array, const std::string& fieldName, int64_t rowIndex,
                   podio::GenericParameters* params) {
     auto map_array = std::static_pointer_cast<arrow::MapArray>(struct_array->GetFieldByName(fieldName));
@@ -65,8 +24,6 @@ namespace {
     int32_t start = map_array->value_offset(rowIndex);
     int32_t end = map_array->value_offset(rowIndex + 1);
 
-    using ArrayType = typename Setter::ArrayType;
-    using ValueType = typename Setter::ValueType;
     auto val_array = std::static_pointer_cast<ArrayType>(list_items->values());
 
     for (int32_t i = start; i < end; ++i) {
@@ -78,9 +35,13 @@ namespace {
       std::vector<ValueType> vals;
       vals.reserve(list_end - list_start);
       for (int32_t j = list_start; j < list_end; ++j) {
-        vals.push_back(Setter::getValue(val_array.get(), j));
+        if constexpr (std::is_same_v<ArrayType, arrow::StringArray>) {
+          vals.push_back(val_array->GetString(j));
+        } else {
+          vals.push_back(val_array->Value(j));
+        }
       }
-      Setter::set(params, key, vals);
+      params->set(key, vals);
     }
   }
 
@@ -185,10 +146,10 @@ std::unique_ptr<podio::GenericParameters> ArrowFrameData::getParameters() {
   auto struct_array = std::static_pointer_cast<arrow::StructArray>(chunk);
   auto params = std::make_unique<podio::GenericParameters>();
 
-  extractMap<IntSetter>(struct_array.get(), "int_params", remaining_idx, params.get());
-  extractMap<FloatSetter>(struct_array.get(), "float_params", remaining_idx, params.get());
-  extractMap<DoubleSetter>(struct_array.get(), "double_params", remaining_idx, params.get());
-  extractMap<StringSetter>(struct_array.get(), "string_params", remaining_idx, params.get());
+  extractMap<arrow::Int32Array, int32_t>(struct_array.get(), "int_params", remaining_idx, params.get());
+  extractMap<arrow::FloatArray, float>(struct_array.get(), "float_params", remaining_idx, params.get());
+  extractMap<arrow::DoubleArray, double>(struct_array.get(), "double_params", remaining_idx, params.get());
+  extractMap<arrow::StringArray, std::string>(struct_array.get(), "string_params", remaining_idx, params.get());
 
   return params;
 }

--- a/src/ArrowFrameData.cc
+++ b/src/ArrowFrameData.cc
@@ -84,6 +84,18 @@ namespace {
     }
   }
 
+  std::shared_ptr<arrow::Array> getChunkOrThrow(const std::shared_ptr<arrow::ChunkedArray>& chunked_array,
+                                                int64_t rowIndex, int64_t& remaining_idx) {
+    remaining_idx = rowIndex;
+    for (const auto& c : chunked_array->chunks()) {
+      if (remaining_idx < c->length()) {
+        return c;
+      }
+      remaining_idx -= c->length();
+    }
+    throw std::runtime_error("Row index out of bounds in chunked array");
+  }
+
 } // namespace
 
 ArrowFrameData::ArrowFrameData(std::shared_ptr<arrow::Table> table, int64_t rowIndex) :
@@ -145,25 +157,21 @@ std::optional<podio::CollectionReadBuffers> ArrowFrameData::getCollectionBuffers
   std::string typeName = metadata->value(typeNameIdx);
   bool isSubset = (metadata->value(isSubsetIdx) == "1");
 
-  int64_t remaining_idx = m_rowIndex;
-  std::shared_ptr<arrow::Array> chunk;
-  for (const auto& c : chunked_array->chunks()) {
-    if (remaining_idx < c->length()) {
-      chunk = c;
-      break;
-    }
-    remaining_idx -= c->length();
+  auto schemaVersionIdx = metadata->FindKey("schema_version");
+  uint32_t schemaVersion = 1;
+  if (schemaVersionIdx != -1) {
+    schemaVersion = std::stoul(metadata->value(schemaVersionIdx));
   }
-  if (!chunk) {
-    throw std::runtime_error("Row index out of bounds in chunked array");
-  }
+
+  int64_t remaining_idx = 0;
+  auto chunk = getChunkOrThrow(chunked_array, m_rowIndex, remaining_idx);
 
   auto reader = podio::ArrowConverterRegistry::instance().getReader(typeName);
   if (!reader) {
     throw std::runtime_error("No Arrow reader registered for type: " + typeName);
   }
 
-  return reader(chunk, remaining_idx, isSubset);
+  return reader(chunk, remaining_idx, isSubset, schemaVersion);
 }
 
 std::unique_ptr<podio::GenericParameters> ArrowFrameData::getParameters() {
@@ -171,18 +179,8 @@ std::unique_ptr<podio::GenericParameters> ArrowFrameData::getParameters() {
   if (!chunked_array) {
     return std::make_unique<podio::GenericParameters>();
   }
-  int64_t remaining_idx = m_rowIndex;
-  std::shared_ptr<arrow::Array> chunk;
-  for (const auto& c : chunked_array->chunks()) {
-    if (remaining_idx < c->length()) {
-      chunk = c;
-      break;
-    }
-    remaining_idx -= c->length();
-  }
-  if (!chunk) {
-    return std::make_unique<podio::GenericParameters>();
-  }
+  int64_t remaining_idx = 0;
+  auto chunk = getChunkOrThrow(chunked_array, m_rowIndex, remaining_idx);
 
   auto struct_array = std::static_pointer_cast<arrow::StructArray>(chunk);
   auto params = std::make_unique<podio::GenericParameters>();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,11 +151,11 @@ endif()
 
 # --- Arrow functionality
 if(ENABLE_ARROW)
-  SET(arrow_sources
     ArrowFrameConverter.cc
     ArrowUtils.cc
     ArrowTypeRegistry.cc
     ArrowConverterRegistry.cc
+    ArrowFrameData.cc
     )
 
   add_library(podioArrow SHARED ${arrow_sources})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ endif()
 
 # --- Arrow functionality
 if(ENABLE_ARROW)
+  SET(arrow_sources
     ArrowFrameConverter.cc
     ArrowUtils.cc
     ArrowTypeRegistry.cc

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -545,7 +545,6 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Round-Trip)",
 
   // Verify Hits collection
   const auto& recHits = reconstructedFrame->get<ExampleHitCollection>("Hits");
-  REQUIRE(recHits.isValid());
   REQUIRE(recHits.size() == 2);
   REQUIRE(recHits[0].x() == 1.0f);
   REQUIRE(recHits[1].x() == 4.0f);
@@ -553,7 +552,6 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Round-Trip)",
 
   // Verify Clusters collection and its hit relations
   const auto& recClusters = reconstructedFrame->get<ExampleClusterCollection>("Clusters");
-  REQUIRE(recClusters.isValid());
   REQUIRE(recClusters.size() == 1);
   REQUIRE(recClusters[0].energy() == 100.0);
   REQUIRE(recClusters[0].Hits_size() == 2);
@@ -562,13 +560,11 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Round-Trip)",
 
   // Verify OneRelation
   const auto& recRelColls = reconstructedFrame->get<ExampleWithOneRelationCollection>("OneRelation");
-  REQUIRE(recRelColls.isValid());
   REQUIRE(recRelColls.size() == 1);
   REQUIRE(recRelColls[0].cluster().energy() == 100.0);
 
   // Verify VectorMember
   const auto& recVecColls = reconstructedFrame->get<ExampleWithVectorMemberCollection>("VectorMember");
-  REQUIRE(recVecColls.isValid());
   REQUIRE(recVecColls.size() == 1);
   REQUIRE(recVecColls[0].count_size() == 2);
   REQUIRE(recVecColls[0].count(0) == 42);
@@ -576,7 +572,6 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Round-Trip)",
 
   // Verify SubsetHits
   const auto& recSubsetHits = reconstructedFrame->get<ExampleHitCollection>("SubsetHits");
-  REQUIRE(recSubsetHits.isValid());
   REQUIRE(recSubsetHits.isSubsetCollection());
   REQUIRE(recSubsetHits.size() == 1);
   REQUIRE(recSubsetHits[0].x() == 1.0f);
@@ -645,7 +640,6 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Reader-Only Verification", 
   REQUIRE(frame != nullptr);
 
   const auto& recHits = frame->get<ExampleHitCollection>("Hits");
-  REQUIRE(recHits.isValid());
   REQUIRE(recHits.size() == 2);
   REQUIRE(recHits[0].cellID() == 0x100ULL);
   REQUIRE(recHits[0].x() == 10.0f);
@@ -684,8 +678,6 @@ void verifyEventNoUserData(const podio::Frame& event, int eventNum) {
   REQUIRE((hits[1] == hitRefs[0] && hits[0] == hitRefs[1]));
 
   checkClusterCollection(event, hits);
-
-  auto& clusters = event.get<ExampleClusterCollection>("clusters");
 
   auto& mcpRefs = event.get<ExampleMCCollection>("mcParticleRefs");
   for (auto ref : mcpRefs) {

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -185,9 +185,8 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Reader-Only Verification", 
   const auto& table = tableResult.ValueOrDie();
 
   auto frame = podio::convertTableToFrame(table, 0);
-  REQUIRE(frame != nullptr);
 
-  const auto& recHits = frame->get<ExampleHitCollection>("Hits");
+  const auto& recHits = frame.get<ExampleHitCollection>("Hits");
   REQUIRE(recHits.size() == 2);
   REQUIRE(recHits[0].cellID() == 0x100ULL);
   REQUIRE(recHits[0].x() == 10.0f);
@@ -376,23 +375,22 @@ TEST_CASE("ArrowFrameConverter - Comprehensive Round-Trip (No-UserData)", "[arro
   REQUIRE(table != nullptr);
 
   auto reconstructedFrame = podio::convertTableToFrame(table, 0);
-  REQUIRE(reconstructedFrame != nullptr);
 
-  verifyEventNoUserData(*reconstructedFrame, 0);
+  verifyEventNoUserData(reconstructedFrame, 0);
 
-  processExtensions(*reconstructedFrame, 0, podio::version::build_version);
-  checkVecMemSubsetColl(*reconstructedFrame);
-  checkInterfaceCollection(*reconstructedFrame);
-  checkInterfaceExtension(*reconstructedFrame);
+  processExtensions(reconstructedFrame, 0, podio::version::build_version);
+  checkVecMemSubsetColl(reconstructedFrame);
+  checkInterfaceCollection(reconstructedFrame);
+  checkInterfaceExtension(reconstructedFrame);
 
-  const auto& hits = reconstructedFrame->get<ExampleHitCollection>("hits");
-  const auto& clusters = reconstructedFrame->get<ExampleClusterCollection>("clusters");
-  checkLinkCollection(*reconstructedFrame, hits, clusters);
+  const auto& hits = reconstructedFrame.get<ExampleHitCollection>("hits");
+  const auto& clusters = reconstructedFrame.get<ExampleClusterCollection>("clusters");
+  checkLinkCollection(reconstructedFrame, hits, clusters);
 
   // Verify Link collection with interfaces
-  const auto& interfaceLinks = reconstructedFrame->get<TestInterfaceLinkCollection>("links_with_interfaces");
+  const auto& interfaceLinks = reconstructedFrame.get<TestInterfaceLinkCollection>("links_with_interfaces");
   REQUIRE(interfaceLinks.size() == 3);
-  const auto& mcps = reconstructedFrame->get<ExampleMCCollection>("mcparticles");
+  const auto& mcps = reconstructedFrame.get<ExampleMCCollection>("mcparticles");
   REQUIRE(interfaceLinks[0].get<ExampleCluster>() == clusters[0]);
   REQUIRE(interfaceLinks[0].get<TypeWithEnergy>() == hits[0]);
   REQUIRE(interfaceLinks[1].get<ExampleCluster>() == clusters[1]);
@@ -473,11 +471,9 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Multi-Row / r
 
   // --- Reconstruct and verify Frame 1 at rowIndex = 0 ---
   auto reconstructedFrame1 = podio::convertTableToFrame(concatTable, 0);
-  REQUIRE(reconstructedFrame1 != nullptr);
-  verifyFrame(*reconstructedFrame1, 0);
+  verifyFrame(reconstructedFrame1, 0);
 
   // --- Reconstruct and verify Frame 2 at rowIndex = 1 ---
   auto reconstructedFrame2 = podio::convertTableToFrame(concatTable, 1);
-  REQUIRE(reconstructedFrame2 != nullptr);
-  verifyFrame(*reconstructedFrame2, 1);
+  verifyFrame(reconstructedFrame2, 1);
 }

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -21,6 +21,7 @@
 
 // Arrow headers
 #include <arrow/api.h>
+#include <arrow/table.h>
 #include <arrow/type.h>
 #include <iostream>
 #include <nlohmann/json.hpp>
@@ -854,4 +855,85 @@ TEST_CASE("ArrowFrameConverter - Comprehensive Round-Trip (No-UserData)", "[arro
   REQUIRE(interfaceLinks[1].get<TypeWithEnergy>() == mcps[0]);
   REQUIRE(interfaceLinks[2].get<ExampleCluster>() == clusters[0]);
   REQUIRE(interfaceLinks[2].get<TypeWithEnergy>() == clusters[1]);
+}
+
+TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Multi-Row / rowIndex > 0)",
+          "[arrow][converter][reader]") {
+  auto frame1 = makeFrame(0);
+  auto frame2 = makeFrame(1);
+
+  const std::vector<std::string> colls = {"mcparticles",
+                                          "moreMCs",
+                                          "arrays",
+                                          "mcParticleRefs",
+                                          "hits",
+                                          "hitRefs",
+                                          "refs",
+                                          "refs2",
+                                          "clusters",
+                                          "OneRelation",
+                                          "info",
+                                          "WithVectorMember",
+                                          "VectorMemberSubsetColl",
+                                          "fixedWidthInts",
+                                          "WithNamespaceMember",
+                                          "WithNamespaceRelation",
+                                          "WithNamespaceRelationCopy",
+                                          "emptyCollection",
+                                          "emptySubsetColl",
+                                          "extension_Contained",
+                                          "extension_ExternalComponent",
+                                          "extension_ExternalRelation",
+                                          "interface_examples",
+                                          "anotherHits",
+                                          "extension_interface_relation",
+                                          "links",
+                                          "links_with_interfaces",
+                                          "extension_interface_links"};
+
+  // Convert both frames to Arrow Tables
+  auto table1 = podio::convertFrameToTable(frame1, colls);
+  REQUIRE(table1 != nullptr);
+  auto table2 = podio::convertFrameToTable(frame2, colls);
+  REQUIRE(table2 != nullptr);
+
+  // Concatenate tables to simulate a multi-row table (e.g. from multiple events)
+  auto concatResult = arrow::ConcatenateTables({table1, table2});
+  REQUIRE(concatResult.ok());
+  const auto& concatTable = concatResult.ValueOrDie();
+  REQUIRE(concatTable->num_rows() == 2);
+
+  auto verifyFrame = [](const podio::Frame& reconstructedFrame, int eventNum) {
+    verifyEventNoUserData(reconstructedFrame, eventNum);
+
+    processExtensions(reconstructedFrame, eventNum, podio::version::build_version);
+    checkVecMemSubsetColl(reconstructedFrame);
+    checkInterfaceCollection(reconstructedFrame);
+    checkInterfaceExtension(reconstructedFrame);
+
+    const auto& hits = reconstructedFrame.get<ExampleHitCollection>("hits");
+    const auto& clusters = reconstructedFrame.get<ExampleClusterCollection>("clusters");
+    checkLinkCollection(reconstructedFrame, hits, clusters);
+
+    // Verify Link collection with interfaces
+    const auto& interfaceLinks = reconstructedFrame.get<TestInterfaceLinkCollection>("links_with_interfaces");
+    REQUIRE(interfaceLinks.size() == 3);
+    const auto& mcps = reconstructedFrame.get<ExampleMCCollection>("mcparticles");
+    REQUIRE(interfaceLinks[0].get<ExampleCluster>() == clusters[0]);
+    REQUIRE(interfaceLinks[0].get<TypeWithEnergy>() == hits[0]);
+    REQUIRE(interfaceLinks[1].get<ExampleCluster>() == clusters[1]);
+    REQUIRE(interfaceLinks[1].get<TypeWithEnergy>() == mcps[0]);
+    REQUIRE(interfaceLinks[2].get<ExampleCluster>() == clusters[0]);
+    REQUIRE(interfaceLinks[2].get<TypeWithEnergy>() == clusters[1]);
+  };
+
+  // --- Reconstruct and verify Frame 1 at rowIndex = 0 ---
+  auto reconstructedFrame1 = podio::convertTableToFrame(concatTable, 0);
+  REQUIRE(reconstructedFrame1 != nullptr);
+  verifyFrame(*reconstructedFrame1, 0);
+
+  // --- Reconstruct and verify Frame 2 at rowIndex = 1 ---
+  auto reconstructedFrame2 = podio::convertTableToFrame(concatTable, 1);
+  REQUIRE(reconstructedFrame2 != nullptr);
+  verifyFrame(*reconstructedFrame2, 1);
 }

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -16,8 +16,8 @@
 #include "podio/utilities/ArrowTypeRegistry.h"
 
 // Test frame validation helpers
-#include "write_frame.h"
 #include "read_frame.h"
+#include "write_frame.h"
 
 // Arrow headers
 #include <arrow/api.h>
@@ -624,9 +624,7 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Reader-Only Verification", 
   std::shared_ptr<arrow::Array> array;
   REQUIRE(collectionBuilder->Finish(&array).ok());
 
-  auto metadata = arrow::KeyValueMetadata::Make(
-      {"value_type", "is_subset", "coll_id"},
-      {"ExampleHit", "0", "101"});
+  auto metadata = arrow::KeyValueMetadata::Make({"value_type", "is_subset", "coll_id"}, {"ExampleHit", "0", "101"});
   auto field = arrow::field("Hits", arrowType, true, std::move(metadata));
 
   auto schema = arrow::schema({field});
@@ -634,7 +632,7 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Reader-Only Verification", 
   REQUIRE(batch != nullptr);
   auto tableResult = arrow::Table::FromRecordBatches({batch});
   REQUIRE(tableResult.ok());
-  auto table = tableResult.ValueOrDie();
+  const auto& table = tableResult.ValueOrDie();
 
   auto frame = podio::convertTableToFrame(table, 0);
   REQUIRE(frame != nullptr);
@@ -800,33 +798,34 @@ void verifyEventNoUserData(const podio::Frame& event, int eventNum) {
 TEST_CASE("ArrowFrameConverter - Comprehensive Round-Trip (No-UserData)", "[arrow][converter][common]") {
   auto originalFrame = makeFrame(0);
 
-  const std::vector<std::string> colls = {
-    "mcparticles",
-    "moreMCs",
-    "arrays",
-    "mcParticleRefs",
-    "hits",
-    "hitRefs",
-    "refs",
-    "refs2",
-    "clusters",
-    "OneRelation",
-    "info",
-    "WithVectorMember",
-    "VectorMemberSubsetColl",
-    "fixedWidthInts",
-    "WithNamespaceMember",
-    "WithNamespaceRelation",
-    "WithNamespaceRelationCopy",
-    "emptyCollection",
-    "emptySubsetColl",
-    "extension_Contained",
-    "extension_ExternalComponent",
-    "extension_ExternalRelation",
-    "interface_examples",
-    "anotherHits",
-    "extension_interface_relation"
-  };
+  const std::vector<std::string> colls = {"mcparticles",
+                                          "moreMCs",
+                                          "arrays",
+                                          "mcParticleRefs",
+                                          "hits",
+                                          "hitRefs",
+                                          "refs",
+                                          "refs2",
+                                          "clusters",
+                                          "OneRelation",
+                                          "info",
+                                          "WithVectorMember",
+                                          "VectorMemberSubsetColl",
+                                          "fixedWidthInts",
+                                          "WithNamespaceMember",
+                                          "WithNamespaceRelation",
+                                          "WithNamespaceRelationCopy",
+                                          "emptyCollection",
+                                          "emptySubsetColl",
+                                          "extension_Contained",
+                                          "extension_ExternalComponent",
+                                          "extension_ExternalRelation",
+                                          "interface_examples",
+                                          "anotherHits",
+                                          "extension_interface_relation",
+                                          "links",
+                                          "links_with_interfaces",
+                                          "extension_interface_links"};
 
   auto table = podio::convertFrameToTable(originalFrame, colls);
   REQUIRE(table != nullptr);
@@ -839,22 +838,20 @@ TEST_CASE("ArrowFrameConverter - Comprehensive Round-Trip (No-UserData)", "[arro
   processExtensions(*reconstructedFrame, 0, podio::version::build_version);
   checkVecMemSubsetColl(*reconstructedFrame);
   checkInterfaceCollection(*reconstructedFrame);
-  // verify interface relation (excluding link collection check)
-  const auto& interfaceColl = reconstructedFrame->get<iextension::ExampleWithInterfaceRelationCollection>("extension_interface_relation");
-  REQUIRE(interfaceColl.size() == 2);
-  const auto& hits = reconstructedFrame->get<ExampleHitCollection>("hits");
-  const auto& anotherHits = reconstructedFrame->get<iextension::AnotherHitCollection>("anotherHits");
-  const auto iface0 = interfaceColl[0];
-  const auto iface1 = interfaceColl[1];
-  REQUIRE(iface0.singleEnergy() == hits[0]);
-  REQUIRE(iface1.singleEnergy() == anotherHits[0]);
-  const auto iface0Rels = iface0.manyEnergies();
-  REQUIRE(iface0Rels.size() == 2);
-  REQUIRE(iface0Rels[0] == hits[0]);
-  REQUIRE(iface0Rels[1] == anotherHits[0]);
-  const auto iface1Rels = iface1.manyEnergies();
-  REQUIRE(iface1Rels.size() == 2);
-  REQUIRE(iface1Rels[0] == hits[0]);
-  REQUIRE(iface1Rels[1] == anotherHits[0]);
-}
+  checkInterfaceExtension(*reconstructedFrame);
 
+  const auto& hits = reconstructedFrame->get<ExampleHitCollection>("hits");
+  const auto& clusters = reconstructedFrame->get<ExampleClusterCollection>("clusters");
+  checkLinkCollection(*reconstructedFrame, hits, clusters);
+
+  // Verify Link collection with interfaces
+  const auto& interfaceLinks = reconstructedFrame->get<TestInterfaceLinkCollection>("links_with_interfaces");
+  REQUIRE(interfaceLinks.size() == 3);
+  const auto& mcps = reconstructedFrame->get<ExampleMCCollection>("mcparticles");
+  REQUIRE(interfaceLinks[0].get<ExampleCluster>() == clusters[0]);
+  REQUIRE(interfaceLinks[0].get<TypeWithEnergy>() == hits[0]);
+  REQUIRE(interfaceLinks[1].get<ExampleCluster>() == clusters[1]);
+  REQUIRE(interfaceLinks[1].get<TypeWithEnergy>() == mcps[0]);
+  REQUIRE(interfaceLinks[2].get<ExampleCluster>() == clusters[0]);
+  REQUIRE(interfaceLinks[2].get<TypeWithEnergy>() == clusters[1]);
+}

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -3,7 +3,6 @@
 #include "podio/Frame.h"
 
 // Test datatypes
-#include "datamodel/EventInfoCollection.h"
 #include "datamodel/ExampleClusterCollection.h"
 #include "datamodel/ExampleHitCollection.h"
 #include "datamodel/ExampleWithArrayCollection.h"
@@ -342,35 +341,14 @@ void verifyEventNoUserData(const podio::Frame& event, int eventNum) {
 TEST_CASE("ArrowFrameConverter - Comprehensive Round-Trip (No-UserData)", "[arrow][converter][common]") {
   auto originalFrame = makeFrame(0);
 
-  const std::vector<std::string> colls = {"mcparticles",
-                                          "moreMCs",
-                                          "arrays",
-                                          "mcParticleRefs",
-                                          "hits",
-                                          "hitRefs",
-                                          "refs",
-                                          "refs2",
-                                          "clusters",
-                                          "OneRelation",
-                                          "info",
-                                          "WithVectorMember",
-                                          "VectorMemberSubsetColl",
-                                          "fixedWidthInts",
-                                          "WithNamespaceMember",
-                                          "WithNamespaceRelation",
-                                          "WithNamespaceRelationCopy",
-                                          "emptyCollection",
-                                          "emptySubsetColl",
-                                          "extension_Contained",
-                                          "extension_ExternalComponent",
-                                          "extension_ExternalRelation",
-                                          "interface_examples",
-                                          "anotherHits",
-                                          "extension_interface_relation",
-                                          "links",
-                                          "links_with_interfaces",
-                                          "extension_interface_links"};
-
+  std::vector<std::string> colls;
+  for (const auto& name : originalFrame.getAvailableCollections()) {
+    if (const auto* coll = originalFrame.get(name)) {
+      if (coll->isSubsetCollection() || podio::ArrowTypeRegistry::instance().getType(std::string(coll->getValueTypeName()))) {
+        colls.push_back(name);
+      }
+    }
+  }
   auto table = podio::convertFrameToTable(originalFrame, colls);
   REQUIRE(table != nullptr);
 
@@ -404,35 +382,14 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Multi-Row / r
   auto frame1 = makeFrame(0);
   auto frame2 = makeFrame(1);
 
-  const std::vector<std::string> colls = {"mcparticles",
-                                          "moreMCs",
-                                          "arrays",
-                                          "mcParticleRefs",
-                                          "hits",
-                                          "hitRefs",
-                                          "refs",
-                                          "refs2",
-                                          "clusters",
-                                          "OneRelation",
-                                          "info",
-                                          "WithVectorMember",
-                                          "VectorMemberSubsetColl",
-                                          "fixedWidthInts",
-                                          "WithNamespaceMember",
-                                          "WithNamespaceRelation",
-                                          "WithNamespaceRelationCopy",
-                                          "emptyCollection",
-                                          "emptySubsetColl",
-                                          "extension_Contained",
-                                          "extension_ExternalComponent",
-                                          "extension_ExternalRelation",
-                                          "interface_examples",
-                                          "anotherHits",
-                                          "extension_interface_relation",
-                                          "links",
-                                          "links_with_interfaces",
-                                          "extension_interface_links"};
-
+  std::vector<std::string> colls;
+  for (const auto& name : frame1.getAvailableCollections()) {
+    if (const auto* coll = frame1.get(name)) {
+      if (coll->isSubsetCollection() || podio::ArrowTypeRegistry::instance().getType(std::string(coll->getValueTypeName()))) {
+        colls.push_back(name);
+      }
+    }
+  }
   // Convert both frames to Arrow Tables
   auto table1 = podio::convertFrameToTable(frame1, colls);
   REQUIRE(table1 != nullptr);

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -682,11 +682,11 @@ void verifyEventNoUserData(const podio::Frame& event, int eventNum) {
   for (auto ref : mcpRefs) {
     const auto daughters = ref.daughters();
     if (!daughters.empty()) {
-      auto d [[maybe_unused]] = daughters[0];
+      REQUIRE(daughters[0].isAvailable());
     }
     const auto parents = ref.parents();
     if (!parents.empty()) {
-      auto d [[maybe_unused]] = parents[0];
+      REQUIRE(parents[0].isAvailable());
     }
   }
 
@@ -716,13 +716,8 @@ void verifyEventNoUserData(const podio::Frame& event, int eventNum) {
     }
   }
 
-  auto& refs = event.get<ExampleReferencingTypeCollection>("refs");
-  auto ref = refs[0];
-  for (auto cluster : ref.Clusters()) {
-    for (auto hit [[maybe_unused]] : cluster.Hits()) {
-    }
-  }
-  auto& rels [[maybe_unused]] = event.get<ExampleWithOneRelationCollection>("OneRelation");
+  const auto& rels = event.get<ExampleWithOneRelationCollection>("OneRelation");
+  REQUIRE(rels.size() == 2);
 
   auto& vecs = event.get<ExampleWithVectorMemberCollection>("WithVectorMember");
   REQUIRE(vecs.size() == 2);

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -24,57 +24,11 @@
 #include <arrow/table.h>
 #include <arrow/type.h>
 #include <iostream>
-#include <nlohmann/json.hpp>
 
 TEST_CASE("ArrowFrameConverter - convertFrameToTable Verification", "[arrow][converter]") {
-  podio::Frame originalFrame;
+  auto originalFrame = makeFrame(0);
 
-  // 1. Prepare some hits
-  ExampleHitCollection hits;
-  auto hit1 = MutableExampleHit(0x42ULL, 1.0f, 2.0f, 3.0f, 10.5);
-  auto hit2 = MutableExampleHit(0x43ULL, 4.0f, 5.0f, 6.0f, 20.5);
-  hits.push_back(hit1);
-  hits.push_back(hit2);
-
-  // 2. Prepare some clusters with relations to hits
-  ExampleClusterCollection clusters;
-  auto cluster1 = MutableExampleCluster();
-  cluster1.energy(100.0);
-  cluster1.addHits(hit1);
-  cluster1.addHits(hit2);
-  clusters.push_back(cluster1);
-
-  // 3. Prepare a relation collection
-  ExampleWithOneRelationCollection relColls;
-  auto relObj = MutableExampleWithOneRelation();
-  relObj.cluster(cluster1);
-  relColls.push_back(relObj);
-
-  // 4. Prepare a vector member collection
-  ExampleWithVectorMemberCollection vecColls;
-  auto vecObj = MutableExampleWithVectorMember();
-  vecObj.addcount(42);
-  vecObj.addcount(137);
-  vecColls.push_back(vecObj);
-
-  // 5. Prepare a subset collection of hits
-  ExampleHitCollection subsetHits;
-  subsetHits.setSubsetCollection(true);
-  subsetHits.push_back(hit1);
-
-  // Put them all into the frame
-  originalFrame.put(std::move(hits), "Hits");
-  originalFrame.put(std::move(clusters), "Clusters");
-  originalFrame.put(std::move(relColls), "OneRelation");
-  originalFrame.put(std::move(vecColls), "VectorMember");
-  originalFrame.put(std::move(subsetHits), "SubsetHits");
-
-  // Put some frame parameters
-  originalFrame.putParameter("anInt", 42);
-  originalFrame.putParameter("someFloats", std::vector<float>{1.23f, 2.34f, 3.45f});
-  originalFrame.putParameter("someStrings", std::vector<std::string>{"hello", "world"});
-
-  std::vector<std::string> colls = {"Hits", "Clusters", "OneRelation", "VectorMember", "SubsetHits"};
+  std::vector<std::string> colls = {"hits", "clusters", "OneRelation", "WithVectorMember", "hitRefs"};
 
   // Convert to Arrow Table
   auto table = podio::convertFrameToTable(originalFrame, colls);
@@ -87,83 +41,86 @@ TEST_CASE("ArrowFrameConverter - convertFrameToTable Verification", "[arrow][con
 
   // Check columns present
   auto schema = table->schema();
-  REQUIRE(schema->GetFieldByName("Hits") != nullptr);
-  REQUIRE(schema->GetFieldByName("Clusters") != nullptr);
+  REQUIRE(schema->GetFieldByName("hits") != nullptr);
+  REQUIRE(schema->GetFieldByName("clusters") != nullptr);
   REQUIRE(schema->GetFieldByName("OneRelation") != nullptr);
-  REQUIRE(schema->GetFieldByName("VectorMember") != nullptr);
-  REQUIRE(schema->GetFieldByName("SubsetHits") != nullptr);
+  REQUIRE(schema->GetFieldByName("WithVectorMember") != nullptr);
+  REQUIRE(schema->GetFieldByName("hitRefs") != nullptr);
   REQUIRE(schema->GetFieldByName("frame_parameters") != nullptr);
 
-  // Assertions on Hits table structure and metadata
-  auto hitsField = schema->GetFieldByName("Hits");
+  // Assertions on hits table structure and metadata
+  auto hitsField = schema->GetFieldByName("hits");
   auto hitsMeta = hitsField->metadata();
   REQUIRE(hitsMeta != nullptr);
   REQUIRE(hitsMeta->Get("value_type").ValueOrDie() == "ExampleHit");
   REQUIRE(hitsMeta->Get("is_subset").ValueOrDie() == "0");
 
-  auto hitsArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("Hits")->chunk(0));
+  auto hitsArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("hits")->chunk(0));
   REQUIRE(hitsArray != nullptr);
   REQUIRE(hitsArray->length() == 1);
   REQUIRE(hitsArray->value_length(0) == 2);
 
   auto hitsStruct = std::static_pointer_cast<arrow::StructArray>(hitsArray->values());
   auto hitsX = std::static_pointer_cast<arrow::DoubleArray>(hitsStruct->GetFieldByName("x"));
-  REQUIRE(hitsX->Value(0) == 1.0);
-  REQUIRE(hitsX->Value(1) == 4.0);
+  REQUIRE(hitsX->Value(0) == 0.0);
+  REQUIRE(hitsX->Value(1) == 1.0);
 
   auto hitsEnergy = std::static_pointer_cast<arrow::DoubleArray>(hitsStruct->GetFieldByName("energy"));
-  REQUIRE(hitsEnergy->Value(0) == 10.5);
-  REQUIRE(hitsEnergy->Value(1) == 20.5);
+  REQUIRE(hitsEnergy->Value(0) == 23.0);
+  REQUIRE(hitsEnergy->Value(1) == 12.0);
 
-  // Assertions on Clusters table structure and metadata
-  auto clustersField = schema->GetFieldByName("Clusters");
+  // Assertions on clusters table structure and metadata
+  auto clustersField = schema->GetFieldByName("clusters");
   auto clustersMeta = clustersField->metadata();
   REQUIRE(clustersMeta->Get("value_type").ValueOrDie() == "ExampleCluster");
 
-  auto clustersArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("Clusters")->chunk(0));
-  REQUIRE(clustersArray->value_length(0) == 1);
+  auto clustersArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("clusters")->chunk(0));
+  REQUIRE(clustersArray->value_length(0) == 3);
 
   auto clustersStruct = std::static_pointer_cast<arrow::StructArray>(clustersArray->values());
   auto clustersEnergy = std::static_pointer_cast<arrow::DoubleArray>(clustersStruct->GetFieldByName("energy"));
-  REQUIRE(clustersEnergy->Value(0) == 100.0);
+  REQUIRE(clustersEnergy->Value(0) == 23.0);
+  REQUIRE(clustersEnergy->Value(1) == 12.0);
+  REQUIRE(clustersEnergy->Value(2) == 35.0);
 
   auto clustersHits = std::static_pointer_cast<arrow::ListArray>(clustersStruct->GetFieldByName("Hits"));
-  REQUIRE(clustersHits->value_length(0) == 2);
+  REQUIRE(clustersHits->value_length(0) == 1);
+  REQUIRE(clustersHits->value_length(2) == 2);
 
   auto clustersHitsStruct = std::static_pointer_cast<arrow::StructArray>(clustersHits->values());
   auto clustersHitsIndex = std::static_pointer_cast<arrow::Int32Array>(clustersHitsStruct->GetFieldByName("index"));
-  REQUIRE(clustersHitsIndex->Value(0) == 0); // hit1 index
-  REQUIRE(clustersHitsIndex->Value(1) == 1); // hit2 index
+  REQUIRE(clustersHitsIndex->Value(0) == 0); // hit0 index
 
   // Assertions on OneRelation
   auto relArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("OneRelation")->chunk(0));
-  REQUIRE(relArray->value_length(0) == 1);
+  REQUIRE(relArray->value_length(0) == 2);
 
   auto relStruct = std::static_pointer_cast<arrow::StructArray>(relArray->values());
   auto relCluster = std::static_pointer_cast<arrow::StructArray>(relStruct->GetFieldByName("cluster"));
   auto relClusterIndex = std::static_pointer_cast<arrow::Int32Array>(relCluster->GetFieldByName("index"));
-  REQUIRE(relClusterIndex->Value(0) == 0); // cluster1 index
+  REQUIRE(relClusterIndex->Value(0) == 2); // cluster index 2
 
-  // Assertions on VectorMember
-  auto vecArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("VectorMember")->chunk(0));
-  REQUIRE(vecArray->value_length(0) == 1);
+  // Assertions on WithVectorMember
+  auto vecArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("WithVectorMember")->chunk(0));
+  REQUIRE(vecArray->value_length(0) == 2);
 
   auto vecStruct = std::static_pointer_cast<arrow::StructArray>(vecArray->values());
   auto vecCount = std::static_pointer_cast<arrow::ListArray>(vecStruct->GetFieldByName("count"));
   auto vecCountVal = std::static_pointer_cast<arrow::Int32Array>(vecCount->values());
-  REQUIRE(vecCountVal->Value(0) == 42);
-  REQUIRE(vecCountVal->Value(1) == 137);
+  REQUIRE(vecCountVal->Value(0) == 0);
+  REQUIRE(vecCountVal->Value(1) == 10);
 
-  // Assertions on SubsetHits
-  auto subField = schema->GetFieldByName("SubsetHits");
+  // Assertions on hitRefs (subset collection)
+  auto subField = schema->GetFieldByName("hitRefs");
   REQUIRE(subField->metadata()->Get("is_subset").ValueOrDie() == "1");
 
-  auto subArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("SubsetHits")->chunk(0));
-  REQUIRE(subArray->value_length(0) == 1);
+  auto subArray = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("hitRefs")->chunk(0));
+  REQUIRE(subArray->value_length(0) == 2);
 
   auto subObjectID = std::static_pointer_cast<arrow::StructArray>(subArray->values());
   auto subIndex = std::static_pointer_cast<arrow::Int32Array>(subObjectID->GetFieldByName("index"));
-  REQUIRE(subIndex->Value(0) == 0); // pointing to hit1 index
+  REQUIRE(subIndex->Value(0) == 1); // pointing to hits[1]
+  REQUIRE(subIndex->Value(1) == 0); // pointing to hits[0]
 
   // Assertions on frame parameters
   auto paramArray = std::static_pointer_cast<arrow::StructArray>(table->GetColumnByName("frame_parameters")->chunk(0));
@@ -174,419 +131,11 @@ TEST_CASE("ArrowFrameConverter - convertFrameToTable Verification", "[arrow][con
   auto intParams = std::static_pointer_cast<arrow::MapArray>(paramArray->GetFieldByName("int_params"));
   REQUIRE(intParams != nullptr);
   REQUIRE(intParams->length() == 1);
+  REQUIRE(intParams->value_length(0) == 3);
   auto intKeys = std::static_pointer_cast<arrow::StringArray>(intParams->keys());
-  auto intItems = std::static_pointer_cast<arrow::ListArray>(intParams->items());
-  REQUIRE(intKeys->GetString(0) == "anInt");
-  auto intValues = std::static_pointer_cast<arrow::Int32Array>(intItems->values());
-  REQUIRE(intValues->Value(0) == 42);
-
-  // Verify float_params
-  auto floatParams = std::static_pointer_cast<arrow::MapArray>(paramArray->GetFieldByName("float_params"));
-  REQUIRE(floatParams != nullptr);
-  REQUIRE(floatParams->length() == 1);
-  auto floatKeys = std::static_pointer_cast<arrow::StringArray>(floatParams->keys());
-  auto floatItems = std::static_pointer_cast<arrow::ListArray>(floatParams->items());
-  REQUIRE(floatKeys->GetString(0) == "someFloats");
-  auto floatValues = std::static_pointer_cast<arrow::FloatArray>(floatItems->values());
-  REQUIRE(floatValues->Value(0) == 1.23f);
-  REQUIRE(floatValues->Value(1) == 2.34f);
-  REQUIRE(floatValues->Value(2) == 3.45f);
-
-  // Verify string_params
-  auto stringParams = std::static_pointer_cast<arrow::MapArray>(paramArray->GetFieldByName("string_params"));
-  REQUIRE(stringParams != nullptr);
-  REQUIRE(stringParams->length() == 1);
-  auto stringKeys = std::static_pointer_cast<arrow::StringArray>(stringParams->keys());
-  auto stringItems = std::static_pointer_cast<arrow::ListArray>(stringParams->items());
-  REQUIRE(stringKeys->GetString(0) == "someStrings");
-  auto stringValues = std::static_pointer_cast<arrow::StringArray>(stringItems->values());
-  REQUIRE(stringValues->GetString(0) == "hello");
-  REQUIRE(stringValues->GetString(1) == "world");
-}
-
-// ============================================================================
-// Arrow Table & Frame Parameters JSON Serialization Helpers
-// ============================================================================
-
-namespace {
-
-// wrap_relation:
-// In PODIO's native JSON output:
-//   - A one-to-one relation is wrapped in a 1-element array: "cluster": [{"collectionID": X, "index": Y}]
-//   - A one-to-many relation or subset collection is a simple flat list of elements: "Hits": [{"collectionID": X,
-//   "index": Y}, ...]
-// Since the Arrow Table structures them both as relation reference structs, we use wrap_relation=false inside list
-// loops (like listToJson) to prevent wrapping each individual element of a one-to-many list in its own array.
-nlohmann::json arrayElementToJson(const arrow::Array& array, int64_t idx, bool wrap_relation = true);
-
-nlohmann::json structToJson(const arrow::StructArray& struct_array, int64_t idx, bool wrap_relation = true) {
-  auto struct_type = struct_array.struct_type();
-
-  bool is_relation = false;
-  if (struct_array.num_fields() == 2) {
-    std::string f0 = struct_type->field(0)->name();
-    std::string f1 = struct_type->field(1)->name();
-    if ((f0 == "collectionID" && f1 == "index") || (f0 == "index" && f1 == "collectionID")) {
-      is_relation = true;
-    }
-  }
-
-  if (is_relation) {
-    auto ref = nlohmann::json::object();
-    for (int f = 0; f < struct_array.num_fields(); ++f) {
-      std::string name = struct_type->field(f)->name();
-      const auto& field_array = struct_array.field(f);
-      ref[name] = arrayElementToJson(*field_array, idx, true);
-    }
-    if (wrap_relation) {
-      return nlohmann::json::array({ref});
-    } else {
-      return ref;
-    }
-  }
-
-  auto j = nlohmann::json::object();
-  for (int f = 0; f < struct_array.num_fields(); ++f) {
-    std::string name = struct_type->field(f)->name();
-    const auto& field_array = struct_array.field(f);
-    j[name] = arrayElementToJson(*field_array, idx, true);
-  }
-  return j;
-}
-
-nlohmann::json listToJson(const arrow::ListArray& list_array, int64_t idx) {
-  auto j = nlohmann::json::array();
-  int64_t offset = list_array.value_offset(idx);
-  int64_t length = list_array.value_length(idx);
-  const auto& values = list_array.values();
-  for (int64_t val_i = 0; val_i < length; ++val_i) {
-    j.push_back(arrayElementToJson(*values, offset + val_i, false));
-  }
-  return j;
-}
-
-nlohmann::json fixedSizeListToJson(const arrow::FixedSizeListArray& list_array, int64_t idx) {
-  auto j = nlohmann::json::array();
-  int64_t offset = list_array.value_offset(idx);
-  int64_t length = list_array.value_length();
-  const auto& values = list_array.values();
-  for (int64_t val_i = 0; val_i < length; ++val_i) {
-    j.push_back(arrayElementToJson(*values, offset + val_i, false));
-  }
-  return j;
-}
-
-nlohmann::json mapToJson(const arrow::MapArray& map_array, int64_t idx) {
-  auto j = nlohmann::json::object();
-  int64_t offset = map_array.value_offset(idx);
-  int64_t length = map_array.value_length(idx);
-  const auto& keys = map_array.keys();
-  const auto& items = map_array.items();
-
-  auto string_keys = std::static_pointer_cast<arrow::StringArray>(keys);
-  for (int64_t k = 0; k < length; ++k) {
-    std::string key = string_keys->GetString(offset + k);
-    j[key] = arrayElementToJson(*items, offset + k, true);
-  }
-  return j;
-}
-
-nlohmann::json arrayElementToJson(const arrow::Array& array, int64_t idx, bool wrap_relation) {
-  if (array.IsNull(idx)) {
-    return nullptr;
-  }
-  switch (array.type()->id()) {
-  case arrow::Type::BOOL:
-    return static_cast<const arrow::BooleanArray&>(array).Value(idx);
-  case arrow::Type::INT8:
-    return static_cast<const arrow::Int8Array&>(array).Value(idx);
-  case arrow::Type::UINT8:
-    return static_cast<const arrow::UInt8Array&>(array).Value(idx);
-  case arrow::Type::INT16:
-    return static_cast<const arrow::Int16Array&>(array).Value(idx);
-  case arrow::Type::UINT16:
-    return static_cast<const arrow::UInt16Array&>(array).Value(idx);
-  case arrow::Type::INT32:
-    return static_cast<const arrow::Int32Array&>(array).Value(idx);
-  case arrow::Type::UINT32:
-    return static_cast<const arrow::UInt32Array&>(array).Value(idx);
-  case arrow::Type::INT64:
-    return static_cast<const arrow::Int64Array&>(array).Value(idx);
-  case arrow::Type::UINT64:
-    return static_cast<const arrow::UInt64Array&>(array).Value(idx);
-  case arrow::Type::FLOAT:
-    return static_cast<const arrow::FloatArray&>(array).Value(idx);
-  case arrow::Type::DOUBLE:
-    return static_cast<const arrow::DoubleArray&>(array).Value(idx);
-  case arrow::Type::STRING:
-    return static_cast<const arrow::StringArray&>(array).GetString(idx);
-  case arrow::Type::STRUCT:
-    return structToJson(static_cast<const arrow::StructArray&>(array), idx, wrap_relation);
-  case arrow::Type::LIST:
-    return listToJson(static_cast<const arrow::ListArray&>(array), idx);
-  case arrow::Type::FIXED_SIZE_LIST:
-    return fixedSizeListToJson(static_cast<const arrow::FixedSizeListArray&>(array), idx);
-  case arrow::Type::MAP:
-    return mapToJson(static_cast<const arrow::MapArray&>(array), idx);
-  default:
-    throw std::runtime_error("Unsupported Arrow type in JSON converter: " + array.type()->ToString());
-  }
-}
-
-nlohmann::json arrowTableToJson(const std::shared_ptr<arrow::Table>& table) {
-  auto j = nlohmann::json::object();
-  for (int c = 0; c < table->num_columns(); ++c) {
-    std::string name = table->schema()->field(c)->name();
-    auto chunked_arr = table->column(c);
-    auto chunk = chunked_arr->chunk(0);
-    j[name] = arrayElementToJson(*chunk, 0);
-  }
-  return j;
-}
-
-nlohmann::json genericParametersToJson(const podio::GenericParameters& params) {
-  auto j = nlohmann::json::object();
-
-  auto int_params = nlohmann::json::object();
-  for (const auto& key : params.getKeys<int>()) {
-    int_params[key] = params.get<std::vector<int>>(key).value_or(std::vector<int>{});
-  }
-  j["int_params"] = int_params;
-
-  auto float_params = nlohmann::json::object();
-  for (const auto& key : params.getKeys<float>()) {
-    float_params[key] = params.get<std::vector<float>>(key).value_or(std::vector<float>{});
-  }
-  j["float_params"] = float_params;
-
-  auto double_params = nlohmann::json::object();
-  for (const auto& key : params.getKeys<double>()) {
-    double_params[key] = params.get<std::vector<double>>(key).value_or(std::vector<double>{});
-  }
-  j["double_params"] = double_params;
-
-  auto string_params = nlohmann::json::object();
-  for (const auto& key : params.getKeys<std::string>()) {
-    string_params[key] = params.get<std::vector<std::string>>(key).value_or(std::vector<std::string>{});
-  }
-  j["string_params"] = string_params;
-
-  return j;
-}
-
-} // namespace
-
-TEST_CASE("ArrowFrameConverter - JSON Equivalence Check", "[arrow][converter][json]") {
-  podio::Frame originalFrame;
-
-  // 1. Prepare some hits
-  ExampleHitCollection hits;
-  auto hit1 = MutableExampleHit(0x42ULL, 1.0f, 2.0f, 3.0f, 10.5);
-  auto hit2 = MutableExampleHit(0x43ULL, 4.0f, 5.0f, 6.0f, 20.5);
-  hits.push_back(hit1);
-  hits.push_back(hit2);
-
-  // 2. Prepare some clusters with relations to hits
-  ExampleClusterCollection clusters;
-  auto cluster1 = MutableExampleCluster();
-  cluster1.energy(100.0);
-  cluster1.addHits(hit1);
-  cluster1.addHits(hit2);
-  clusters.push_back(cluster1);
-
-  // 3. Prepare a relation collection
-  ExampleWithOneRelationCollection relColls;
-  auto relObj = MutableExampleWithOneRelation();
-  relObj.cluster(cluster1);
-  relColls.push_back(relObj);
-  // Add an unset relation reference object
-  auto unsetRelObj = MutableExampleWithOneRelation();
-  relColls.push_back(unsetRelObj);
-
-  // 4. Prepare a vector member collection
-  ExampleWithVectorMemberCollection vecColls;
-  auto vecObj = MutableExampleWithVectorMember();
-  vecObj.addcount(42);
-  vecObj.addcount(137);
-  vecColls.push_back(vecObj);
-
-  // 5. Prepare a subset collection of hits
-  ExampleHitCollection subsetHits;
-  subsetHits.setSubsetCollection(true);
-  subsetHits.push_back(hit1);
-
-  // 6. Prepare a collection with fixed-size arrays (FixedSizeList)
-  ExampleWithArrayCollection arrays;
-  std::array<int, 4> arrayTest = {0, 1, 2, 3};
-  std::array<int, 4> arrayTest2 = {4, 5, 6, 7};
-  NotSoSimpleStruct a;
-  a.data.p = arrayTest2;
-  ex2::NamespaceStruct nstruct;
-  nstruct.x = 42;
-  std::array<ex2::NamespaceStruct, 4> structArrayTest = {nstruct, nstruct, nstruct, nstruct};
-  auto arrayObj = MutableExampleWithArray(a, arrayTest, arrayTest, arrayTest, arrayTest, structArrayTest);
-  arrays.push_back(arrayObj);
-
-  // 7. Prepare an empty collection
-  ExampleClusterCollection emptyClusterColl;
-
-  // 8. Prepare a fixed-width integers collection
-  ExampleWithFixedWidthIntegersCollection fixedWidthInts;
-  auto fixedWidthObj = fixedWidthInts.create();
-  fixedWidthObj.fixedI16(-12345);
-  fixedWidthObj.fixedU32(1234567890U);
-  fixedWidthObj.fixedU64(1234567890123456789ULL);
-
-  auto& maxComp = fixedWidthObj.fixedWidthStruct();
-  maxComp.fixedUnsigned16 = 65535;
-  maxComp.fixedInteger64 = 9223372036854775807LL;
-  maxComp.fixedInteger32 = 2147483647;
-
-  std::array<int16_t, 2> arrVal = {-10, 20};
-  fixedWidthObj.fixedWidthArray(arrVal);
-
-  // Put them all into the frame
-  originalFrame.put(std::move(hits), "Hits");
-  originalFrame.put(std::move(clusters), "Clusters");
-  originalFrame.put(std::move(relColls), "OneRelation");
-  originalFrame.put(std::move(vecColls), "VectorMember");
-  originalFrame.put(std::move(subsetHits), "SubsetHits");
-  originalFrame.put(std::move(arrays), "ExampleWithArray");
-  originalFrame.put(std::move(emptyClusterColl), "EmptyCluster");
-  originalFrame.put(std::move(fixedWidthInts), "FixedWidthInts");
-
-  // Put some frame parameters
-  originalFrame.putParameter("anInt", 42);
-  originalFrame.putParameter("someFloats", std::vector<float>{1.23f, 2.34f, 3.45f});
-  originalFrame.putParameter("someStrings", std::vector<std::string>{"hello", "world"});
-
-  std::vector<std::string> colls = {"Hits",       "Clusters",         "OneRelation",  "VectorMember",
-                                    "SubsetHits", "ExampleWithArray", "EmptyCluster", "FixedWidthInts"};
-
-  // Convert to Arrow Table
-  auto table = podio::convertFrameToTable(originalFrame, colls);
-  REQUIRE(table != nullptr);
-
-  // Convert Arrow Table to JSON
-  nlohmann::json arrowJson = arrowTableToJson(table);
-
-  // Convert Frame to JSON directly
-  nlohmann::json frameJson = nlohmann::json::object();
-  frameJson["Hits"] = originalFrame.get<ExampleHitCollection>("Hits");
-  frameJson["Clusters"] = originalFrame.get<ExampleClusterCollection>("Clusters");
-  frameJson["OneRelation"] = originalFrame.get<ExampleWithOneRelationCollection>("OneRelation");
-  frameJson["VectorMember"] = originalFrame.get<ExampleWithVectorMemberCollection>("VectorMember");
-  frameJson["SubsetHits"] = originalFrame.get<ExampleHitCollection>("SubsetHits");
-  frameJson["ExampleWithArray"] = originalFrame.get<ExampleWithArrayCollection>("ExampleWithArray");
-  frameJson["EmptyCluster"] = originalFrame.get<ExampleClusterCollection>("EmptyCluster");
-  frameJson["FixedWidthInts"] = originalFrame.get<ExampleWithFixedWidthIntegersCollection>("FixedWidthInts");
-  frameJson["frame_parameters"] = genericParametersToJson(originalFrame.getParameters());
-
-  // Compare the JSON representations
-  REQUIRE(arrowJson == frameJson);
-}
-
-TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Round-Trip)", "[arrow][converter][reader]") {
-  podio::Frame originalFrame;
-
-  // 1. Prepare some hits
-  ExampleHitCollection hits;
-  auto hit1 = MutableExampleHit(0x42ULL, 1.0f, 2.0f, 3.0f, 10.5);
-  auto hit2 = MutableExampleHit(0x43ULL, 4.0f, 5.0f, 6.0f, 20.5);
-  hits.push_back(hit1);
-  hits.push_back(hit2);
-
-  // 2. Prepare some clusters with relations to hits
-  ExampleClusterCollection clusters;
-  auto cluster1 = MutableExampleCluster();
-  cluster1.energy(100.0);
-  cluster1.addHits(hit1);
-  cluster1.addHits(hit2);
-  clusters.push_back(cluster1);
-
-  // 3. Prepare a relation collection
-  ExampleWithOneRelationCollection relColls;
-  auto relObj = MutableExampleWithOneRelation();
-  relObj.cluster(cluster1);
-  relColls.push_back(relObj);
-
-  // 4. Prepare a vector member collection
-  ExampleWithVectorMemberCollection vecColls;
-  auto vecObj = MutableExampleWithVectorMember();
-  vecObj.addcount(42);
-  vecObj.addcount(137);
-  vecColls.push_back(vecObj);
-
-  // 5. Prepare a subset collection of hits
-  ExampleHitCollection subsetHits;
-  subsetHits.setSubsetCollection(true);
-  subsetHits.push_back(hit1);
-
-  // Put them all into the frame
-  originalFrame.put(std::move(hits), "Hits");
-  originalFrame.put(std::move(clusters), "Clusters");
-  originalFrame.put(std::move(relColls), "OneRelation");
-  originalFrame.put(std::move(vecColls), "VectorMember");
-  originalFrame.put(std::move(subsetHits), "SubsetHits");
-
-  // Put some frame parameters
-  originalFrame.putParameter("anInt", 42);
-  originalFrame.putParameter("someFloats", std::vector<float>{1.23f, 2.34f, 3.45f});
-  originalFrame.putParameter("someStrings", std::vector<std::string>{"hello", "world"});
-
-  std::vector<std::string> colls = {"Hits", "Clusters", "OneRelation", "VectorMember", "SubsetHits"};
-
-  // Convert to Arrow Table
-  auto table = podio::convertFrameToTable(originalFrame, colls);
-  REQUIRE(table != nullptr);
-
-  // Reconstruct the Frame from the Table
-  auto reconstructedFrame = podio::convertTableToFrame(table, 0);
-  REQUIRE(reconstructedFrame != nullptr);
-
-  // Verify Hits collection
-  const auto& recHits = reconstructedFrame->get<ExampleHitCollection>("Hits");
-  REQUIRE(recHits.size() == 2);
-  REQUIRE(recHits[0].x() == 1.0f);
-  REQUIRE(recHits[1].x() == 4.0f);
-  REQUIRE(recHits[0].energy() == 10.5);
-
-  // Verify Clusters collection and its hit relations
-  const auto& recClusters = reconstructedFrame->get<ExampleClusterCollection>("Clusters");
-  REQUIRE(recClusters.size() == 1);
-  REQUIRE(recClusters[0].energy() == 100.0);
-  REQUIRE(recClusters[0].Hits_size() == 2);
-  REQUIRE(recClusters[0].Hits(0).x() == 1.0f);
-  REQUIRE(recClusters[0].Hits(1).x() == 4.0f);
-
-  // Verify OneRelation
-  const auto& recRelColls = reconstructedFrame->get<ExampleWithOneRelationCollection>("OneRelation");
-  REQUIRE(recRelColls.size() == 1);
-  REQUIRE(recRelColls[0].cluster().energy() == 100.0);
-
-  // Verify VectorMember
-  const auto& recVecColls = reconstructedFrame->get<ExampleWithVectorMemberCollection>("VectorMember");
-  REQUIRE(recVecColls.size() == 1);
-  REQUIRE(recVecColls[0].count_size() == 2);
-  REQUIRE(recVecColls[0].count(0) == 42);
-  REQUIRE(recVecColls[0].count(1) == 137);
-
-  // Verify SubsetHits
-  const auto& recSubsetHits = reconstructedFrame->get<ExampleHitCollection>("SubsetHits");
-  REQUIRE(recSubsetHits.isSubsetCollection());
-  REQUIRE(recSubsetHits.size() == 1);
-  REQUIRE(recSubsetHits[0].x() == 1.0f);
-
-  // Verify Frame parameters
-  REQUIRE(reconstructedFrame->getParameter<int>("anInt") == 42);
-  auto recFloats = reconstructedFrame->getParameter<std::vector<float>>("someFloats");
-  REQUIRE(recFloats.has_value());
-  REQUIRE(recFloats->size() == 3);
-  REQUIRE((*recFloats)[0] == 1.23f);
-  auto recStrings = reconstructedFrame->getParameter<std::vector<std::string>>("someStrings");
-  REQUIRE(recStrings.has_value());
-  REQUIRE(recStrings->size() == 2);
-  REQUIRE((*recStrings)[0] == "hello");
+  REQUIRE(intKeys->GetString(0) == "SomeValue");
+  REQUIRE(intKeys->GetString(1) == "SomeVectorData");
+  REQUIRE(intKeys->GetString(2) == "anInt");
 }
 
 TEST_CASE("ArrowFrameConverter - convertTableToFrame Reader-Only Verification", "[arrow][converter][reader]") {

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -13,6 +13,11 @@
 
 // Arrow Frame Converter
 #include "podio/utilities/ArrowFrameConverter.h"
+#include "podio/utilities/ArrowTypeRegistry.h"
+
+// Test frame validation helpers
+#include "write_frame.h"
+#include "read_frame.h"
 
 // Arrow headers
 #include <arrow/api.h>
@@ -479,3 +484,385 @@ TEST_CASE("ArrowFrameConverter - JSON Equivalence Check", "[arrow][converter][js
   // Compare the JSON representations
   REQUIRE(arrowJson == frameJson);
 }
+
+TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Round-Trip)", "[arrow][converter][reader]") {
+  podio::Frame originalFrame;
+
+  // 1. Prepare some hits
+  ExampleHitCollection hits;
+  auto hit1 = MutableExampleHit(0x42ULL, 1.0f, 2.0f, 3.0f, 10.5);
+  auto hit2 = MutableExampleHit(0x43ULL, 4.0f, 5.0f, 6.0f, 20.5);
+  hits.push_back(hit1);
+  hits.push_back(hit2);
+
+  // 2. Prepare some clusters with relations to hits
+  ExampleClusterCollection clusters;
+  auto cluster1 = MutableExampleCluster();
+  cluster1.energy(100.0);
+  cluster1.addHits(hit1);
+  cluster1.addHits(hit2);
+  clusters.push_back(cluster1);
+
+  // 3. Prepare a relation collection
+  ExampleWithOneRelationCollection relColls;
+  auto relObj = MutableExampleWithOneRelation();
+  relObj.cluster(cluster1);
+  relColls.push_back(relObj);
+
+  // 4. Prepare a vector member collection
+  ExampleWithVectorMemberCollection vecColls;
+  auto vecObj = MutableExampleWithVectorMember();
+  vecObj.addcount(42);
+  vecObj.addcount(137);
+  vecColls.push_back(vecObj);
+
+  // 5. Prepare a subset collection of hits
+  ExampleHitCollection subsetHits;
+  subsetHits.setSubsetCollection(true);
+  subsetHits.push_back(hit1);
+
+  // Put them all into the frame
+  originalFrame.put(std::move(hits), "Hits");
+  originalFrame.put(std::move(clusters), "Clusters");
+  originalFrame.put(std::move(relColls), "OneRelation");
+  originalFrame.put(std::move(vecColls), "VectorMember");
+  originalFrame.put(std::move(subsetHits), "SubsetHits");
+
+  // Put some frame parameters
+  originalFrame.putParameter("anInt", 42);
+  originalFrame.putParameter("someFloats", std::vector<float>{1.23f, 2.34f, 3.45f});
+  originalFrame.putParameter("someStrings", std::vector<std::string>{"hello", "world"});
+
+  std::vector<std::string> colls = {"Hits", "Clusters", "OneRelation", "VectorMember", "SubsetHits"};
+
+  // Convert to Arrow Table
+  auto table = podio::convertFrameToTable(originalFrame, colls);
+  REQUIRE(table != nullptr);
+
+  // Reconstruct the Frame from the Table
+  auto reconstructedFrame = podio::convertTableToFrame(table, 0);
+  REQUIRE(reconstructedFrame != nullptr);
+
+  // Verify Hits collection
+  const auto& recHits = reconstructedFrame->get<ExampleHitCollection>("Hits");
+  REQUIRE(recHits.isValid());
+  REQUIRE(recHits.size() == 2);
+  REQUIRE(recHits[0].x() == 1.0f);
+  REQUIRE(recHits[1].x() == 4.0f);
+  REQUIRE(recHits[0].energy() == 10.5);
+
+  // Verify Clusters collection and its hit relations
+  const auto& recClusters = reconstructedFrame->get<ExampleClusterCollection>("Clusters");
+  REQUIRE(recClusters.isValid());
+  REQUIRE(recClusters.size() == 1);
+  REQUIRE(recClusters[0].energy() == 100.0);
+  REQUIRE(recClusters[0].Hits_size() == 2);
+  REQUIRE(recClusters[0].Hits(0).x() == 1.0f);
+  REQUIRE(recClusters[0].Hits(1).x() == 4.0f);
+
+  // Verify OneRelation
+  const auto& recRelColls = reconstructedFrame->get<ExampleWithOneRelationCollection>("OneRelation");
+  REQUIRE(recRelColls.isValid());
+  REQUIRE(recRelColls.size() == 1);
+  REQUIRE(recRelColls[0].cluster().energy() == 100.0);
+
+  // Verify VectorMember
+  const auto& recVecColls = reconstructedFrame->get<ExampleWithVectorMemberCollection>("VectorMember");
+  REQUIRE(recVecColls.isValid());
+  REQUIRE(recVecColls.size() == 1);
+  REQUIRE(recVecColls[0].count_size() == 2);
+  REQUIRE(recVecColls[0].count(0) == 42);
+  REQUIRE(recVecColls[0].count(1) == 137);
+
+  // Verify SubsetHits
+  const auto& recSubsetHits = reconstructedFrame->get<ExampleHitCollection>("SubsetHits");
+  REQUIRE(recSubsetHits.isValid());
+  REQUIRE(recSubsetHits.isSubsetCollection());
+  REQUIRE(recSubsetHits.size() == 1);
+  REQUIRE(recSubsetHits[0].x() == 1.0f);
+
+  // Verify Frame parameters
+  REQUIRE(reconstructedFrame->getParameter<int>("anInt") == 42);
+  auto recFloats = reconstructedFrame->getParameter<std::vector<float>>("someFloats");
+  REQUIRE(recFloats.has_value());
+  REQUIRE(recFloats->size() == 3);
+  REQUIRE((*recFloats)[0] == 1.23f);
+  auto recStrings = reconstructedFrame->getParameter<std::vector<std::string>>("someStrings");
+  REQUIRE(recStrings.has_value());
+  REQUIRE(recStrings->size() == 2);
+  REQUIRE((*recStrings)[0] == "hello");
+}
+
+TEST_CASE("ArrowFrameConverter - convertTableToFrame Reader-Only Verification", "[arrow][converter][reader]") {
+  auto arrowType = podio::ArrowTypeRegistry::instance().getType("ExampleHit");
+  REQUIRE(arrowType != nullptr);
+
+  std::unique_ptr<arrow::ArrayBuilder> builder;
+  auto status = arrow::MakeBuilder(arrow::default_memory_pool(), arrowType, &builder);
+  REQUIRE(status.ok());
+  auto* collectionBuilder = static_cast<arrow::ListBuilder*>(builder.get());
+  auto* objectBuilder = static_cast<arrow::StructBuilder*>(collectionBuilder->value_builder());
+  auto* builder_cellID = static_cast<arrow::UInt64Builder*>(objectBuilder->child(0));
+  auto* builder_x = static_cast<arrow::DoubleBuilder*>(objectBuilder->child(1));
+  auto* builder_y = static_cast<arrow::DoubleBuilder*>(objectBuilder->child(2));
+  auto* builder_z = static_cast<arrow::DoubleBuilder*>(objectBuilder->child(3));
+  auto* builder_energy = static_cast<arrow::DoubleBuilder*>(objectBuilder->child(4));
+
+  REQUIRE(collectionBuilder->Append().ok());
+
+  // Hit 1
+  REQUIRE(builder_cellID->Append(0x100ULL).ok());
+  REQUIRE(builder_x->Append(10.0).ok());
+  REQUIRE(builder_y->Append(20.0).ok());
+  REQUIRE(builder_z->Append(30.0).ok());
+  REQUIRE(builder_energy->Append(5.5).ok());
+  REQUIRE(objectBuilder->Append().ok());
+
+  // Hit 2
+  REQUIRE(builder_cellID->Append(0x200ULL).ok());
+  REQUIRE(builder_x->Append(-1.0).ok());
+  REQUIRE(builder_y->Append(-2.0).ok());
+  REQUIRE(builder_z->Append(-3.0).ok());
+  REQUIRE(builder_energy->Append(0.5).ok());
+  REQUIRE(objectBuilder->Append().ok());
+
+  std::shared_ptr<arrow::Array> array;
+  REQUIRE(collectionBuilder->Finish(&array).ok());
+
+  auto metadata = arrow::KeyValueMetadata::Make(
+      {"value_type", "is_subset", "coll_id"},
+      {"ExampleHit", "0", "101"});
+  auto field = arrow::field("Hits", arrowType, true, std::move(metadata));
+
+  auto schema = arrow::schema({field});
+  auto batch = arrow::RecordBatch::Make(schema, 1, {array});
+  REQUIRE(batch != nullptr);
+  auto tableResult = arrow::Table::FromRecordBatches({batch});
+  REQUIRE(tableResult.ok());
+  auto table = tableResult.ValueOrDie();
+
+  auto frame = podio::convertTableToFrame(table, 0);
+  REQUIRE(frame != nullptr);
+
+  const auto& recHits = frame->get<ExampleHitCollection>("Hits");
+  REQUIRE(recHits.isValid());
+  REQUIRE(recHits.size() == 2);
+  REQUIRE(recHits[0].cellID() == 0x100ULL);
+  REQUIRE(recHits[0].x() == 10.0f);
+  REQUIRE(recHits[0].energy() == 5.5);
+  REQUIRE(recHits[1].cellID() == 0x200ULL);
+  REQUIRE(recHits[1].x() == -1.0f);
+  REQUIRE(recHits[1].energy() == 0.5);
+}
+
+void verifyEventNoUserData(const podio::Frame& event, int eventNum) {
+  const float evtWeight = event.getParameter<float>("UserEventWeight").value();
+  REQUIRE(evtWeight == 100.f * eventNum);
+
+  std::stringstream ss;
+  ss << " event_number_" << eventNum;
+  const auto evtName = event.getParameter<std::string>("UserEventName").value();
+  REQUIRE(evtName == ss.str());
+
+  const auto someVectorData = event.getParameter<std::vector<int>>("SomeVectorData").value();
+  REQUIRE(someVectorData.size() == 4);
+  for (int i = 0; i < 4; ++i) {
+    REQUIRE(someVectorData[i] == i + 1);
+  }
+
+  const auto doubleParams = event.getParameter<std::vector<double>>("SomeVectorData").value();
+  REQUIRE(doubleParams.size() == 2);
+  REQUIRE(doubleParams[0] == eventNum * 1.1);
+  REQUIRE(doubleParams[1] == eventNum * 2.2);
+
+  checkHitCollection(event, eventNum);
+
+  auto& hits = event.get<ExampleHitCollection>("hits");
+
+  auto& hitRefs = event.get<ExampleHitCollection>("hitRefs");
+  REQUIRE(hitRefs.size() == hits.size());
+  REQUIRE((hits[1] == hitRefs[0] && hits[0] == hitRefs[1]));
+
+  checkClusterCollection(event, hits);
+
+  auto& clusters = event.get<ExampleClusterCollection>("clusters");
+
+  auto& mcpRefs = event.get<ExampleMCCollection>("mcParticleRefs");
+  for (auto ref : mcpRefs) {
+    const auto daughters = ref.daughters();
+    if (!daughters.empty()) {
+      auto d [[maybe_unused]] = daughters[0];
+    }
+    const auto parents = ref.parents();
+    if (!parents.empty()) {
+      auto d [[maybe_unused]] = parents[0];
+    }
+  }
+
+  checkMCParticleCollection(event, podio::version::build_version);
+
+  auto& mcps = event.get<ExampleMCCollection>("mcparticles");
+
+  for (auto pr : mcpRefs) {
+    REQUIRE(static_cast<unsigned>(pr.getObjectID().collectionID) != mcpRefs.getID());
+  }
+
+  auto& moreMCs = event.get<ExampleMCCollection>("moreMCs");
+  REQUIRE(mcps.size() == moreMCs.size());
+
+  for (size_t index = 0; index < mcps.size(); ++index) {
+    REQUIRE(mcps[index].energy() == moreMCs[index].energy());
+    REQUIRE(mcps[index].daughters().size() == moreMCs[index].daughters().size());
+  }
+
+  REQUIRE(mcpRefs.size() == mcps.size());
+  for (size_t i = 0; i < mcpRefs.size(); ++i) {
+    if (i < 5) {
+      REQUIRE(mcpRefs[i] == mcps[2 * i + 1]);
+    } else {
+      const int index = (i - 5) * 2;
+      REQUIRE(mcpRefs[i] == moreMCs[index]);
+    }
+  }
+
+  auto& refs = event.get<ExampleReferencingTypeCollection>("refs");
+  auto ref = refs[0];
+  for (auto cluster : ref.Clusters()) {
+    for (auto hit [[maybe_unused]] : cluster.Hits()) {
+    }
+  }
+  auto& rels [[maybe_unused]] = event.get<ExampleWithOneRelationCollection>("OneRelation");
+
+  auto& vecs = event.get<ExampleWithVectorMemberCollection>("WithVectorMember");
+  REQUIRE(vecs.size() == 2);
+
+  for (auto vec : vecs) {
+    REQUIRE(vec.count().size() == 2);
+  }
+  REQUIRE(vecs[0].count(0) == eventNum);
+  REQUIRE(vecs[0].count(1) == eventNum + 10);
+  REQUIRE(vecs[1].count(0) == eventNum + 1);
+  REQUIRE(vecs[1].count(1) == eventNum + 11);
+
+  auto& arrays = event.get<ExampleWithArrayCollection>("arrays");
+  REQUIRE(!arrays.empty());
+  auto array = arrays[0];
+  REQUIRE(array.myArray(1) == eventNum);
+  REQUIRE(array.arrayStruct().data.p.at(2) == 2 * eventNum);
+  REQUIRE(array.structArray(0).x == eventNum);
+
+  auto& nmspaces = event.get<ex42::ExampleWithARelationCollection>("WithNamespaceRelation");
+  auto& copies = event.get<ex42::ExampleWithARelationCollection>("WithNamespaceRelationCopy");
+
+  auto cpytest = ex42::ExampleWithARelationCollection{};
+  for (size_t j = 0; j < nmspaces.size(); j++) {
+    auto nmsp = nmspaces[j];
+    auto cpy = copies[j];
+    cpytest.push_back(nmsp.clone());
+    if (nmsp.ref().isAvailable()) {
+      REQUIRE(nmsp.ref().component().x == cpy.ref().component().x);
+      REQUIRE(nmsp.ref().component().y == cpy.ref().component().y);
+      REQUIRE(nmsp.ref().x() == cpy.ref().x());
+      REQUIRE(nmsp.number() == cpy.number());
+      REQUIRE(nmsp.ref().getObjectID() == cpy.ref().getObjectID());
+    }
+    auto cpy_it = cpy.refs_begin();
+    for (auto it = nmsp.refs_begin(); it != nmsp.refs_end(); ++it, ++cpy_it) {
+      REQUIRE(it->component().x == cpy_it->component().x);
+      REQUIRE(it->component().y == cpy_it->component().y);
+      REQUIRE(it->getObjectID() == cpy_it->getObjectID());
+    }
+  }
+
+  const auto& fixedWidthInts = event.get<ExampleWithFixedWidthIntegersCollection>("fixedWidthInts");
+  REQUIRE(fixedWidthInts.size() == 3);
+
+  auto maxValues = fixedWidthInts[0];
+  const auto& maxComps = maxValues.fixedWidthStruct();
+  REQUIRE(maxValues.fixedI16() == std::numeric_limits<std::int16_t>::max());
+  REQUIRE(maxValues.fixedU32() == std::numeric_limits<std::uint32_t>::max());
+  REQUIRE(maxValues.fixedU64() == std::numeric_limits<std::uint64_t>::max());
+  REQUIRE(maxComps.fixedInteger64 == std::numeric_limits<std::int64_t>::max());
+  REQUIRE(maxComps.fixedInteger32 == std::numeric_limits<std::int32_t>::max());
+  REQUIRE(maxComps.fixedUnsigned16 == std::numeric_limits<std::uint16_t>::max());
+
+  auto minValues = fixedWidthInts[1];
+  const auto& minComps = minValues.fixedWidthStruct();
+  REQUIRE(minValues.fixedI16() == std::numeric_limits<std::int16_t>::min());
+  REQUIRE(minValues.fixedU32() == std::numeric_limits<std::uint32_t>::min());
+  REQUIRE(minValues.fixedU64() == std::numeric_limits<std::uint64_t>::min());
+  REQUIRE(minComps.fixedInteger64 == std::numeric_limits<std::int64_t>::min());
+  REQUIRE(minComps.fixedInteger32 == std::numeric_limits<std::int32_t>::min());
+  REQUIRE(minComps.fixedUnsigned16 == std::numeric_limits<std::uint16_t>::min());
+
+  auto arbValues = fixedWidthInts[2];
+  const auto& arbComps = arbValues.fixedWidthStruct();
+  REQUIRE(arbValues.fixedI16() == std::int16_t{-12345});
+  REQUIRE(arbValues.fixedU32() == std::uint32_t{1234567890});
+  REQUIRE(arbValues.fixedU64() == std::uint64_t{1234567890123456789});
+  REQUIRE(arbComps.fixedInteger64 == std::int64_t{-1234567890123456789});
+  REQUIRE(arbComps.fixedInteger32 == std::int64_t{-1234567890});
+  REQUIRE(arbComps.fixedUnsigned16 == std::uint16_t{12345});
+}
+
+TEST_CASE("ArrowFrameConverter - Comprehensive Round-Trip (No-UserData)", "[arrow][converter][common]") {
+  auto originalFrame = makeFrame(0);
+
+  const std::vector<std::string> colls = {
+    "mcparticles",
+    "moreMCs",
+    "arrays",
+    "mcParticleRefs",
+    "hits",
+    "hitRefs",
+    "refs",
+    "refs2",
+    "clusters",
+    "OneRelation",
+    "info",
+    "WithVectorMember",
+    "VectorMemberSubsetColl",
+    "fixedWidthInts",
+    "WithNamespaceMember",
+    "WithNamespaceRelation",
+    "WithNamespaceRelationCopy",
+    "emptyCollection",
+    "emptySubsetColl",
+    "extension_Contained",
+    "extension_ExternalComponent",
+    "extension_ExternalRelation",
+    "interface_examples",
+    "anotherHits",
+    "extension_interface_relation"
+  };
+
+  auto table = podio::convertFrameToTable(originalFrame, colls);
+  REQUIRE(table != nullptr);
+
+  auto reconstructedFrame = podio::convertTableToFrame(table, 0);
+  REQUIRE(reconstructedFrame != nullptr);
+
+  verifyEventNoUserData(*reconstructedFrame, 0);
+
+  processExtensions(*reconstructedFrame, 0, podio::version::build_version);
+  checkVecMemSubsetColl(*reconstructedFrame);
+  checkInterfaceCollection(*reconstructedFrame);
+  // verify interface relation (excluding link collection check)
+  const auto& interfaceColl = reconstructedFrame->get<iextension::ExampleWithInterfaceRelationCollection>("extension_interface_relation");
+  REQUIRE(interfaceColl.size() == 2);
+  const auto& hits = reconstructedFrame->get<ExampleHitCollection>("hits");
+  const auto& anotherHits = reconstructedFrame->get<iextension::AnotherHitCollection>("anotherHits");
+  const auto iface0 = interfaceColl[0];
+  const auto iface1 = interfaceColl[1];
+  REQUIRE(iface0.singleEnergy() == hits[0]);
+  REQUIRE(iface1.singleEnergy() == anotherHits[0]);
+  const auto iface0Rels = iface0.manyEnergies();
+  REQUIRE(iface0Rels.size() == 2);
+  REQUIRE(iface0Rels[0] == hits[0]);
+  REQUIRE(iface0Rels[1] == anotherHits[0]);
+  const auto iface1Rels = iface1.manyEnergies();
+  REQUIRE(iface1Rels.size() == 2);
+  REQUIRE(iface1Rels[0] == hits[0]);
+  REQUIRE(iface1Rels[1] == anotherHits[0]);
+}
+

--- a/tests/unittests/test_arrow_converter.cpp
+++ b/tests/unittests/test_arrow_converter.cpp
@@ -344,7 +344,8 @@ TEST_CASE("ArrowFrameConverter - Comprehensive Round-Trip (No-UserData)", "[arro
   std::vector<std::string> colls;
   for (const auto& name : originalFrame.getAvailableCollections()) {
     if (const auto* coll = originalFrame.get(name)) {
-      if (coll->isSubsetCollection() || podio::ArrowTypeRegistry::instance().getType(std::string(coll->getValueTypeName()))) {
+      if (coll->isSubsetCollection() ||
+          podio::ArrowTypeRegistry::instance().getType(std::string(coll->getValueTypeName()))) {
         colls.push_back(name);
       }
     }
@@ -385,7 +386,8 @@ TEST_CASE("ArrowFrameConverter - convertTableToFrame Verification (Multi-Row / r
   std::vector<std::string> colls;
   for (const auto& name : frame1.getAvailableCollections()) {
     if (const auto* coll = frame1.get(name)) {
-      if (coll->isSubsetCollection() || podio::ArrowTypeRegistry::instance().getType(std::string(coll->getValueTypeName()))) {
+      if (coll->isSubsetCollection() ||
+          podio::ArrowTypeRegistry::instance().getType(std::string(coll->getValueTypeName()))) {
         colls.push_back(name);
       }
     }


### PR DESCRIPTION
This PR implements the deserialization capability for the Apache Arrow backend, completing the round-trip workflow. It adds support for reconstructing PODIO Frame objects from a single-row slice of an Apache Arrow Table.

**Key Features & Changes**

- **convertTableToFrame API**: Introduced a public utility to read and reconstruct a Frame from a specific row of an Arrow Table.
- **Auto-generated Readers**: Updated cpp_generator.py and generator templates (ArrowMapper.cc.jinja2) to generate deserialization/reader functions for all concrete data model types.
- **Complex Type Support:** Handles reconstruction of collections, subset collections, vector members, relations/references, and Link Collections.
- **Generic Parameters**: Reconstructs GenericParameters from the frame_parameters struct column in the Arrow Table.

**Testing**

- Added comprehensive unit tests in test_arrow_converter.cpp covering:
- Full round-trip (Frame $\rightarrow$ Table $\rightarrow$ Frame) checks.
- Multi-row tables and non-zero row index offset mapping.
- Verification of reconstructed relations, subsets, and parameter maps.

Fixes: #986 

BEGINRELEASENOTES

* Add support for Arrow-to-Frame conversion (deserialization) for the Apache Arrow backend to complete the round-trip workflow.
* Introduce the `convertTableToFrame` API to reconstruct `podio::Frame` objects from a specific row of an Arrow `Table`.
* Add support for reconstructing complex types (collections, vector members, relations, subsets) and `GenericParameters`.

ENDRELEASENOTES
