### PR TITLE
Make it possible to use the templated Link::set with mutable handles

### DIFF
--- a/include/podio/detail/Link.h
+++ b/include/podio/detail/Link.h
@@ -281,9 +281,9 @@ public:
              (isMutableFromOrToT<T> || detail::isInterfaceInitializableFrom<ToT, T> ||
               detail::isInterfaceInitializableFrom<FromT, T>))
   void set(T value) {
-    if constexpr (std::is_same_v<T, FromT>) {
+    if constexpr (std::is_same_v<detail::GetDefaultHandleType<T>, FromT>) {
       setFrom(std::move(value));
-    } else if constexpr (std::is_same_v<T, ToT>) {
+    } else if constexpr (std::is_same_v<detail::GetDefaultHandleType<T>, ToT>) {
       setTo(std::move(value));
     } else if constexpr (detail::isInterfaceInitializableFrom<FromT, T> &&
                          !detail::isInterfaceInitializableFrom<ToT, T>) {

--- a/tests/unittests/links.cpp
+++ b/tests/unittests/links.cpp
@@ -274,7 +274,7 @@ TEST_CASE("Links templated accessors", "[links]") {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): There are quite a few
   // false positives here from clang-tidy that we are confident are false
   // positives, because we don't see issues in our builds with sanitizers
-  ExampleHit hit;
+  MutableExampleHit hit;
   ExampleCluster cluster;
 
   TestMutL link;


### PR DESCRIPTION

BEGINRELEASENOTES
- Make `Link::set<T>` accept `MutableT` as well instead of wrongly triggering a `static_assert`

ENDRELEASENOTES

Fixes #1013 