### PR TITLE
fix: take the upstream EDM into account when reading old schemas

### DIFF
--- a/python/podio_gen/cpp_generator.py
+++ b/python/podio_gen/cpp_generator.py
@@ -664,13 +664,20 @@ class CPPClassGenerator(ClassGeneratorBaseMixin):
         reader = PodioConfigReader()
         # Read the current model again into a "new" namespace to have it more
         # easily discerned from the "old" model
-        datamodel_new = reader.read(self.yamlfile, package_name="new")
+        datamodel_new = reader.read(
+            self.yamlfile, package_name="new", upstream_edm=self.upstream_edm
+        )
         comparator = DataModelComparator(datamodel_new)
         judge = SchemaEvolutionJudge(comparator.datamodel_new, evolution_file=self.evolution_file)
 
         # Process each old schema version
         for old_yamlfile in self.old_yamlfiles:
-            datamodel_old = reader.read(old_yamlfile, package_name="old", ignore_extracode=True)
+            datamodel_old = reader.read(
+                old_yamlfile,
+                package_name="old",
+                upstream_edm=self.upstream_edm,
+                ignore_extracode=True,
+            )
             detected_changes = comparator.compare(datamodel_old)
             comparison_results = judge.judge(datamodel_old, detected_changes)
 


### PR DESCRIPTION
This should make OLD_DESCRIPTIONS usable for downstream models.

BEGINRELEASENOTES
- Take the upstream EDM into account when re-reading the old and current schemas, so that `OLD_DESCRIPTIONS` can be used together with `UPSTREAM_EDM`.

ENDRELEASENOTES