### PR TITLE
Add a create factory method for link collections that take objects to link

### DIFF
--- a/doc/links.md
+++ b/doc/links.md
@@ -87,6 +87,21 @@ auto recoP = link.getTo();
 auto weight = link.getWeight();
 ```
 
+The objects that should be linked (and optionally the weight) can also be
+passed directly to `create`
+```cpp
+auto link = mcRecoLinks.create(mcParticle, recoParticle, 1.0);
+```
+
+If `FromT` and `ToT` are different types, the two objects can be passed in any
+order and the direction of the link is deduced at compile time
+```cpp
+// equivalent to the above, the weight defaults to 1
+auto link = mcRecoLinks.create(recoParticle, mcParticle);
+```
+
+In all other cases the *canonical order*, i.e. **_from_ first, _to_ second**, is used.
+
 In the above examples the `From` and `To` in the method names imply a direction,
 but it is also possible to use a templated `get` and `set` method to retrieve
 the linked objects via their type:

--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -19,6 +19,18 @@
 
 namespace podio {
 
+namespace detail {
+  /// Check whether a Link<FromT, ToT> can be initialized from values of types
+  /// FromU and ToU in exactly this order, i.e. whether its From element can be
+  /// set from a FromU and its To element from a ToU. Passing FromT and ToT in
+  /// swapped order checks the reversed order.
+  template <typename FromT, typename ToT, typename FromU, typename ToU>
+  concept LinkInitializableFrom = requires(podio::MutableLink<FromT, ToT> link, FromU from, ToU to) {
+    link.setFrom(from);
+    link.setTo(to);
+  };
+} // namespace detail
+
 /// Generalized Link type for both Mutable and immutable (default)
 /// versions. User facing classes with the expected naming scheme are defined via
 /// template aliases in LinkFwd.h

--- a/include/podio/detail/LinkCollectionImpl.h
+++ b/include/podio/detail/LinkCollectionImpl.h
@@ -34,6 +34,7 @@
 #include <ostream>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 namespace podio {
 
@@ -133,6 +134,42 @@ public:
     auto obj = m_storage.entries.emplace_back(new LinkObj<FromT, ToT>());
     obj->id = {int(m_storage.entries.size() - 1), m_collectionID};
     return mutable_type(podio::utils::MaybeSharedPtr(obj));
+  }
+
+  /// Append a new link to the collection, linking the two passed objects, and
+  /// return this object
+  ///
+  /// If FromT and ToT are different types, the two objects may be passed in any
+  /// order and the direction of the link is deduced at compile time. If both
+  /// orders are possible (e.g. because interface types are involved) the
+  /// canonical order, i.e. *from first, to second*, takes precedence. If FromT
+  /// and ToT are the same type, the canonical order is the only possible one.
+  ///
+  /// @tparam FromU the type of the first object (**inferred!**)
+  /// @tparam ToU   the type of the second object (**inferred!**)
+  ///
+  /// @param from   the object to link (the *from* object in canonical order)
+  /// @param to     the object to link (the *to* object in canonical order)
+  /// @param weight the weight of the link (defaults to 1)
+  ///
+  /// @returns the newly created (mutable) link
+  ///
+  /// @throws std::logic_error if this is a subset collection
+  template <typename FromU, typename ToU>
+    requires detail::LinkInitializableFrom<FromT, ToT, FromU, ToU> ||
+      detail::LinkInitializableFrom<ToT, FromT, FromU, ToU>
+  mutable_type create(FromU&& from, ToU&& to, float weight = 1.0f) {
+    auto link = create();
+    link.setWeight(weight);
+    // The canonical order takes precedence if both orders are possible
+    if constexpr (detail::LinkInitializableFrom<FromT, ToT, FromU, ToU>) {
+      link.setFrom(std::forward<FromU>(from));
+      link.setTo(std::forward<ToU>(to));
+    } else {
+      link.setTo(std::forward<FromU>(from));
+      link.setFrom(std::forward<ToU>(to));
+    }
+    return link;
   }
 
   /// Returns the immutable object of given index

--- a/include/podio/detail/LinkFwd.h
+++ b/include/podio/detail/LinkFwd.h
@@ -42,7 +42,7 @@ using LinkObjPointerContainer = std::deque<LinkObj<FromT, ToT>*>;
 /// Simple struct to keep implementation more in line with generated links and
 /// to ease evolution of generated links into templated ones
 struct LinkData {
-  float weight{};
+  float weight{1.0f};
 };
 
 using LinkDataContainer = std::vector<LinkData>;

--- a/python/podio/test_LinkCollection.py
+++ b/python/podio/test_LinkCollection.py
@@ -61,3 +61,26 @@ class LinkCollectionImportTest(unittest.TestCase):
         link.setTo(cluster)
 
         self.assertEqual(len(coll), 1)
+
+    def test_link_collection_create_links_with_objects(self):
+        """Test that links can be created from the objects that should be linked"""
+        hits = ExampleHitCollection()
+        hit = hits.create()
+
+        clusters = ExampleClusterCollection()
+        cluster = clusters.create()
+
+        coll = LinkCollection[ExampleHit, ExampleCluster]()
+        link = coll.create(hit, cluster)
+        self.assertEqual(len(coll), 1)
+        self.assertEqual(link.getFrom(), hit)
+        self.assertEqual(link.getTo(), cluster)
+        self.assertEqual(link.getWeight(), 1.0)
+
+        # The objects can be passed in any order and an optional weight can be
+        # passed as well
+        other_link = coll.create(cluster, hit, 3.14)
+        self.assertEqual(len(coll), 2)
+        self.assertEqual(other_link.getFrom(), hit)
+        self.assertEqual(other_link.getTo(), cluster)
+        self.assertAlmostEqual(other_link.getWeight(), 3.14, places=5)

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -449,6 +449,84 @@ TEST_CASE("LinkCollection basics", "[links]") {
   }
 }
 
+TEST_CASE("LinkCollection create with linked objects", "[links][basics]") {
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): There are quite a few
+  // false positives here from clang-tidy that we are confident are false
+  // positives, because we don't see issues in our builds with sanitizers
+  auto hits = ExampleHitCollection();
+  auto clusters = ExampleClusterCollection();
+  auto hit = hits.create();
+  auto cluster = clusters.create();
+
+  auto links = TestLColl();
+
+  SECTION("Canonical order") {
+    auto link = links.create(hit, cluster);
+    REQUIRE(links.size() == 1);
+    REQUIRE(link.getFrom() == hit);
+    REQUIRE(link.getTo() == cluster);
+    // The weight defaults to the same value as for a default constructed link
+    REQUIRE(link.getWeight() == 1.f);
+    REQUIRE(link.getWeight() == links.create().getWeight());
+  }
+
+  SECTION("Reversed order") {
+    auto link = links.create(cluster, hit);
+    REQUIRE(links.size() == 1);
+    REQUIRE(link.getFrom() == hit);
+    REQUIRE(link.getTo() == cluster);
+    REQUIRE(link.getWeight() == 1.f);
+  }
+
+  SECTION("With a weight") {
+    auto link = links.create(hit, cluster, 3.14f);
+    REQUIRE(link.getFrom() == hit);
+    REQUIRE(link.getTo() == cluster);
+    REQUIRE(link.getWeight() == 3.14f);
+
+    auto reversed = links.create(cluster, hit, 42.f);
+    REQUIRE(reversed.getFrom() == hit);
+    REQUIRE(reversed.getTo() == cluster);
+    REQUIRE(reversed.getWeight() == 42.f);
+  }
+
+  SECTION("Immutable handles") {
+    auto link = links.create(std::as_const(hits)[0], std::as_const(clusters)[0]);
+    REQUIRE(link.getFrom() == hit);
+    REQUIRE(link.getTo() == cluster);
+  }
+
+  SECTION("Links are appended to the collection") {
+    links.create(hit, cluster, 1.f);
+    links.create(cluster, hit, 2.f);
+    REQUIRE(links.size() == 2);
+    REQUIRE(links[0].getWeight() == 1.f);
+    REQUIRE(links[1].getWeight() == 2.f);
+    for (auto link : links) {
+      REQUIRE(link.getFrom() == hit);
+      REQUIRE(link.getTo() == cluster);
+    }
+  }
+
+  SECTION("Subset collections cannot create links") {
+    auto subsetColl = TestLColl();
+    subsetColl.setSubsetCollection();
+    REQUIRE_THROWS_AS(subsetColl.create(hit, cluster), std::logic_error);
+  }
+
+  SECTION("Links with the same From and To type") {
+    using SameTypeLColl = podio::LinkCollection<ExampleHit, ExampleHit>;
+    auto otherHit = hits.create();
+    auto sameTypeLinks = SameTypeLColl();
+    // Only the canonical order is possible here
+    auto link = sameTypeLinks.create(hit, otherHit, 1.23f);
+    REQUIRE(link.getFrom() == hit);
+    REQUIRE(link.getTo() == otherHit);
+    REQUIRE(link.getWeight() == 1.23f);
+  }
+}
+// NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+
 auto createLinkCollections(const size_t nElements = 3u) {
   auto colls = std::make_tuple(TestLColl(), ExampleHitCollection(), ExampleClusterCollection());
 
@@ -609,6 +687,34 @@ TEST_CASE("Links with interfaces", "[links][interface-types]") {
   rLink.set(hit);
   REQUIRE(rLink.get<TypeWithEnergy>() == hit);
   REQUIRE(rLink.get<ExampleCluster>() == cluster);
+
+  SECTION("Creating links with interfaces") {
+    // Interface types can be passed directly
+    auto ifaceLink = coll.create(cluster, iface, 1.f);
+    REQUIRE(ifaceLink.getFrom() == cluster);
+    REQUIRE(ifaceLink.getTo() == iface);
+    REQUIRE(ifaceLink.getWeight() == 1.f);
+
+    // As can types that implicitly convert to an interface, in any order
+    auto convLink = coll.create(cluster, hit);
+    REQUIRE(convLink.getFrom() == cluster);
+    REQUIRE(convLink.getTo() == hit);
+
+    auto reversedLink = coll.create(hit, cluster);
+    REQUIRE(reversedLink.getFrom() == cluster);
+    REQUIRE(reversedLink.getTo() == hit);
+
+    // If both orders are possible the canonical one (from, to) wins
+    auto otherCluster = ExampleCluster();
+    auto ambiguousLink = coll.create(cluster, otherCluster);
+    REQUIRE(ambiguousLink.getFrom() == cluster);
+    REQUIRE(ambiguousLink.get<TypeWithEnergy>() == otherCluster);
+
+    // Also works for links that go in the other direction
+    auto rIfaceLink = rColl.create(cluster, hit);
+    REQUIRE(rIfaceLink.getFrom() == hit);
+    REQUIRE(rIfaceLink.getTo() == cluster);
+  }
 }
 
 TEST_CASE("Links reverse iterators", "[links][iterator]") {


### PR DESCRIPTION

BEGINRELEASENOTES
- Add a `LinkCollection::create` overload that takes the objects that should be linked to facilitate creating links.

ENDRELEASENOTES

Fixes #1008 