### PR TITLE
fix: detach stack metadata tree before closing ROOT file

### DIFF
--- a/src/ROOTWriter.cc
+++ b/src/ROOTWriter.cc
@@ -202,6 +202,7 @@ void ROOTWriter::finish() {
   metaTree.Fill();
 
   m_file.Write();
+  metaTree.SetDirectory(nullptr);
   m_file.Close();
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES

- Detach the metadata `TTree` from the output `TFile` before closing the file.

ENDRELEASENOTES

`ROOTWriter::finish()` creates `metaTree` with automatic storage duration, then calls `metaTree.SetDirectory(&m_file)`. This registers the tree in the directory's list of owned objects. When `TFile::Close()` cleans up that list, ROOT can attempt to delete the stack object.

Failing CI job (second time I saw that test failing): https://github.com/AIDASoft/podio/actions/runs/32955383073/job/98135801000

<details>
<summary>Stack trace</summary>

```text
     35/271 Test   #6: write_frame_root .......................................................................***Failed    7.05 sec
    
     *** Break *** segmentation violation
    
    
    
    ===========================================================
    There was a crash.
    This is the entire stack trace of all threads:
    ===========================================================
    #0  0x00007f5a61ad034a in wait4 () from /lib64/libc.so.6
    #1  0x00007f5a61a45383 in do_system () from /lib64/libc.so.6
    #2  0x00007f5a6231c348 in TUnixSystem::StackTrace() () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libCore.so
    #3  0x00007f5a6231bd08 in TUnixSystem::DispatchSignals(ESignals) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libCore.so
    #4  <signal handler called>
    #5  0x00007f5a61a9177b in free () from /lib64/libc.so.6
    #6  0x00007f5a6225d758 in TList::Delete(char const*) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libCore.so
    #7  0x00007f5a62254317 in THashList::Delete(char const*) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libCore.so
    #8  0x00007f5a6276e5fc in TDirectoryFile::Close(char const*) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libRIO.so
    #9  0x00007f5a62792cdb in TFile::Close(char const*) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libRIO.so
    #10 0x00007f5a64323011 in podio::ROOTWriter::finish (this=this
    entry=0x7ffed750df70) at /home/runner/work/podio/podio/src/ROOTWriter.cc:205
    #11 0x000000000042a71a in write_frames<podio::ROOTWriter> (filename=...) at /home/runner/work/podio/podio/tests/write_frame.h:557
    #12 0x0000000000415aa7 in main () at /home/runner/work/podio/podio/tests/root_io/write_frame_root.cpp:9
    ===========================================================
    
    
    The lines below might hint at the cause of the crash. If you see question
    marks as part of the stack trace, try to recompile with debugging information
    enabled and export CLING_DEBUG=1 environment variable before running.
    You may get help by asking at the ROOT forum https://root.cern/forum
    preferably using the command (.forum bug) in the ROOT prompt.
    Only if you are really convinced it is a bug in ROOT then please submit a
    report at https://root.cern/bugs or (preferably) using the command (.gh bug) in
    the ROOT prompt. Please post the ENTIRE stack trace
    from above as an attachment in addition to anything else
    that might help us fixing this issue.
    ===========================================================
    #5  0x00007f5a61a9177b in free () from /lib64/libc.so.6
    #6  0x00007f5a6225d758 in TList::Delete(char const*) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libCore.so
    #7  0x00007f5a62254317 in THashList::Delete(char const*) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libCore.so
    #8  0x00007f5a6276e5fc in TDirectoryFile::Close(char const*) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libRIO.so
    #9  0x00007f5a62792cdb in TFile::Close(char const*) () from /cvmfs/sft.cern.ch/lcg/views/LCG_108/x86_64-el9-gcc15-opt/lib/libRIO.so
    #10 0x00007f5a64323011 in podio::ROOTWriter::finish (this=this
    entry=0x7ffed750df70) at /home/runner/work/podio/podio/src/ROOTWriter.cc:205
    #11 0x000000000042a71a in write_frames<podio::ROOTWriter> (filename=...) at /home/runner/work/podio/podio/tests/write_frame.h:557
    #12 0x0000000000415aa7 in main () at /home/runner/work/podio/podio/tests/root_io/write_frame_root.cpp:9
    ===========================================================
```

</details>

Since this doesn't happen all the time, it's not clear if this is fixing it but probably doesn't hurt.
