### PR TITLE
Apply a few suggestions from clang-tidy

### DIFF
--- a/python/templates/CollectionData.cc.jinja2
+++ b/python/templates/CollectionData.cc.jinja2
@@ -46,11 +46,15 @@
   // https://github.com/AIDASoft/podio/pull/817#issuecomment-3266748609 and
   // https://github.com/AIDASoft/podio/pull/842
   volatile std::uint64_t s = m_data->size();
-  if (s > 1e15) throw std::runtime_error("Bad data after reading: a collection is too big ({{ class.full_type }})");
-  else
-    if (s == 0)
-      for ([[maybe_unused]] const auto& _ : *m_data.get())
+  if (s > 1e15) {
+    throw std::runtime_error("Bad data after reading: a collection is too big ({{ class.full_type }})");
+  } else {
+    if (s == 0) {
+      for ([[maybe_unused]] const auto& _ : *m_data.get()) {
         throw std::runtime_error("Bad data after reading: zero-sized collection with data ({{ class.full_type }})");
+      }
+    }
+  }
   // end of ugly
 
 
@@ -96,7 +100,9 @@ void {{ class_type }}::clear(bool isSubsetColl) {
 {{ macros.clear_relation(relation) }}
 {% endfor %}
 {% for member in VectorMembers %}
-  if (m_vec_{{ member.name }}) m_vec_{{ member.name }}->clear();
+  if (m_vec_{{ member.name }}) {
+    m_vec_{{ member.name }}->clear();
+  }
   m_vecs_{{ member.name }}.clear();
 
 {% endfor %}

--- a/python/templates/Interface.h.jinja2
+++ b/python/templates/Interface.h.jinja2
@@ -66,8 +66,8 @@ private:
 
   template<typename ValueT>
   struct Model final : Concept {
-    ~Model() = default;
-    Model(ValueT value) : m_value(value) {}
+    ~Model() override = default;
+    Model(const ValueT& value) : m_value(value) {}
 
     std::unique_ptr<Concept> clone() const final {
       return std::make_unique<Model<ValueT>>(m_value);
@@ -107,7 +107,7 @@ public:
   // {{ class.bare_type }} can only be initialized with one of the following types (and their Mutable counter parts): {{ Types | join(", ") }}
   template<typename ValueT>
   requires isInitializableFrom<ValueT>
-  {{ class.bare_type }}(ValueT value) :
+  {{ class.bare_type }}(const ValueT& value) :
     m_self(std::make_unique<Model<podio::detail::GetDefaultHandleType<ValueT>>>(value)) {
   }
 

--- a/python/templates/Obj.cc.jinja2
+++ b/python/templates/Obj.cc.jinja2
@@ -43,17 +43,19 @@
 }
 
 {% if not is_trivial_type -%}
-{{ obj_type }}::~{{ obj_type }}() {
 {% with multi_relations = OneToManyRelations + VectorMembers %}
 {%- if multi_relations %}
+{{ obj_type }}::~{{ obj_type }}() {
   if (id.index == podio::ObjectID::untracked) {
 {% for relation in multi_relations %}
     delete m_{{ relation.name }};
 {% endfor %}
   }
-{% endif %}
-{%- endwith %}
 }
+{%- else %}
+{{ obj_type }}::~{{ obj_type }}() = default;
+{%- endif %}
+{%- endwith %}
 {%- endif %}
 
 {% endwith %}


### PR DESCRIPTION
BEGINRELEASENOTES
- Add const in the Model constructor in Interface.h (avoiding one copy)
- Add a default destructor for types that have one-to-one relations (since it is a `unique_ptr` that can be destroyed)
- Add a few brackets `{` and `}` instead of having one-line ifs.

ENDRELEASENOTES

I'm not sure if we don't get these in CI because it's a different version; I'm running on Clang 22.