### PR TITLE
CI: test with GCC 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         LCG: ["dev3/x86_64-el9-gcc15-opt",
-              "dev4/x86_64-el9-clang22-opt",
-              "dev4/x86_64-el9-gcc15-opt",
-              "LCG_108/x86_64-el9-gcc15-opt",  # root 6.36.02 with c++23
+               "dev4/x86_64-el9-clang22-opt",
+               "dev4/x86_64-el9-gcc15-opt",
+               "dev4/x86_64-el9-gcc16-opt",
+               "LCG_108/x86_64-el9-gcc15-opt",  # root 6.36.02 with c++23
               "LCG_107/x86_64-el9-gcc13-opt",  # root 6.34.02 !minimal root version for RNTuple
               "LCG_104/x86_64-el9-gcc13-opt"]  # root 6.28.04 !minimal root version check
     steps:

--- a/src/ArrowFrameConverter.cc
+++ b/src/ArrowFrameConverter.cc
@@ -5,8 +5,18 @@
 #include "podio/utilities/ArrowTypeRegistry.h"
 #include "podio/utilities/ArrowUtils.h"
 
-#include <algorithm>
-#include <arrow/api.h>
+#include <arrow/array/array_base.h>
+#include <arrow/array/array_nested.h>
+#include <arrow/array/builder_base.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_nested.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/memory_pool.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+
 #include <stdexcept>
 
 namespace podio {

--- a/src/ArrowFrameConverter.cc
+++ b/src/ArrowFrameConverter.cc
@@ -5,18 +5,8 @@
 #include "podio/utilities/ArrowTypeRegistry.h"
 #include "podio/utilities/ArrowUtils.h"
 
-#include <arrow/array/array_base.h>
-#include <arrow/array/array_nested.h>
-#include <arrow/array/builder_base.h>
-#include <arrow/array/builder_binary.h>
-#include <arrow/array/builder_nested.h>
-#include <arrow/array/builder_primitive.h>
-#include <arrow/memory_pool.h>
-#include <arrow/record_batch.h>
-#include <arrow/table.h>
-#include <arrow/type.h>
-#include <arrow/util/key_value_metadata.h>
-
+#include <algorithm>
+#include <arrow/api.h>
 #include <stdexcept>
 
 namespace podio {


### PR DESCRIPTION
BEGINRELEASENOTES
- Add GCC 16 coverage in the CI test matrix.

ENDRELEASENOTES