### PR TITLE
Remove leftover Python include dirs from PODIO_ADD_ROOT_IO_DICT

### DIFF
--- a/cmake/podioMacros.cmake
+++ b/cmake/podioMacros.cmake
@@ -277,9 +277,6 @@ function(PODIO_ADD_ROOT_IO_DICT dict_name CORE_LIB HEADERS SELECTION_XML)
     $<BUILD_INTERFACE:${ARG_OUTPUT_FOLDER}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
-  target_include_directories(${dict_name} SYSTEM PUBLIC
-    ${Python3_INCLUDE_DIRS}
-    )
   PODIO_GENERATE_DICTIONARY(${dict_name} ${HEADERS} SELECTION ${selectionfile}
     OPTIONS --library ${CMAKE_SHARED_LIBRARY_PREFIX}${dict_name}${CMAKE_SHARED_LIBRARY_SUFFIX}
     )


### PR DESCRIPTION
### BEGINRELEASENOTES

- Remove the leftover `Python3_INCLUDE_DIRS` from `PODIO_ADD_ROOT_IO_DICT`. It is no longer needed, and because it was not wrapped in a generator expression it made generated dictionary targets un-exportable in some environments.

### ENDRELEASENOTES

Deletes this call from `PODIO_ADD_ROOT_IO_DICT`:

```cmake
  target_include_directories(${dict_name} SYSTEM PUBLIC
    ${Python3_INCLUDE_DIRS}
    )
```

**It is dead.** #910 forward-declared `PyObject` so `podio/detail/Pythonizations.h` no longer includes `<Python.h>`, and removed this same line from `PODIO_ADD_LIB_AND_DICT`; the copy here was missed. On master `<Python.h>` remains only in `src/Pythonizations.cc`, which gets it from `target_link_libraries(podio PRIVATE Python3::Python)`. Nothing in a dictionary compile needs Python headers.

**It is also harmful.** Unlike the call above it the path is not in a generator expression, so a bare absolute path lands in the dictionary's `INTERFACE_INCLUDE_DIRECTORIES`. That makes `install(TARGETS <dict> EXPORT <set>)` fail whenever the Python prefix sits under the consumer's `CMAKE_SOURCE_DIR`:

```
CMake Error: Target "..." INTERFACE_INCLUDE_DIRECTORIES property contains path:
  "<prefix>/include/python3.14"
which is prefixed in the source directory.
```

Reported by ACTS, which builds a spack stack inside its CI workspace. Introduced in #839; #840 removed the duplicate just above but left this one.

**Testing.** LCG_109 `x86_64-el9-gcc14-opt` (ROOT 6.38.00): `ctest` 194/194 with `ENABLE_SIO=OFF`, 217/217 with `ENABLE_SIO=ON`. A minimal downstream consumer using `install(TARGETS ... EXPORT ...)` with Python under its source dir fails to configure against master and succeeds against this branch, with a clean relocatable exported target; the dictionary loads and `TClass::GetClass` resolves the generated classes. Also verified on macOS 15 arm64 / ROOT 6.40.02.
