### PR TITLE
Use constexpr and consteval when possible

### DIFF
--- a/include/podio/LinkNavigator.h
+++ b/include/podio/LinkNavigator.h
@@ -22,7 +22,7 @@ namespace detail::links {
     T o;          ///< The object
     float weight; ///< The weight in the link
 
-    bool operator==(const WeightedObject<T>& other) const {
+    constexpr bool operator==(const WeightedObject<T>& other) const {
       return other.o == o && other.weight == weight;
     }
   };

--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -27,12 +27,7 @@ public:
 
   /// index and collectionID uniquely defines the object.
   /// this operator is necessary for meaningful comparisons in python
-  bool operator==(const ObjectID& other) const {
-    return index == other.index && collectionID == other.collectionID;
-  }
-  bool operator!=(const ObjectID& other) const {
-    return !(*this == other);
-  }
+  constexpr bool operator==(const ObjectID&) const noexcept = default;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const podio::ObjectID& id) {
@@ -52,6 +47,8 @@ inline void to_json(nlohmann::json& j, const podio::ObjectID& id) {
 
 template <>
 struct std::hash<podio::ObjectID> {
+  // constexpr works with GCC 16 and Clang 22, but doesn't with
+  // older compilers
   std::size_t operator()(const podio::ObjectID& id) const noexcept {
     auto hash_collectionID = std::hash<uint32_t>{}(id.collectionID);
     auto hash_index = std::hash<int>{}(id.index);

--- a/include/podio/RelationRange.h
+++ b/include/podio/RelationRange.h
@@ -14,50 +14,50 @@ public:
 
   RelationRange() = delete;
 
-  RelationRange(ConstIteratorType begin, ConstIteratorType end) :
+  constexpr RelationRange(ConstIteratorType begin, ConstIteratorType end) :
       m_begin(begin), m_end(end), m_size(std::distance(m_begin, m_end)) {
   }
 
   /// begin of the range (necessary for range-based for loop)
-  ConstIteratorType begin() const {
+  constexpr ConstIteratorType begin() const {
     return m_begin;
   }
   /// end of the range (necessary for range-based for loop)
-  ConstIteratorType end() const {
+  constexpr ConstIteratorType end() const {
     return m_end;
   }
   /// constant begin of the range
-  ConstIteratorType cbegin() const {
+  constexpr ConstIteratorType cbegin() const {
     return begin();
   }
   /// constant end of the range
-  ConstIteratorType cend() const {
+  constexpr ConstIteratorType cend() const {
     return end();
   }
   /// convenience overload for size
-  size_t size() const {
+  constexpr size_t size() const {
     return m_size;
   }
   /// convenience overload to check if the range is empty
-  bool empty() const {
+  constexpr bool empty() const {
     return m_begin == m_end;
   }
   /// check whether the range is not empty
-  explicit operator bool() const {
+  constexpr explicit operator bool() const {
     return !empty();
   }
   /// Indexed access
-  ReferenceType operator[](size_t i) const {
+  constexpr ReferenceType operator[](size_t i) const {
     auto it = m_begin;
     std::advance(it, i);
     return *it;
   }
   /// First element of the range
-  ReferenceType front() const {
+  constexpr ReferenceType front() const {
     return *m_begin;
   }
   /// Last element of the range
-  ReferenceType back() const {
+  constexpr ReferenceType back() const {
     return *(m_end - 1);
   }
 

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -306,27 +306,27 @@ public:
     return getObjectID();
   }
 
-  bool operator==(const LinkT& other) const {
+  constexpr bool operator==(const LinkT& other) const {
     return m_obj == other.m_obj;
   }
 
-  bool operator!=(const LinkT& other) const {
+  constexpr bool operator!=(const LinkT& other) const {
     return !(*this == other);
   }
 
   template <typename FromU, typename ToU>
     requires sameTypes<FromU, ToU>
-  bool operator==(const LinkT<FromU, ToU, !Mutable>& other) const {
+  constexpr bool operator==(const LinkT<FromU, ToU, !Mutable>& other) const {
     return m_obj == other.m_obj;
   }
 
   template <typename FromU, typename ToU>
     requires sameTypes<FromU, ToU>
-  bool operator!=(const LinkT<FromU, ToU, !Mutable>& other) const {
+  constexpr bool operator!=(const LinkT<FromU, ToU, !Mutable>& other) const {
     return !(*this == other);
   }
 
-  bool operator<(const LinkT& other) const {
+  constexpr bool operator<(const LinkT& other) const {
     return m_obj < other.m_obj;
   }
 

--- a/include/podio/detail/LinkCollectionIterator.h
+++ b/include/podio/detail/LinkCollectionIterator.h
@@ -33,11 +33,11 @@ public:
   LinkCollectionIteratorT& operator=(LinkCollectionIteratorT&&) = default;
   ~LinkCollectionIteratorT() = default;
 
-  auto operator<=>(const LinkCollectionIteratorT& other) const {
+  constexpr auto operator<=>(const LinkCollectionIteratorT& other) const {
     return m_index <=> other.m_index;
   }
 
-  bool operator==(const LinkCollectionIteratorT& other) const {
+  constexpr bool operator==(const LinkCollectionIteratorT& other) const {
     return m_index == other.m_index;
   }
 

--- a/include/podio/detail/OrderKey.h
+++ b/include/podio/detail/OrderKey.h
@@ -14,9 +14,9 @@ namespace podio::detail {
 /// from different datamodels in an interface type.
 class OrderKey {
 public:
-  OrderKey(const void* orderKey) noexcept : m_orderKey(orderKey) {
+  constexpr OrderKey(const void* orderKey) noexcept : m_orderKey(orderKey) {
   }
-  friend bool operator<(const OrderKey& lhs, const OrderKey& rhs) noexcept {
+  friend constexpr bool operator<(const OrderKey& lhs, const OrderKey& rhs) noexcept {
     return std::less<const void*>{}(lhs.m_orderKey, rhs.m_orderKey);
   }
 

--- a/include/podio/utilities/MaybeSharedPtr.h
+++ b/include/podio/utilities/MaybeSharedPtr.h
@@ -88,7 +88,7 @@ public:
     return m_ptr;
   }
 
-  operator bool() const {
+  constexpr operator bool() const {
     return m_ptr;
   }
 
@@ -113,11 +113,11 @@ public:
   // comparison operators
 #define DECLARE_COMPARISON_OPERATOR(op)                                                                                \
   template <typename U>                                                                                                \
-  friend bool operator op(const MaybeSharedPtr<U>& lhs, const MaybeSharedPtr<U>& rhs);                                 \
+  friend constexpr bool operator op(const MaybeSharedPtr<U>& lhs, const MaybeSharedPtr<U>& rhs);                       \
   template <typename U>                                                                                                \
-  friend bool operator op(const MaybeSharedPtr<U>& lhs, const U* rhs);                                                 \
+  friend constexpr bool operator op(const MaybeSharedPtr<U>& lhs, const U* rhs);                                       \
   template <typename U>                                                                                                \
-  friend bool operator op(const U* lhs, const MaybeSharedPtr<U>& rhs);
+  friend constexpr bool operator op(const U* lhs, const MaybeSharedPtr<U>& rhs);
 
   DECLARE_COMPARISON_OPERATOR(==)
   DECLARE_COMPARISON_OPERATOR(!=)
@@ -149,7 +149,7 @@ void swap(MaybeSharedPtr<T>& a, MaybeSharedPtr<T>& b) {
 // helper macro for avoiding a bit of typing/repetition
 #define DEFINE_COMPARISON_OPERATOR(op)                                                                                 \
   template <typename U>                                                                                                \
-  bool operator op(const MaybeSharedPtr<U>& lhs, const MaybeSharedPtr<U>& rhs) {                                       \
+  constexpr bool operator op(const MaybeSharedPtr<U>& lhs, const MaybeSharedPtr<U>& rhs) {                             \
     return lhs.m_ptr op rhs.m_ptr;                                                                                     \
   }
 

--- a/include/podio/utilities/StaticConcatenate.h
+++ b/include/podio/utilities/StaticConcatenate.h
@@ -7,9 +7,16 @@
 namespace podio::utils {
 
 /// Helper struct to concatenate a set of string_views into a single string_view at compile time
+///
+// consteval fails with GCC 13
+#if defined(__GNUC__) && __GNUC__ < 14
+  #define PODIO_STATIC_CONCATENATE_INIT_CONSTEVAL constexpr
+#else
+  #define PODIO_STATIC_CONCATENATE_INIT_CONSTEVAL consteval
+#endif
 template <const std::string_view&... strs>
 struct static_concatenate {
-  static constexpr auto init_arr() {
+  static PODIO_STATIC_CONCATENATE_INIT_CONSTEVAL auto init_arr() {
     constexpr auto total_size = (strs.size() + ... + 1); // reserve space for '\0'
     auto arr = std::array<char, total_size>();
     auto it = arr.begin();
@@ -20,6 +27,8 @@ struct static_concatenate {
   constexpr static auto array = init_arr();
   constexpr static auto value = std::string_view(array.data(), array.size() - 1); // skip '\0'
 };
+
+#undef PODIO_STATIC_CONCATENATE_INIT_CONSTEVAL
 
 /// Variable template for concatenating a set of string_views into a single string_view at compile time
 template <const std::string_view&... strs>

--- a/podioVersion.in.h
+++ b/podioVersion.in.h
@@ -72,7 +72,7 @@ inline std::ostream& operator<<(std::ostream& os, const Version& v) {
 static constexpr Version build_version{podio_VERSION_MAJOR, podio_VERSION_MINOR, podio_VERSION_PATCH};
 
 /// Decode a version from a 64 bit unsigned
-static constexpr Version decode_version(unsigned long version) noexcept {
+static consteval Version decode_version(unsigned long version) noexcept {
   return Version{static_cast<uint16_t>(PODIO_MAJOR_VERSION(version)),
                  static_cast<uint16_t>(PODIO_MINOR_VERSION(version)),
                  static_cast<uint16_t>(PODIO_PATCH_VERSION(version))};

--- a/python/templates/macros/declarations.jinja2
+++ b/python/templates/macros/declarations.jinja2
@@ -86,10 +86,10 @@
   void unlink() { m_obj = podio::utils::MaybeSharedPtr<{{ type }}Obj>{nullptr}; }
 
 {% set inverse_type = type if prefix else 'Mutable' + type %}
-  bool operator==(const {{ full_type }}& other) const { return m_obj == other.m_obj; }
+  constexpr bool operator==(const {{ full_type }}& other) const { return m_obj == other.m_obj; }
   bool operator==(const {{ inverse_type }}& other) const;
 
-  bool operator!=(const {{ full_type }}& other) const { return !(*this == other); }
+  constexpr bool operator!=(const {{ full_type }}& other) const { return !(*this == other); }
   bool operator!=(const {{ inverse_type }}& other) const { return !(*this == other); }
 
   // less comparison operator, so that objects can be e.g. stored in sets.

--- a/python/templates/macros/iterator.jinja2
+++ b/python/templates/macros/iterator.jinja2
@@ -21,11 +21,11 @@ public:
   {{ iterator_type }}& operator=({{iterator_type}}&&) = default;
   ~{{ iterator_type }}() = default;
 
-  auto operator<=>(const {{ iterator_type}}& other) const {
+  constexpr auto operator<=>(const {{ iterator_type}}& other) const {
     return m_index <=> other.m_index;
   }
 
-  bool operator==(const {{ iterator_type }}& x) const {
+  constexpr bool operator==(const {{ iterator_type }}& x) const {
     return m_index ==  x.m_index;
   }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Use constexpr and consteval when possible
- Only define `operator==` for ObjectID since defaulting it also creates `operator!=` (see https://en.cppreference.com/cpp/language/default_comparisons?)

ENDRELEASENOTES