### PR TITLE
pin pre-commit hook revisions with SHA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
     hooks:
       - id: mixed-line-ending
       - id: trailing-whitespace
         exclude: (doc/ReleaseNotes.md)
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 2a1c67e0b2f81df602ec1f6e7aeb030b9709dc7c # frozen: 23.11.0
     hooks:
       - id: black
   - repo: local


### PR DESCRIPTION

BEGINRELEASENOTES
- Pin pre-commit hook revisions with SHA rather than tag name

ENDRELEASENOTES

Similar to what was done for actions in #963 but this time for pre-commit hooks
This is compatible with dependabot updates for pre-commit, `pre-commit update --freeze` and `prek update --freeze`