### PR TITLE
Add a comparison operator for ObjectID

### DIFF
--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -31,8 +31,7 @@ public:
   constexpr bool operator==(const ObjectID&) const noexcept = default;
 
   /// Provide an order solely for use in ordered containers.
-  /// Order ObjectIDs by collection first and then by their index within the collection.
-  /// Only comparisons between ObjectIDs from the same collection make sense.
+  /// Order ObjectIDs by collectionID first and then by their index within the collection.
   constexpr std::strong_ordering operator<=>(const ObjectID& other) const noexcept {
     if (const auto comparison = collectionID <=> other.collectionID; comparison != 0) {
       return comparison;

--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -30,7 +30,9 @@ public:
   /// this operator is necessary for meaningful comparisons in python
   constexpr bool operator==(const ObjectID&) const noexcept = default;
 
+  /// Provide an order solely for use in ordered containers.
   /// Order ObjectIDs by collection first and then by their index within the collection.
+  /// Only comparisons between ObjectIDs from the same collection make sense.
   constexpr std::strong_ordering operator<=>(const ObjectID& other) const noexcept {
     if (const auto comparison = collectionID <=> other.collectionID; comparison != 0) {
       return comparison;

--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -27,7 +27,6 @@ public:
   uint32_t collectionID{static_cast<uint32_t>(untracked)};
 
   /// index and collectionID uniquely defines the object.
-  /// this operator is necessary for meaningful comparisons in python
   constexpr bool operator==(const ObjectID&) const noexcept = default;
 
   /// Provide an order solely for use in ordered containers.

--- a/include/podio/ObjectID.h
+++ b/include/podio/ObjectID.h
@@ -1,6 +1,7 @@
 #ifndef PODIO_OBJECTID_H
 #define PODIO_OBJECTID_H
 
+#include <compare>
 #include <cstdint>
 #include <functional>
 #include <iomanip>
@@ -28,6 +29,14 @@ public:
   /// index and collectionID uniquely defines the object.
   /// this operator is necessary for meaningful comparisons in python
   constexpr bool operator==(const ObjectID&) const noexcept = default;
+
+  /// Order ObjectIDs by collection first and then by their index within the collection.
+  constexpr std::strong_ordering operator<=>(const ObjectID& other) const noexcept {
+    if (const auto comparison = collectionID <=> other.collectionID; comparison != 0) {
+      return comparison;
+    }
+    return index <=> other.index;
+  }
 };
 
 inline std::ostream& operator<<(std::ostream& os, const podio::ObjectID& id) {

--- a/tests/unittests/interface_types.cpp
+++ b/tests/unittests/interface_types.cpp
@@ -127,6 +127,29 @@ TEST_CASE("InterfaceTypes hash and containers", "[interface-types][hash]") {
   }
 }
 
+TEST_CASE("ObjectID ordering", "[object-id][containers]") {
+  constexpr auto firstInCollection = podio::ObjectID{1, 42};
+  constexpr auto secondInCollection = podio::ObjectID{2, 42};
+  constexpr auto firstInNextCollection = podio::ObjectID{0, 43};
+
+  STATIC_REQUIRE(firstInCollection < secondInCollection);
+  STATIC_REQUIRE(secondInCollection < firstInNextCollection);
+
+  std::map<podio::ObjectID, int> counterMap{};
+  counterMap[secondInCollection]++;
+  counterMap[firstInNextCollection]++;
+  counterMap[firstInCollection]++;
+  counterMap[firstInCollection]++;
+
+  REQUIRE(counterMap.size() == 3);
+  REQUIRE(counterMap[firstInCollection] == 2);
+
+  auto it = counterMap.begin();
+  REQUIRE(it++->first == firstInCollection);
+  REQUIRE(it++->first == secondInCollection);
+  REQUIRE(it->first == firstInNextCollection);
+}
+
 TEST_CASE("InterfaceType construction and type checking", "[interface-types][basics]") {
   using WrapperT = TypeWithEnergy;
 


### PR DESCRIPTION
BEGINRELEASENOTES
 - Add a comparison operator for ObjectID, allowing ObjectIDs to be used in `std::map` containers and not only `std::unordered_map`.
 - Add a test for `ObjectID` ordering and `std::map` usage.

ENDRELEASENOTES

Allows also to do several things for debugging, like filling a map to do something with the elements with deterministic ordering (and ordered within a collection).