### PR TITLE
Look for lz4 quietly when finding Arrow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ endif()
 
 # optionally build with Arrow -----------------------------------------------
 if(ENABLE_ARROW)
+  set(lz4Alt_FIND_QUIETLY TRUE)
   find_package(Arrow REQUIRED)
   if(TARGET Arrow::arrow_shared)
     set(PODIO_ARROW_TARGET Arrow::arrow_shared)

--- a/cmake/podioConfig.cmake.in
+++ b/cmake/podioConfig.cmake.in
@@ -48,6 +48,7 @@ endif()
 
 SET(PODIO_ENABLE_ARROW @ENABLE_ARROW@)
 if(PODIO_ENABLE_ARROW)
+  set(lz4Alt_FIND_QUIETLY TRUE)
   find_dependency(Arrow)
   set(PODIO_ARROW_TARGET @PODIO_ARROW_TARGET@)
 endif()


### PR DESCRIPTION
BEGINRELEASENOTES

- Look for `lz4` quietly when looking for Arrow to avoid a warning when `lz4` doesn't provide a CMake config file.

ENDRELEASENOTES

Arrow's `Findlz4Alt.cmake` starts by calling `find_package(lz4)`, which only succeeds if lz4 ships `lz4Config.cmake` or `lz4-config.cmake`. When lz4 provides neither (LCG stacks), that call warns:

```
CMake Warning at .../cmake/Arrow/Findlz4Alt.cmake:29 (find_package):
  By not providing "Findlz4.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "lz4", but
  CMake did not find one.
```

Claude :robot: (after being instructed to use this `lz4Alt_FIND_QUIETLY` variable: 

The warning is spurious: the module then falls back to pkg-config and `find_library`, and lz4 is found. It shows up whenever lz4 comes from a location that pkg-config can't see either, for example when using an LCG view, where `PKG_CONFIG_PATH` points only into the view while lz4 comes from the system. Adding the system paths to `PKG_CONFIG_PATH` would fix the warning but would also expose every other system package to the build, which is not wanted.

`Findlz4Alt.cmake` already forwards `QUIET` to the inner `find_package(lz4)` when `lz4Alt_FIND_QUIETLY` is set, so setting that variable before looking for Arrow silences the config-file lookup while leaving the working fallback untouched. It is set in two places, so that it applies both when building podio and for downstream consumers going through `podioConfig.cmake`, which is where the warning was originally seen (via `find_dependency(Arrow)`).

Tested by building podio with `-DENABLE_ARROW=ON` and then configuring EDM4hep against it with no changes on the EDM4hep side: Arrow is still found and the warning is gone in both.