### PR TITLE
Export Arrow target from podio config

### DIFF
--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -49,6 +49,7 @@ endif()
 SET(PODIO_ENABLE_ARROW @ENABLE_ARROW@)
 if(PODIO_ENABLE_ARROW)
   find_dependency(Arrow)
+  set(PODIO_ARROW_TARGET @PODIO_ARROW_TARGET@)
 endif()
 
 if(NOT TARGET podio::podio)

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -52,6 +52,7 @@ provided at the Github web page when creating the PR, e.g.
 ```text
 
 BEGINRELEASENOTES
+- export the selected Arrow CMake target for consumers building Arrow I/O libraries
 - updated documentation
     - add guidelines for contributing
 - reverted some name changes in tests/examples
@@ -62,5 +63,4 @@ ENDRELEASENOTES
 
 
 ```
-
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -52,7 +52,6 @@ provided at the Github web page when creating the PR, e.g.
 ```text
 
 BEGINRELEASENOTES
-- export the selected Arrow CMake target for consumers building Arrow I/O libraries
 - updated documentation
     - add guidelines for contributing
 - reverted some name changes in tests/examples
@@ -63,4 +62,5 @@ ENDRELEASENOTES
 
 
 ```
+
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Export the Arrow target selected while configuring podio, otherwise `PODIO_ARROW_TARGET` will be empty and this is used inside the macro in `target_link_libraries`, making downstream targets not link to Arrow

ENDRELEASENOTES

It works in CI because everything is available in a view in the LCG stacks, but it doesn't work when building.