### PR TITLE
Let ROOT bind to the right type instead of casting to std::vector<int>

### DIFF
--- a/src/RNTupleWriter.cc
+++ b/src/RNTupleWriter.cc
@@ -135,11 +135,9 @@ void RNTupleWriter::writeFrame(const podio::Frame& frame, std::string_view categ
 
       if (const auto vmInfo = collBuffers.vectorMembers) {
         size_t i = 0;
-        for (const auto& [type, vec] : *vmInfo) {
-          const auto typeName = "vector<" + type + ">";
+        for (const auto& vectorMember : *vmInfo) {
           const auto brName = root_utils::vecBranch(name, relVecNames.vectorMembers[i]);
-          auto ptr = *static_cast<std::vector<int>**>(vec);
-          entry->BindRawPtr(brName, ptr);
+          entry->BindRawPtr(brName, *static_cast<void**>(vectorMember.second));
           ++i;
         }
       }


### PR DESCRIPTION
BEGINRELEASENOTES
- Let ROOT bind to the right type instead of casting to std::vector<int>

ENDRELEASENOTES

Currently failing in dev3 with:

```
       5/268 Test  #20: write_interface_rntuple .......................................................Subprocess aborted***Exception:   1.08 sec
    terminate called after throwing an instance of 'ROOT::RException'
      what():  type mismatch for field _extension_ExternalRelation_someStructs: std::vector<SimpleStruct> vs. std::vector<std::int32_t>
    At:
      void ROOT::REntry::EnsureMatchingType(ROOT::RFieldToken) const [with T = std::vector<int, std::allocator<int> >] [/cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev3/Fri/ROOT/HEAD/x86_64-el9-gcc15-opt/include/ROOT/REntry.hxx:138]

```

It seems there are new checks in ROOT (https://github.com/root-project/root/pull/22857?); the issue happens because we always cast to `std::vector<int>` for vector members but they may not be int with RNTuples.

Edit: it's unclear to me how we could trigger this in a test in podio since the path was already being exercised (otherwise it wouldn't have crashed), but apparently reading was fine. 